### PR TITLE
Make the state property @dynamic (silences a warning in Xcode 6.3)

### DIFF
--- a/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKMix.m
+++ b/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKMix.m
@@ -20,8 +20,6 @@
     AKParameter *current;
 }
 
-@dynamic state;
-
 - (instancetype)initWithInput1:(AKParameter *)input1
                         input2:(AKParameter *)input2
                         balance:(AKParameter *)balancePoint;

--- a/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKMix.m
+++ b/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKMix.m
@@ -11,10 +11,6 @@
 
 #import "AKMix.h"
 
-@interface AKMix ()
-@property NSString *state;
-@end
-
 @implementation AKMix
 {
     AKParameter *in1;
@@ -23,6 +19,8 @@
     AKConstant *max;
     AKParameter *current;
 }
+
+@dynamic state;
 
 - (instancetype)initWithInput1:(AKParameter *)input1
                         input2:(AKParameter *)input2


### PR DESCRIPTION
A simple fix as the Xcode 6.3 beta warns about reusing the `state` property in this class that is already declared in a parent class. I'm assuming here that reusing that property is the desired effect.
