### PR TITLE
Centralized all AudioKit.plist in AKSettings class, file no longer required

### DIFF
--- a/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit.xcodeproj/project.pbxproj
@@ -53,7 +53,7 @@
 		EA8E95D11AD3C6850057E979 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = EA8E945B1AD3C6840057E979 /* TPCircularBuffer.c */; };
 		EA8E95D21AD3C6850057E979 /* AKPropertyLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94661AD3C6840057E979 /* AKPropertyLabel.m */; };
 		EA8E95D31AD3C6850057E979 /* AKPropertySlider.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94681AD3C6840057E979 /* AKPropertySlider.m */; };
-		EA8E95D41AD3C6850057E979 /* LevelMeter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946A1AD3C6840057E979 /* LevelMeter.m */; };
+		EA8E95D41AD3C6850057E979 /* AKLevelMeter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946A1AD3C6840057E979 /* AKLevelMeter.m */; };
 		EA8E95D51AD3C6850057E979 /* AKSoundFileTable.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946D1AD3C6840057E979 /* AKSoundFileTable.m */; };
 		EA8E95D61AD3C6850057E979 /* AKTable.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946F1AD3C6840057E979 /* AKTable.m */; };
 		EA8E95D71AD3C6850057E979 /* AKExponentialTableGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94721AD3C6840057E979 /* AKExponentialTableGenerator.m */; };
@@ -224,7 +224,7 @@
 		EA8E969B1AD3C92B0057E979 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = EA8E945B1AD3C6840057E979 /* TPCircularBuffer.c */; };
 		EA8E969C1AD3C94F0057E979 /* AKPropertyLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94661AD3C6840057E979 /* AKPropertyLabel.m */; };
 		EA8E969D1AD3C94F0057E979 /* AKPropertySlider.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94681AD3C6840057E979 /* AKPropertySlider.m */; };
-		EA8E969E1AD3C94F0057E979 /* LevelMeter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946A1AD3C6840057E979 /* LevelMeter.m */; };
+		EA8E969E1AD3C94F0057E979 /* AKLevelMeter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946A1AD3C6840057E979 /* AKLevelMeter.m */; };
 		EA8E969F1AD3C9580057E979 /* AKSoundFileTable.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946D1AD3C6840057E979 /* AKSoundFileTable.m */; };
 		EA8E96A01AD3C9580057E979 /* AKTable.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E946F1AD3C6840057E979 /* AKTable.m */; };
 		EA8E96A11AD3C9640057E979 /* AKExponentialTableGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94721AD3C6840057E979 /* AKExponentialTableGenerator.m */; };
@@ -460,8 +460,8 @@
 		EA8E94661AD3C6840057E979 /* AKPropertyLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKPropertyLabel.m; sourceTree = "<group>"; };
 		EA8E94671AD3C6840057E979 /* AKPropertySlider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPropertySlider.h; sourceTree = "<group>"; };
 		EA8E94681AD3C6840057E979 /* AKPropertySlider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKPropertySlider.m; sourceTree = "<group>"; };
-		EA8E94691AD3C6840057E979 /* LevelMeter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LevelMeter.h; sourceTree = "<group>"; };
-		EA8E946A1AD3C6840057E979 /* LevelMeter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LevelMeter.m; sourceTree = "<group>"; };
+		EA8E94691AD3C6840057E979 /* AKLevelMeter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKLevelMeter.h; sourceTree = "<group>"; };
+		EA8E946A1AD3C6840057E979 /* AKLevelMeter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKLevelMeter.m; sourceTree = "<group>"; };
 		EA8E946C1AD3C6840057E979 /* AKSoundFileTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSoundFileTable.h; sourceTree = "<group>"; };
 		EA8E946D1AD3C6840057E979 /* AKSoundFileTable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSoundFileTable.m; sourceTree = "<group>"; };
 		EA8E946E1AD3C6840057E979 /* AKTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKTable.h; sourceTree = "<group>"; };
@@ -1011,8 +1011,8 @@
 				EA8E94661AD3C6840057E979 /* AKPropertyLabel.m */,
 				EA8E94671AD3C6840057E979 /* AKPropertySlider.h */,
 				EA8E94681AD3C6840057E979 /* AKPropertySlider.m */,
-				EA8E94691AD3C6840057E979 /* LevelMeter.h */,
-				EA8E946A1AD3C6840057E979 /* LevelMeter.m */,
+				EA8E94691AD3C6840057E979 /* AKLevelMeter.h */,
+				EA8E946A1AD3C6840057E979 /* AKLevelMeter.m */,
 			);
 			path = "User Interface Elements";
 			sourceTree = "<group>";
@@ -1729,7 +1729,7 @@
 				EA8E95CB1AD3C6850057E979 /* AKPlotView.m in Sources */,
 				EA8E96161AD3C6850057E979 /* Sekere.m in Sources */,
 				EA8E95D21AD3C6850057E979 /* AKPropertyLabel.m in Sources */,
-				EA8E95D41AD3C6850057E979 /* LevelMeter.m in Sources */,
+				EA8E95D41AD3C6850057E979 /* AKLevelMeter.m in Sources */,
 				EA8E95C71AD3C6850057E979 /* AKAudioOutputPlot.m in Sources */,
 				EA8E96441AD3C6850057E979 /* AKParallelCombLowPassFilterReverb.m in Sources */,
 				EA8E95F81AD3C6850057E979 /* AKLinearADSREnvelope.m in Sources */,
@@ -1984,7 +1984,7 @@
 				EA8E96861AD3C89F0057E979 /* StruckMetalBar.m in Sources */,
 				EA8E96951AD3C92B0057E979 /* AKPlotView.m in Sources */,
 				EA8E969C1AD3C94F0057E979 /* AKPropertyLabel.m in Sources */,
-				EA8E969E1AD3C94F0057E979 /* LevelMeter.m in Sources */,
+				EA8E969E1AD3C94F0057E979 /* AKLevelMeter.m in Sources */,
 				EA8E96911AD3C92B0057E979 /* AKAudioOutputPlot.m in Sources */,
 				EA8E96721AD3C85D0057E979 /* AKMidi.m in Sources */,
 				EA8E96A51AD3C9640057E979 /* AKRandomDistributionTableGenerator.m in Sources */,

