### PR TITLE
Reworked the plot views so that explicit addBinding: calls to AKManager are no longer needed

### DIFF
--- a/AudioKit/Core Classes/AKManager.h
+++ b/AudioKit/Core Classes/AKManager.h
@@ -98,4 +98,7 @@
 /// @param binding The object that will be added to Csound's binding list
 + (void)addBinding:(id)binding;
 
+/// @param binding The object that will be removed from Csound's binding list
++ (void)removeBinding:(id)binding;
+
 @end

--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -331,4 +331,9 @@ static AKManager *_sharedManager = nil;
     [[[self sharedManager] engine] addBinding:binding];
 }
 
++ (void)removeBinding:(id)binding
+{
+    [[[self sharedManager] engine] removeBinding:binding];
+}
+
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
@@ -12,7 +12,11 @@
 IB_DESIGNABLE
 @interface AKAudioInputFFTPlot : AKPlotView
 
-@property IBInspectable AKColor *lineColor;
+#if TARGET_OS_IPHONE
+@property IBInspectable UIColor *lineColor;
+#else
+@property IBInspectable NSColor *lineColor;
+#endif
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.h
@@ -6,22 +6,13 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-@import Foundation;
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// Plots the FFT of the audio input
 IB_DESIGNABLE
-@interface AKAudioInputFFTPlot : UIView
-@property IBInspectable UIColor *lineColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plots the FFT of the audio input
-IB_DESIGNABLE
-@interface AKAudioInputFFTPlot : NSView
-@property IBInspectable NSColor *lineColor;
-#endif
+@interface AKAudioInputFFTPlot : AKPlotView
 
+@property IBInspectable AKColor *lineColor;
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.h
@@ -12,7 +12,12 @@
 IB_DESIGNABLE
 @interface AKAudioInputPlot : AKPlotView
 
-@property IBInspectable AKColor *lineColor;
+// Can't simply use AKColor here as Xcode fails to interpret it correctly in IB
+#if TARGET_OS_IPHONE
+@property IBInspectable UIColor *lineColor;
+#else
+@property IBInspectable NSColor *lineColor;
+#endif
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.h
@@ -6,20 +6,13 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#if TARGET_OS_IPHONE
-@import UIKit;
-/// Plots the incoming audio source signal, usually the microphone
-IB_DESIGNABLE
-@interface AKAudioInputPlot : UIView
-@property IBInspectable UIColor *lineColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plots the incoming audio source signal, usually the microphone
-IB_DESIGNABLE
-@interface AKAudioInputPlot : NSView
-@property IBInspectable NSColor *lineColor;
-#endif
+#import "AKPlotView.h"
 
+/// Plots the incoming audio source signal, usually the microphone
+IB_DESIGNABLE
+@interface AKAudioInputPlot : AKPlotView
+
+@property IBInspectable AKColor *lineColor;
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.m
@@ -16,27 +16,19 @@
     int sampleSize;
     CsoundObj *cs;
 }
+
 @end
 
 @implementation AKAudioInputPlot
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
-- (instancetype)initWithFrame:(CGRect)frame
+- (void) defaultValues
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        _lineWidth = 4.0f;
-        _lineColor = [AKColor yellowColor];
-    }
-    return self;
+    _lineWidth = 4.0f;
+    _lineColor = [AKColor yellowColor];
 }
