### PR TITLE
Various improvements for the *Plot views

### DIFF
--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
@@ -13,10 +13,12 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plots the FFT of the audio input
-@interface AKAudioInputFFTPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioInputFFTPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plots the FFT of the audio input
+IB_DESIGNABLE
 @interface AKAudioInputFFTPlot : NSView
 #endif
 

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
@@ -6,20 +6,22 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "CsoundObj.h"
-#import <Accelerate/Accelerate.h>
-
+@import Foundation;
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plots the FFT of the audio input
 IB_DESIGNABLE
 @interface AKAudioInputFFTPlot : UIView
+@property IBInspectable UIColor *lineColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plots the FFT of the audio input
 IB_DESIGNABLE
 @interface AKAudioInputFFTPlot : NSView
+@property IBInspectable NSColor *lineColor;
 #endif
+
+@property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
@@ -8,6 +8,8 @@
 
 #import "AKAudioInputFFTPlot.h"
 #import "AKFoundation.h"
+#import "CsoundObj.h"
+
 #import <Accelerate/Accelerate.h>
 
 @interface AKAudioInputFFTPlot() <CsoundBinding>
@@ -36,7 +38,17 @@
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
-- (void)drawHistoryWithColor:(UIColor *)color width:(float)width
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _lineWidth = 1.0f;
+        _lineColor = [UIColor whiteColor];
+    }
+    return self;
+}
+
+- (void)drawHistoryWithColor:(UIColor *)color width:(CGFloat)width
 {
     // Draw waveform
     UIBezierPath *wavePath = [UIBezierPath bezierPath];
@@ -79,7 +91,7 @@
 }
 
 - (void)drawRect:(CGRect)rect {
-    [self drawHistoryWithColor:[UIColor whiteColor] width:1.0];
+    [self drawHistoryWithColor:self.lineColor width:self.lineWidth];
     
 }
 

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
@@ -10,7 +10,7 @@
 #import "AKFoundation.h"
 #import <Accelerate/Accelerate.h>
 
