### PR TITLE
New AKSetting to turn on the way Csound messages are displayed

### DIFF
--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -305,8 +305,13 @@ static AKManager *_sharedManager = nil;
 
 - (void)messageReceivedFrom:(CsoundObj *)csoundObj attr:(int)attr message:(NSString *)msg
 {
-    if (_isLogging)
-        NSLog(@"Csound Message (%d): %@", attr, msg);
+    if (_isLogging) {
+        if (AKSettings.settings.messagesEnabled) {
+            NSLog(@"Csound(%d): %@", attr, msg);
+        } else {
+            NSLog(@"%@", msg);
+        }
+    }
 }
 
 

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -18,6 +18,6 @@
 @property (nonatomic, readonly) UInt32 sampleRate, samplesPerControlPeriod;
 @property (nonatomic, readonly) UInt16 numberOfChannels;
 @property (nonatomic, readonly) float zeroDBFullScaleValue;
-@property (nonatomic, readonly) BOOL loggingEnabled, audioInputEnabled;
+@property (nonatomic, readonly) BOOL loggingEnabled, audioInputEnabled, messagesEnabled;
 
 @end

--- a/AudioKit/Core Classes/AKSettings.m
+++ b/AudioKit/Core Classes/AKSettings.m
@@ -33,6 +33,7 @@ static AKSettings *_settings = nil;
         _numberOfChannels = 2;
         _zeroDBFullScaleValue = 1.0;
         _loggingEnabled = NO;
+        _messagesEnabled = NO;
         _audioInputEnabled = YES;
         
         // Try to load from AudioKit.plist if found
@@ -55,6 +56,8 @@ static AKSettings *_settings = nil;
                 _loggingEnabled = [dict[@"Enable Logging By Default"] boolValue];
             if (dict[@"Enable Audio Input By Default"])
                 _audioInputEnabled = [dict[@"Enable Audio Input By Default"] boolValue];
+            if (dict[@"Prefix Csound Messages"])
+                _messagesEnabled = [dict[@"Prefix Csound Messages"] boolValue];
         }
     }
     return self;

--- a/AudioKit/Core Classes/AudioKit.plist
+++ b/AudioKit/Core Classes/AudioKit.plist
@@ -16,6 +16,8 @@
 	<integer>1</integer>
 	<key>Enable Logging By Default</key>
 	<false/>
+	<key>Prefix Csound Messages</key>
+	<false/>
 	<key>Enable Audio Input By Default</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Setting is off by default to restore the old behavior, and can be turned on in the plist.