+
 
 - (void)drawWithColor:(AKColor *)color lineWidth:(CGFloat)width
 {
@@ -86,8 +78,8 @@
     NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
     NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
     
-    int samplesPerControlPeriod = [[dict objectForKey:@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [[dict objectForKey:@"Number Of Channels"] intValue];
+    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
+    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
     
     sampleSize = numberOfChannels * samplesPerControlPeriod;
     samples = (MYFLT *)malloc(sampleSize * sizeof(MYFLT));

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
@@ -12,6 +12,10 @@
 IB_DESIGNABLE
 @interface AKAudioInputRollingWaveformPlot : AKPlotView
 
-@property (nonatomic) IBInspectable AKColor *plotColor;
+#if TARGET_OS_IPHONE
+@property (nonatomic) IBInspectable UIColor *plotColor;
+#else
+@property (nonatomic) IBInspectable NSColor *plotColor;
+#endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
@@ -6,20 +6,12 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-@import Foundation;
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// A Rolling Waveform for of the audio input
 IB_DESIGNABLE
-@interface AKAudioInputRollingWaveformPlot : UIView
-@property (nonatomic) IBInspectable UIColor *plotColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// A Rolling Waveform for of the audio input
-IB_DESIGNABLE
-@interface AKAudioInputRollingWaveformPlot : NSView
-@property (nonatomic) IBInspectable NSColor *plotColor;
-#endif
+@interface AKAudioInputRollingWaveformPlot : AKPlotView
+
+@property (nonatomic) IBInspectable AKColor *plotColor;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
@@ -26,19 +26,9 @@
 
 @implementation AKAudioInputRollingWaveformPlot
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
-- (instancetype)initWithFrame:(CGRect)frame
+- (void)defaultValues
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        _plotColor = [AKColor yellowColor];
-    }
-    return self;
+    _plotColor = [AKColor yellowColor];
 }
 
 
@@ -52,8 +42,8 @@
     NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
     NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
     
-    int samplesPerControlPeriod = [[dict objectForKey:@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [[dict objectForKey:@"Number Of Channels"] intValue];
+    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
+    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
     sampleSize = numberOfChannels * samplesPerControlPeriod;
     samples = (MYFLT *)malloc(sampleSize * sizeof(MYFLT));
     
@@ -78,7 +68,7 @@
 - (void)updateValuesFromCsound
 {
     outSamples = [cs getInSamples];
-    samples = (MYFLT *)[outSamples bytes];
+    samples = (MYFLT *)[outSamples bytes]; // FIXME: Memory leak, overwriting malloc()
     
     dispatch_async(dispatch_get_main_queue(),^{
         audioPlot.bounds = self.bounds;

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
@@ -12,7 +12,11 @@
 IB_DESIGNABLE
 @interface AKAudioOutputFFTPlot : AKPlotView
 
-@property IBInspectable AKColor *lineColor;
+#if TARGET_OS_IPHONE
+@property IBInspectable UIColor *lineColor;
+#else
+@property IBInspectable NSColor *lineColor;
+#endif
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.h
@@ -6,22 +6,13 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-@import Foundation;
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// Plots the FFT of the audio output
 IB_DESIGNABLE
-@interface AKAudioOutputFFTPlot : UIView
-@property IBInspectable UIColor *lineColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plots the FFT of the audio output
-IB_DESIGNABLE
-@interface AKAudioOutputFFTPlot : NSView
-@property IBInspectable NSColor *lineColor;
-#endif
+@interface AKAudioOutputFFTPlot : AKPlotView
 
+@property IBInspectable AKColor *lineColor;
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
@@ -33,19 +33,21 @@
 
 @implementation AKAudioOutputFFTPlot
 
+- (void)defaultValues
+{
+    _lineWidth = 1.0f;
+    _lineColor = [AKColor whiteColor];
+}
+
+- (void)dealloc
+{
+    // free(samples); // Might not be safe
+    free(history);
+}
+
 #if TARGET_OS_IPHONE
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
-- (instancetype)initWithFrame:(CGRect)frame
-{
-    self = [super initWithFrame:frame];
-    if (self) {
-        _lineWidth = 1.0f;
-        _lineColor = [UIColor whiteColor];
-    }
-    return self;
-}
 
 - (void)drawHistoryWithColor:(UIColor *)color width:(CGFloat)width
 {
@@ -162,7 +164,7 @@
 - (void)updateValuesFromCsound
 {
     outSamples = [cs getOutSamples];
-    samples = (MYFLT *)[outSamples bytes];
+    samples = (MYFLT *)[outSamples bytes]; // FIXME: Very likely we're leaking memory here
     
     //[self updateFFTWithBufferSize:sampleSize withAudioData:samples];
     
@@ -187,8 +189,8 @@
     NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
     NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
     
-    int samplesPerControlPeriod = [[dict objectForKey:@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [[dict objectForKey:@"Number Of Channels"] intValue];
+    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
+    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
     sampleSize = numberOfChannels * samplesPerControlPeriod;
     samples = (MYFLT *)malloc(sampleSize * sizeof(MYFLT));
     

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
@@ -6,22 +6,13 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-@import Foundation;
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// Plot the raw samples of the audio output to the DAC
 IB_DESIGNABLE
-@interface AKAudioOutputPlot : UIView
-@property IBInspectable UIColor *lineColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plot the raw samples of the audio output to the DAC
-IB_DESIGNABLE
-@interface AKAudioOutputPlot : NSView
-@property IBInspectable NSColor *lineColor;
-#endif
+@interface AKAudioOutputPlot : AKPlotView
 
+@property IBInspectable AKColor *lineColor;
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.h
@@ -12,7 +12,11 @@
 IB_DESIGNABLE
 @interface AKAudioOutputPlot : AKPlotView
 
-@property IBInspectable AKColor *lineColor;
+#if TARGET_OS_IPHONE
+@property IBInspectable UIColor *lineColor;
+#else
+@property IBInspectable NSColor *lineColor;
+#endif
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
@@ -26,20 +26,10 @@
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
-- (instancetype)initWithFrame:(CGRect)frame
+- (void)defaultValues
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        _lineWidth = 4.0f;
-        _lineColor = [AKColor greenColor];
-    }
-    return self;
+    _lineWidth = 4.0f;
+    _lineColor = [AKColor greenColor];
 }
 
 - (void)drawWithColor:(AKColor *)color lineWidth:(CGFloat)width
@@ -95,8 +85,8 @@
     NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
     NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
     
-    int samplesPerControlPeriod = [[dict objectForKey:@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [[dict objectForKey:@"Number Of Channels"] intValue];
+    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
+    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
     sampleSize = numberOfChannels * samplesPerControlPeriod;
     samples = (MYFLT *)malloc(sampleSize * sizeof(MYFLT));
 }
@@ -104,7 +94,7 @@
 - (void)updateValuesFromCsound
 {
     outSamples = [cs getOutSamples];
-    samples = (MYFLT *)[outSamples bytes];
+    samples = (MYFLT *)[outSamples bytes]; // FIXME: Memory leak
 
     [self performSelectorOnMainThread:@selector(setNeedsDisplay) withObject:nil waitUntilDone:NO];
 

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
@@ -12,6 +12,10 @@
 IB_DESIGNABLE
 @interface AKAudioOutputRollingWaveformPlot : AKPlotView
 
-@property (nonatomic) IBInspectable AKColor *plotColor;
+#if TARGET_OS_IPHONE
+@property (nonatomic) IBInspectable UIColor *plotColor;
+#else
+@property (nonatomic) IBInspectable NSColor *plotColor;
+#endif
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
@@ -6,21 +6,12 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-@import Foundation;
-
-#if TARGET_OS_IPHONE
-@import UIKit;
+#import "AKPlotView.h"
 
 /// A Rolling Waveform for of the audio output
 IB_DESIGNABLE
-@interface AKAudioOutputRollingWaveformPlot : UIView
-@property (nonatomic) IBInspectable UIColor *plotColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// A Rolling Waveform for of the audio output
-IB_DESIGNABLE
-@interface AKAudioOutputRollingWaveformPlot : NSView
-@property (nonatomic) IBInspectable NSColor *plotColor;
-#endif
+@interface AKAudioOutputRollingWaveformPlot : AKPlotView
+
+@property (nonatomic) IBInspectable AKColor *plotColor;
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
@@ -26,19 +26,9 @@
 
 @implementation AKAudioOutputRollingWaveformPlot
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
-- (instancetype)initWithFrame:(CGRect)frame
+- (void)defaultValues
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        _plotColor = [AKColor yellowColor];
-    }
-    return self;
+    _plotColor = [AKColor yellowColor];
 }
 
 // -----------------------------------------------------------------------------
@@ -51,8 +41,8 @@
     NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
     NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
     
-    int samplesPerControlPeriod = [[dict objectForKey:@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [[dict objectForKey:@"Number Of Channels"] intValue];
+    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
+    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
     sampleSize = numberOfChannels * samplesPerControlPeriod;
     samples = (MYFLT *)malloc(sampleSize * sizeof(MYFLT));
     
@@ -77,7 +67,7 @@
 - (void)updateValuesFromCsound
 {
     outSamples = [cs getOutSamples];
-    samples = (MYFLT *)[outSamples bytes];
+    samples = (MYFLT *)[outSamples bytes]; // FIXME: Very likely leaking memory
     
     dispatch_async(dispatch_get_main_queue(),^{
         audioPlot.bounds = self.bounds;

--- a/AudioKit/Utilities/Plots/AKFloatPlot.h
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.h
@@ -12,7 +12,11 @@
 IB_DESIGNABLE
 @interface AKFloatPlot : AKPlotView
 
-@property IBInspectable AKColor *lineColor;
+#if TARGET_OS_IPHONE
+@property IBInspectable UIColor *lineColor;
+#else
+@property IBInspectable NSColor *lineColor;
+#endif
 
 @property IBInspectable float minimum;
 @property IBInspectable float maximum;

--- a/AudioKit/Utilities/Plots/AKFloatPlot.h
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.h
@@ -6,21 +6,13 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-@import Foundation;
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// Plots the floating point value given a minimum and maximum
 IB_DESIGNABLE
-@interface AKFloatPlot : UIView
-@property IBInspectable UIColor *lineColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plots the floating point value given a minimum and maximum
-IB_DESIGNABLE
-@interface AKFloatPlot : NSView
-@property IBInspectable NSColor *lineColor;
-#endif
+@interface AKFloatPlot : AKPlotView
+
+@property IBInspectable AKColor *lineColor;
 
 @property IBInspectable float minimum;
 @property IBInspectable float maximum;

--- a/AudioKit/Utilities/Plots/AKFloatPlot.m
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.m
@@ -8,12 +8,6 @@
 
 #import "AKFloatPlot.h"
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
 @implementation AKFloatPlot
 {
     float *history;
@@ -21,21 +15,26 @@
     int index;
 }
 
+- (void)defaultValues
+{
+    index = 0;
+    historySize = 64;
+    history = (float *)malloc(historySize * sizeof(float));
+    _lineWidth = 4.0f;
+    _lineColor = [AKColor blueColor];
+}
+
 - (instancetype)init
 {
     self = [super init];
     if (self) {
-        index = 0;
-        historySize = 64;
-        history = (float *)malloc(historySize * sizeof(float));
-        _lineWidth = 4.0f;
-        _lineColor = [AKColor blueColor];
+        [self defaultValues];
     }
     return self;
 }
 
 - (instancetype)initWithMinimum:(float)minimum
-                      maximum:(float)maximum;
+                        maximum:(float)maximum
 {
     self = [self init];
     if (self) {
@@ -43,6 +42,11 @@
         _maximum = maximum;
     }
     return self;
+}
+
+- (void)dealloc
+{
+    free(history);
 }
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
@@ -7,20 +7,13 @@
 //
 
 #import "AKInstrumentProperty.h"
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// Plot of the given instrument property
 IB_DESIGNABLE
-@interface AKInstrumentPropertyPlot : UIView
-@property IBInspectable UIColor *lineColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plot of the given instrument property
-IB_DESIGNABLE
-@interface AKInstrumentPropertyPlot : NSView
-@property IBInspectable NSColor *lineColor;
-#endif
+@interface AKInstrumentPropertyPlot : AKPlotView
+
+@property IBInspectable AKColor *lineColor;
 
 @property AKInstrumentProperty *property;
 @property AKInstrumentProperty *plottedValue;

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.h
@@ -13,8 +13,11 @@
 IB_DESIGNABLE
 @interface AKInstrumentPropertyPlot : AKPlotView
 
-@property IBInspectable AKColor *lineColor;
-
+#if TARGET_OS_IPHONE
+@property IBInspectable UIColor *lineColor;
+#else
+@property IBInspectable NSColor *lineColor;
+#endif
 @property AKInstrumentProperty *property;
 @property AKInstrumentProperty *plottedValue;
 

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
@@ -14,12 +14,6 @@
 
 @end
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
 @implementation AKInstrumentPropertyPlot
 {
     MYFLT *history;
@@ -27,15 +21,20 @@
     int index;
 }
 
+- (void)defaultValues
+{
+    index = 0;
+    historySize = 512;
+    history = (MYFLT *)malloc(historySize * sizeof(MYFLT));
+    _lineWidth = 4.0f;
+    _lineColor = [AKColor blueColor];
+}
+
 - (instancetype)init
 {
     self = [super init];
     if (self) {
-        index = 0;
-        historySize = 512;
-        history = (MYFLT *)malloc(historySize * sizeof(MYFLT));
-        _lineWidth = 4.0f;
-        _lineColor = [AKColor blueColor];
+        [self defaultValues];
     }
     return self;
 }
@@ -47,6 +46,11 @@
         _property = property;
     }
     return self;
+}
+
+- (void)dealloc
+{
+    free(history);
 }
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))

--- a/AudioKit/Utilities/Plots/AKPlotView.h
+++ b/AudioKit/Utilities/Plots/AKPlotView.h
@@ -1,0 +1,31 @@
+//
+//  AKPlotView.h
+//  AudioKit
+//
+//  Created by Stéphane Peter on 4/2/15.
+//  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
+//
+
+#import <TargetConditionals.h>
+
+// Base class for all plot views
+
+#if TARGET_OS_IPHONE
+@import UIKit;
+
+@interface AKPlotView : UIView
+
+@end
+
+#define AKColor UIColor
+
+#elif TARGET_OS_MAC
+@import Cocoa;
+
+@interface AKPlotView : NSView
+
+@end
+
+#define AKColor NSColor
+
+#endif

--- a/AudioKit/Utilities/Plots/AKPlotView.m
+++ b/AudioKit/Utilities/Plots/AKPlotView.m
@@ -1,0 +1,61 @@
+//
+//  AKPlotView.m
+//  AudioKit
+//
+//  Created by Stéphane Peter on 4/2/15.
+//  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
+//
+
+#import "AKPlotView.h"
+#import "AKFoundation.h"
+
+@implementation AKPlotView
+
+- (void)defaultValues
+{
+    NSAssert(nil, @"You must override defaultValues in your subclass.");
+}
+
+#if TARGET_OS_IPHONE
+- (void)didMoveToSuperview
+#elif TARGET_OS_MAC
+- (void)viewDidMoveToSuperview
+#endif
+{
+    // Some of the subclasses don't implement the CsoundBinding protocol
+    if (![self respondsToSelector:@selector(setup:)])
+        return;
+    
+    if (self.superview) {
+        [AKManager addBinding:self];
+    } else {
+        [AKManager removeBinding:self];
+    }
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self defaultValues];
+    }
+    return self;
+}
+
+// Needed to properly load from nib or storyboard
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self defaultValues];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    if ([self respondsToSelector:@selector(setup:)])
+        [AKManager removeBinding:self];
+}
+
+@end

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
@@ -12,7 +12,12 @@
 IB_DESIGNABLE
 @interface AKStereoOutputPlot : AKPlotView
 
-@property IBInspectable AKColor *leftLineColor, *rightLineColor;
+#if TARGET_OS_IPHONE
+@property IBInspectable UIColor *leftLineColor, *rightLineColor;
+#else
+@property IBInspectable NSColor *leftLineColor, *rightLineColor;
+#endif
+
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.h
@@ -6,22 +6,13 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-@import Foundation;
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// Plot the raw samples of the audio output to the DAC as left and right signals
 IB_DESIGNABLE
-@interface AKStereoOutputPlot : UIView
-@property IBInspectable UIColor *leftLineColor, *rightLineColor;
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plot the raw samples of the audio output to the DAC as keft and right signals
-IB_DESIGNABLE
-@interface AKStereoOutputPlot : NSView
-@property IBInspectable NSColor *leftLineColor, *rightLineColor;
-#endif
+@interface AKStereoOutputPlot : AKPlotView
 
+@property IBInspectable AKColor *leftLineColor, *rightLineColor;
 @property IBInspectable CGFloat lineWidth;
 
 @end

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -15,8 +15,6 @@
     NSData *outSamples;
     MYFLT *samples;
     int sampleSize;
-    MYFLT *history;
-    int historySize;
     int index;
     CsoundObj *cs;
 }
@@ -26,21 +24,11 @@
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
-#if TARGET_OS_IPHONE
-#define AKColor UIColor
-#elif TARGET_OS_MAC
-#define AKColor NSColor
-#endif
-
-- (instancetype)initWithFrame:(CGRect)frame
+- (void)defaultValues
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        _lineWidth = 4.0f;
-        _leftLineColor = [AKColor greenColor];
-        _rightLineColor = [AKColor redColor];
-    }
-    return self;
+    _lineWidth = 4.0f;
+    _leftLineColor = [AKColor greenColor];
+    _rightLineColor = [AKColor redColor];
 }
 
 - (void)drawChannel:(int)channel offset:(float)offset color:(AKColor *)color width:(CGFloat)width
@@ -104,7 +92,7 @@
 - (void)updateValuesFromCsound
 {
     outSamples = [cs getOutSamples];
-    samples = (MYFLT *)[outSamples bytes];
+    samples = (MYFLT *)[outSamples bytes]; // FIXME: Probably memory leak
 
     [self performSelectorOnMainThread:@selector(setNeedsDisplay) withObject:nil waitUntilDone:NO];
 

--- a/AudioKit/Utilities/Plots/AKTablePlot.h
+++ b/AudioKit/Utilities/Plots/AKTablePlot.h
@@ -7,18 +7,11 @@
 //
 
 #import "AKTable.h"
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-@import UIKit;
 /// Plots the values of the given table
 IB_DESIGNABLE
-@interface AKTablePlot : UIView
-#elif TARGET_OS_MAC
-@import Cocoa;
-/// Plots the values of the given table
-IB_DESIGNABLE
-@interface AKTablePlot : NSView
-#endif
+@interface AKTablePlot : AKPlotView
 
 /// Creates the table plot
 /// @param frame Bounding frame for the plot

--- a/AudioKit/Utilities/Plots/AKTablePlot.m
+++ b/AudioKit/Utilities/Plots/AKTablePlot.m
@@ -25,7 +25,6 @@
    
     self = [super initWithFrame:frame];
     if (self) {
-#if TARGET_OS_IPHONE
         fTableNumber = table.number;
         CSOUND *cs = [[[AKManager sharedManager] engine]  getCsound];
         while (csoundTableLength(cs, fTableNumber) < 0) {
@@ -55,17 +54,24 @@
                 displayData[i] = (-(tableValues[index]/max) * middle * scalingFactor) + middle;
             }
             
+#if TARGET_OS_IPHONE
             [self setNeedsDisplay];
-
-        }
 #elif TARGET_OS_MAC
+            [self setNeedsDisplay:YES];
 #endif
+        }
         
     }
     return self;
 }
 
