### PR TITLE
Fix EZAudioPlot crashes

### DIFF
--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.m
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.m
@@ -31,7 +31,6 @@
 //  TPCircularBuffer _historyBuffer;
 
   // Rolling History
-  BOOL    _setMaxLength;
   float   *_scrollHistory;
   int     _scrollHistoryIndex;
   UInt32  _scrollHistoryLength;
@@ -151,9 +150,7 @@
     
     //
     [self setSampleData:_scrollHistory
-                 length:(!_setMaxLength?kEZAudioPlotMaxHistoryBufferLength:_scrollHistoryLength)];
-    _setMaxLength = YES;
-    
+                 length:(_scrollHistoryLength)];
 }
     
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
Hope this doesn't break anything else though, but kEZAudioPlotMaxHistoryBufferLength was double the size of the actual buffer.