### PR TITLE
Fixed the memory drainage

### DIFF
--- a/AudioKit/Platforms/OSX/CsoundObj.h
+++ b/AudioKit/Platforms/OSX/CsoundObj.h
@@ -129,8 +129,14 @@ typedef struct {
 - (MYFLT *)getOutputChannelPtr:(NSString *)channelName
                    channelType:(controlChannelType)channelType;
 
+// Read-only samples
 - (NSData *)getOutSamples;
 - (NSData *)getInSamples;
+
+// Writable alternatives
+- (NSMutableData *)getMutableInSamples;
+- (NSMutableData *)getMutableOutSamples;
+
 - (int)getNumChannels;
 - (int)getKsmps;
 

--- a/AudioKit/Platforms/iOS/classes/CsoundObj.m
+++ b/AudioKit/Platforms/iOS/classes/CsoundObj.m
@@ -390,44 +390,44 @@ OSStatus  Csound_Render(void *inRefCon,
     
     
     for(frame=0;frame < inNumberFrames;frame++){
-        
-        if(cdata->useAudioInput) {
-            for (k = 0; k < nchnls; k++){
+        @autoreleasepool {
+            if(cdata->useAudioInput) {
+                for (k = 0; k < nchnls; k++){
+                    buffer = (SInt32 *) ioData->mBuffers[k].mData;
+                    spin[insmps++] =(1./coef)*buffer[frame];
+                }
+            }
+            
+            for (k = 0; k < nchnls; k++) {
                 buffer = (SInt32 *) ioData->mBuffers[k].mData;
-                spin[insmps++] =(1./coef)*buffer[frame];
-            }
-        }
-        
-        for (k = 0; k < nchnls; k++) {
-            buffer = (SInt32 *) ioData->mBuffers[k].mData;
-            if (cdata->shouldMute == false) {
-                buffer[frame] = (SInt32) lrintf(spout[nsmps++]*coef) ;
-            } else {
-                buffer[frame] = 0;
-            }
-        }
-        
-        if(nsmps == ksmps*nchnls){
-            for (int i = 0; i < cache.count; i++) {
-                id<CsoundBinding> binding = [cache objectAtIndex:i];
-                if ([binding respondsToSelector:@selector(updateValuesToCsound)]) {
-                    [binding updateValuesToCsound];
+                if (cdata->shouldMute == false) {
+                    buffer[frame] = (SInt32) lrintf(spout[nsmps++]*coef) ;
+                } else {
+                    buffer[frame] = 0;
                 }
             }
-            if(!ret) {
-                ret = csoundPerformKsmps(cdata->cs);
-            } else {
-                cdata->running = false;
-            }
-            for (int i = 0; i < cache.count; i++) {
-                id<CsoundBinding> binding = [cache objectAtIndex:i];
-                if ([binding respondsToSelector:@selector(updateValuesFromCsound)]) {
-                    [binding updateValuesFromCsound];
+            
+            if(nsmps == ksmps*nchnls){
+                for (int i = 0; i < cache.count; i++) {
+                    id<CsoundBinding> binding = [cache objectAtIndex:i];
+                    if ([binding respondsToSelector:@selector(updateValuesToCsound)]) {
+                        [binding updateValuesToCsound];
+                    }
                 }
+                if(!ret) {
+                    ret = csoundPerformKsmps(cdata->cs);
+                } else {
+                    cdata->running = false;
+                }
+                for (int i = 0; i < cache.count; i++) {
+                    id<CsoundBinding> binding = [cache objectAtIndex:i];
+                    if ([binding respondsToSelector:@selector(updateValuesFromCsound)]) {
+                        [binding updateValuesFromCsound];
+                    }
+                }
+                insmps = nsmps = 0;
             }
-            insmps = nsmps = 0;
         }
-        
     }
     
     // Write to file.

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
@@ -50,6 +50,13 @@
     });
 }
 
+- (void)drawRect:(CGRect)rect
+{
+    @synchronized(self) {
+        [audioPlot updateBuffer:(MYFLT *)inSamples.mutableBytes withBufferSize:sampleSize];
+    }
+}
+
 // -----------------------------------------------------------------------------
 # pragma mark - CsoundBinding
 // -----------------------------------------------------------------------------
@@ -74,12 +81,7 @@
     @synchronized(self) {
         inSamples = [cs getMutableInSamples];
     }
-    
-    dispatch_async(dispatch_get_main_queue(),^{
-        @synchronized(self) {
-            [audioPlot updateBuffer:(MYFLT *)inSamples.mutableBytes withBufferSize:sampleSize];
-        }
-    });
+    [self performSelectorOnMainThread:@selector(updateUI) withObject:nil waitUntilDone:NO];
 }
 
 

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
@@ -42,6 +42,22 @@
     [self addSubview:audioPlot];
 }
 
+- (void)setPlotColor:(AKColor *)plotColor
+{
+    _plotColor = plotColor;
+    dispatch_async(dispatch_get_main_queue(),^{
+        audioPlot.color = plotColor;
+    });
+}
+
+
+- (void)drawRect:(CGRect)rect
+{
+    @synchronized(self) {
+        [audioPlot updateBuffer:(MYFLT *)outSamples.mutableBytes withBufferSize:sampleSize];
+    }
+}
+
 // -----------------------------------------------------------------------------
 # pragma mark - CsoundBinding
 // -----------------------------------------------------------------------------
@@ -61,25 +77,13 @@
     outSamples = [NSMutableData dataWithBytesNoCopy:samples length:sampleSize*sizeof(MYFLT)];
 }
 
-- (void)setPlotColor:(AKColor *)plotColor
-{
-    _plotColor = plotColor;
-    dispatch_async(dispatch_get_main_queue(),^{
-        audioPlot.color = plotColor;
-    });
-}
-
 - (void)updateValuesFromCsound
 {
     @synchronized(self) {
         outSamples = [cs getMutableOutSamples];
     }
     
-    dispatch_async(dispatch_get_main_queue(),^{
-        @synchronized(self) {
-            [audioPlot updateBuffer:(MYFLT *)outSamples.mutableBytes withBufferSize:sampleSize];
-        }
-    });
+    [self performSelectorOnMainThread:@selector(updateUI) withObject:nil waitUntilDone:NO];
 }
 
 


### PR DESCRIPTION
Finally figured out that the memory getting out of control was mostly as a result of the Csound thread not having a proper autorelease pool setup. Added it to the loop inside `CsoundRender()` seems to do the trick and it's no longer going all over the place for me. I'm sure it should also show in your own code being run from within these callbacks.

Also some minor changes to the plots using EZAudioPlot, however I think there is some serious memory corruption going on in `updateBuffer:` from this class. Not sure what the purpose of `_setMaxLength` is there and it seems to be causing problems with triggering memory access out of bounds. 