--- a/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit.xcodeproj/project.pbxproj
@@ -344,6 +344,9 @@
 		EA8E97131AD3CA4C0057E979 /* AKNote.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95A31AD3C6850057E979 /* AKNote.m */; };
 		EA8E97141AD3CA4C0057E979 /* AKNoteProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95A51AD3C6850057E979 /* AKNoteProperty.m */; };
 		EA8E97151AD3CA6A0057E979 /* CsoundLib64.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA8E95931AD3C6850057E979 /* CsoundLib64.framework */; };
+		EA95E9F11AD5EC50007FC41F /* AKSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = EA95E9EF1AD5EC50007FC41F /* AKSettings.h */; };
+		EA95E9F21AD5EC50007FC41F /* AKSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = EA95E9F01AD5EC50007FC41F /* AKSettings.m */; };
+		EA95E9F31AD5EC50007FC41F /* AKSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = EA95E9F01AD5EC50007FC41F /* AKSettings.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -739,6 +742,8 @@
 		EA8E95A51AD3C6850057E979 /* AKNoteProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKNoteProperty.m; sourceTree = "<group>"; };
 		EA8E96591AD3C6FC0057E979 /* libAudioKit OS X.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libAudioKit OS X.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA8E971A1AD3CF000057E979 /* AKSoundFiles.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AKSoundFiles.bundle; path = AudioKit/AKSoundFiles.bundle; sourceTree = SOURCE_ROOT; };
+		EA95E9EF1AD5EC50007FC41F /* AKSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSettings.h; sourceTree = "<group>"; };
+		EA95E9F01AD5EC50007FC41F /* AKSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSettings.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -802,6 +807,8 @@
 				EA8E93F31AD3C6840057E979 /* AKFoundation.h */,
 				EA8E93F41AD3C6840057E979 /* AKManager.h */,
 				EA8E93F51AD3C6840057E979 /* AKManager.m */,
+				EA95E9EF1AD5EC50007FC41F /* AKSettings.h */,
+				EA95E9F01AD5EC50007FC41F /* AKSettings.m */,
 				EA8E93F61AD3C6840057E979 /* AKOrchestra.h */,
 				EA8E93F71AD3C6840057E979 /* AKOrchestra.m */,
 				EA8E93F91AD3C6840057E979 /* MIDI */,
@@ -1596,6 +1603,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA95E9F11AD5EC50007FC41F /* AKSettings.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1729,6 +1737,7 @@
 				EA8E96371AD3C6850057E979 /* AKLowPassFilter.m in Sources */,
 				EA8E96461AD3C6850057E979 /* AKBalance.m in Sources */,
 				EA8E95A81AD3C6850057E979 /* AKMidi.m in Sources */,
+				EA95E9F21AD5EC50007FC41F /* AKSettings.m in Sources */,
 				EA8E95DB1AD3C6850057E979 /* AKRandomDistributionTableGenerator.m in Sources */,
 				EA8E96331AD3C6850057E979 /* AKDeclick.m in Sources */,
 				EA8E962E1AD3C6850057E979 /* AKDopplerEffect.m in Sources */,
@@ -1919,6 +1928,7 @@
 				EA8E96FF1AD3CA4C0057E979 /* AKMoogVCF.m in Sources */,
 				EA8E97001AD3CA4C0057E979 /* AKResonantFilter.m in Sources */,
 				EA8E97011AD3CA4C0057E979 /* AKStringResonator.m in Sources */,
+				EA95E9F31AD5EC50007FC41F /* AKSettings.m in Sources */,
 				EA8E97021AD3CA4C0057E979 /* AKThreePoleLowpassFilter.m in Sources */,
 				EA8E97031AD3CA4C0057E979 /* AKVariableFrequencyResponseBandPassFilter.m in Sources */,
 				EA8E97041AD3CA4C0057E979 /* AKBandPassButterworthFilter.m in Sources */,

--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -7,6 +7,7 @@
 //
 
 #import "AKManager.h"
+#import "AKSettings.h"
 
 #import "AKStereoAudio.h" // Used for replace instrument which should be refactored
 
@@ -75,26 +76,14 @@ static AKManager *_sharedManager = nil;
 - (instancetype)init {
     self = [super init];
     if (self != nil) {
-        
-        NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-        NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-        
-        // Default Values
-        NSString *audioOutput = @"dac";
-        NSString *audioInput  = @"adc";
-        
-        if (dict) {
-            audioOutput = dict[@"Audio Output"];
-            audioInput  = dict[@"Audio Input"];
-        }
-        
         csound = [[CsoundObj alloc] init];
+        
         _engine= csound; 
         [csound addListener:self];
         [csound setMessageCallback:@selector(messageCallback:) withListener:self];
         
         _isRunning = NO;
-        _isLogging = [dict[@"Enable Logging By Default"] boolValue];
+        _isLogging = AKSettings.settings.loggingEnabled;
         
         totalRunDuration = 10000000;
 
@@ -108,7 +97,7 @@ static AKManager *_sharedManager = nil;
                    "--expression-opt ; Enable expression optimizations\n"
                    "-m0              ; Print raw amplitudes\n"
                    "-i %@            ; Request sound from the host audio input device",
-                   audioOutput, audioInput];
+                   AKSettings.settings.audioOutput, AKSettings.settings.audioInput];
         
         templateString = @""
         "<CsoundSynthesizer>\n\n"

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -1,0 +1,23 @@
+//
+//  AKSettings.h
+//  AudioKit
+//
+//  Created by Stéphane Peter on 4/8/15.
+//  Copyright (c) 2015 AudioKit. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+// These values are initialized from AudioKit.plist if it is present in the app bundle
+
+@interface AKSettings : NSObject
+
++ (AKSettings *)settings;
+
+@property (nonatomic, readonly) NSString *audioInput, *audioOutput;
+@property (nonatomic, readonly) UInt32 sampleRate, samplesPerControlPeriod;
+@property (nonatomic, readonly) UInt16 numberOfChannels;
+@property (nonatomic, readonly) float zeroDBFullScaleValue;
+@property (nonatomic, readonly) BOOL loggingEnabled, audioInputEnabled;
+
+@end

