### PR TITLE
Fixes for AKTable and related classes

### DIFF
--- a/AudioKit/Tables/AKTable.h
+++ b/AudioKit/Tables/AKTable.h
@@ -16,7 +16,7 @@
 @interface AKTable : NSObject
 
 /// The number of elements in the table.  Often required to be a multiple of 2.
-@property int size;
+@property NSUInteger size;
 
 /// A reference lookup number for the table.
 @property (readonly) int number;
@@ -31,7 +31,7 @@
 
 /// Creates an empty table with the given number of elements.
 /// @param size Number of elements in the table
-- (instancetype)initWithSize:(int)size;
+- (instancetype)initWithSize:(NSUInteger)size;
 
 - (instancetype)initWithArray:(NSArray *)array;
 

--- a/AudioKit/Tables/Generators/AKExponentialTableGenerator.m
+++ b/AudioKit/Tables/Generators/AKExponentialTableGenerator.m
@@ -40,7 +40,7 @@
     [self addValue:value atIndex:index];
 }
 
-- (NSArray *)parametersWithSize:(int)size
+- (NSArray *)parametersWithSize:(NSUInteger)size
 {
     [points sortUsingComparator:^NSComparisonResult(NSArray *obj1, NSArray *obj2) {
         return [obj1[0] compare: obj2[0]];

--- a/AudioKit/Tables/Generators/AKFourierSeriesTableGenerator.m
+++ b/AudioKit/Tables/Generators/AKFourierSeriesTableGenerator.m
@@ -44,7 +44,7 @@
     
 }
 
-- (NSArray *)parametersWithSize:(int)size
+- (NSArray *)parametersWithSize:(NSUInteger)size
 {
     if (sinusoids.count == 0) {
         [self addSinusoidWithPartialNumber:1 strength:1];

--- a/AudioKit/Tables/Generators/AKHarmonicCosineTableGenerator.m
+++ b/AudioKit/Tables/Generators/AKHarmonicCosineTableGenerator.m
@@ -55,7 +55,7 @@
     self.partialMultiplier = partialMultiplier;
 }
 
-- (NSArray *)parametersWithSize:(int)size
+- (NSArray *)parametersWithSize:(NSUInteger)size
 {
     return @[[NSNumber numberWithInt:_numberOfHarmonics],
              [NSNumber numberWithInt:_lowestHarmonic],

--- a/AudioKit/Tables/Generators/AKLineTableGenerator.m
+++ b/AudioKit/Tables/Generators/AKLineTableGenerator.m
@@ -92,7 +92,7 @@
     [self addValue:value atIndex:index];
 }
 
-- (NSArray *)parametersWithSize:(int)size
+- (NSArray *)parametersWithSize:(NSUInteger)size
 {
     [points sortUsingComparator:^NSComparisonResult(NSArray *obj1, NSArray *obj2) {
         return [obj1[0] compare: obj2[0]];

--- a/AudioKit/Tables/Generators/AKRandomDistributionTableGenerator.m
+++ b/AudioKit/Tables/Generators/AKRandomDistributionTableGenerator.m
@@ -130,14 +130,14 @@
     return [[self alloc] initBetaDistributionWithAlpha:alpha beta:beta];
 }
 
-- (NSArray *)parametersWithSize:(int)size
+- (NSArray *)parametersWithSize:(NSUInteger)size
 {
     if (type == 9) {
-        return @[[NSNumber numberWithInt:type], [NSNumber numberWithFloat:_alpha], [NSNumber numberWithFloat:_beta]];
+        return @[@(type), @(_alpha), @(_beta)];
     } else if (type == 10) {
-        return @[[NSNumber numberWithInt:type], [NSNumber numberWithFloat:_sigma]];
+        return @[@(type), @(_sigma)];
     } else {
-        return @[[NSNumber numberWithInt:type]];
+        return @[@(type)];
     }
 }
 

--- a/AudioKit/Tables/Generators/AKTableGenerator.h
+++ b/AudioKit/Tables/Generators/AKTableGenerator.h
@@ -17,6 +17,6 @@
 
 /// Parameters for the generator
 /// @param size The final size of the table, useful for scaling
-- (NSArray *)parametersWithSize:(int)size;
+- (NSArray *)parametersWithSize:(NSUInteger)size;
 
 @end

--- a/AudioKit/Tables/Generators/AKTableGenerator.m
+++ b/AudioKit/Tables/Generators/AKTableGenerator.m
@@ -16,7 +16,7 @@
 }
 
 // Overwrite in subclass
-- (NSArray *)parametersWithSize:(int)size {
+- (NSArray *)parametersWithSize:(NSUInteger)size {
     return @[];
 }
 

--- a/AudioKit/Tables/Generators/AKWindowTableGenerator.m
+++ b/AudioKit/Tables/Generators/AKWindowTableGenerator.m
@@ -139,12 +139,12 @@
     return [[self alloc] initSyncWindow];
 }
 
-- (NSArray *)parametersWithSize:(int)size
+- (NSArray *)parametersWithSize:(NSUInteger)size
 {
     if (type == 6 || type == 7) {
-        return @[[NSNumber numberWithInt:type], @1, [NSNumber numberWithFloat:extra_term]];
+        return @[@(type), @1, @(extra_term)];
     } else {
-        return @[[NSNumber numberWithInt:type]];
+        return @[@(type)];
     }
 }
 


### PR DESCRIPTION
OK, so `AKTable` was broken as I misunderstood the way it was working (the `malloc()` usage threw me off). Basically `AKTable` is now a simple proxy for the Csound tables, and we leave it to them to manage memory allocation. There's no real need to hold a pointer to the buffer in the class itself.

A couple of other mostly stylistic improvements to related code:
* Use `NSUInteger` instead of `int` for array table sizes, to be consistent with Cocoa `NSArray` semantics.
* Use modern Objective-C syntax to create `NSNumber`
