### PR TITLE
Basic operators overloading in Swift

### DIFF
--- a/AudioKit/Platforms/OSX/CsoundObj.m
+++ b/AudioKit/Platforms/OSX/CsoundObj.m
@@ -459,7 +459,7 @@ OSStatus  Csound_Render(void *inRefCon,
         //    }
         
         char *argv[5] = { "csound", "-+ignore_csopts=0",
-            "-+rtaudio=coreaudio", "-b256", (char*)[csdFilePath
+            "-+rtaudio=portaudio", "-b256", (char*)[csdFilePath
                                                     cStringUsingEncoding:NSASCIIStringEncoding]};
         int ret = csoundCompile(cs, 5, argv);
         mCsData.running = true;

--- a/AudioKit/Platforms/OSX/CsoundObj.m
+++ b/AudioKit/Platforms/OSX/CsoundObj.m
@@ -459,7 +459,7 @@ OSStatus  Csound_Render(void *inRefCon,
         //    }
         
         char *argv[5] = { "csound", "-+ignore_csopts=0",
-            "-+rtaudio=portaudio", "-b256", (char*)[csdFilePath
+            "-+rtaudio=coreaudio", "-b256", (char*)[csdFilePath
                                                     cStringUsingEncoding:NSASCIIStringEncoding]};
         int ret = csoundCompile(cs, 5, argv);
         mCsData.running = true;

--- a/AudioKit/Platforms/Swift/Extensions/Arithmetic.swift
+++ b/AudioKit/Platforms/Swift/Extensions/Arithmetic.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Ales Tsurko. All rights reserved.
 //
 
+// Converts midi note number to ratio (speed)
 extension Float {
     var midiratio: Float {return pow(2, self * 0.083333333333)}
 }

--- a/AudioKit/Platforms/Swift/Extensions/Arithmetic.swift
+++ b/AudioKit/Platforms/Swift/Extensions/Arithmetic.swift
@@ -1,0 +1,59 @@
+//
+//  Arithmetic.swift
+//  AudioKit
+//
+//  Created by Ales Tsurko on 18.03.15.
+//  Copyright (c) 2015 Ales Tsurko. All rights reserved.
+//
+
+extension Float {
+    var midiratio: Float {return pow(2, self * 0.083333333333)}
+}
+
+func + (left: AKParameter, right: AKParameter) -> AKParameter {
+    return left.plus(right)
+}
+
+func + (left: AKControl, right: AKControl) -> AKControl {
+    return left.plus(right)
+}
+
+func + (left: AKConstant, right: AKConstant) -> AKConstant {
+    return left.plus(right)
+}
+
+func - (left: AKParameter, right: AKParameter) -> AKParameter {
+    return left.minus(right)
+}
+
+func - (left: AKControl, right: AKControl) -> AKControl {
+    return left.minus(right)
+}
+
+func - (left: AKConstant, right: AKConstant) -> AKConstant {
+    return left.minus(right)
+}
+
+func * (left: AKParameter, right: AKParameter) -> AKParameter {
+    return left.scaledBy(right)
+}
+
+func * (left: AKControl, right: AKControl) -> AKControl {
+    return left.scaledBy(right)
+}
+
+func * (left: AKConstant, right: AKConstant) -> AKConstant {
+    return left.scaledBy(right)
+}
+
+func / (left: AKParameter, right: AKParameter) -> AKParameter {
+    return left.dividedBy(right)
+}
+
+func / (left: AKControl, right: AKControl) -> AKControl {
+    return left.dividedBy(right)
+}
+
+func / (left: AKConstant, right: AKConstant) -> AKConstant {
+    return left.dividedBy(right)
+}


### PR DESCRIPTION
Arithmetic.swift contains overloading for: +, -, *, /. This gives a possibility to use basic operators instead of plus, minus, dividedBy and scaledBy methods. It also contains a useful extension for float, which converts midi note number to ratio (aka speed of AKFileInput aka frequency of AKGranularSynthesisTexture). The last one ported from SuperCollider.