--- a/AudioKit/Core Classes/AKSettings.m
+++ b/AudioKit/Core Classes/AKSettings.m
@@ -1,0 +1,63 @@
+//
+//  AKSettings.m
+//  AudioKit
+//
+//  Created by Stéphane Peter on 4/8/15.
+//  Copyright (c) 2015 AudioKit. All rights reserved.
+//
+
+#import "AKSettings.h"
+
+@implementation AKSettings
+
+static AKSettings *_settings = nil;
+
++ (AKSettings *)settings
+{
+    @synchronized(self) {
+        if (_settings == nil)
+            _settings = [[AKSettings alloc] init];
+    }
+    return _settings;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        // Sensible defaults
+        _audioOutput = @"dac";
+        _audioInput = @"adc";
+        _sampleRate = 44100;
+        _samplesPerControlPeriod = 64;
+        _numberOfChannels = 2;
+        _zeroDBFullScaleValue = 1.0;
+        _loggingEnabled = NO;
+        _audioInputEnabled = YES;
+        
+        // Try to load from AudioKit.plist if found
+        NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
+        if (path) {
+            NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
+            if (dict[@"Audio Output"])
+                _audioOutput = [dict[@"Audio Output"] copy];
+            if (dict[@"Audio Input"])
+                _audioInput = [dict[@"Audio Input"] copy];
+            if (dict[@"Sample Rate"])
+                _sampleRate = [dict[@"Sample Rate"] unsignedIntValue];
+            if (dict[@"Samples Per Control Period"])
+                _samplesPerControlPeriod = [dict[@"Samples Per Control Period"] unsignedIntValue];
+            if (dict[@"Number Of Channels"])
+                _numberOfChannels = [dict[@"Number Of Channels"] unsignedIntValue];
+            if (dict[@"Zero dB Full Scale Value"])
+                _zeroDBFullScaleValue = [dict[@"Zero dB Full Scale Value"] floatValue];
+            if (dict[@"Enable Logging By Default"])
+                _loggingEnabled = [dict[@"Enable Logging By Default"] boolValue];
+            if (dict[@"Enable Audio Input By Default"])
+                _audioInputEnabled = [dict[@"Enable Audio Input By Default"] boolValue];
+        }
+    }
+    return self;
+}
+
+@end

--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
@@ -8,6 +8,7 @@
 
 #import "AKAudioInputFFTPlot.h"
 #import "AKFoundation.h"
+#import "AKSettings.h"
 #import "CsoundObj.h"
 
 #import <Accelerate/Accelerate.h>
@@ -15,7 +16,7 @@
 @interface AKAudioInputFFTPlot() <CsoundBinding>
 {
     NSMutableData *inSamples;
-    int sampleSize;
+    UInt32 sampleSize;
     MYFLT *history;
     int historySize;
     int index;
@@ -159,12 +160,7 @@
 {
     cs = csoundObj;
     
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-    
-    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
-    sampleSize = numberOfChannels * samplesPerControlPeriod;
+    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
 
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));

--- a/AudioKit/Utilities/Plots/AKAudioInputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputPlot.m
@@ -6,13 +6,14 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 #import "CsoundObj.h"
-#import "AKAudioInputPlot.h"
 #import "AKFoundation.h"
+#import "AKSettings.h"
+#import "AKAudioInputPlot.h"
 
 @interface AKAudioInputPlot() <CsoundBinding>
 {
     NSData *inSamples;
-    int sampleSize;
+    UInt32 sampleSize;
     CsoundObj *cs;
 }
 
@@ -66,13 +67,7 @@
 {
     cs = csoundObj;
     
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-    
-    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
-    
-    sampleSize = numberOfChannels * samplesPerControlPeriod;
+    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
     
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));

--- a/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputRollingWaveformPlot.m
@@ -8,13 +8,14 @@
 
 #import "AKAudioInputRollingWaveformPlot.h"
 #import "AKFoundation.h"
+#import "AKSettings.h"
 #import "CsoundObj.h"
 
 @interface AKAudioInputRollingWaveformPlot() <CsoundBinding>
 {
     // AudioKit sound data
     NSMutableData *inSamples;
-    int sampleSize;
+    UInt32 sampleSize;
     
     CsoundObj *cs;
 }
@@ -46,12 +47,8 @@
 - (void)setup:(CsoundObj *)csoundObj
 {
     cs = csoundObj;
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-    
-    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
-    sampleSize = numberOfChannels * samplesPerControlPeriod;
+
+    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
     
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
@@ -8,13 +8,14 @@
 
 #import "AKAudioOutputFFTPlot.h"
 #import "AKFoundation.h"
+#import "AKSettings.h"
 #import "CsoundObj.h"
 #import <Accelerate/Accelerate.h>
 
 @interface AKAudioOutputFFTPlot() <CsoundBinding>
 {
     NSMutableData *outSamples;
-    int sampleSize;
+    UInt32 sampleSize;
     MYFLT *history;
     int historySize;
     int index;
@@ -88,6 +89,7 @@
 }
 
 #elif TARGET_OS_MAC
+// TODO
 #endif
 
 -(void)createFFTWithBufferSize:(float)bufferSize {
@@ -170,12 +172,7 @@
 {
     cs = csoundObj;
     
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-    
-    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
-    sampleSize = numberOfChannels * samplesPerControlPeriod;
+    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
     
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));

--- a/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputPlot.m
@@ -8,12 +8,13 @@
 
 #import "AKAudioOutputPlot.h"
 #import "AKFoundation.h"
+#import "AKSettings.h"
 #import "CsoundObj.h"
 
 @interface AKAudioOutputPlot() <CsoundBinding>
 {
     NSData *outSamples;
-    int sampleSize;
+    UInt32 sampleSize;
     int index;
     CsoundObj *cs;
 }
@@ -73,12 +74,8 @@
 - (void)setup:(CsoundObj *)csoundObj
 {
     cs = csoundObj;
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
     
-    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
-    sampleSize = numberOfChannels * samplesPerControlPeriod;
+    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
 
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));

--- a/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputRollingWaveformPlot.m
@@ -8,13 +8,14 @@
 
 #import "AKAudioOutputRollingWaveformPlot.h"
 #import "AKFoundation.h"
+#import "AKSettings.h"
 #import "CsoundObj.h"
 
 @interface AKAudioOutputRollingWaveformPlot() <CsoundBinding>
 {
     // AudioKit sound data
     NSMutableData *outSamples;
-    int sampleSize;
+    UInt32 sampleSize;
     
     CsoundObj *cs;
 }
