### PR TITLE
AKManager and CsoundObj improvements

### DIFF
--- a/AudioKit/Core Classes/AKManager.h
+++ b/AudioKit/Core Classes/AKManager.h
@@ -19,7 +19,7 @@
  */
 @interface AKManager : NSObject
 
-@property (readonly) CsoundObj *engine;
+@property (nonnull, readonly) CsoundObj *engine;
 
 /// Determines whether or not AudioKit is available to send events to.
 @property (readonly) BOOL isRunning;
@@ -28,16 +28,16 @@
 @property BOOL isLogging;
 
 /// The default orchestra
-@property AKOrchestra *orchestra;
+@property (nonnull) AKOrchestra *orchestra;
 
 /// Common midi property shared across the application
-@property (readonly) AKMidi *midi;
+@property (nonnull, readonly) AKMidi *midi;
 
 /// A dictionary of named sequences
-@property NSMutableDictionary *sequences;
+@property (nonnull) NSMutableDictionary *sequences;
 
 /// @returns the shared instance of AKManager
-+ (AKManager *)sharedManager;
++ (AKManager * __nonnull)sharedManager;
 
 /// Run AudioKit using an AKOrchestra
 - (void)runOrchestra;
@@ -54,7 +54,7 @@
 
 /// Triggers an AKEvent
 /// @param event AKEvent to be triggered
-- (void)triggerEvent:(AKEvent *)event;
+- (void)triggerEvent:(AKEvent * __nonnull)event;
 
 /// Allow batching of events with a start batch command
 - (void)startBatch;
@@ -64,19 +64,24 @@
 
 /// Stop all notes of an instrument
 /// @param instrument The instrument that needs to be turned off.
-- (void)stopInstrument:(AKInstrument *)instrument;
+- (void)stopInstrument:(AKInstrument * __nonnull)instrument;
 
 /// Stop playback of a given note
 /// @param note Note to stop
-- (void)stopNote:(AKNote *)note;
+- (void)stopNote:(AKNote * __nonnull)note;
 
 /// Update playback of a given note
 /// @param note Note to update
-- (void)updateNote:(AKNote *)note;
+- (void)updateNote:(AKNote * __nonnull)note;
 
 /// Helper function to get the string out of a file.
 /// @param filename Full path of file on disk
-+ (NSString *)stringFromFile:(NSString *)filename;
++ (NSString * __nullable)stringFromFile:(NSString * __nonnull)filename;
+
+/// Get the path to a resource file in AKSoundFiles.bundle, may fail if not found
+/// @param filename The file name without its extension
+/// @param extension The extension for the file (i.e. @"wav", etc)
++ (NSString * __nullable)pathToSoundFile:(NSString * __nonnull)filename ofType:(NSString * __nonnull)extension;
 
 /// Enable Audio Input
 - (void)enableAudioInput;
@@ -89,7 +94,7 @@
 
 /// Start recording to a given URL
 /// @param url URL to save the recording at
-- (void)startRecordingToURL:(NSURL *)url;
+- (void)startRecordingToURL:(NSURL * __nonnull)url;
 
 /// Enable MIDI
 - (void)enableMidi;
@@ -99,9 +104,9 @@
 
 /// Utilities
 /// @param binding The object that will be added to Csound's binding list
-+ (void)addBinding:(id)binding;
++ (void)addBinding:(__nonnull id)binding;
 
 /// @param binding The object that will be removed from Csound's binding list
-+ (void)removeBinding:(id)binding;
++ (void)removeBinding:(__nonnull id)binding;
 
 @end