- #if TARGET_OS_IPHONE
+- (void)dealloc
+{
+    free(displayData);
+    free(tableValues);
+}
+
+#if TARGET_OS_IPHONE
 - (void)drawRect:(CGRect)rect
 {
     CGContextRef context = UIGraphicsGetCurrentContext();
@@ -96,6 +102,7 @@
 
 
 #elif TARGET_OS_MAC
+// TODO
 #endif
 
 @end

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		C47546B51A9BD266006151DE /* Tambourine.m in Sources */ = {isa = PBXBuildFile; fileRef = C47546B21A9BD266006151DE /* Tambourine.m */; };
 		C47546B61A9BD266006151DE /* FMSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = C47546B41A9BD266006151DE /* FMSynthesizer.m */; };
 		C47546BA1A9BDA11006151DE /* TouchView.m in Sources */ = {isa = PBXBuildFile; fileRef = C47546B91A9BDA11006151DE /* TouchView.m */; };
+		EA2F5F8F1ACE839C00F1BCFB /* AKPlotView.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F8D1ACE839C00F1BCFB /* AKPlotView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -580,6 +581,8 @@
 		C47546B41A9BD266006151DE /* FMSynthesizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FMSynthesizer.m; path = ../../../iOS/AudioKitDemo/AudioKitDemo/Synthesis/Instruments/FMSynthesizer.m; sourceTree = "<group>"; };
 		C47546B81A9BDA11006151DE /* TouchView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TouchView.h; path = Synthesis/TouchView.h; sourceTree = "<group>"; };
 		C47546B91A9BDA11006151DE /* TouchView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TouchView.m; path = Synthesis/TouchView.m; sourceTree = "<group>"; };
+		EA2F5F8D1ACE839C00F1BCFB /* AKPlotView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKPlotView.m; sourceTree = "<group>"; };
+		EA2F5F8E1ACE839C00F1BCFB /* AKPlotView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPlotView.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -597,6 +600,8 @@
 		C404E3D31AC3843C00979876 /* Plots */ = {
 			isa = PBXGroup;
 			children = (
+				EA2F5F8D1ACE839C00F1BCFB /* AKPlotView.m */,
+				EA2F5F8E1ACE839C00F1BCFB /* AKPlotView.h */,
 				C404E3D41AC3843C00979876 /* AKAudioInputFFTPlot.h */,
 				C404E3D51AC3843C00979876 /* AKAudioInputFFTPlot.m */,
 				C404E3D61AC3843C00979876 /* AKAudioInputPlot.h */,
@@ -1630,6 +1635,7 @@
 				C4624CBE1AAC36B800555883 /* AKBalance.m in Sources */,
 				C4624CB31AAC36B800555883 /* AKStringResonator.m in Sources */,
 				C4624C691AAC36B800555883 /* AKMinimum.m in Sources */,
+				EA2F5F8F1ACE839C00F1BCFB /* AKPlotView.m in Sources */,
 				C4624CA61AAC36B800555883 /* AKDopplerEffect.m in Sources */,
 				C4624C781AAC36B800555883 /* AKTableLooper.m in Sources */,
 				C4624CB11AAC36B800555883 /* AKMoogVCF.m in Sources */,

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
@@ -45,7 +45,6 @@
     [AKOrchestra addInstrument:analyzer];
     [inputPlot setWantsLayer:YES];
     [inputPlot.layer setBackgroundColor:[[NSColor blackColor] CGColor]];
-    [AKManager addBinding:inputPlot];
 }
 
 - (void)viewDidAppear

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -184,6 +184,16 @@
 		C4ED1DEF1AB7FEFE00366020 /* AKInstrumentPropertyPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C4ED1DE71AB7FEFE00366020 /* AKInstrumentPropertyPlot.m */; };
 		C4ED1DF01AB7FEFE00366020 /* AKStereoOutputPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C4ED1DE91AB7FEFE00366020 /* AKStereoOutputPlot.m */; };
 		C4ED1DF11AB7FEFE00366020 /* AKTablePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C4ED1DEB1AB7FEFE00366020 /* AKTablePlot.m */; };
