### PR TITLE
More cleanups in plots, fixed a bunch of memory leaks

### DIFF
--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -84,8 +84,8 @@ static AKManager *_sharedManager = nil;
         NSString *audioInput  = @"adc";
         
         if (dict) {
-            audioOutput = [dict objectForKey:@"Audio Output"];
-            audioInput  = [dict objectForKey:@"Audio Input"];
+            audioOutput = dict[@"Audio Output"];
+            audioInput  = dict[@"Audio Input"];
         }
         
         csound = [[CsoundObj alloc] init];
@@ -94,7 +94,7 @@ static AKManager *_sharedManager = nil;
         [csound setMessageCallback:@selector(messageCallback:) withListener:self];
         
         _isRunning = NO;
-        _isLogging = [[dict objectForKey:@"Enable Logging By Default"] boolValue];
+        _isLogging = [dict[@"Enable Logging By Default"] boolValue];
         
         totalRunDuration = 10000000;
 

--- a/AudioKit/Core Classes/AKOrchestra.m
+++ b/AudioKit/Core Classes/AKOrchestra.m
@@ -40,10 +40,10 @@
         _zeroDBFullScaleValue = 1.0f;
         
         if (dict) {
-            sampleRate = [[dict objectForKey:@"Sample Rate"] intValue];
-            samplesPerControlPeriod = [[dict objectForKey:@"Samples Per Control Period"] intValue];
-            _numberOfChannels = [[dict objectForKey:@"Number Of Channels"] intValue];
-            _zeroDBFullScaleValue = [[dict objectForKey:@"Zero dB Full Scale Value"] floatValue];
+            sampleRate = [dict[@"Sample Rate"] intValue];
+            samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
+            _numberOfChannels = [dict[@"Number Of Channels"] intValue];
+            _zeroDBFullScaleValue = [dict[@"Zero dB Full Scale Value"] floatValue];
         }
         
         udoFiles = [[NSMutableSet alloc] init];
@@ -90,7 +90,7 @@
     BOOL enableAudioInput = YES;
     
     if (dict) {
-        enableAudioInput = [[dict objectForKey:@"Enable Audio Input By Default"] boolValue];
+        enableAudioInput = [dict[@"Enable Audio Input By Default"] boolValue];
     }
     
     if (enableAudioInput) {

--- a/AudioKit/Tables/AKTable.m
+++ b/AudioKit/Tables/AKTable.m
@@ -63,6 +63,10 @@ static int currentID = 2000;
     return self;
 }
 