-@interface AKAudioInputFFTPlot()
+@interface AKAudioInputFFTPlot() <CsoundBinding>
 {
     NSData *outSamples;
     MYFLT *samples;

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.h
@@ -11,11 +11,13 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plots the incoming audio source signal, usually the microphone
-@interface AKAudioInputPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioInputPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plots the incoming audio source signal, usually the microphone
-@interface AKAudioInputPlot : NSView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioInputPlot : NSView
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.h
@@ -6,18 +6,20 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "CsoundObj.h"
-
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plots the incoming audio source signal, usually the microphone
 IB_DESIGNABLE
 @interface AKAudioInputPlot : UIView
+@property IBInspectable UIColor *lineColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plots the incoming audio source signal, usually the microphone
 IB_DESIGNABLE
 @interface AKAudioInputPlot : NSView
+@property IBInspectable NSColor *lineColor;
 #endif
+
+@property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.m
@@ -9,7 +9,7 @@
 #import "AKAudioInputPlot.h"
 #import "AKFoundation.h"
 
-@interface AKAudioInputPlot()
+@interface AKAudioInputPlot() <CsoundBinding>
 {
     NSData *inSamples;
     MYFLT *samples;

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.m
@@ -5,7 +5,7 @@
 //  Created by Aurelius Prochazka on 2/6/15.
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
-
+#import "CsoundObj.h"
 #import "AKAudioInputPlot.h"
 #import "AKFoundation.h"
 
@@ -28,7 +28,17 @@
 #define AKColor NSColor
 #endif
 
-- (void)drawWithColor:(AKColor *)color lineWidth:(float)width
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _lineWidth = 4.0f;
+        _lineColor = [AKColor yellowColor];
+    }
+    return self;
+}
+
+- (void)drawWithColor:(AKColor *)color lineWidth:(CGFloat)width
 {
     // Draw waveform
 #if TARGET_OS_IPHONE
@@ -62,7 +72,7 @@
 }
 
 - (void)drawRect:(CGRect)rect {
-    [self drawWithColor:[AKColor yellowColor] lineWidth:4.0];
+    [self drawWithColor:self.lineColor lineWidth:self.lineWidth];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
@@ -11,11 +11,13 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// A Rolling Waveform for of the audio input
-@interface AKAudioInputRollingWaveformPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioInputRollingWaveformPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// A Rolling Waveform for of the audio input
-@interface AKAudioInputRollingWaveformPlot : NSView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioInputRollingWaveformPlot : NSView
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
@@ -6,18 +6,20 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "CsoundObj.h"
+@import Foundation;
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// A Rolling Waveform for of the audio input
 IB_DESIGNABLE
 @interface AKAudioInputRollingWaveformPlot : UIView
+@property (nonatomic) IBInspectable UIColor *plotColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// A Rolling Waveform for of the audio input
 IB_DESIGNABLE
 @interface AKAudioInputRollingWaveformPlot : NSView
+@property (nonatomic) IBInspectable NSColor *plotColor;
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
@@ -10,7 +10,7 @@
 #import "AKFoundation.h"
 #import "EZAudioPlot.h"
 
-@interface AKAudioInputRollingWaveformPlot()
+@interface AKAudioInputRollingWaveformPlot() <CsoundBinding>
 {
     // AudioKit sound data
     NSData *outSamples;

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
@@ -9,6 +9,7 @@
 #import "AKAudioInputRollingWaveformPlot.h"
 #import "AKFoundation.h"
 #import "EZAudioPlot.h"
+#import "CsoundObj.h"
 
 @interface AKAudioInputRollingWaveformPlot() <CsoundBinding>
 {
@@ -31,6 +32,16 @@
 #define AKColor NSColor
 #endif
 
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _plotColor = [AKColor yellowColor];
+    }
+    return self;
+}
+
+
 // -----------------------------------------------------------------------------
 # pragma mark - CsoundBinding
 // -----------------------------------------------------------------------------
@@ -50,10 +61,18 @@
     audioPlot.backgroundColor = [AKColor blackColor];
     [self addSubview:audioPlot];
     
-    audioPlot.color = [AKColor yellowColor];
+    audioPlot.color = self.plotColor;
     audioPlot.shouldFill   = YES;
     audioPlot.shouldMirror = YES;
     [audioPlot setRollingHistoryLength:4096];
+}
+
+- (void)setPlotColor:(AKColor *)plotColor
+{
+    _plotColor = plotColor;
+    dispatch_async(dispatch_get_main_queue(),^{
+        audioPlot.color = plotColor;
+    });
 }
 
 - (void)updateValuesFromCsound
@@ -66,7 +85,6 @@
         audioPlot.frame = self.frame;
         [audioPlot setFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
     
-        audioPlot.backgroundColor = [AKColor blackColor];
         [audioPlot updateBuffer:samples withBufferSize:sampleSize];
     });
 }

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
@@ -13,11 +13,13 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plots the FFT of the audio output
-@interface AKAudioOutputFFTPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioOutputFFTPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plots the FFT of the audio output
-@interface AKAudioOutputFFTPlot : NSView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioOutputFFTPlot : NSView
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
@@ -6,20 +6,22 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "CsoundObj.h"
-#import <Accelerate/Accelerate.h>
-
+@import Foundation;
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plots the FFT of the audio output
 IB_DESIGNABLE
 @interface AKAudioOutputFFTPlot : UIView
+@property IBInspectable UIColor *lineColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plots the FFT of the audio output
 IB_DESIGNABLE
 @interface AKAudioOutputFFTPlot : NSView
+@property IBInspectable NSColor *lineColor;
 #endif
+
+@property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
@@ -10,7 +10,7 @@
 #import "AKFoundation.h"
 #import <Accelerate/Accelerate.h>
 