--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -67,9 +67,27 @@ static AKManager *_sharedManager = nil;
 }
 
 + (NSString *)stringFromFile:(NSString *)filename {
-    return [[NSString alloc] initWithContentsOfFile:filename 
-                                           encoding:NSUTF8StringEncoding 
-                                              error:nil];
+    NSError *err;
+    NSString *str = [[NSString alloc] initWithContentsOfFile:filename
+                                                    encoding:NSUTF8StringEncoding
+                                                       error:&err];
+    if (!str) {
+        NSLog(@"Error reading contents of file %@: %@", filename, err);
+    }
+    return str;
+}
+
++ (NSString *)pathToSoundFile:(NSString *)filename ofType:(NSString *)extension
+{
+    NSString *path = [[NSBundle mainBundle] pathForResource:filename ofType:extension
+                                                   inDirectory:@"AKSoundFiles.bundle/Sounds"];
+    NSAssert(path, @"Make sure to include AKSoundFiles.bundle in your project's resources! Unable to locate file: %@.%@", filename, extension);
+    
+    // If the file is still nil and we haven't aborted, then we are probably in tests
+    if (!path) {
+        path = [NSString stringWithFormat:@"AKSoundFiles.bundle/Sounds/%@.%@", filename, extension];
+    }
+    return path;
 }
 
 - (instancetype)init {
@@ -112,8 +130,7 @@ static AKManager *_sharedManager = nil;
         "<CsScore>\nf0 %d\n</CsScore>\n\n"
         "</CsoundSynthesizer>\n";
         
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-        csdFile = [NSString stringWithFormat:@"%@/AudioKit.csd", paths[0]];
+        csdFile = [NSString stringWithFormat:@"%@/AudioKit-%@.csd", NSTemporaryDirectory(), @(getpid())];
         _midi = [[AKMidi alloc] init];
         _sequences = [NSMutableDictionary dictionary];
     }

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -12,9 +12,9 @@
 
 @interface AKSettings : NSObject
 
-+ (AKSettings *)settings;
++ (AKSettings * __nonnull)settings;
 
-@property (nonatomic, readonly) NSString *audioInput, *audioOutput;
+@property (nonatomic, readonly, nonnull) NSString *audioInput, *audioOutput;
 @property (nonatomic, readonly) UInt32 sampleRate, samplesPerControlPeriod;
 @property (nonatomic, readonly) UInt16 numberOfChannels;
 @property (nonatomic, readonly) float zeroDBFullScaleValue;

--- a/AudioKit/Operations/Signal Generators/Physical Models/AKMandolin.m
+++ b/AudioKit/Operations/Signal Generators/Physical Models/AKMandolin.m
@@ -33,15 +33,8 @@
         _loopGain = loopGain;
         
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"mandpluk" ofType:@"aif" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
         
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/mandpluk.aif";
-        }
-
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:[AKManager pathToSoundFile:@"mandpluk" ofType:@"aif"]];
         
         [self setUpConnections];
 }
@@ -61,15 +54,8 @@
         _loopGain = akp(0.99);
         
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"mandpluk" ofType:@"aif" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
-        
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/mandpluk.aif";
-        }
 
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:[AKManager pathToSoundFile:@"mandpluk" ofType:@"aif"]];
         
         [self setUpConnections];
     }

--- a/AudioKit/Operations/Signal Generators/Physical Models/AKMarimba.m
+++ b/AudioKit/Operations/Signal Generators/Physical Models/AKMarimba.m
@@ -39,15 +39,7 @@
         _tripleStrikePercentage = tripleStrikePercentage;
         
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"marmstk1" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
-        
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/marmstk1.wav";
-        }
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:[AKManager pathToSoundFile:@"marmstk1" ofType:@"wav"]];
         
         [self setUpConnections];
 }
@@ -71,15 +63,8 @@
         _tripleStrikePercentage = akp(20);
         
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"marmstk1" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
         
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/marmstk1.wav";
-        }
-        
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:[AKManager pathToSoundFile:@"marmstk1" ofType:@"wav"]];
         
         [self setUpConnections];
     }

--- a/AudioKit/Operations/Signal Generators/Physical Models/AKPluckedString.m
+++ b/AudioKit/Operations/Signal Generators/Physical Models/AKPluckedString.m
@@ -30,18 +30,12 @@
         _samplePosition = samplePosition;
         _reflectionCoefficient = reflectionCoefficient;
         _amplitude = amplitude;