+- (void)dealloc {
+    free(table);
+}
+
 - (void)populateTableWithGenerator:(AKTableGenerator *)tableGenerator
 {
     NSString *parameters = [[tableGenerator parametersWithSize:self.size] componentsJoinedByString:@", "];

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
@@ -47,8 +47,6 @@
 
 #if TARGET_OS_IPHONE
 
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
 - (void)drawHistoryWithColor:(UIColor *)color width:(CGFloat)width
 {
     // Draw waveform
@@ -78,7 +76,7 @@
     [wavePath addLineToPoint:CGPointMake(x, y2)];
     for (int i = 0; i < historySize/2; i++) {
         y = yOffset - (history[i] * yScale);
-        y = CLAMP(y, 0.0, self.bounds.size.height);
+        y = AK_CLAMP(y, 0.0, self.bounds.size.height);
         //NSLog(@"%index:d value:%f x:%f y:%f y2:%f", i%historySize, history[i % historySize], x, y, y2 );
         
         [wavePath addLineToPoint:CGPointMake(x, y)];

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.m
@@ -21,8 +21,6 @@
 
 @implementation AKAudioInputPlot
 
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
 - (void) defaultValues
 {
     _lineWidth = 4.0f;
@@ -42,7 +40,7 @@
     CGFloat x = 0.0f;
     CGFloat y = 0.0f;
     for (int i = 0; i < sampleSize/2; i++) {
-        y = CLAMP(samples[i*2], -1.0f, 1.0f);
+        y = AK_CLAMP(samples[i*2], -1.0f, 1.0f);
         y = self.bounds.size.height * (y + 1.0) / 2.0;
         
         if (i == 0) {

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.m
@@ -91,12 +91,4 @@
     
 }
 
-- (void)updateUI {
-#if TARGET_OS_IPHONE
-    [self setNeedsDisplay];
-#elif TARGET_OS_MAC
-    [self setNeedsDisplay:YES];
-#endif
-}
-
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
@@ -47,8 +47,6 @@
 
 #if TARGET_OS_IPHONE
 
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
 - (void)drawHistoryWithColor:(UIColor *)color width:(CGFloat)width
 {
     // Draw waveform
@@ -78,7 +76,7 @@
     [wavePath addLineToPoint:CGPointMake(x, y2)];
     for (int i = 0; i < historySize/2; i++) {
         y = yOffset - (history[i] * yScale);
-        y = CLAMP(y, 0.0, self.bounds.size.height);
+        y = AK_CLAMP(y, 0.0, self.bounds.size.height);
         //NSLog(@"%index:d value:%f x:%f y:%f y2:%f", i%historySize, history[i % historySize], x, y, y2 );
         
         [wavePath addLineToPoint:CGPointMake(x, y)];

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
@@ -15,16 +15,12 @@
     NSData *outSamples;
     MYFLT *samples;
     int sampleSize;
-    MYFLT *history;
-    int historySize;
     int index;
     CsoundObj *cs;
 }
 @end
 
 @implementation AKAudioOutputPlot
-
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
 - (void)defaultValues
 {
@@ -49,7 +45,7 @@
     CGFloat x = 0.0f;
     CGFloat y = 0.0f;
     for (int i = 0; i < plotPoints; i++) {
-        y = CLAMP(y, -1.0f, 1.0f);
+        y = AK_CLAMP(y, -1.0f, 1.0f);
         y = (samples[(i * 2)]+1.0) * yScale;
         if (i == 0) {
             [wavePath moveToPoint:CGPointMake(x, y)];
@@ -68,7 +64,7 @@
     [wavePath stroke];
 }
 
-//        y = CLAMP(samples[i*2], -1.0f, 1.0f);
+//        y = AK_CLAMP(samples[i*2], -1.0f, 1.0f);
 //        y = self.bounds.size.height * (y + 1.0) / 2.0;
 
 - (void)drawRect:(CGRect)rect {

--- a/AudioKit/Utilities/Plots/AKFloatPlot.m
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.m
@@ -20,6 +20,7 @@
     index = 0;
     historySize = 64;
     history = (float *)malloc(historySize * sizeof(float));
+    bzero(history, historySize * sizeof(float));
     _lineWidth = 4.0f;
     _lineColor = [AKColor blueColor];
 }
@@ -52,12 +53,7 @@
 - (void)drawWithColor:(AKColor *)color width:(CGFloat)width
 {
     // Draw waveform
-#if TARGET_OS_IPHONE
-    UIBezierPath *wavePath = [UIBezierPath bezierPath];
-#elif TARGET_OS_MAC
-    NSBezierPath *wavePath = [NSBezierPath bezierPath];
-#endif
-    
+    AKBezierPath *wavePath = [AKBezierPath bezierPath];
     
     CGFloat yScale  =  self.bounds.size.height / (_maximum - _minimum);
     
@@ -93,22 +89,11 @@
 }
 
 - (void)updateWithValue:(float)value {
-    if (history) {
-        history[index] = value;
-        index++;
-        if (index >= historySize) index = 0;
-    } else {
+    history[index] = value;
+    index++;
+    if (index >= historySize)
         index = 0;
-        historySize = 64;
-        history = (float *)malloc(historySize * sizeof(float));
-    }
-
-#if TARGET_OS_IPHONE
-    [self setNeedsDisplay];
-#elif TARGET_OS_MAC
-    [self setNeedsDisplay:YES];
-#endif
-    
+    [self updateUI];
 }
 
 @end

--- a/AudioKit/Utilities/Plots/AKFloatPlot.m
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.m
@@ -49,8 +49,6 @@
     free(history);
 }
 
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
 - (void)drawWithColor:(AKColor *)color width:(CGFloat)width
 {
     // Draw waveform
@@ -70,7 +68,7 @@
     for (int i = index; i < index+historySize; i++) {
         
         y = self.bounds.size.height - (history[i % historySize] - _minimum) * yScale;
-        y = CLAMP(y, 0.0, self.bounds.size.height);
+        y = AK_CLAMP(y, 0.0, self.bounds.size.height);
         
         if (i == index) {
             [wavePath moveToPoint:CGPointMake(x, y)];

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
@@ -126,12 +126,4 @@
     }
 }
 
-- (void)updateUI {
-#if TARGET_OS_IPHONE
-    [self setNeedsDisplay];
-#elif TARGET_OS_MAC
-    [self setNeedsDisplay:YES];
-#endif
-}
-
 @end

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
@@ -53,8 +53,6 @@
     free(history);
 }
 
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
 - (void)drawWithColor:(AKColor *)color width:(float)width
 {
     // Draw waveform
@@ -74,7 +72,7 @@
     for (int i = index; i < index+historySize; i++) {
         
         y = self.bounds.size.height - (history[i % historySize] - yMin) * yScale;
-        y = CLAMP(y, 0.0, self.bounds.size.height);
+        y = AK_CLAMP(y, 0.0, self.bounds.size.height);
         if (x != x || y != y) {
             NSLog(@"Something is not a number");
         } else {

--- a/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
+++ b/AudioKit/Utilities/Plots/AKInstrumentPropertyPlot.m
@@ -26,6 +26,7 @@
     index = 0;
     historySize = 512;
     history = (MYFLT *)malloc(historySize * sizeof(MYFLT));
+    bzero(history, historySize * sizeof(MYFLT));
     _lineWidth = 4.0f;
     _lineColor = [AKColor blueColor];
 }
@@ -56,11 +57,7 @@
 - (void)drawWithColor:(AKColor *)color width:(float)width
 {
     // Draw waveform
-#if TARGET_OS_IPHONE
-    UIBezierPath *waveformPath = [UIBezierPath bezierPath];
-#elif TARGET_OS_MAC
-    NSBezierPath *waveformPath = [NSBezierPath bezierPath];
-#endif
+    AKBezierPath *waveformPath = [AKBezierPath bezierPath];
     
     CGFloat yMin = self.property.minimum;
     CGFloat yScale  =  self.bounds.size.height / (self.property.maximum - self.property.minimum);
@@ -111,19 +108,14 @@
 
 - (void)updateValuesFromCsound
 {
-    if (history) {
-        if (_plottedValue) {
-            _property = _plottedValue;
-        }
-        history[index] = self.property.value;
-        index++;
-        if (index >= historySize) index = 0;
-        [self performSelectorOnMainThread:@selector(updateUI) withObject:nil waitUntilDone:NO];
-    } else {
-        index = 0;
-        historySize = 512;
-        history = (MYFLT *)malloc(historySize * sizeof(MYFLT));
+    if (_plottedValue) {
+        _property = _plottedValue;
     }
+    history[index] = self.property.value;
+    index++;
+    if (index >= historySize)
+        index = 0;
+    [self performSelectorOnMainThread:@selector(updateUI) withObject:nil waitUntilDone:NO];
 }
 
 @end

--- a/AudioKit/Utilities/Plots/AKPlotView.h
+++ b/AudioKit/Utilities/Plots/AKPlotView.h
@@ -29,3 +29,6 @@
 #define AKColor NSColor
 
 #endif
+
+// Commonly used macro in the plot classes
+#define AK_CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))

--- a/AudioKit/Utilities/Plots/AKPlotView.h
+++ b/AudioKit/Utilities/Plots/AKPlotView.h
@@ -15,6 +15,7 @@
 
 @interface AKPlotView : UIView
 
+- (void)updateUI;
 @end
 
 #define AKColor UIColor
@@ -24,6 +25,7 @@
 
 @interface AKPlotView : NSView
 
+- (void)updateUI;
 @end
 
 #define AKColor NSColor

--- a/AudioKit/Utilities/Plots/AKPlotView.h
+++ b/AudioKit/Utilities/Plots/AKPlotView.h
@@ -19,6 +19,7 @@
 @end
 
 #define AKColor UIColor
+#define AKBezierPath UIBezierPath
 
 #elif TARGET_OS_MAC
 @import Cocoa;
@@ -29,6 +30,7 @@
 @end
 
 #define AKColor NSColor
+#define AKBezierPath NSBezierPath
 
 #endif
 

--- a/AudioKit/Utilities/Plots/AKPlotView.m
+++ b/AudioKit/Utilities/Plots/AKPlotView.m
@@ -33,6 +33,14 @@
     }
 }
 
+- (void)updateUI {
+#if TARGET_OS_IPHONE
+    [self setNeedsDisplay];
+#elif TARGET_OS_MAC
+    [self setNeedsDisplay:YES];
+#endif
+}
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];

--- a/AudioKit/Utilities/Plots/AKPlots.h
+++ b/AudioKit/Utilities/Plots/AKPlots.h
@@ -1,0 +1,25 @@
+//
+//  AKPlots.h
+//  AudioKit
+//
+//  Created by Stéphane Peter on 4/4/15.
+//  Copyright (c) 2015 Catloaf Software, LLC. All rights reserved.
+//
+
+#ifndef _AKPlots_h
+#define _AKPlots_h
+
+// Include all available AK*Plot classes
+
+#import "AKAudioInputPlot.h"
+#import "AKAudioOutputPlot.h"
+#import "AKStereoOutputPlot.h"
+#import "AKAudioInputFFTPlot.h"
+#import "AKAudioOutputFFTPlot.h"
+#import "AKAudioInputRollingWaveformPlot.h"
+#import "AKAudioOutputRollingWaveformPlot.h"
+#import "AKInstrumentPropertyPlot.h"
+#import "AKFloatPlot.h"
+#import "AKTablePlot.h"
+
+#endif

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -13,7 +13,6 @@
 @interface AKStereoOutputPlot() <CsoundBinding>
 {
     NSData *outSamples;
-    MYFLT *samples;
     int sampleSize;
     int index;
     CsoundObj *cs;
@@ -33,11 +32,7 @@
 {
     int plotPoints = sampleSize / 2;
     // Draw waveform
-#if TARGET_OS_IPHONE
-    UIBezierPath *wavePath = [UIBezierPath bezierPath];
-#elif TARGET_OS_MAC
-    NSBezierPath *wavePath = [NSBezierPath bezierPath];
-#endif
+    AKBezierPath *wavePath = [AKBezierPath bezierPath];
     
     CGFloat yOffset = self.bounds.size.height * offset;
     CGFloat yScale  = self.bounds.size.height / 4;
@@ -46,20 +41,25 @@
     
     CGFloat x = 0.0f;
     CGFloat y = 0.0f;
-    for (int i = 0; i < plotPoints; i++) {
-        y = AK_CLAMP(y, -1.0f, 1.0f);
-        y = samples[(i * 2) + channel] * yScale + yOffset;
-        if (i == 0) {
-            [wavePath moveToPoint:CGPointMake(x, y)];
-        } else {
+    
+    @synchronized(self) {
+        const MYFLT *samples = (const MYFLT *)outSamples.bytes;
+        
+        for (int i = 0; i < plotPoints; i++) {
+            y = AK_CLAMP(y, -1.0f, 1.0f);
+            y = samples[(i * 2) + channel] * yScale + yOffset;
+            if (i == 0) {
+                [wavePath moveToPoint:CGPointMake(x, y)];
+            } else {
 #if TARGET_OS_IPHONE
-            [wavePath addLineToPoint:CGPointMake(x, y)];
+                [wavePath addLineToPoint:CGPointMake(x, y)];
 #elif TARGET_OS_MAC
-            [wavePath lineToPoint:CGPointMake(x, y)];
+                [wavePath lineToPoint:CGPointMake(x, y)];
 #endif
+            }
+            x += deltaX;
         }
-        x += deltaX;
-    };
+    }
     
     [wavePath setLineWidth:width];
     [color setStroke];
@@ -84,15 +84,19 @@
     int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
     int numberOfChannels = [dict[@"Number Of Channels"] intValue];
     sampleSize = numberOfChannels * samplesPerControlPeriod;
-    samples = (MYFLT *)malloc(sampleSize * sizeof(MYFLT));
+    
+    void *samples = malloc(sampleSize * sizeof(MYFLT));
+    bzero(samples, sampleSize * sizeof(MYFLT));
+    outSamples = [NSData dataWithBytesNoCopy:samples length:sampleSize * sizeof(MYFLT)];
 }
 
 - (void)updateValuesFromCsound
 {
-    outSamples = [cs getOutSamples];
-    samples = (MYFLT *)[outSamples bytes]; // FIXME: Probably memory leak
-
-    [self performSelectorOnMainThread:@selector(setNeedsDisplay) withObject:nil waitUntilDone:NO];
+    @synchronized(self) {
+        outSamples = [cs getOutSamples];
+    }
+    
+    [self performSelectorOnMainThread:@selector(updateUI) withObject:nil waitUntilDone:NO];
 
 }
 

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -81,8 +81,8 @@
     NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
     NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
     
-    int samplesPerControlPeriod = [[dict objectForKey:@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [[dict objectForKey:@"Number Of Channels"] intValue];
+    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
+    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
     sampleSize = numberOfChannels * samplesPerControlPeriod;
     samples = (MYFLT *)malloc(sampleSize * sizeof(MYFLT));
 }

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -22,8 +22,6 @@
 
 @implementation AKStereoOutputPlot
 
-#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
-
 - (void)defaultValues
 {
     _lineWidth = 4.0f;
@@ -49,7 +47,7 @@
     CGFloat x = 0.0f;
     CGFloat y = 0.0f;
     for (int i = 0; i < plotPoints; i++) {
-        y = CLAMP(y, -1.0f, 1.0f);
+        y = AK_CLAMP(y, -1.0f, 1.0f);
         y = samples[(i * 2) + channel] * yScale + yOffset;
         if (i == 0) {
             [wavePath moveToPoint:CGPointMake(x, y)];

--- a/AudioKit/Utilities/Plots/AKTablePlot.m
+++ b/AudioKit/Utilities/Plots/AKTablePlot.m
@@ -53,12 +53,7 @@
                 int index = (int)(percent * tableLength);
                 displayData[i] = (-(tableValues[index]/max) * middle * scalingFactor) + middle;
             }
-            
-#if TARGET_OS_IPHONE
-            [self setNeedsDisplay];
-#elif TARGET_OS_MAC
-            [self setNeedsDisplay:YES];
-#endif
+            [self updateUI];
         }
         
     }

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 		C47546B91A9BDA11006151DE /* TouchView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TouchView.m; path = Synthesis/TouchView.m; sourceTree = "<group>"; };
 		EA2F5F8D1ACE839C00F1BCFB /* AKPlotView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKPlotView.m; sourceTree = "<group>"; };
 		EA2F5F8E1ACE839C00F1BCFB /* AKPlotView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPlotView.h; sourceTree = "<group>"; };
+		EA398BBB1ACFD3910056C94C /* AKPlots.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPlots.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -600,6 +601,7 @@
 		C404E3D31AC3843C00979876 /* Plots */ = {
 			isa = PBXGroup;
 			children = (
+				EA398BBB1ACFD3910056C94C /* AKPlots.h */,
 				EA2F5F8D1ACE839C00F1BCFB /* AKPlotView.m */,
 				EA2F5F8E1ACE839C00F1BCFB /* AKPlotView.h */,
 				C404E3D41AC3843C00979876 /* AKAudioInputFFTPlot.h */,

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -586,6 +586,7 @@
 		EA2F5F811ACE74AA00F1BCFB /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		EA2F5F821ACE74AA00F1BCFB /* TPCircularBuffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = TPCircularBuffer.c; sourceTree = "<group>"; };
 		EA2F5F831ACE74AA00F1BCFB /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
+		EA398BBA1ACFD2C30056C94C /* AKPlots.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPlots.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1411,6 +1412,7 @@
 		C4ED1DDF1AB7FEFE00366020 /* Plots */ = {
 			isa = PBXGroup;
 			children = (
+				EA398BBA1ACFD2C30056C94C /* AKPlots.h */,
 				EA2F5F6F1ACE406E00F1BCFB /* AKPlotView.h */,
 				EA2F5F701ACE406E00F1BCFB /* AKPlotView.m */,
 				C4ED1DE01AB7FEFE00366020 /* AKAudioInputPlot.h */,


### PR DESCRIPTION
* Moved more of the duplicate code to the parent `AKPlotView` class
* Audited calls to `malloc()` to make sure that memory is not leaked, replaced by direct access to the `NSData` buffer when possible.
* Added convenience `AKPlots.h` for use in Swift bridging headers, etc.