-@interface AKAudioOutputFFTPlot()
+@interface AKAudioOutputFFTPlot() <CsoundBinding>
 {
     NSData *outSamples;
     MYFLT *samples;

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
@@ -8,6 +8,7 @@
 
 #import "AKAudioOutputFFTPlot.h"
 #import "AKFoundation.h"
+#import "CsoundObj.h"
 #import <Accelerate/Accelerate.h>
 
 @interface AKAudioOutputFFTPlot() <CsoundBinding>
@@ -36,7 +37,17 @@
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
-- (void)drawHistoryWithColor:(UIColor *)color width:(float)width
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _lineWidth = 1.0f;
+        _lineColor = [UIColor whiteColor];
+    }
+    return self;
+}
+
+- (void)drawHistoryWithColor:(UIColor *)color width:(CGFloat)width
 {
     // Draw waveform
     UIBezierPath *wavePath = [UIBezierPath bezierPath];
@@ -79,7 +90,7 @@
 }
 
 - (void)drawRect:(CGRect)rect {
-    [self drawHistoryWithColor:[UIColor whiteColor] width:1.0];
+    [self drawHistoryWithColor:self.lineColor width:self.lineWidth];
     
 }
 

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
@@ -6,18 +6,22 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "CsoundObj.h"
+@import Foundation;
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plot the raw samples of the audio output to the DAC
 IB_DESIGNABLE
 @interface AKAudioOutputPlot : UIView
+@property IBInspectable UIColor *lineColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plot the raw samples of the audio output to the DAC
 IB_DESIGNABLE
 @interface AKAudioOutputPlot : NSView
+@property IBInspectable NSColor *lineColor;
 #endif
+
+@property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
@@ -11,11 +11,13 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plot the raw samples of the audio output to the DAC
-@interface AKAudioOutputPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioOutputPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plot the raw samples of the audio output to the DAC
-@interface AKAudioOutputPlot : NSView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioOutputPlot : NSView
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
@@ -9,7 +9,7 @@
 #import "AKAudioOutputPlot.h"
 #import "AKFoundation.h"
 
-@interface AKAudioOutputPlot()
+@interface AKAudioOutputPlot() <CsoundBinding>
 {
     NSData *outSamples;
     MYFLT *samples;

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
@@ -8,6 +8,7 @@
 
 #import "AKAudioOutputPlot.h"
 #import "AKFoundation.h"
+#import "CsoundObj.h"
 
 @interface AKAudioOutputPlot() <CsoundBinding>
 {
@@ -31,7 +32,17 @@
 #define AKColor NSColor
 #endif
 
-- (void)drawWithColor:(AKColor *)color lineWidth:(float)width
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _lineWidth = 4.0f;
+        _lineColor = [AKColor greenColor];
+    }
+    return self;
+}
+
+- (void)drawWithColor:(AKColor *)color lineWidth:(CGFloat)width
 {
     int plotPoints = sampleSize / 2;
     // Draw waveform
@@ -71,7 +82,7 @@
 //        y = self.bounds.size.height * (y + 1.0) / 2.0;
 
 - (void)drawRect:(CGRect)rect {
-    [self drawWithColor:[AKColor greenColor] lineWidth:4.0];
+    [self drawWithColor:self.lineColor lineWidth:self.lineWidth];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
@@ -6,18 +6,21 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "CsoundObj.h"
+@import Foundation;
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
+
 /// A Rolling Waveform for of the audio output
 IB_DESIGNABLE
 @interface AKAudioOutputRollingWaveformPlot : UIView
+@property (nonatomic) IBInspectable UIColor *plotColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// A Rolling Waveform for of the audio output
 IB_DESIGNABLE
 @interface AKAudioOutputRollingWaveformPlot : NSView
+@property (nonatomic) IBInspectable NSColor *plotColor;
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
@@ -11,11 +11,13 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// A Rolling Waveform for of the audio output
-@interface AKAudioOutputRollingWaveformPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioOutputRollingWaveformPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// A Rolling Waveform for of the audio output
-@interface AKAudioOutputRollingWaveformPlot : NSView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKAudioOutputRollingWaveformPlot : NSView
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
@@ -9,6 +9,7 @@
 #import "AKAudioOutputRollingWaveformPlot.h"
 #import "AKFoundation.h"
 #import "EZAudioPlot.h"
+#import "CsoundObj.h"
 
 @interface AKAudioOutputRollingWaveformPlot() <CsoundBinding>
 {
@@ -31,6 +32,15 @@
 #define AKColor NSColor
 #endif
 
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _plotColor = [AKColor yellowColor];
+    }
+    return self;
+}
+
 // -----------------------------------------------------------------------------
 # pragma mark - CsoundBinding
 // -----------------------------------------------------------------------------
@@ -50,10 +60,18 @@
     audioPlot.backgroundColor = [AKColor blackColor];
     [self addSubview:audioPlot];
     
-    audioPlot.color = [AKColor yellowColor];
+    audioPlot.color = self.plotColor;
     audioPlot.shouldFill   = YES;
     audioPlot.shouldMirror = YES;
     [audioPlot setRollingHistoryLength:4096];
+}
+
+- (void)setPlotColor:(AKColor *)plotColor
+{
+    _plotColor = plotColor;
+    dispatch_async(dispatch_get_main_queue(),^{
+        audioPlot.color = plotColor;
+    });
 }
 
 - (void)updateValuesFromCsound
