### PR TITLE
A few more fixes to AKTable and AKTablePlot

### DIFF
--- a/AudioKit/Tables/AKTable.h
+++ b/AudioKit/Tables/AKTable.h
@@ -13,16 +13,20 @@
 /** All purpose array of float values.  Often used for waveforms and 
  lookup tables at the time of note creation/initialization.
  */
+NS_ASSUME_NONNULL_BEGIN
 @interface AKTable : NSObject
 
 /// The number of elements in the table.  Often required to be a multiple of 2.
 @property NSUInteger size;
 
+/// All continguous values of the table, up to size.
+@property (nonatomic, readonly, nullable) float *values;
+
 /// A reference lookup number for the table.
 @property (readonly) int number;
 
 /// An entirely optional name, can be useful for debugging.
-@property NSString *name;
+@property (nullable) NSString *name;
 
 /// Creates an empty table with the default size (number of elements).
 - (instancetype)init;
@@ -33,10 +37,16 @@
 /// @param size Number of elements in the table
 - (instancetype)initWithSize:(NSUInteger)size;
 
+/// Creates a table from an array of objects.
+/// @param array An array of NSNumber instances.
 - (instancetype)initWithArray:(NSArray *)array;
 
 /// Creates an empty table with the default size (number of elements).
 + (instancetype)table;
+
+/// Access one of the values of the table
+/// @param index The index of the value, must be less than size
+- (float)valueAtIndex:(NSUInteger)index;
 
 /// Run a mathematical function on each value of the function table
 /// @param function Function to run on each table value
@@ -44,7 +54,7 @@
 
 /// Populate the table with given function on integer elements
 /// @param function Function to applied to each index element
-- (void)populateTableWithIndexFunction:(float (^)(int))function;
+- (void)populateTableWithIndexFunction:(float (^)(NSUInteger))function;
 
 /// Populate a table based on a float value from zero to one.
 /// @param function Function to be applied to a value that varies from 0 to 1.
@@ -69,4 +79,6 @@
 
 /// Returns an ftlen() wrapped around the output of this table.
 - (AKConstant *)length;
+
 @end
+NS_ASSUME_NONNULL_END

--- a/AudioKit/Tables/AKTable.m
+++ b/AudioKit/Tables/AKTable.m
@@ -17,7 +17,7 @@ static int currentID = 2000;
 + (void)resetID { currentID = 2000; }
 
 // Returns a pointer to the table managed internally by Csound
-- (MYFLT *)_getTable
+- (MYFLT *)values
 {
     NSAssert(csoundTableLength(_cs, _number) == _size, @"Inconsistent table sizes (not %@)", @(_size));
 
@@ -58,7 +58,7 @@ static int currentID = 2000;
         _csoundObj = [[AKManager sharedManager] engine];
         _cs = [_csoundObj getCsound];
         [_csoundObj updateOrchestra:self.orchestraString];
-        MYFLT *table = [self _getTable];
+        MYFLT *table = self.values;
         
         if (table) {
             for (int i = 0; i < _size; i++) {
@@ -69,6 +69,18 @@ static int currentID = 2000;
         }
     }
     return self;
+}
+
+- (float)valueAtIndex:(NSUInteger)index
+{
+    NSAssert(index < _size, @"Index out of bounds: %@", @(index));
+    if (index < _size) {
+        MYFLT *vals = self.values;
+        if (vals) {
+            return vals[index];
+        }
+    }
+    return 0.0f;
 }
 
 - (void)populateTableWithGenerator:(AKTableGenerator *)tableGenerator
