### PR TITLE
More plot cleanups

### DIFF
--- a/AudioKit/Platforms/iOS/classes/CsoundObj.h
+++ b/AudioKit/Platforms/iOS/classes/CsoundObj.h
@@ -132,8 +132,13 @@ typedef struct {
 - (MYFLT *)getOutputChannelPtr:(NSString *)channelName
                    channelType:(controlChannelType)channelType;
 
+// Read-only samples
 - (NSData *)getOutSamples;
 - (NSData *)getInSamples;
+
+// Writable alternatives
+- (NSMutableData *)getMutableInSamples;
+- (NSMutableData *)getMutableOutSamples;
 
 - (int)getNumChannels;
 - (int)getKsmps;

--- a/AudioKit/Platforms/iOS/classes/CsoundObj.m
+++ b/AudioKit/Platforms/iOS/classes/CsoundObj.m
@@ -307,8 +307,19 @@ static void messageCallback(CSOUND *cs, int attr, const char *format, va_list va
     float *spout = csoundGetSpout(csound);
     int nchnls = csoundGetNchnls(csound);
     int ksmps = csoundGetKsmps(csound);
-    NSData* data = [NSData dataWithBytes:spout length:(nchnls * ksmps * sizeof(MYFLT))];
-    return data;
+    return [NSData dataWithBytes:spout length:(nchnls * ksmps * sizeof(MYFLT))];
+}
+
+- (NSMutableData *)getMutableOutSamples
+{
+    if (!mCsData.running) {
+        return nil;
+    }
+    CSOUND *csound = [self getCsound];
+    float *spout = csoundGetSpout(csound);
+    int nchnls = csoundGetNchnls(csound);
+    int ksmps = csoundGetKsmps(csound);
+    return [NSMutableData dataWithBytes:spout length:(nchnls * ksmps * sizeof(MYFLT))];
 }
 
 - (NSData *)getInSamples
@@ -320,8 +331,19 @@ static void messageCallback(CSOUND *cs, int attr, const char *format, va_list va
     float *spin = csoundGetSpin(csound);
     int nchnls = csoundGetNchnls(csound);
     int ksmps = csoundGetKsmps(csound);
-    NSData* data = [NSData dataWithBytes:spin length:(nchnls * ksmps * sizeof(MYFLT))];
-    return data;
+    return [NSData dataWithBytes:spin length:(nchnls * ksmps * sizeof(MYFLT))];
+}
+
+- (NSMutableData *)getMutableInSamples
+{
+    if (!mCsData.running) {
+        return nil;
+    }
+    CSOUND *csound = [self getCsound];
+    float *spin = csoundGetSpin(csound);
+    int nchnls = csoundGetNchnls(csound);
+    int ksmps = csoundGetKsmps(csound);
+    return [NSMutableData dataWithBytes:spin length:(nchnls * ksmps * sizeof(MYFLT))];
 }
 
 - (int)getNumChannels

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
@@ -14,7 +14,7 @@
 
 @interface AKAudioInputFFTPlot() <CsoundBinding>
 {
-    NSMutableData *outSamples;
+    NSMutableData *inSamples;
     int sampleSize;
     MYFLT *history;
     int historySize;
@@ -46,7 +46,7 @@
 
 #if TARGET_OS_IPHONE
 
-- (void)drawHistoryWithColor:(UIColor *)color width:(CGFloat)width
+- (void)drawRect:(CGRect)rect
 {
     // Draw waveform
     UIBezierPath *wavePath = [UIBezierPath bezierPath];
@@ -83,20 +83,17 @@
         x += deltaX;
     };
     
-    [wavePath setLineWidth:width];
-    [color setStroke];
+    [wavePath setLineWidth:self.lineWidth];
+    [self.lineColor setStroke];
     [wavePath stroke];
 }
 
-- (void)drawRect:(CGRect)rect {
-    [self drawHistoryWithColor:self.lineColor width:self.lineWidth];
-}
-
 #elif TARGET_OS_MAC
+// TODO
 #endif
 
 -(void)createFFTWithBufferSize:(float)bufferSize {
-    MYFLT *data = (MYFLT *)outSamples.mutableBytes;
+    MYFLT *data = (MYFLT *)inSamples.mutableBytes;
     
     // Setup the length
     _log2n = log2f(bufferSize);
@@ -121,7 +118,7 @@
 }
 
 -(void)updateFFTWithBufferSize:(float)bufferSize {
-    const MYFLT *data = (const MYFLT *)outSamples.bytes;
+    const MYFLT *data = (const MYFLT *)inSamples.bytes;
 
     // For an FFT, numSamples must be a power of 2, i.e. is always even
     int nOver2 = bufferSize/2;
@@ -171,7 +168,7 @@
 
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));
-    outSamples = [NSMutableData dataWithBytesNoCopy:samples length:sampleSize * sizeof(MYFLT)];
+    inSamples = [NSMutableData dataWithBytesNoCopy:samples length:sampleSize * sizeof(MYFLT)];
 
     historySize = 128;
     
