### PR TITLE
Greatly simplified rolling waveform plots

### DIFF
--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.h
@@ -6,16 +6,10 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "AKPlotView.h"
+#import "EZAudioPlot.h"
 
 /// A Rolling Waveform for of the audio input
 IB_DESIGNABLE
-@interface AKAudioInputRollingWaveformPlot : AKPlotView
-
-#if TARGET_OS_IPHONE
-@property (nonatomic) IBInspectable UIColor *plotColor;
-#else
-@property (nonatomic) IBInspectable NSColor *plotColor;
-#endif
+@interface AKAudioInputRollingWaveformPlot : EZAudioPlot
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
@@ -8,7 +8,6 @@
 
 #import "AKAudioInputRollingWaveformPlot.h"
 #import "AKFoundation.h"
-#import "EZAudioPlot.h"
 #import "CsoundObj.h"
 
 @interface AKAudioInputRollingWaveformPlot() <CsoundBinding>
@@ -18,8 +17,6 @@
     int sampleSize;
     
     CsoundObj *cs;
-    
-    EZAudioPlot *audioPlot;
 }
 @end
 
@@ -27,40 +24,19 @@
 
 - (void)defaultValues
 {
-    _plotColor = [AKColor yellowColor];
+    [super defaultValues];
 
-    audioPlot = [[EZAudioPlot alloc] initWithFrame:self.frame];
-    audioPlot.backgroundColor = [AKColor blackColor];
-    audioPlot.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
-
-    audioPlot.color = _plotColor;
-    audioPlot.shouldFill   = YES;
-    audioPlot.shouldMirror = YES;
-    [audioPlot setRollingHistoryLength:4096];
-    [self addSubview:audioPlot];
+    [self setRollingHistoryLength:2048];
 }
 
-- (void)setPlotColor:(AKColor *)plotColor
-{
-    _plotColor = plotColor;
-    dispatch_async(dispatch_get_main_queue(),^{
-        audioPlot.color = plotColor;
-    });
-}
 