@@ -84,7 +96,7 @@ static int currentID = 2000;
 
 - (void)operateOnTableWithFunction:(float (^)(float))function
 {
-    MYFLT *table = [self _getTable];
+    MYFLT *table = self.values;
     if (table) {
         for (int i = 0; i < _size; i++) {
             table[i] = function(table[i]);
@@ -92,9 +104,9 @@ static int currentID = 2000;
     }
 }
 
-- (void)populateTableWithIndexFunction:(float (^)(int))function
+- (void)populateTableWithIndexFunction:(float (^)(NSUInteger))function
 {
-    MYFLT *table = [self _getTable];
+    MYFLT *table = self.values;
     if (table) {
         for (int i = 0; i < _size; i++) {
             table[i] = function(i);
@@ -104,7 +116,7 @@ static int currentID = 2000;
 
 - (void)populateTableWithFractionalWidthFunction:(float (^)(float))function
 {
-    MYFLT *table = [self _getTable];
+    MYFLT *table = self.values;
     if (table) {
         for (int i = 0; i < _size; i++) {
             float x = (float) i / _size;
@@ -122,9 +134,9 @@ static int currentID = 2000;
 
 - (void)normalize
 {
-    MYFLT *table = [self _getTable];
+    MYFLT *table = self.values;
     if (table) {
-        float max = 0.0;
+        MYFLT max = 0.0;
         for (int i = 0; i < _size; i++) {
             max = MAX(max, fabsf(table[i]));
         }

--- a/AudioKit/Utilities/Plots/AKTablePlot.h
+++ b/AudioKit/Utilities/Plots/AKTablePlot.h
@@ -14,17 +14,15 @@ IB_DESIGNABLE
 @interface AKTablePlot : AKPlotView
 
 #if TARGET_OS_IPHONE
-@property IBInspectable UIColor *lineColor;
+@property (nonnull) IBInspectable UIColor *lineColor;
 #else
-@property IBInspectable NSColor *lineColor;
+@property (nonnull) IBInspectable NSColor *lineColor;
 #endif
 @property IBInspectable CGFloat lineWidth;
 
-/// Creates the table plot
-/// @param frame Bounding frame for the plot
-/// @param table Table to plot
-- (instancetype)initWithFrame:(CGRect)frame table:(AKTable *)table;
+/// Defaults to 0.9
+@property IBInspectable float scalingFactor;
 
-@property (nonatomic) AKTable *table;
+@property (nonatomic, nullable) AKTable *table;
 
 @end

--- a/Examples/iOS/TableDemo/TableDemo/Base.lproj/Main.storyboard
+++ b/Examples/iOS/TableDemo/TableDemo/Base.lproj/Main.storyboard
@@ -107,6 +107,7 @@
                         </variation>
                     </view>
                     <connections>
+                        <outlet property="choices" destination="bVa-Tg-hHm" id="IKI-zw-O9L"/>
                         <outlet property="frequencyLabel" destination="4jf-qj-tXT" id="t6x-97-Cem"/>
                         <outlet property="frequencySlider" destination="p3U-SY-cI4" id="A3H-nJ-M3m"/>
                         <outlet property="tablePlot" destination="4s8-0W-pAB" id="wJM-p8-Odc"/>

--- a/Examples/iOS/TableDemo/TableDemo/ViewController.m
+++ b/Examples/iOS/TableDemo/TableDemo/ViewController.m
@@ -15,6 +15,7 @@
     OscillatorInstrument *oscillatorInstrument;
     NSArray *waveforms;
     BOOL isPlaying;
+    IBOutlet UISegmentedControl *choices;
     IBOutlet AKTablePlot *tablePlot;
     IBOutlet AKPropertyLabel *frequencyLabel;
     IBOutlet AKPropertySlider *frequencySlider;
@@ -40,7 +41,9 @@
                   [AKTable standardSineWave],
                   playableSquare,
                   [AKTable standardTriangleWave]];
-    tablePlot.table = waveforms[1];
+
+    choices.selectedSegmentIndex = 1; // Sine wave by default
+    [self changeWaveform:choices];
     
     frequencyLabel.property  = oscillatorInstrument.frequency;
     frequencySlider.property = oscillatorInstrument.frequency;
@@ -60,7 +63,7 @@
 
 - (IBAction)changeWaveform:(UISegmentedControl *)sender
 {
-    NSUInteger index = [sender selectedSegmentIndex];
+    NSUInteger index = sender.selectedSegmentIndex;
     oscillatorInstrument.oscillator.waveform = waveforms[index];
     tablePlot.table = waveforms[index];
     [AKOrchestra updateInstrument:oscillatorInstrument];


### PR DESCRIPTION
* Expose the `float` values straight from `AKTable` to make it easier to integrate with other classes like `AKTablePlot`, and remove some boilerplate and direct Csound API access there.
* Also added a method to look up a single value from the table.
* Fixed a possible memory leak in `AKTablePlot`
* Exposed `scalingFactor` as an inspectable property for the plot
* In the table demo, initialize the segmented control properly and leave the handler to take care of the table setup.

Only weird thing I've noticed is that for some reason the first table plot to load seems to display incorrectly, not sure what may be the cause of this. Works just fine when switching table types back and forth.