@@ -183,7 +180,7 @@
 
 - (void)updateValuesFromCsound
 {
-    outSamples = [NSMutableData dataWithData:[cs getInSamples]];
+    inSamples = [cs getMutableInSamples];
     
     // Get the FFT data
     [self updateFFTWithBufferSize:sampleSize];

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.m
@@ -27,7 +27,7 @@
 }
 
 
-- (void)drawWithColor:(AKColor *)color lineWidth:(CGFloat)width
+- (void)drawRect:(CGRect)rect
 {
     // Draw waveform
     AKBezierPath *waveformPath = [AKBezierPath bezierPath];
@@ -53,13 +53,9 @@
             x += (self.frame.size.width / (sampleSize/2));
         };
     }
-    [waveformPath setLineWidth:width];
-    [color setStroke];
+    [waveformPath setLineWidth:self.lineWidth];
+    [self.lineColor setStroke];
     [waveformPath stroke];
-}
-
-- (void)drawRect:(CGRect)rect {
-    [self drawWithColor:self.lineColor lineWidth:self.lineWidth];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
@@ -45,7 +45,7 @@
 
 #if TARGET_OS_IPHONE
 
-- (void)drawHistoryWithColor:(UIColor *)color width:(CGFloat)width
+- (void)drawRect:(CGRect)rect
 {
     // Draw waveform
     UIBezierPath *wavePath = [UIBezierPath bezierPath];
@@ -82,13 +82,9 @@
         x += deltaX;
     };
     
-    [wavePath setLineWidth:width];
-    [color setStroke];
+    [wavePath setLineWidth:self.lineWidth];
+    [self.lineColor setStroke];
     [wavePath stroke];
-}
-
-- (void)drawRect:(CGRect)rect {
-    [self drawHistoryWithColor:self.lineColor width:self.lineWidth];
 }
 
 #elif TARGET_OS_MAC
@@ -163,7 +159,7 @@
 
 - (void)updateValuesFromCsound
 {
-    outSamples = [NSMutableData dataWithData:[cs getOutSamples]];
+    outSamples = [cs getMutableOutSamples];
     
     // Get the FFT data
     [self updateFFTWithBufferSize:sampleSize];

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
@@ -27,7 +27,7 @@
     _lineColor = [AKColor greenColor];
 }
 
-- (void)drawWithColor:(AKColor *)color lineWidth:(CGFloat)width
+- (void)drawRect:(CGRect)rect
 {
     int plotPoints = sampleSize / 2;
     // Draw waveform
@@ -58,17 +58,13 @@
         };
     }
     
-    [wavePath setLineWidth:width];
-    [color setStroke];
+    [wavePath setLineWidth:self.lineWidth];
+    [self.lineColor setStroke];
     [wavePath stroke];
 }
 
 //        y = AK_CLAMP(samples[i*2], -1.0f, 1.0f);
 //        y = self.bounds.size.height * (y + 1.0) / 2.0;