+		EA2F5F711ACE406E00F1BCFB /* AKPlotView.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F701ACE406E00F1BCFB /* AKPlotView.m */; };
+		EA2F5F841ACE74AA00F1BCFB /* AKAudioInputFFTPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F731ACE74AA00F1BCFB /* AKAudioInputFFTPlot.m */; };
+		EA2F5F851ACE74AA00F1BCFB /* AKAudioInputRollingWaveformPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F751ACE74AA00F1BCFB /* AKAudioInputRollingWaveformPlot.m */; };
+		EA2F5F861ACE74AA00F1BCFB /* AKAudioOutputFFTPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F771ACE74AA00F1BCFB /* AKAudioOutputFFTPlot.m */; };
+		EA2F5F871ACE74AA00F1BCFB /* AKAudioOutputRollingWaveformPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F791ACE74AA00F1BCFB /* AKAudioOutputRollingWaveformPlot.m */; };
+		EA2F5F881ACE74AA00F1BCFB /* AEFloatConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F7C1ACE74AA00F1BCFB /* AEFloatConverter.m */; };
+		EA2F5F891ACE74AA00F1BCFB /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F7E1ACE74AA00F1BCFB /* EZAudio.m */; };
+		EA2F5F8A1ACE74AA00F1BCFB /* EZAudioPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F801ACE74AA00F1BCFB /* EZAudioPlot.m */; };
+		EA2F5F8B1ACE74AA00F1BCFB /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = EA2F5F811ACE74AA00F1BCFB /* LICENSE */; };
+		EA2F5F8C1ACE74AA00F1BCFB /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = EA2F5F821ACE74AA00F1BCFB /* TPCircularBuffer.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -557,6 +567,25 @@
 		C4ED1DE91AB7FEFE00366020 /* AKStereoOutputPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKStereoOutputPlot.m; sourceTree = "<group>"; };
 		C4ED1DEA1AB7FEFE00366020 /* AKTablePlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKTablePlot.h; sourceTree = "<group>"; };
 		C4ED1DEB1AB7FEFE00366020 /* AKTablePlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKTablePlot.m; sourceTree = "<group>"; };
+		EA2F5F6F1ACE406E00F1BCFB /* AKPlotView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPlotView.h; sourceTree = "<group>"; };
+		EA2F5F701ACE406E00F1BCFB /* AKPlotView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKPlotView.m; sourceTree = "<group>"; };
+		EA2F5F721ACE74AA00F1BCFB /* AKAudioInputFFTPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioInputFFTPlot.h; sourceTree = "<group>"; };
+		EA2F5F731ACE74AA00F1BCFB /* AKAudioInputFFTPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioInputFFTPlot.m; sourceTree = "<group>"; };
+		EA2F5F741ACE74AA00F1BCFB /* AKAudioInputRollingWaveformPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioInputRollingWaveformPlot.h; sourceTree = "<group>"; };
+		EA2F5F751ACE74AA00F1BCFB /* AKAudioInputRollingWaveformPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioInputRollingWaveformPlot.m; sourceTree = "<group>"; };
+		EA2F5F761ACE74AA00F1BCFB /* AKAudioOutputFFTPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioOutputFFTPlot.h; sourceTree = "<group>"; };
+		EA2F5F771ACE74AA00F1BCFB /* AKAudioOutputFFTPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioOutputFFTPlot.m; sourceTree = "<group>"; };
+		EA2F5F781ACE74AA00F1BCFB /* AKAudioOutputRollingWaveformPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioOutputRollingWaveformPlot.h; sourceTree = "<group>"; };
+		EA2F5F791ACE74AA00F1BCFB /* AKAudioOutputRollingWaveformPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioOutputRollingWaveformPlot.m; sourceTree = "<group>"; };
+		EA2F5F7B1ACE74AA00F1BCFB /* AEFloatConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEFloatConverter.h; sourceTree = "<group>"; };
+		EA2F5F7C1ACE74AA00F1BCFB /* AEFloatConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AEFloatConverter.m; sourceTree = "<group>"; };
+		EA2F5F7D1ACE74AA00F1BCFB /* EZAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudio.h; sourceTree = "<group>"; };
+		EA2F5F7E1ACE74AA00F1BCFB /* EZAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudio.m; sourceTree = "<group>"; };
+		EA2F5F7F1ACE74AA00F1BCFB /* EZAudioPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioPlot.h; sourceTree = "<group>"; };
+		EA2F5F801ACE74AA00F1BCFB /* EZAudioPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioPlot.m; sourceTree = "<group>"; };
+		EA2F5F811ACE74AA00F1BCFB /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		EA2F5F821ACE74AA00F1BCFB /* TPCircularBuffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = TPCircularBuffer.c; sourceTree = "<group>"; };
+		EA2F5F831ACE74AA00F1BCFB /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1382,10 +1411,20 @@
 		C4ED1DDF1AB7FEFE00366020 /* Plots */ = {
 			isa = PBXGroup;
 			children = (
+				EA2F5F6F1ACE406E00F1BCFB /* AKPlotView.h */,
+				EA2F5F701ACE406E00F1BCFB /* AKPlotView.m */,
 				C4ED1DE01AB7FEFE00366020 /* AKAudioInputPlot.h */,
 				C4ED1DE11AB7FEFE00366020 /* AKAudioInputPlot.m */,
 				C45266871AC1234A009C8F4A /* AKAudioOutputPlot.h */,
 				C45266881AC1234A009C8F4A /* AKAudioOutputPlot.m */,
+				EA2F5F721ACE74AA00F1BCFB /* AKAudioInputFFTPlot.h */,
+				EA2F5F731ACE74AA00F1BCFB /* AKAudioInputFFTPlot.m */,
+				EA2F5F741ACE74AA00F1BCFB /* AKAudioInputRollingWaveformPlot.h */,
+				EA2F5F751ACE74AA00F1BCFB /* AKAudioInputRollingWaveformPlot.m */,
+				EA2F5F761ACE74AA00F1BCFB /* AKAudioOutputFFTPlot.h */,
+				EA2F5F771ACE74AA00F1BCFB /* AKAudioOutputFFTPlot.m */,
+				EA2F5F781ACE74AA00F1BCFB /* AKAudioOutputRollingWaveformPlot.h */,
+				EA2F5F791ACE74AA00F1BCFB /* AKAudioOutputRollingWaveformPlot.m */,
 				C4ED1DE41AB7FEFE00366020 /* AKFloatPlot.h */,
 				C4ED1DE51AB7FEFE00366020 /* AKFloatPlot.m */,
 				C4ED1DE61AB7FEFE00366020 /* AKInstrumentPropertyPlot.h */,
@@ -1394,8 +1433,25 @@
 				C4ED1DE91AB7FEFE00366020 /* AKStereoOutputPlot.m */,
 				C4ED1DEA1AB7FEFE00366020 /* AKTablePlot.h */,
 				C4ED1DEB1AB7FEFE00366020 /* AKTablePlot.m */,
+				EA2F5F7A1ACE74AA00F1BCFB /* EZAudio */,
 			);
 			path = Plots;
+			sourceTree = "<group>";
+		};
+		EA2F5F7A1ACE74AA00F1BCFB /* EZAudio */ = {
+			isa = PBXGroup;
+			children = (
+				EA2F5F7B1ACE74AA00F1BCFB /* AEFloatConverter.h */,
+				EA2F5F7C1ACE74AA00F1BCFB /* AEFloatConverter.m */,
+				EA2F5F7D1ACE74AA00F1BCFB /* EZAudio.h */,
+				EA2F5F7E1ACE74AA00F1BCFB /* EZAudio.m */,
+				EA2F5F7F1ACE74AA00F1BCFB /* EZAudioPlot.h */,
+				EA2F5F801ACE74AA00F1BCFB /* EZAudioPlot.m */,
+				EA2F5F811ACE74AA00F1BCFB /* LICENSE */,
+				EA2F5F821ACE74AA00F1BCFB /* TPCircularBuffer.c */,
+				EA2F5F831ACE74AA00F1BCFB /* TPCircularBuffer.h */,
+			);
+			path = EZAudio;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1461,6 +1517,7 @@
 				C43F55241AB14045005E437A /* 808loop.wav in Resources */,
 				C43F55271AB14045005E437A /* marmstk1.wav in Resources */,
 				C4BACD1D1A8FFC3200736291 /* LaunchScreen.xib in Resources */,
+				EA2F5F8B1ACE74AA00F1BCFB /* LICENSE in Resources */,
 				C43F550B1AB14045005E437A /* LICENSE.TXT in Resources */,
 				C43F54921AB14045005E437A /* AudioKit.plist in Resources */,
 				C43F55281AB14045005E437A /* PianoBassDrumLoop.wav in Resources */,
@@ -1488,9 +1545,11 @@
 				C43F54D11AB14045005E437A /* AKBowedString.m in Sources */,
 				C43F54F81AB14045005E437A /* AKBandRejectButterworthFilter.m in Sources */,
 				C43F54971AB14045005E437A /* AKNoteProperty.m in Sources */,
+				EA2F5F891ACE74AA00F1BCFB /* EZAudio.m in Sources */,
 				C4BACF401A90606300736291 /* ConvolutionInstrument.m in Sources */,
 				C43F54BF1AB14045005E437A /* AKPhasor.m in Sources */,
 				C43F54951AB14045005E437A /* AKInstrumentProperty.m in Sources */,
+				EA2F5F881ACE74AA00F1BCFB /* AEFloatConverter.m in Sources */,
 				C43F54E51AB14045005E437A /* AKVariableDelay.m in Sources */,
 				C43F54B01AB14045005E437A /* AKADSREnvelope.m in Sources */,
 				C43F54E11AB14045005E437A /* AKConvolution.m in Sources */,
@@ -1537,6 +1596,7 @@
 				C43F54B31AB14045005E437A /* AKLinearEnvelope.m in Sources */,
 				C43F54F01AB14045005E437A /* AKLowPassFilter.m in Sources */,
 				C43F54D71AB14045005E437A /* AKRandomNumbers.m in Sources */,
+				EA2F5F711ACE406E00F1BCFB /* AKPlotView.m in Sources */,
 				C4BACF3F1A90606300736291 /* AudioFilePlayer.m in Sources */,
 				C43F54A61AB14045005E437A /* AKAssignment.m in Sources */,
 				C43F54EE1AB14045005E437A /* AKHighPassFilter.m in Sources */,
@@ -1554,8 +1614,10 @@
 				C45266831AC08A53009C8F4A /* Vibraphone.m in Sources */,
 				C43F54D91AB14045005E437A /* AKSegmentArrayLoop.m in Sources */,
 				C43F54F61AB14045005E437A /* AKVariableFrequencyResponseBandPassFilter.m in Sources */,
+				EA2F5F861ACE74AA00F1BCFB /* AKAudioOutputFFTPlot.m in Sources */,
 				C43F54AE1AB14045005E437A /* AKSum.m in Sources */,
 				C43F55171AB14045005E437A /* AKLineTableGenerator.m in Sources */,
+				EA2F5F851ACE74AA00F1BCFB /* AKAudioInputRollingWaveformPlot.m in Sources */,
 				C43F55041AB14045005E437A /* AKControl.m in Sources */,
 				C43F55161AB14045005E437A /* AKHarmonicCosineTableGenerator.m in Sources */,
 				C43F54FF1AB14045005E437A /* AKBalance.m in Sources */,
@@ -1564,6 +1626,7 @@
 				C45266781AC08A53009C8F4A /* Amplifier.m in Sources */,
 				C43F55111AB14045005E437A /* AKSequence.m in Sources */,
 				C43F54B11AB14045005E437A /* AKLine.m in Sources */,
+				EA2F5F8C1ACE74AA00F1BCFB /* TPCircularBuffer.c in Sources */,
 				C43F54901AB14045005E437A /* AKManager.m in Sources */,
 				C43F55191AB14045005E437A /* AKTableGenerator.m in Sources */,
 				C43F54E91AB14045005E437A /* AKCombFilter.m in Sources */,
@@ -1571,9 +1634,11 @@
 				C43F54B51AB14045005E437A /* AKGranularSynthesizer.m in Sources */,
 				C43F54E81AB14045005E437A /* AKFlanger.m in Sources */,
 				C43F549D1AB14045005E437A /* AKCrossSynthesizedFFT.m in Sources */,
+				EA2F5F8A1ACE74AA00F1BCFB /* EZAudioPlot.m in Sources */,
 				C43F54A01AB14045005E437A /* AKMixedFFT.m in Sources */,
 				C43F55031AB14045005E437A /* AKConstant.m in Sources */,
 				C43F55181AB14045005E437A /* AKRandomDistributionTableGenerator.m in Sources */,
+				EA2F5F841ACE74AA00F1BCFB /* AKAudioInputFFTPlot.m in Sources */,
 				C4ED1DEE1AB7FEFE00366020 /* AKFloatPlot.m in Sources */,
 				C4BACF461A9060A100736291 /* AnalysisViewController.m in Sources */,
 				C43F54DA1AB14045005E437A /* AKAdditiveCosines.m in Sources */,
@@ -1609,6 +1674,7 @@
 				C43F54AC1AB14045005E437A /* AKProduct.m in Sources */,
 				C4ED1DF11AB7FEFE00366020 /* AKTablePlot.m in Sources */,
 				C43F54C81AB14045005E437A /* AKCrunch.m in Sources */,
+				EA2F5F871ACE74AA00F1BCFB /* AKAudioOutputRollingWaveformPlot.m in Sources */,
 				C45266891AC1234A009C8F4A /* AKAudioOutputPlot.m in Sources */,
 				C43F54C91AB14045005E437A /* AKDroplet.m in Sources */,
 				C4BACD0C1A8FFC3100736291 /* main.m in Sources */,

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
@@ -47,14 +47,11 @@
     [AKOrchestra addInstrument:microphone];
     analyzer = [[AKAudioAnalyzer alloc] initWithAudioSource:microphone.auxilliaryOutput];
     [AKOrchestra addInstrument:analyzer];
-    [AKManager addBinding:inputPlot];
     amplitudePlot.property = analyzer.trackedAmplitude;
     
     normalizedFrequency = [[AKInstrumentProperty alloc] initWithValue:0.0 minimum:16.35 maximum:30.87];
     frequencyPlot.property = analyzer.trackedFrequency;
     frequencyPlot.plottedValue = normalizedFrequency;
-    [AKManager addBinding:amplitudePlot];
-    [AKManager addBinding:frequencyPlot];
     
     normalizedFrequencyPlot.minimum = 15;
     normalizedFrequencyPlot.maximum = 32;


### PR DESCRIPTION
As we discussed in my last pull request, here is what I've done:

* Added a new `removeBinding:` class method to AKManager
* New `AKPlotView` class that is the base of all plot classes, abstracting away a lot of the boilerplate and automatically registering the objects with AKManager when views are added/removed from the hierarchy.
* This also greatly simplified the differences between iOS and OS X.
* Fixed a few memory leaks in several of these classes (particularly calls to `malloc` without a corresponding `free`). There are actually quite a few outstanding ones where pointers get obviously overwritten by NSData, I haven't touched that as I'm not sure what the intent is, but I made some FIXME notes.