+
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"marmstk1" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
-        
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/marmstk1.wav";
-        }
-        
-        AKSoundFileTable *_strikeImpulseTable;
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
-        _excitationSignal = [[AKMonoSoundFileLooper alloc] initWithSoundFile:_strikeImpulseTable];
+        NSString *file = [AKManager pathToSoundFile:@"marmstk1" ofType:@"wav"];
+        AKSoundFileTable *strikeImpulseTable;
+        strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _excitationSignal = [[AKMonoSoundFileLooper alloc] initWithSoundFile:strikeImpulseTable];
         _excitationSignal.loopMode = [AKMonoSoundFileLooper loopPlaysOnce];
 
         [self setUpConnections];
@@ -59,18 +53,12 @@
         _samplePosition = akp(0.1);
         _reflectionCoefficient = akp(0.1);
         _amplitude = akp(1.0);
+
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"marmstk1" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
-        
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/marmstk1.wav";
-        }
-        
-        AKSoundFileTable *_strikeImpulseTable;
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
-        _excitationSignal = [[AKMonoSoundFileLooper alloc] initWithSoundFile:_strikeImpulseTable];
+        NSString *file = [AKManager pathToSoundFile:@"marmstk1" ofType:@"wav"];
+        AKSoundFileTable *strikeImpulseTable;
+        strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _excitationSignal = [[AKMonoSoundFileLooper alloc] initWithSoundFile:strikeImpulseTable];
         _excitationSignal.loopMode = [AKMonoSoundFileLooper loopPlaysOnce];
         [self setUpConnections];
     }

--- a/AudioKit/Operations/Signal Generators/Physical Models/AKVibes.m
+++ b/AudioKit/Operations/Signal Generators/Physical Models/AKVibes.m
@@ -35,15 +35,8 @@
         _tremoloAmplitude = tremoloAmplitude;
         
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"marmstk1" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
         
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/marmstk1.wav";
-        }
-        
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:[AKManager pathToSoundFile:@"marmstk1" ofType:@"wav"]];
         
         [self setUpConnections];
 }
@@ -65,15 +58,7 @@
         _tremoloAmplitude = akp(0);
         
         // Constant Values
-        NSString *file = [[NSBundle mainBundle] pathForResource:@"marmstk1" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSAssert(file, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
-        
-        // if the file is still null then we are probably in tests
-        if (!file) {
-            file = @"AKSoundFiles.bundle/Sounds/marmstk1.wav";
-        }
-        
-        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:file];
+        _strikeImpulseTable = [[AKSoundFileTable alloc] initWithFilename:[AKManager pathToSoundFile:@"marmstk1" ofType:@"wav"]];
         
         [self setUpConnections];
     }

--- a/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AK3DBinauralAudio.m
+++ b/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AK3DBinauralAudio.m
@@ -117,21 +117,9 @@
         [inputsString appendFormat:@"AKControl(%@), ", _elevation];
     }
     