-- (void)layoutSubviews
-{
-    audioPlot.bounds = self.bounds;
-    audioPlot.frame = self.frame;
-    [audioPlot setFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
-    [super layoutSubviews];
-}
 
 - (void)drawRect:(CGRect)rect
 {
     @synchronized(self) {
-        [audioPlot updateBuffer:(MYFLT *)inSamples.mutableBytes withBufferSize:sampleSize];
+        [self updateBuffer:(MYFLT *)inSamples.mutableBytes withBufferSize:sampleSize];
     }
+    [super drawRect:rect];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.h
@@ -6,16 +6,10 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "AKPlotView.h"
+#import "EZAudioPlot.h"
 
 /// A Rolling Waveform for of the audio output
 IB_DESIGNABLE
-@interface AKAudioOutputRollingWaveformPlot : AKPlotView
-
-#if TARGET_OS_IPHONE
-@property (nonatomic) IBInspectable UIColor *plotColor;
-#else
-@property (nonatomic) IBInspectable NSColor *plotColor;
-#endif
+@interface AKAudioOutputRollingWaveformPlot : EZAudioPlot
 
 @end

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
@@ -8,7 +8,6 @@
 
 #import "AKAudioOutputRollingWaveformPlot.h"
 #import "AKFoundation.h"
-#import "EZAudioPlot.h"
 #import "CsoundObj.h"
 
 @interface AKAudioOutputRollingWaveformPlot() <CsoundBinding>
@@ -18,8 +17,6 @@
     int sampleSize;
     
     CsoundObj *cs;
-    
-    EZAudioPlot *audioPlot;
 }
 @end
 
@@ -27,40 +24,17 @@
 
 - (void)defaultValues
 {
-    _plotColor = [AKColor yellowColor];
+    [super defaultValues];
     
-    audioPlot = [[EZAudioPlot alloc] initWithFrame:self.frame];
-    audioPlot.backgroundColor = [AKColor blackColor];
-    audioPlot.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
-    
-    audioPlot.color = self.plotColor;
-    audioPlot.shouldFill   = YES;
-    audioPlot.shouldMirror = YES;
-    [audioPlot setRollingHistoryLength:4096];
-    [self addSubview:audioPlot];
-}
-
-- (void)setPlotColor:(AKColor *)plotColor
-{
-    _plotColor = plotColor;
-    dispatch_async(dispatch_get_main_queue(),^{
-        audioPlot.color = plotColor;
-    });
-}
-
-- (void)layoutSubviews
-{
-    audioPlot.bounds = self.bounds;
-    audioPlot.frame = self.frame;
-    [audioPlot setFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
-    [super layoutSubviews];
+    [self setRollingHistoryLength:2048];
 }
 
 - (void)drawRect:(CGRect)rect
 {
     @synchronized(self) {
-        [audioPlot updateBuffer:(MYFLT *)outSamples.mutableBytes withBufferSize:sampleSize];
+        [self updateBuffer:(MYFLT *)outSamples.mutableBytes withBufferSize:sampleSize];
     }
+    [super drawRect:rect];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Utilities/Plots/AKPlotView.h
+++ b/AudioKit/Utilities/Plots/AKPlotView.h
@@ -14,7 +14,7 @@
 @import UIKit;
 
 @interface AKPlotView : UIView
-
+- (void)defaultValues;
 - (void)updateUI;
 @end
 
@@ -25,7 +25,7 @@
 @import Cocoa;
 
 @interface AKPlotView : NSView
-
+- (void)defaultValues;
 - (void)updateUI;
 @end
 

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.h
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.h
@@ -44,20 +44,11 @@
  
  */
 
-#import <Foundation/Foundation.h>
 #import "AKFoundation.h"
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
-@interface EZAudioPlot : UIView
-#elif TARGET_OS_MAC
-#import <Cocoa/Cocoa.h>
-@interface EZAudioPlot : NSView
-#endif
-{
-    CGPoint *plotData;
-    UInt32   plotLength;
-}
+IB_DESIGNABLE
+@interface EZAudioPlot : AKPlotView
 
 #pragma mark - Adjust Resolution
 ///-----------------------------------------------------------
@@ -88,29 +79,36 @@
               length:(int)length;
 
 
-
-@property (nonatomic,strong) id backgroundColor;
+#if TARGET_OS_IPHONE
+@property (nonatomic,strong) IBInspectable UIColor *backgroundColor;
+#else
+@property (nonatomic,strong) IBInspectable NSColor *backgroundColor;
+#endif
 
 /**
  The default color of the plot's data (i.e. waveform, y-axis values). For iOS the color is specified as a UIColor while for OSX the color is an NSColor. The default value on both platforms is red.
  */
-@property (nonatomic,strong) id color;
+#if TARGET_OS_IPHONE
+@property (nonatomic,strong) IBInspectable UIColor *plotColor;
+#else
+@property (nonatomic,strong) IBInspectable NSColor *plotColor;
+#endif
 
 /**
  The plot's gain value, which controls the scale of the y-axis values. The default value of the gain is 1.0f and should always be greater than 0.0f.
  */
-@property (nonatomic,assign,setter=setGain:) float gain;
+@property (nonatomic,assign,setter=setGain:) IBInspectable float gain;
 
 
 /**
  A boolean indicating whether or not to fill in the graph. A value of YES will make a filled graph (filling in the space between the x-axis and the y-value), while a value of NO will create a stroked graph (connecting the points along the y-axis).
  */
-@property (nonatomic,assign,setter=setShouldFill:) BOOL shouldFill;
+@property (nonatomic,assign,setter=setShouldFill:) IBInspectable BOOL shouldFill;
 
 /**
  A boolean indicating whether the graph should be rotated along the x-axis to give a mirrored reflection. This is typical for audio plots to produce the classic waveform look. A value of YES will produce a mirrored reflection of the y-values about the x-axis, while a value of NO will only plot the y-values.
  */
-@property (nonatomic,assign,setter=setShouldMirror:) BOOL shouldMirror;
+@property (nonatomic,assign,setter=setShouldMirror:) IBInspectable BOOL shouldMirror;
 
 #pragma mark - Get Samples
 ///-----------------------------------------------------------

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.m
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.m
@@ -129,17 +129,15 @@
     NSRect frame = self.bounds;
 #endif
     
+      // Set the background color
+      [self.backgroundColor set];
 #if TARGET_OS_IPHONE
-    // Set the background color
-    [self.backgroundColor set];
-    UIRectFill(frame);
-    // Set the waveform line color
-    [self.plotColor set];
+      UIRectFill(frame);
 #elif TARGET_OS_MAC
-    [self.backgroundColor set];
-    NSRectFill(frame);
-    [self.plotColor set];
+      NSRectFill(frame);
 #endif
+      // Set the waveform line color
+      [self.plotColor set];
     
     if(plotLength > 0) {
       


### PR DESCRIPTION
Basically switched to inherit from `EZAudioPlot` instead of compositing it in these classes, just makes it a lot easier to deal with and also this way we're taking ownership of that class. This way it works more like the other plot classes.

Another side effect: more IBDesignable properties are now exposed. :)

Basically now `EZAudioPlot` is the base class for the waveform plots, and it itself is now a subclass of `AKPlotView`. They already shared quite a bit of code in common so it simplifies that class too.

I also reduced the history size in half which should make it go by faster at the same dimensions.