@@ -66,7 +84,6 @@
         audioPlot.frame = self.frame;
         [audioPlot setFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
     
-        audioPlot.backgroundColor = [AKColor blackColor];
         [audioPlot updateBuffer:samples withBufferSize:sampleSize];
     });
 }

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
@@ -10,7 +10,7 @@
 #import "AKFoundation.h"
 #import "EZAudioPlot.h"
 
-@interface AKAudioOutputRollingWaveformPlot()
+@interface AKAudioOutputRollingWaveformPlot() <CsoundBinding>
 {
     // AudioKit sound data
     NSData *outSamples;

--- a/AudioKit/Utilities/Plots/AKFloatPlot.h
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.h
@@ -6,22 +6,26 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plots the floating point value given a minimum and maximum
 IB_DESIGNABLE
 @interface AKFloatPlot : UIView
+@property IBInspectable UIColor *lineColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plots the floating point value given a minimum and maximum
 IB_DESIGNABLE
 @interface AKFloatPlot : NSView
+@property IBInspectable NSColor *lineColor;
 #endif
 
 @property IBInspectable float minimum;
 @property IBInspectable float maximum;
+
+@property IBInspectable CGFloat lineWidth;
 
 - (instancetype)initWithMinimum:(float)minimum maximum:(float)maximum;
 

--- a/AudioKit/Utilities/Plots/AKFloatPlot.h
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.h
@@ -11,15 +11,17 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plots the floating point value given a minimum and maximum
+IB_DESIGNABLE
 @interface AKFloatPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plots the floating point value given a minimum and maximum
+IB_DESIGNABLE
 @interface AKFloatPlot : NSView
 #endif
 
-@property float minimum;
-@property float maximum;
+@property IBInspectable float minimum;
+@property IBInspectable float maximum;
 
 - (instancetype)initWithMinimum:(float)minimum maximum:(float)maximum;
 

--- a/AudioKit/Utilities/Plots/AKFloatPlot.m
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.m
@@ -8,6 +8,12 @@
 
 #import "AKFloatPlot.h"
 
+#if TARGET_OS_IPHONE
+#define AKColor UIColor
+#elif TARGET_OS_MAC
+#define AKColor NSColor
+#endif
+
 @implementation AKFloatPlot
 {
     float *history;
@@ -15,13 +21,15 @@
     int index;
 }
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {
         index = 0;
         historySize = 64;
         history = (float *)malloc(historySize * sizeof(float));
+        _lineWidth = 4.0f;
+        _lineColor = [AKColor blueColor];
     }
     return self;
 }
