### PR TITLE
Added podspec file

### DIFF
--- a/AudioKit.podspec
+++ b/AudioKit.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |spec|
     spec.authors                  = { 'YOUR NAME HERE' => 'YOUR EMAIL HERE' }
     spec.license                  = { :type => 'LGPL' }
     spec.homepage                 = 'http://audiokit.io/'
-    spec.source                   = { :git => 'https://github.com/aure/AudioKit', :tag => 'v1.2-01-04-2015' }
+    spec.source                   = { :git => 'https://github.com/audiokit/AudioKit', :tag => 'v1.2-01-04-2015' }
     spec.summary                  = 'Open-source audio synthesis, processing, & analysis platform.'
 
     spec.source_files             = 'AudioKit/Core Classes/**/*.{h,m}',

--- a/AudioKit.podspec
+++ b/AudioKit.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
     spec.name                     = 'AudioKit'
     spec.version                  = '1.2'
     spec.authors                  = { 'YOUR NAME HERE' => 'YOUR EMAIL HERE' }
-    spec.license                  = { :type => 'GLPL' }
+    spec.license                  = { :type => 'LGPL' }
     spec.homepage                 = 'http://audiokit.io/'
     spec.source                   = { :git => 'https://github.com/aure/AudioKit', :tag => 'v1.2-01-04-2015' }
     spec.summary                  = 'Open-source audio synthesis, processing, & analysis platform.'

--- a/AudioKit.podspec
+++ b/AudioKit.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |spec|
+    spec.name                     = 'AudioKit'
+    spec.version                  = '1.2'
+    spec.authors                  = { 'YOUR NAME HERE' => 'YOUR EMAIL HERE' }
+    spec.license                  = { :type => 'GLPL' }
+    spec.homepage                 = 'http://audiokit.io/'
+    spec.source                   = { :git => 'https://github.com/aure/AudioKit', :tag => 'v1.2-01-04-2015' }
+    spec.summary                  = 'Open-source audio synthesis, processing, & analysis platform.'
+
+    spec.source_files             = 'AudioKit/Core Classes/**/*.{h,m}',
+                                    'AudioKit/Operations/**/*.{h,m}',
+                                    'AudioKit/Parameters/**/*.{h,m}',
+                                    'AudioKit/Utilities/**/*.{h,m}'
+
+    spec.osx.deployment_target    = '10.10'
+    spec.osx.frameworks           = 'CsoundLib64'
+    spec.osx.vendored_frameworks  = 'AudioKit/Libraries/OSX/csound-OSX/CsoundLib64.framework'
+    spec.osx.source_files         = 'AudioKit/Libraries/OSX/*.{h,m}',
+                                    'AudioKit/Libraries/OSX/csound-OSX/*.{h,m}'
+
+    spec.ios.deployment_target    = '8.0'
+    spec.ios.libraries            = 'csound', 'sndfile'
+    spec.ios.vendored_libraries   = 'AudioKit/Libraries/iOS/csound-iOS/libs/libcsound.a', 'AudioKit/Libraries/iOS/csound-iOS/libs/libsndfile.a'
+    spec.ios.source_files         = 'AudioKit/Libraries/iOS/*.{h,m}',
+                                    'AudioKit/Libraries/iOS/csound-iOS/classes/*.{h,m}',
+                                    'AudioKit/Libraries/iOS/csound-iOS/headers/*.{h,hpp}'
+end


### PR DESCRIPTION
I made a podspec file, so you can install AudioKit using CocoaPods...

Haven't tested on OS X yet, but working just fine on iOS with the following Podfile and the AudioKit repo in a neighbouring directory.

    source 'https://github.com/CocoaPods/Specs.git'
    platform :ios, '8.0'
    pod 'AudioKit', :path => '../AudioKit' 