### PR TITLE
Fix typo in AKManager

### DIFF
--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -258,7 +258,7 @@ static AKManager *_sharedManager = nil;
 
 /// Disable AudioInput
 - (void)disableAudioInput {
-    [csound setUseAudioInput:YES];    
+    [csound setUseAudioInput:NO];    
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Never actually tested this, but it definitely looks like a typo since the function body is identical to `enableAudioInput`.