@@ -44,12 +45,8 @@
 - (void)setup:(CsoundObj *)csoundObj
 {
     cs = csoundObj;
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-    
-    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
-    sampleSize = numberOfChannels * samplesPerControlPeriod;
+
+    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
 
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -8,12 +8,13 @@
 
 #import "AKStereoOutputPlot.h"
 #import "AKFoundation.h"
+#import "AKSettings.h"
 #import "CsoundObj.h"
 
 @interface AKStereoOutputPlot() <CsoundBinding>
 {
     NSData *outSamples;
-    int sampleSize;
+    UInt32 sampleSize;
     int index;
     CsoundObj *cs;
 }
@@ -78,12 +79,8 @@
 - (void)setup:(CsoundObj *)csoundObj
 {
     cs = csoundObj;
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-    
-    int samplesPerControlPeriod = [dict[@"Samples Per Control Period"] intValue];
-    int numberOfChannels = [dict[@"Number Of Channels"] intValue];
-    sampleSize = numberOfChannels * samplesPerControlPeriod;
+
+    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
     
     void *samples = malloc(sampleSize * sizeof(MYFLT));
     bzero(samples, sampleSize * sizeof(MYFLT));
@@ -97,7 +94,6 @@
     }
     
     [self performSelectorOnMainThread:@selector(updateUI) withObject:nil waitUntilDone:NO];
-
 }
 
 

--- a/AudioKit/Utilities/User Interface Elements/AKLevelMeter.h
+++ b/AudioKit/Utilities/User Interface Elements/AKLevelMeter.h
@@ -51,15 +51,33 @@
 
 #if TARGET_OS_IPHONE
 
-#import <UIKit/UIKit.h>
-
-#ifndef LEVELMETER_CLAMP
-#define LEVELMETER_CLAMP(min,x,max) (x < min ? min : (x > max ? max : x))
-#endif
+@import UIKit;
 
 IB_DESIGNABLE
 /// A level meter that can be drawn from any property
-@interface LevelMeter : UIView
+@interface AKLevelMeter : UIView
+
+// The background color of the lights
+@property(retain)				IBInspectable UIColor *bgColor;
+
+// The border color of the lights
+@property(retain)				IBInspectable UIColor *borderColor;
+
+#elif TARGET_OS_MAC
+
+@import Cocoa;
+
+IB_DESIGNABLE
+/// A level meter that can be drawn from any property
+@interface AKLevelMeter : NSView
+
+// The background color of the lights
+@property(retain)				IBInspectable NSColor *bgColor;
+
+// The border color of the lights
+@property(retain)				IBInspectable NSColor *borderColor;
+
+#endif
 
 // The current level, from 0 - 1
 @property						IBInspectable CGFloat level;
@@ -77,16 +95,7 @@ IB_DESIGNABLE
 // Whether to use variable intensity lights. Has no effect if numLights == 0.
 @property						IBInspectable BOOL variableLightIntensity;
 
-// The background color of the lights
-@property(retain)				IBInspectable UIColor *bgColor;
-
-// The border color of the lights
-@property(retain)				IBInspectable UIColor *borderColor;
-
 
 @end
 
 
-#elif TARGET_OS_MAC
-
-#endif

--- a/AudioKit/Utilities/User Interface Elements/AKLevelMeter.m
+++ b/AudioKit/Utilities/User Interface Elements/AKLevelMeter.m
@@ -46,18 +46,17 @@
  
  */
 
-#import "LevelMeter.h"
+#import "AKLevelMeter.h"
+#import "AKPlotView.h"
 
-#if TARGET_OS_IPHONE
-
-@implementation LevelMeter {
+@implementation AKLevelMeter {
     NSUInteger					_numLights;
     CGFloat						_level, _peakLevel;
     //	LevelMeterColorThreshold	*_colorThresholds;
     NSUInteger					_numColorThresholds;
     BOOL						_vertical;
     BOOL						_variableLightIntensity;
-    UIColor						*_bgColor, *_borderColor;
+    AKColor						*_bgColor, *_borderColor;
     CGFloat                     _scaleFactor;
 }
 
@@ -68,8 +67,8 @@
 	_numLights = 0;
 	_numColorThresholds = 3;
 	_variableLightIntensity = YES;
-	_bgColor = [[UIColor alloc] initWithRed:0. green:0. blue:0. alpha:0];
-	_borderColor = [[UIColor alloc] initWithRed:0. green:0. blue:0. alpha:0.6];
+	_bgColor = [AKColor colorWithRed:0. green:0. blue:0. alpha:0];
+	_borderColor = [AKColor colorWithRed:0. green:0. blue:0. alpha:0.6];
 	_vertical = ([self frame].size.width < [self frame].size.height) ? YES : NO;
 }
 
@@ -91,6 +90,7 @@
 	return self;
 }
 
+#if TARGET_OS_IPHONE
 
 - (void)drawRect:(CGRect)rect
 {
@@ -178,7 +178,7 @@
 				lightIntensity = 1.;
 			} else {
 				lightIntensity = (_level - lightMinVal) / (lightMaxVal - lightMinVal);
-				lightIntensity = LEVELMETER_CLAMP(0., lightIntensity, 1.);
+				lightIntensity = AK_CLAMP(0., lightIntensity, 1.);
 				if ((!_variableLightIntensity) && (lightIntensity > 0.)) lightIntensity = 1.;
 			}
             
@@ -220,6 +220,9 @@
 	
 	CGColorSpaceRelease(cs);
 }
+#elif TARGET_OS_MAC
+// TODO
+#endif
 
 
 - (CGFloat)level { return _level; }
@@ -234,6 +237,3 @@
 
 @end
 
-#elif TARGET_OS_MAC
-
-#endif

--- a/AudioKit/Utilities/User Interface Elements/AKPropertyLabel.h
+++ b/AudioKit/Utilities/User Interface Elements/AKPropertyLabel.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import "AKParameter.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -18,6 +18,6 @@
 @interface AKPropertyLabel : NSTextField
 #endif
 
-@property (nonatomic) id property;
+@property (nonatomic) AKParameter *property;
 
 @end

