### PR TITLE
Added OS X versions of missing plots, AKLevelMeter

### DIFF
--- a/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioInputFFTPlot.m
@@ -45,12 +45,10 @@
     free(_A.imagp);
 }
 
-#if TARGET_OS_IPHONE
-
 - (void)drawRect:(CGRect)rect
 {
     // Draw waveform
-    UIBezierPath *wavePath = [UIBezierPath bezierPath];
+    AKBezierPath *wavePath = [AKBezierPath bezierPath];
     
     CGFloat yOffset = self.bounds.size.height;
     
@@ -73,25 +71,27 @@
     CGFloat y = 0.0f;
     CGFloat y2 = 0.0f;
     [wavePath moveToPoint:CGPointMake(x, y)];
+#if TARGET_OS_IPHONE
     [wavePath addLineToPoint:CGPointMake(x, y2)];
+#elif TARGET_OS_MAC
+    [wavePath lineToPoint:CGPointMake(x, y2)];
+#endif
     for (int i = 0; i < historySize/2; i++) {
         y = yOffset - (history[i] * yScale);
         y = AK_CLAMP(y, 0.0, self.bounds.size.height);
         //NSLog(@"%index:d value:%f x:%f y:%f y2:%f", i%historySize, history[i % historySize], x, y, y2 );
-        
+#if TARGET_OS_IPHONE
         [wavePath addLineToPoint:CGPointMake(x, y)];
-        
+#elif TARGET_OS_MAC
+        [wavePath lineToPoint:CGPointMake(x, y)];
+#endif
         x += deltaX;
-    };
+    }
     
     [wavePath setLineWidth:self.lineWidth];
     [self.lineColor setStroke];
     [wavePath stroke];
 }
-
-#elif TARGET_OS_MAC
-// TODO
-#endif
 
 -(void)createFFTWithBufferSize:(float)bufferSize {
     MYFLT *data = (MYFLT *)inSamples.mutableBytes;

--- a/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioOutputFFTPlot.m
@@ -45,12 +45,10 @@
     free(_A.imagp);
 }
 
-#if TARGET_OS_IPHONE
-
 - (void)drawRect:(CGRect)rect
 {
     // Draw waveform
-    UIBezierPath *wavePath = [UIBezierPath bezierPath];
+    AKBezierPath *wavePath = [AKBezierPath bezierPath];
     
     CGFloat yOffset = self.bounds.size.height;
     
@@ -73,25 +71,28 @@
     CGFloat y = 0.0f;
     CGFloat y2 = 0.0f;
     [wavePath moveToPoint:CGPointMake(x, y)];
+#if TARGET_OS_IPHONE
     [wavePath addLineToPoint:CGPointMake(x, y2)];
+#elif TARGET_OS_MAC
+    [wavePath lineToPoint:CGPointMake(x, y2)];
+#endif
     for (int i = 0; i < historySize/2; i++) {
         y = yOffset - (history[i] * yScale);
         y = AK_CLAMP(y, 0.0, self.bounds.size.height);
         //NSLog(@"%index:d value:%f x:%f y:%f y2:%f", i%historySize, history[i % historySize], x, y, y2 );
         
+#if TARGET_OS_IPHONE
         [wavePath addLineToPoint:CGPointMake(x, y)];
-        
+#elif TARGET_OS_MAC
+        [wavePath lineToPoint:CGPointMake(x, y)];
+#endif
         x += deltaX;
-    };
+    }
     
     [wavePath setLineWidth:self.lineWidth];
     [self.lineColor setStroke];
     [wavePath stroke];
 }
-
-#elif TARGET_OS_MAC
-// TODO
-#endif
 
 -(void)createFFTWithBufferSize:(float)bufferSize {
     MYFLT *data = (MYFLT *)outSamples.mutableBytes;

--- a/AudioKit/Utilities/User Interface Elements/AKLevelMeter.m
+++ b/AudioKit/Utilities/User Interface Elements/AKLevelMeter.m
@@ -90,15 +90,19 @@
 	return self;
 }
 
-#if TARGET_OS_IPHONE
-
 - (void)drawRect:(CGRect)rect
 {
 	CGColorSpaceRef cs = NULL;
 	CGContextRef cxt = NULL;
 	CGRect bds;
 	
+#if TARGET_OS_IPHONE
 	cxt = UIGraphicsGetCurrentContext();
+#elif TARGET_OS_MAC // FIXME: Might have to worry about flipped coordinates below
+    NSGraphicsContext * nsGraphicsContext = [NSGraphicsContext currentContext];
+    cxt = (CGContextRef) [nsGraphicsContext graphicsPort];
+#endif
+    
 	cs = CGColorSpaceCreateDeviceRGB();
 	
 	if (_vertical)
@@ -136,7 +140,7 @@
 									 bds.size.width,
 									 (bds.size.height) * (val - currentTop)
 									 );
-			UIColor *lightColor = [[UIColor alloc] initWithRed:0. green:1. blue:0. alpha:1.];
+			AKColor *lightColor = [AKColor colorWithRed:0. green:1. blue:0. alpha:1.];
             [lightColor set];
 			CGContextFillRect(cxt, rect);
             
@@ -170,9 +174,9 @@
 			CGFloat lightMaxVal = (CGFloat)(light_i + 1) / (CGFloat)_numLights;
 			CGFloat lightIntensity;
 			CGRect lightRect;
-			UIColor *lightColor;
+			AKColor *lightColor;
 			
-            lightColor = [UIColor greenColor];
+            lightColor = [AKColor greenColor];
 			if (light_i == peakLight)
 			{
 				lightIntensity = 1.;
@@ -220,9 +224,7 @@
 	
 	CGColorSpaceRelease(cs);
 }
-#elif TARGET_OS_MAC
-// TODO
-#endif
+
 
 
 - (CGFloat)level { return _level; }


### PR DESCRIPTION
This was actually rather quick to do just by comparing with the other plots which already had working OS X versions.

Also fixed some memory corruption that would likely lead to some crashes in `AKTablePlot`, and cleaned it up further.

I don't have a good test case at the moment for these but I'm pretty confident they should be pretty functional on OS X.