-
-- (void)drawRect:(CGRect)rect {
-    [self drawWithColor:self.lineColor lineWidth:self.lineWidth];
-}
 
 // -----------------------------------------------------------------------------
 # pragma mark - CsoundBinding

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
@@ -14,7 +14,7 @@
 @interface AKAudioOutputRollingWaveformPlot() <CsoundBinding>
 {
     // AudioKit sound data
-    NSData *outSamples;
+    NSMutableData *outSamples;
     int sampleSize;
     
     CsoundObj *cs;
@@ -28,6 +28,18 @@
 - (void)defaultValues
 {
     _plotColor = [AKColor yellowColor];
+    
+    audioPlot = [[EZAudioPlot alloc] initWithFrame:self.frame];
+    audioPlot.bounds = self.bounds;
+    audioPlot.frame = self.frame;
+    [audioPlot setFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
+    audioPlot.backgroundColor = [AKColor blackColor];
+    
+    audioPlot.color = self.plotColor;
+    audioPlot.shouldFill   = YES;
+    audioPlot.shouldMirror = YES;
+    [audioPlot setRollingHistoryLength:4096];
+    [self addSubview:audioPlot];
 }
 
 // -----------------------------------------------------------------------------
@@ -46,16 +58,7 @@
 
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));
-    outSamples = [NSData dataWithBytesNoCopy:samples length:sampleSize*sizeof(MYFLT)];
-    
-    audioPlot = [[EZAudioPlot alloc] initWithFrame:self.frame];
-    audioPlot.backgroundColor = [AKColor blackColor];
-    [self addSubview:audioPlot];
-    
-    audioPlot.color = self.plotColor;
-    audioPlot.shouldFill   = YES;
-    audioPlot.shouldMirror = YES;
-    [audioPlot setRollingHistoryLength:4096];
+    outSamples = [NSMutableData dataWithBytesNoCopy:samples length:sampleSize*sizeof(MYFLT)];
 }
 
 - (void)setPlotColor:(AKColor *)plotColor
@@ -68,14 +71,14 @@
 
 - (void)updateValuesFromCsound
 {
-    outSamples = [cs getOutSamples];
+    @synchronized(self) {
+        outSamples = [cs getMutableOutSamples];
+    }
     
     dispatch_async(dispatch_get_main_queue(),^{
-        audioPlot.bounds = self.bounds;
-        audioPlot.frame = self.frame;
-        [audioPlot setFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
-    
-        [audioPlot updateBuffer:(MYFLT *)outSamples.bytes withBufferSize:sampleSize];
+        @synchronized(self) {
+            [audioPlot updateBuffer:(MYFLT *)outSamples.mutableBytes withBufferSize:sampleSize];
+        }
     });
 }
 

--- a/AudioKit/Utilities/Plots/AKFloatPlot.m
+++ b/AudioKit/Utilities/Plots/AKFloatPlot.m
@@ -50,7 +50,7 @@
     free(history);
 }
 
-- (void)drawWithColor:(AKColor *)color width:(CGFloat)width
+- (void)drawRect:(CGRect)rect
 {
     // Draw waveform
     AKBezierPath *wavePath = [AKBezierPath bezierPath];
@@ -78,14 +78,9 @@
         x += deltaX;
     };
     
-    [wavePath setLineWidth:width];
-    [color setStroke];
+    [wavePath setLineWidth:self.lineWidth];
+    [self.lineColor setStroke];
     [wavePath stroke];
-}
-
-- (void)drawRect:(CGRect)rect {
-    
-    [self drawWithColor:self.lineColor width:self.lineWidth];
 }
 
 - (void)updateWithValue:(float)value {

--- a/AudioKit/Utilities/Plots/AKPlotView.m
+++ b/AudioKit/Utilities/Plots/AKPlotView.m
@@ -16,11 +16,13 @@
     NSAssert(nil, @"You must override defaultValues in your subclass.");
 }
 
-#if TARGET_OS_IPHONE
+
+#if !TARGET_INTERFACE_BUILDER // Don't do AKManager binding from within IB
+# if TARGET_OS_IPHONE
 - (void)didMoveToSuperview
-#elif TARGET_OS_MAC
+# elif TARGET_OS_MAC
 - (void)viewDidMoveToSuperview
-#endif
+# endif
 {
     // Some of the subclasses don't implement the CsoundBinding protocol
     if (![self respondsToSelector:@selector(setup:)])
@@ -32,6 +34,7 @@
         [AKManager removeBinding:self];
     }
 }
+#endif
 
 - (void)updateUI {
 #if TARGET_OS_IPHONE
@@ -60,10 +63,12 @@
     return self;
 }
 
+#if !TARGET_INTERFACE_BUILDER
 - (void)dealloc
 {
     if ([self respondsToSelector:@selector(setup:)])
         [AKManager removeBinding:self];
 }
+#endif
 
 @end

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Base.lproj/Main.storyboard
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -555,11 +555,8 @@
                                         <rect key="frame" x="20" y="893" width="384" height="100"/>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="lineColor">
-                                                <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="lineWidth">
-                                                <real key="value" value="4"/>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="plotColor">
+                                                <color key="value" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>


### PR DESCRIPTION
* Remove unused code for rendering views in IB
* Fixed storyboard with non-existing properties
* New methods to get `NSMutableData` samples
* Made waveforms plots using `EZAudioPlot` thread-safe, moved the UIKit code out of Csound's way