--- a/AudioKit/Utilities/User Interface Elements/AKPropertyLabel.m
+++ b/AudioKit/Utilities/User Interface Elements/AKPropertyLabel.m
@@ -12,7 +12,7 @@
 @implementation AKPropertyLabel
 
 
-- (void)setProperty:(id)property
+- (void)setProperty:(AKParameter *)property
 {
     _property = property;
     [self.property addObserver:self forKeyPath:@"value" options:NSKeyValueObservingOptionNew context:NULL];

--- a/AudioKit/Utilities/User Interface Elements/AKPropertySlider.h
+++ b/AudioKit/Utilities/User Interface Elements/AKPropertySlider.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import "AKParameter.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -19,6 +19,6 @@
 #endif
 
 
-@property (nonatomic) id property;
+@property (nonatomic) AKParameter *property;
 
 @end

--- a/AudioKit/Utilities/User Interface Elements/AKPropertySlider.m
+++ b/AudioKit/Utilities/User Interface Elements/AKPropertySlider.m
@@ -30,7 +30,7 @@
 #define min minValue
 #endif
 
-- (void)setProperty:(id)property
+- (void)setProperty:(AKParameter *)property
 {
     if ([property isKindOfClass:[AKInstrumentProperty class]])
     {
@@ -49,11 +49,10 @@
         _property = p;
     }
     
-    [property addObserver:self forKeyPath:@"value" options:NSKeyValueObservingOptionNew context:Nil];
+    [property addObserver:self forKeyPath:@"value" options:NSKeyValueObservingOptionNew context:nil];
     
 #if TARGET_OS_IPHONE
     [self addTarget:self action:@selector(changed:) forControlEvents:UIControlEventValueChanged];
-#define min minimumValue
 #elif TARGET_OS_MAC
     [self setAction:@selector(changed:)];
     [self setTarget:self];

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		EA5D42171AD4BC0100BEA03A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5D42161AD4BC0100BEA03A /* AVFoundation.framework */; };
 		EA5D421A1AD4BC3200BEA03A /* CsoundLib64.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5D42191AD4BC3200BEA03A /* CsoundLib64.framework */; };
 		EA5D421B1AD4BC4A00BEA03A /* CsoundLib64.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = EA5D42191AD4BC3200BEA03A /* CsoundLib64.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EA8E97351AD4D0A80057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E97341AD4D0A80057E979 /* AudioKit.plist */; };
 		EAB29D731AD51CC8000EA118 /* AKSoundFiles.bundle in Resources */ = {isa = PBXBuildFile; fileRef = EAB29D721AD51CC8000EA118 /* AKSoundFiles.bundle */; };
 /* End PBXBuildFile section */
 
@@ -91,7 +90,6 @@
 		EA5D420A1AD4BBDD00BEA03A /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EA5D42161AD4BC0100BEA03A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		EA5D42191AD4BC3200BEA03A /* CsoundLib64.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CsoundLib64.framework; path = ../../../AudioKit/Platforms/OSX/CsoundLib64.framework; sourceTree = SOURCE_ROOT; };
-		EA8E97341AD4D0A80057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 		EAB29D721AD51CC8000EA118 /* AKSoundFiles.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AKSoundFiles.bundle; path = ../../../../AudioKit/AKSoundFiles.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -161,8 +159,6 @@
 		C47544901A9BD0DF006151DE /* AudioKitDemo */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E97341AD4D0A80057E979 /* AudioKit.plist */,
-				EAB29D721AD51CC8000EA118 /* AKSoundFiles.bundle */,
 				C475449D1A9BD0DF006151DE /* Main.storyboard */,
 				C47546B01A9BD244006151DE /* Synthesis */,
 				C42DC32B1A9C617B0041B644 /* Processing */,
@@ -176,6 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				C475449B1A9BD0DF006151DE /* Images.xcassets */,
+				EAB29D721AD51CC8000EA118 /* AKSoundFiles.bundle */,
 				C47544931A9BD0DF006151DE /* AppDelegate.h */,
 				C47544941A9BD0DF006151DE /* AppDelegate.m */,
 				C47544981A9BD0DF006151DE /* ViewController.h */,
@@ -310,7 +307,6 @@
 			files = (
 				C475449C1A9BD0DF006151DE /* Images.xcassets in Resources */,
 				C475449F1A9BD0DF006151DE /* Main.storyboard in Resources */,
-				EA8E97351AD4D0A80057E979 /* AudioKit.plist in Resources */,
 				EAB29D731AD51CC8000EA118 /* AKSoundFiles.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/OSX/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
+++ b/Examples/OSX/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		C4BACA251A8FDEDC00736291 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C4BACA241A8FDEDC00736291 /* ViewController.m */; };
 		C4BACA271A8FDEDC00736291 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4BACA261A8FDEDC00736291 /* Images.xcassets */; };
 		C4BACA2A1A8FDEDC00736291 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4BACA281A8FDEDC00736291 /* Main.storyboard */; };
-		EA8E97431AD4D1880057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E97421AD4D1880057E979 /* AudioKit.plist */; };
 		EABF23CB1AD4B0190008F3B7 /* libAudioKit OS X.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23C81AD4AFFB0008F3B7 /* libAudioKit OS X.a */; };
 		EABF23CD1AD4B0200008F3B7 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23CC1AD4B0200008F3B7 /* AVFoundation.framework */; };
 		EABF23D01AD4B0940008F3B7 /* CsoundLib64.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23CF1AD4B0940008F3B7 /* CsoundLib64.framework */; };
@@ -66,7 +65,6 @@
 		C4BACA241A8FDEDC00736291 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		C4BACA261A8FDEDC00736291 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		C4BACA291A8FDEDC00736291 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		EA8E97421AD4D1880057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 		EABF23C01AD4AFFB0008F3B7 /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EABF23CC1AD4B0200008F3B7 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		EABF23CF1AD4B0940008F3B7 /* CsoundLib64.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CsoundLib64.framework; path = ../../../AudioKit/Platforms/OSX/CsoundLib64.framework; sourceTree = "<group>"; };
@@ -107,7 +105,6 @@
 		C4BACA1B1A8FDEDC00736291 /* HelloWorld */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E97421AD4D1880057E979 /* AudioKit.plist */,
 				C4BACA241A8FDEDC00736291 /* ViewController.m */,
 				C4BACA281A8FDEDC00736291 /* Main.storyboard */,
 				C4BACA1C1A8FDEDC00736291 /* Supporting Files */,