@@ -39,13 +47,7 @@
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
-- (void)drawWithColor:(AKColor *)color width:(float)width
+- (void)drawWithColor:(AKColor *)color width:(CGFloat)width
 {
     // Draw waveform
 #if TARGET_OS_IPHONE
@@ -85,7 +87,7 @@
 
 - (void)drawRect:(CGRect)rect {
     
-    [self drawWithColor:[AKColor blueColor] width:4.0];
+    [self drawWithColor:self.lineColor width:self.lineWidth];
 }
 
 - (void)updateWithValue:(float)value {

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
@@ -12,11 +12,13 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plot of the given instrument property
-@interface AKInstrumentPropertyPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKInstrumentPropertyPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plot of the given instrument property
-@interface AKInstrumentPropertyPlot : NSView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKInstrumentPropertyPlot : NSView
 #endif
 
 @property AKInstrumentProperty *property;

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
@@ -7,22 +7,25 @@
 //
 
 #import "AKInstrumentProperty.h"
-#import "CsoundObj.h"
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plot of the given instrument property
 IB_DESIGNABLE
 @interface AKInstrumentPropertyPlot : UIView
+@property IBInspectable UIColor *lineColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plot of the given instrument property
 IB_DESIGNABLE
 @interface AKInstrumentPropertyPlot : NSView
+@property IBInspectable NSColor *lineColor;
 #endif
 
 @property AKInstrumentProperty *property;
 @property AKInstrumentProperty *plottedValue;
+
+@property IBInspectable CGFloat lineWidth;
 
 - (instancetype)initWithProperty:(AKInstrumentProperty *)property;
 

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
@@ -9,6 +9,10 @@
 #import "AKInstrumentPropertyPlot.h"
 #import "AKFoundation.h"
 
+@interface AKInstrumentPropertyPlot () <CsoundBinding>
+
+@end
+
 @implementation AKInstrumentPropertyPlot
 {
     MYFLT *history;

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
@@ -8,10 +8,17 @@
 
 #import "AKInstrumentPropertyPlot.h"
 #import "AKFoundation.h"
+#import "CsoundObj.h"
 
 @interface AKInstrumentPropertyPlot () <CsoundBinding>
 
 @end
+
+#if TARGET_OS_IPHONE
+#define AKColor UIColor
+#elif TARGET_OS_MAC
+#define AKColor NSColor
+#endif
 
 @implementation AKInstrumentPropertyPlot
 {
@@ -20,18 +27,20 @@
     int index;
 }
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {
         index = 0;
         historySize = 512;
         history = (MYFLT *)malloc(historySize * sizeof(MYFLT));
+        _lineWidth = 4.0f;
+        _lineColor = [AKColor blueColor];
     }
     return self;
 }
 
-- (id)initWithProperty:(AKInstrumentProperty *)property;
+- (instancetype)initWithProperty:(AKInstrumentProperty *)property;
 {
     self = [self init];
     if (self) {
@@ -41,13 +50,6 @@
 }
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
-
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
 
 - (void)drawWithColor:(AKColor *)color width:(float)width
 {
@@ -91,7 +93,7 @@
 }
 
 - (void)drawRect:(CGRect)rect {
-    [self drawWithColor:[AKColor blueColor] width:4.0];
+    [self drawWithColor:self.lineColor width:self.lineWidth];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
@@ -11,11 +11,13 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plot the raw samples of the audio output to the DAC as left and right signals
-@interface AKStereoOutputPlot : UIView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKStereoOutputPlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plot the raw samples of the audio output to the DAC as keft and right signals
-@interface AKStereoOutputPlot : NSView <CsoundBinding>
+IB_DESIGNABLE
+@interface AKStereoOutputPlot : NSView
 #endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
@@ -6,18 +6,22 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "CsoundObj.h"
+@import Foundation;
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plot the raw samples of the audio output to the DAC as left and right signals
 IB_DESIGNABLE
 @interface AKStereoOutputPlot : UIView
+@property IBInspectable UIColor *leftLineColor, *rightLineColor;
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plot the raw samples of the audio output to the DAC as keft and right signals
 IB_DESIGNABLE
 @interface AKStereoOutputPlot : NSView
+@property IBInspectable NSColor *leftLineColor, *rightLineColor;
 #endif
+
+@property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -8,6 +8,7 @@
 
 #import "AKStereoOutputPlot.h"
 #import "AKFoundation.h"
+#import "CsoundObj.h"
 
 @interface AKStereoOutputPlot() <CsoundBinding>
 {
@@ -31,7 +32,18 @@
 #define AKColor NSColor
 #endif
 
-- (void)drawChannel:(int)channel offset:(float)offset color:(AKColor *)color width:(float)width
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        _lineWidth = 4.0f;
+        _leftLineColor = [AKColor greenColor];
+        _rightLineColor = [AKColor redColor];
+    }
+    return self;
+}
+
+- (void)drawChannel:(int)channel offset:(float)offset color:(AKColor *)color width:(CGFloat)width
 {
     int plotPoints = sampleSize / 2;
     // Draw waveform
@@ -69,8 +81,8 @@
 }
 
 - (void)drawRect:(CGRect)rect {
-    [self drawChannel:0 offset:0.25 color:[AKColor greenColor] width:4.0];
-    [self drawChannel:1 offset:0.75 color:[AKColor redColor]   width:4.0];
+    [self drawChannel:0 offset:0.25 color:self.leftLineColor    width:self.lineWidth];
+    [self drawChannel:1 offset:0.75 color:self.rightLineColor   width:self.lineWidth];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -9,7 +9,7 @@
 #import "AKStereoOutputPlot.h"
 #import "AKFoundation.h"
 
-@interface AKStereoOutputPlot()
+@interface AKStereoOutputPlot() <CsoundBinding>
 {
     NSData *outSamples;
     MYFLT *samples;

--- a/AudioKit/Utilities/Plots/AKTablePlot.h
+++ b/AudioKit/Utilities/Plots/AKTablePlot.h
@@ -11,10 +11,12 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 /// Plots the values of the given table
+IB_DESIGNABLE
 @interface AKTablePlot : UIView
 #elif TARGET_OS_MAC
 #import <Cocoa/Cocoa.h>
 /// Plots the values of the given table
+IB_DESIGNABLE
 @interface AKTablePlot : NSView
 #endif
 
@@ -22,6 +24,7 @@
 /// @param frame Bounding frame for the plot
 /// @param table Table to plot
 - (instancetype)initWithFrame:(CGRect)frame table:(AKTable *)table;
+
 @property AKTable *table;
 
 @end

--- a/AudioKit/Utilities/Plots/AKTablePlot.h
+++ b/AudioKit/Utilities/Plots/AKTablePlot.h
@@ -9,12 +9,12 @@
 #import "AKTable.h"
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+@import UIKit;
 /// Plots the values of the given table
 IB_DESIGNABLE
 @interface AKTablePlot : UIView
 #elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
+@import Cocoa;
 /// Plots the values of the given table
 IB_DESIGNABLE
 @interface AKTablePlot : NSView

--- a/AudioKit/Utilities/Plots/AKTablePlot.m
+++ b/AudioKit/Utilities/Plots/AKTablePlot.m
@@ -25,7 +25,7 @@
    
     self = [super initWithFrame:frame];
     if (self) {
-        #if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
         fTableNumber = table.number;
         CSOUND *cs = [[[AKManager sharedManager] engine]  getCsound];
         while (csoundTableLength(cs, fTableNumber) < 0) {


### PR DESCRIPTION
The main focus on this was making the presentation properties (such as line widths and colors) exposed and inspectable in Interface Builder.

At the same time I also modernized these classes quite a bit, and hid some of the internals by moving the Csound protocol adoption outside of the headers.