-    NSString *leftDat = [[NSBundle mainBundle] pathForResource:@"hrtf-44100-left" ofType:@"dat" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-    NSAssert(leftDat, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
+    NSString *leftDat = [AKManager pathToSoundFile:@"hrtf-44100-left" ofType:@"dat"];
+    NSString *rightDat = [AKManager pathToSoundFile:@"hrtf-44100-right" ofType:@"dat"];
     
-    // if the file is still null then we are probably in tests
-    if (!leftDat) {
-        leftDat = @"AKSoundFiles.bundle/Sounds/hrtf-44100-left.dat";
-    }
-    
-    NSString *rightDat = [[NSBundle mainBundle] pathForResource:@"hrtf-44100-right" ofType:@"dat" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-    NSAssert(rightDat, @"Make sure to include AKSoundFiles.bundle in your project's resources!");
-    
-    // if the file is still null then we are probably in tests
-    if (!rightDat) {
-        rightDat = @"AKSoundFiles.bundle/Sounds/hrtf-44100-right.dat";
-    }
     [inputsString appendFormat:@"\"%@\",\"%@\"", leftDat, rightDat];
     
     return inputsString;

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Processing/AudioFilePlayer.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Processing/AudioFilePlayer.m
@@ -21,12 +21,8 @@
         _sampleMix = [self createPropertyWithValue:0 minimum:0  maximum:1];
         
         // Instrument Definition
-        NSString *file1;
-        file1 = [[NSBundle mainBundle] pathForResource:@"PianoBassDrumLoop" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-
-        NSString *file2;
-        file2 = [[NSBundle mainBundle] pathForResource:@"808loop" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        
+        NSString *file1 = [AKManager pathToSoundFile:@"PianoBassDrumLoop" ofType:@"wav"];
+        NSString *file2 = [AKManager pathToSoundFile:@"808loop" ofType:@"wav"];
         
         AKFileInput *fileIn1 = [[AKFileInput alloc] initWithFilename:file1];
         fileIn1.speed = _speed;

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Processing/ConvolutionInstrument.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Processing/ConvolutionInstrument.m
@@ -20,8 +20,8 @@
         _dryWetBalance   = [self createPropertyWithValue:0 minimum:0 maximum:0.1];
         
         // Instrument definition
-        NSString *dish = [[NSBundle mainBundle] pathForResource:@"dish"      ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
-        NSString *well = [[NSBundle mainBundle] pathForResource:@"Stairwell" ofType:@"wav" inDirectory:@"AKSoundFiles.bundle/Sounds"];
+        NSString *dish = [AKManager pathToSoundFile:@"dish"      ofType:@"wav"];
+        NSString *well = [AKManager pathToSoundFile:@"Stairwell" ofType:@"wav"];
         
         AKConvolution *dishConv = [[AKConvolution alloc] initWithInput:input
                                                impulseResponseFilename:dish];

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Processing/AudioFilePlayer.swift
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Processing/AudioFilePlayer.swift
@@ -25,8 +25,8 @@ class AudioFilePlayer: AKInstrument {
         addProperty(scaling)
         addProperty(sampleMix)
                 
-        let file1 = String(NSBundle.mainBundle().pathForResource("PianoBassDrumLoop", ofType: "wav", inDirectory:"AKSoundFiles.bundle/Sounds")!)
-        let file2 = String(NSBundle.mainBundle().pathForResource("808loop",           ofType: "wav", inDirectory:"AKSoundFiles.bundle/Sounds")!)
+        let file1 = AKManager.pathToSoundFile("PianoBassDrumLoop", ofType: "wav")
+        let file2 = AKManager.pathToSoundFile("808loop",           ofType: "wav")
         
         let fileIn1 = AKFileInput(filename: file1)
         fileIn1.speed = speed

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Processing/ConvolutionInstrument.swift
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Processing/ConvolutionInstrument.swift
@@ -21,8 +21,8 @@ class ConvolutionInstrument: AKInstrument
         addProperty(dishWellBalance)
         addProperty(dryWetBalance)
         
-        let dish = String(NSBundle.mainBundle().pathForResource("dish", ofType: "wav", inDirectory: "AKSoundFiles.bundle/Sounds")!)
-        let well = String(NSBundle.mainBundle().pathForResource("Stairwell", ofType: "wav", inDirectory: "AKSoundFiles.bundle/Sounds")!)
+        let dish = AKManager.pathToSoundFile("dish", ofType: "wav")
+        let well = AKManager.pathToSoundFile("Stairwell", ofType: "wav")
         
         let dishConv = AKConvolution(input: input, impulseResponseFilename: dish)
         


### PR DESCRIPTION
* New utility class method on `AKManager` to simplify loading files from the AKSoundFiles bundle, this simplifies lots of duplicate code in instruments and the demo.
* The temporary `AudioKit.csd` file is now really in a temporary directory, with a temporary name including the process number, and is being removed upon application termination.
* We also wait for the Csound thread to end gracefully when the application terminates, to avoid crashes on OS X. This is now handled through a `NSThread` object instead of the `NSObject` method to launch a selector haphazardly in the background.