@@ -231,7 +228,6 @@
 			files = (
 				C4BACA271A8FDEDC00736291 /* Images.xcassets in Resources */,
 				C4BACA2A1A8FDEDC00736291 /* Main.storyboard in Resources */,
-				EA8E97431AD4D1880057E979 /* AudioKit.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		EA5D423C1AD4BED600BEA03A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5D423B1AD4BED600BEA03A /* AVFoundation.framework */; };
 		EA5D42421AD4BF6A00BEA03A /* AudioKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5D42411AD4BF6A00BEA03A /* AudioKit.swift */; };
 		EA5D42431AD4BFA100BEA03A /* CsoundLib64.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = EA5D422F1AD4BEA200BEA03A /* CsoundLib64.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EA8E97471AD4D1C50057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E97461AD4D1C50057E979 /* AudioKit.plist */; };
 		EAB29D771AD51D79000EA118 /* AKSoundFiles.bundle in Resources */ = {isa = PBXBuildFile; fileRef = EAB29D761AD51D79000EA118 /* AKSoundFiles.bundle */; };
 /* End PBXBuildFile section */
 
@@ -81,7 +80,6 @@
 		EA5D42311AD4BEA800BEA03A /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EA5D423B1AD4BED600BEA03A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		EA5D42411AD4BF6A00BEA03A /* AudioKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AudioKit.swift; path = ../../../../AudioKit/Platforms/Swift/AudioKit.swift; sourceTree = SOURCE_ROOT; };
-		EA8E97461AD4D1C50057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 		EAB29D761AD51D79000EA118 /* AKSoundFiles.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AKSoundFiles.bundle; path = ../../../../../AudioKit/AKSoundFiles.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -152,8 +150,6 @@
 				E4006CD01AB24D4F00375B5B /* Processing */,
 				E4006CCF1AB24D3100375B5B /* Analysis  */,
 				E42CC0DB1AB245DB00689511 /* Main.storyboard */,
-				EA8E97461AD4D1C50057E979 /* AudioKit.plist */,
-				EAB29D761AD51D79000EA118 /* AKSoundFiles.bundle */,
 				E42CC0D31AB245DB00689511 /* Supporting Files */,
 			);
 			path = AudioKitDemo;
@@ -165,6 +161,7 @@
 				E43516BD1AB3B1F600109B4A /* Bridging-Header.h */,
 				EA5D42411AD4BF6A00BEA03A /* AudioKit.swift */,
 				E42CC0D51AB245DB00689511 /* AppDelegate.swift */,
+				EAB29D761AD51D79000EA118 /* AKSoundFiles.bundle */,
 				E42CC0D91AB245DB00689511 /* Images.xcassets */,
 				E42CC0D41AB245DB00689511 /* Info.plist */,
 			);
@@ -274,7 +271,6 @@
 			files = (
 				E42CC0DA1AB245DB00689511 /* Images.xcassets in Resources */,
 				E42CC0DD1AB245DB00689511 /* Main.storyboard in Resources */,
-				EA8E97471AD4D1C50057E979 /* AudioKit.plist in Resources */,
 				EAB29D771AD51D79000EA118 /* AKSoundFiles.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/OSX/Swift/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
+++ b/Examples/OSX/Swift/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		EA5D42291AD4BD9B00BEA03A /* CsoundLib64.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = EA5D421C1AD4BD6000BEA03A /* CsoundLib64.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EA5D422A1AD4BDA900BEA03A /* libAudioKit OS X.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5D42261AD4BD6700BEA03A /* libAudioKit OS X.a */; };
 		EA5D422C1AD4BDAE00BEA03A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5D422B1AD4BDAE00BEA03A /* AVFoundation.framework */; };
-		EA8E974B1AD4D2160057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E974A1AD4D2160057E979 /* AudioKit.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,7 +65,6 @@
 		EA5D421E1AD4BD6700BEA03A /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EA5D422B1AD4BDAE00BEA03A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		EA5D422E1AD4BE0A00BEA03A /* Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bridging-Header.h"; sourceTree = "<group>"; };
-		EA8E974A1AD4D2160057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,7 +104,6 @@
 			children = (
 				E4CC74AF1AA29B2D007E90B8 /* ViewController.swift */,
 				E4CC74B31AA29B2D007E90B8 /* Main.storyboard */,
-				EA8E974A1AD4D2160057E979 /* AudioKit.plist */,
 				E4CC74AB1AA29B2D007E90B8 /* Supporting Files */,
 			);
 			path = HelloWorld;
@@ -226,7 +223,6 @@
 			files = (
 				E4CC74B21AA29B2D007E90B8 /* Images.xcassets in Resources */,
 				E4CC74B51AA29B2D007E90B8 /* Main.storyboard in Resources */,
-				EA8E974B1AD4D2160057E979 /* AudioKit.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		C4BACF541A91BB7100736291 /* FMSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4BACF531A91BB7100736291 /* FMSynthesizer.m */; };
 		EA8E97261AD3D0BB0057E979 /* libAudioKit iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA8E97211AD3D06D0057E979 /* libAudioKit iOS.a */; };
 		EA8E97281AD3D15C0057E979 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA8E97271AD3D15C0057E979 /* AVFoundation.framework */; };
-		EA8E972B1AD3D1D50057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E972A1AD3D1D50057E979 /* AudioKit.plist */; };
 		EA8E972D1AD3D2C40057E979 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA8E972C1AD3D2C40057E979 /* Accelerate.framework */; };
 		EAB29D6C1AD5121B000EA118 /* AKSoundFiles.bundle in Resources */ = {isa = PBXBuildFile; fileRef = EAB29D6B1AD5121B000EA118 /* AKSoundFiles.bundle */; };
 /* End PBXBuildFile section */
