### PR TITLE
Fixes for OS X examples in .pbxproj files

### DIFF
--- a/Examples/OSX/Convolution/Convolution.xcodeproj/project.pbxproj
+++ b/Examples/OSX/Convolution/Convolution.xcodeproj/project.pbxproj
@@ -1542,8 +1542,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Convolution/Convolution-Prefix.pch";
@@ -1566,8 +1566,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Convolution/Convolution-Prefix.pch";

--- a/Examples/OSX/MacSwiftConvolution/MacSwiftConvolution.xcodeproj/project.pbxproj
+++ b/Examples/OSX/MacSwiftConvolution/MacSwiftConvolution.xcodeproj/project.pbxproj
@@ -1530,8 +1530,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1552,8 +1552,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Examples/OSX/PlayAudioFile/PlayAudioFile.xcodeproj/project.pbxproj
+++ b/Examples/OSX/PlayAudioFile/PlayAudioFile.xcodeproj/project.pbxproj
@@ -1540,8 +1540,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PlayAudioFile/PlayAudioFile-Prefix.pch";
@@ -1563,8 +1563,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PlayAudioFile/PlayAudioFile-Prefix.pch";

--- a/Examples/OSX/Sequences/Sequences.xcodeproj/project.pbxproj
+++ b/Examples/OSX/Sequences/Sequences.xcodeproj/project.pbxproj
@@ -1527,8 +1527,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Sequences/Sequences-Prefix.pch";
@@ -1550,8 +1550,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 					"$(SRCROOT)/../../../AudioKit/Libraries/OSX/csound-OSX/",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Sequences/Sequences-Prefix.pch";


### PR DESCRIPTION
All examples run, by simply swapping last two in FRAMEWORK_SEARCH_PATHS
in the .pbxproj files. No need to change -+rtaudio=coreaudio to
portaudio in /Libraries/OSX/csound-OSX/CsoundObj.m
