### PR TITLE
Fix bug with microphone prompt being shown despite plist setting 'Enable...

### DIFF
--- a/AudioKit/Core Classes/AKOrchestra.m
+++ b/AudioKit/Core Classes/AKOrchestra.m
@@ -59,6 +59,21 @@
 + (void)start
 {
     if (![[AKManager sharedManager] isRunning]) {
+        NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
+        NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
+        
+        // Default Value
+        BOOL enableAudioInput = YES;
+        
+        if (dict) {
+            enableAudioInput = [dict[@"Enable Audio Input By Default"] boolValue];
+        }
+        
+        if (enableAudioInput) {
+            [[AKManager sharedManager] enableAudioInput];
+        }else{
+            [[AKManager sharedManager] disableAudioInput];
+        }
         [[AKManager sharedManager] runOrchestra];
     }
 }
@@ -83,22 +98,6 @@
 
 + (void)addInstrument:(AKInstrument *)instrument
 {
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
-    NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
-    
-    // Default Value
-    BOOL enableAudioInput = YES;
-    
-    if (dict) {
-        enableAudioInput = [dict[@"Enable Audio Input By Default"] boolValue];
-    }
-    
-    if (enableAudioInput) {
-        [[AKManager sharedManager] enableAudioInput];
-    }else{
-        [[AKManager sharedManager] disableAudioInput];
-    }
-    
     [AKOrchestra start];
     while (![[AKManager sharedManager] isRunning]) {
         // do nothing


### PR DESCRIPTION
[AKOrchestra addInstrument]  tries to disable the audio input, but is does not effectively avoid the microphone security prompt because [AKInstrument init] calls [AKOrchestra start] - BEFORE any instruments are ever added. Disabling the audio input in [AKOrchestra addInstrument] is too late to avoid prompting for the microphone, since the AKOrchestra has already been started when any subclass of AKInstrument is created. Thus, moving the code to enable or disable the input in  [AKOrchestra start]'s !isRunning condition solves the issue. 