@@ -72,7 +71,6 @@
 		C4BACF531A91BB7100736291 /* FMSynthesizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FMSynthesizer.m; path = Synthesis/Instruments/FMSynthesizer.m; sourceTree = "<group>"; };
 		EA8E971B1AD3D06D0057E979 /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EA8E97271AD3D15C0057E979 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
-		EA8E972A1AD3D1D50057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = "<group>"; };
 		EA8E972C1AD3D2C40057E979 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		EAB29D6B1AD5121B000EA118 /* AKSoundFiles.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AKSoundFiles.bundle; path = ../../../../AudioKit/AKSoundFiles.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -123,8 +121,6 @@
 		C4BACD081A8FFC3100736291 /* AudioKitDemo */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E972A1AD3D1D50057E979 /* AudioKit.plist */,
-				EAB29D6B1AD5121B000EA118 /* AKSoundFiles.bundle */,
 				C4BACD161A8FFC3100736291 /* Main.storyboard */,
 				C4BACF431A90608000736291 /* Synthesis */,
 				C4BACD351A9002CA00736291 /* Processing */,
@@ -137,6 +133,7 @@
 		C4BACD091A8FFC3100736291 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				EAB29D6B1AD5121B000EA118 /* AKSoundFiles.bundle */,
 				C4BACD0D1A8FFC3100736291 /* AppDelegate.h */,
 				C4BACD0E1A8FFC3100736291 /* AppDelegate.m */,
 				C4BACD191A8FFC3100736291 /* Images.xcassets */,
@@ -288,7 +285,6 @@
 				EAB29D6C1AD5121B000EA118 /* AKSoundFiles.bundle in Resources */,
 				C4BACD181A8FFC3100736291 /* Main.storyboard in Resources */,
 				C4BACD1D1A8FFC3200736291 /* LaunchScreen.xib in Resources */,
-				EA8E972B1AD3D1D50057E979 /* AudioKit.plist in Resources */,
 				C4BACD1A1A8FFC3100736291 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/iOS/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
+++ b/Examples/iOS/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		C4BAC8001A8FD91500736291 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4BAC7FE1A8FD91500736291 /* Main.storyboard */; };
 		C4BAC8021A8FD91500736291 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4BAC8011A8FD91500736291 /* Images.xcassets */; };
 		C4BAC8051A8FD91500736291 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4BAC8031A8FD91500736291 /* LaunchScreen.xib */; };
-		EA8E97311AD4CFFF0057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E97301AD4CFFF0057E979 /* AudioKit.plist */; };
 		EABF23AC1AD4AA420008F3B7 /* libAudioKit iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23A41AD4A9EB0008F3B7 /* libAudioKit iOS.a */; };
 		EABF23AE1AD4AA500008F3B7 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23AD1AD4AA500008F3B7 /* AVFoundation.framework */; };
 /* End PBXBuildFile section */
@@ -53,7 +52,6 @@
 		C4BAC7FF1A8FD91500736291 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C4BAC8011A8FD91500736291 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		C4BAC8041A8FD91500736291 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		EA8E97301AD4CFFF0057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 		EABF239E1AD4A9EB0008F3B7 /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EABF23AD1AD4AA500008F3B7 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -94,7 +92,6 @@
 			children = (
 				C4BAC7FC1A8FD91500736291 /* ViewController.m */,
 				C4BAC7FE1A8FD91500736291 /* Main.storyboard */,
-				EA8E97301AD4CFFF0057E979 /* AudioKit.plist */,
 				C4BAC7F41A8FD91500736291 /* Supporting Files */,
 			);
 			path = HelloWorld;
@@ -214,7 +211,6 @@
 			files = (
 				C4BAC8001A8FD91500736291 /* Main.storyboard in Resources */,
 				C4BAC8051A8FD91500736291 /* LaunchScreen.xib in Resources */,
-				EA8E97311AD4CFFF0057E979 /* AudioKit.plist in Resources */,
 				C4BAC8021A8FD91500736291 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		E43516A81AB3ACE600109B4A /* AudioFilePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43516A71AB3ACE600109B4A /* AudioFilePlayer.swift */; };
 		E43516AA1AB3ACEB00109B4A /* ProcessingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43516A91AB3ACEB00109B4A /* ProcessingViewController.swift */; };
 		E43516AC1AB3ACF400109B4A /* AnalysisViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43516AB1AB3ACF400109B4A /* AnalysisViewController.swift */; };
-		EA8E97391AD4D0CB0057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E97381AD4D0CB0057E979 /* AudioKit.plist */; };
 		EA8E97601AD5102D0057E979 /* AKSoundFiles.bundle in Resources */ = {isa = PBXBuildFile; fileRef = EA8E975F1AD5102D0057E979 /* AKSoundFiles.bundle */; };
 		EABF23E61AD4B6A70008F3B7 /* libAudioKit iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23E11AD4B6980008F3B7 /* libAudioKit iOS.a */; };
 		EABF23E81AD4B6B50008F3B7 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23E71AD4B6B50008F3B7 /* AVFoundation.framework */; };
@@ -62,7 +61,6 @@
 		E43516A71AB3ACE600109B4A /* AudioFilePlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AudioFilePlayer.swift; path = Processing/AudioFilePlayer.swift; sourceTree = "<group>"; };
 		E43516A91AB3ACEB00109B4A /* ProcessingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcessingViewController.swift; path = Processing/ProcessingViewController.swift; sourceTree = "<group>"; };
 		E43516AB1AB3ACF400109B4A /* AnalysisViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnalysisViewController.swift; path = AudioKitDemo/Analysis/AnalysisViewController.swift; sourceTree = "<group>"; };
-		EA8E97381AD4D0CB0057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 		EA8E975F1AD5102D0057E979 /* AKSoundFiles.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AKSoundFiles.bundle; path = ../../../../../AudioKit/AKSoundFiles.bundle; sourceTree = "<group>"; };
 		EABF23D31AD4B6350008F3B7 /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../../AudioKit.xcodeproj; sourceTree = SOURCE_ROOT; };
 		EABF23E71AD4B6B50008F3B7 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -103,8 +101,6 @@
 		E41A207A1AA36E120044F08B /* AudioKitDemo */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E97381AD4D0CB0057E979 /* AudioKit.plist */,
-				EA8E975F1AD5102D0057E979 /* AKSoundFiles.bundle */,
 				E41A20811AA36E120044F08B /* Main.storyboard */,
 				E4AA886A1AA3724F001894CC /* Synthesis */,
 				E4AA88721AA372BD001894CC /* Processing */,
@@ -117,6 +113,7 @@
 		E41A207B1AA36E120044F08B /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				EA8E975F1AD5102D0057E979 /* AKSoundFiles.bundle */,
 				C48177461AD087C200D4FAA2 /* Bridging-Header.h */,
 				E41A20841AA36E120044F08B /* Images.xcassets */,
 				E41A20861AA36E120044F08B /* LaunchScreen.xib */,
@@ -272,7 +269,6 @@
 				EA8E97601AD5102D0057E979 /* AKSoundFiles.bundle in Resources */,
 				E41A20831AA36E120044F08B /* Main.storyboard in Resources */,
 				E41A20881AA36E120044F08B /* LaunchScreen.xib in Resources */,
-				EA8E97391AD4D0CB0057E979 /* AudioKit.plist in Resources */,
 				E41A20851AA36E120044F08B /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/iOS/Swift/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
+++ b/Examples/iOS/Swift/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		E4364C691A9A6FB700C0B544 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4364C671A9A6FB700C0B544 /* Main.storyboard */; };
 		E4364C6B1A9A6FB700C0B544 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4364C6A1A9A6FB700C0B544 /* Images.xcassets */; };
 		E4364C6E1A9A6FB700C0B544 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4364C6C1A9A6FB700C0B544 /* LaunchScreen.xib */; };
-		EA8E973D1AD4D1340057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E973C1AD4D1340057E979 /* AudioKit.plist */; };
 		EABF23BC1AD4AD2F0008F3B7 /* libAudioKit iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23B71AD4AD0D0008F3B7 /* libAudioKit iOS.a */; };
 		EABF23BE1AD4AD410008F3B7 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABF23BD1AD4AD410008F3B7 /* AVFoundation.framework */; };
 /* End PBXBuildFile section */
@@ -49,7 +48,6 @@
 		E4364C681A9A6FB700C0B544 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		E4364C6A1A9A6FB700C0B544 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		E4364C6D1A9A6FB700C0B544 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		EA8E973C1AD4D1340057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 		EABF23B01AD4AC840008F3B7 /* Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bridging-Header.h"; sourceTree = "<group>"; };
 		EABF23B11AD4AD0D0008F3B7 /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EABF23BD1AD4AD410008F3B7 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -89,7 +87,6 @@
 		E4364C601A9A6FB700C0B544 /* HelloWorld */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E973C1AD4D1340057E979 /* AudioKit.plist */,
 				E4364C651A9A6FB700C0B544 /* ViewController.swift */,
 				E4364C671A9A6FB700C0B544 /* Main.storyboard */,
 				E4364C611A9A6FB700C0B544 /* Supporting Files */,
@@ -209,7 +206,6 @@
 			files = (
 				E4364C691A9A6FB700C0B544 /* Main.storyboard in Resources */,
 				E4364C6E1A9A6FB700C0B544 /* LaunchScreen.xib in Resources */,
-				EA8E973D1AD4D1340057E979 /* AudioKit.plist in Resources */,
 				E4364C6B1A9A6FB700C0B544 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,6 @@
 * In the **Build Settings** tab for your target :
 	* Look for the **Other Linker Flags** setting, and set it to `-ObjC`
 	* Look for the **User Header Search Paths** setting, point it to the location of the `AudioKit` directory, make sure to set it to **recursive**.
-* Drag and drop the `AudioKit.plist` file from the **Resources** group in the AudioKit project to your own project. You may want to make sure you have your own copy if you intend to change any of the settings in that file.
 
 ## Swift Projects
 * From within the AudioKit subproject in your project, open the `AudioKit > Platforms > Swift` group, and drag and drop at least `AudioKit.swift` to your project. You may also add any of the extensions to your project if you'd like to use them.
@@ -22,3 +21,4 @@
 ## Optional Steps
 Some of the built-in instruments require the use of some sound files, grouped in the `AKSoundFiles.bundle` in the **Resources** group in AudioKit. You may drag this bundle to your own project to have them included.
 
+Similarly, you may want to drag and drop the `AudioKit.plist` file from the **Resources** group if you intend to change any of the settings in that file.

--- a/Playgrounds/AudioKitPlayground/AudioKitPlayground.xcodeproj/project.pbxproj
+++ b/Playgrounds/AudioKitPlayground/AudioKitPlayground.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		C4FE749E1ABA4CF6001641B7 /* Playground.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FE749C1ABA4CF6001641B7 /* Playground.m */; };
 		EA8E97581AD4D72F0057E979 /* libAudioKit iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA8E97531AD4D7100057E979 /* libAudioKit iOS.a */; };
 		EA8E975A1AD4D7340057E979 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA8E97591AD4D7340057E979 /* AVFoundation.framework */; };
-		EA8E975C1AD4D7580057E979 /* AudioKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = EA8E975B1AD4D7580057E979 /* AudioKit.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,7 +59,6 @@
 		E0B3481AC539415D957B1BA4 /* Pods-AudioKitPlayground.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AudioKitPlayground.release.xcconfig"; path = "Pods/Target Support Files/Pods-AudioKitPlayground/Pods-AudioKitPlayground.release.xcconfig"; sourceTree = "<group>"; };
 		EA8E974D1AD4D7100057E979 /* AudioKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AudioKit.xcodeproj; path = ../../AudioKit.xcodeproj; sourceTree = "<group>"; };
 		EA8E97591AD4D7340057E979 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
-		EA8E975B1AD4D7580057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "../../AudioKit/Core Classes/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,7 +116,6 @@
 		C4FE74731AB9FB58001641B7 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E975B1AD4D7580057E979 /* AudioKit.plist */,
 				C4FE74991ABA4CF6001641B7 /* AKPlayground.h */,
 				C4FE749A1ABA4CF6001641B7 /* AKPlayground.m */,
 				C4FE74771AB9FB58001641B7 /* AppDelegate.h */,
@@ -234,7 +231,6 @@
 			files = (
 				C4FE74841AB9FB58001641B7 /* LaunchScreen.xib in Resources */,
 				C4FE74811AB9FB58001641B7 /* Images.xcassets in Resources */,
-				EA8E975C1AD4D7580057E979 /* AudioKit.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This also prevents lots of duplications of the loading code, and makes sure the file is only parsed once per app start. This in turn cleans up a lot of the classes that used these settings.

Removed `AudioKit.plist` from all projects for which the defaults are fine (i.e. all).
