### PR TITLE
Rolling plots improvements

### DIFF
--- a/AudioKit/Utilities/Plots/AKPlotView.m
+++ b/AudioKit/Utilities/Plots/AKPlotView.m
@@ -37,6 +37,8 @@
 #endif
 
 - (void)updateUI {
+    if (self.hidden || self.alpha == 0.0f)
+        return;
 #if TARGET_OS_IPHONE
     [self setNeedsDisplay];
 #elif TARGET_OS_MAC

--- a/AudioKit/Utilities/Plots/AKPlotView.m
+++ b/AudioKit/Utilities/Plots/AKPlotView.m
@@ -37,12 +37,14 @@
 #endif
 
 - (void)updateUI {
-    if (self.hidden || self.alpha == 0.0f)
+    if (self.hidden)
         return;
 #if TARGET_OS_IPHONE
-    [self setNeedsDisplay];
+    if (self.alpha > 0.0f)
+        [self setNeedsDisplay];
 #elif TARGET_OS_MAC
-    [self setNeedsDisplay:YES];
+    if (self.alphaValue > 0.0f)
+        [self setNeedsDisplay:YES];
 #endif
 }
 

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudio.h
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudio.h
@@ -195,7 +195,7 @@
  @param 	bufferSize 	The size of the float buffer
  @return	The root mean squared of the buffer
  */
-+(float)RMS:(MYFLT*)buffer
++(float)RMS:(const MYFLT*)buffer
      length:(int)bufferSize;
 
 /**
@@ -229,7 +229,7 @@
 +(void)updateScrollHistory:(float**)scrollHistory
                 withLength:(int)scrollHistoryLength
                    atIndex:(int*)index
-                withBuffer:(MYFLT*)buffer
+                withBuffer:(const MYFLT*)buffer
             withBufferSize:(int)bufferSize
       isResolutionChanging:(BOOL*)isChanging;
 

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudio.m
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudio.m
@@ -292,7 +292,7 @@
     return rightMin + (valueScaled * rightSpan);
 }
 
-+(float)RMS:(MYFLT *)buffer
++(float)RMS:(const MYFLT *)buffer
      length:(int)bufferSize {
     float sum = 0.0;
     for(int i = 0; i < bufferSize; i++)
@@ -309,7 +309,7 @@
 +(void)updateScrollHistory:(float **)scrollHistory
                 withLength:(int)scrollHistoryLength
                    atIndex:(int*)index
-                withBuffer:(MYFLT *)buffer
+                withBuffer:(const MYFLT *)buffer
             withBufferSize:(int)bufferSize
       isResolutionChanging:(BOOL*)isChanging {
     

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.h
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioPlot.h
@@ -75,7 +75,7 @@ IB_DESIGNABLE
  @param data   <#theplotData description#>
  @param length <#length description#>
  */
--(void)setSampleData:(float *)data
+-(void)setSampleData:(const float *)data
               length:(int)length;
 
 
@@ -106,6 +106,11 @@ IB_DESIGNABLE
 @property (nonatomic,assign,setter=setShouldFill:) IBInspectable BOOL shouldFill;
 
 /**
+ Minimum time between updates of the plot, in seconds (or fractions thereof).
+ */
+@property (nonatomic) IBInspectable float updateInterval;
+
+/**
  A boolean indicating whether the graph should be rotated along the x-axis to give a mirrored reflection. This is typical for audio plots to produce the classic waveform look. A value of YES will produce a mirrored reflection of the y-values about the x-axis, while a value of NO will only plot the y-values.
  */
 @property (nonatomic,assign,setter=setShouldMirror:) IBInspectable BOOL shouldMirror;
@@ -121,6 +126,6 @@ IB_DESIGNABLE
  @param bufferSize The size of the float array that will be mapped to the y-axis.
  @warning The bufferSize is expected to be the same, constant value once initial triggered. For plots using OpenGL a vertex buffer object will be allocated with a maximum buffersize of (2 * the initial given buffer size) to account for any interpolation necessary for filling in the graph. Updates use the glBufferSubData(...) function, which will crash if the buffersize exceeds the initial maximum allocated size.
  */
--(void)updateBuffer:(MYFLT *)buffer
+-(void)updateBuffer:(const MYFLT *)buffer
      withBufferSize:(UInt32)bufferSize;
 @end

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib\n    fi\ndone\n";
+			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib || true\n    fi\ndone\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/iOS/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
+++ b/Examples/iOS/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib\n    fi\ndone\n";
+			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib || true\n    fi\ndone\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -330,7 +330,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib\n    fi\ndone\n";
+			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib || true\n    fi\ndone\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/iOS/Swift/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
+++ b/Examples/iOS/Swift/HelloWorld/HelloWorld.xcodeproj/project.pbxproj
@@ -266,7 +266,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib\n    fi\ndone\n";
+			shellScript = "for lib in CsoundLib libsndfile; do\n    install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH\n    if ! test \"$CURRENT_ARCH\" = x86_64 -o \"$CURRENT_ARCH\" = i386; then\n        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib || true\n    fi\ndone\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/INSTALL-iOS.md
+++ b/INSTALL-iOS.md
@@ -39,7 +39,7 @@ Remember: *your entire application is now bound by the terms of the [GNU LGPL li
 for lib in CsoundLib libsndfile; do
     install_name_tool -change $lib @rpath/$lib.framework/$lib $TARGET_BUILD_DIR/$EXECUTABLE_PATH
     if ! test "$CURRENT_ARCH" = x86_64 -o "$CURRENT_ARCH" = i386; then
-        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib
+        lipo -remove i386 -remove x86_64 $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib -output $CODESIGNING_FOLDER_PATH/Frameworks/$lib.framework/$lib || true
     fi
 done
 ```


### PR DESCRIPTION
I'm trying to improve on the CPU usage for the rolling plots and made a number of improvements, though it's not perfect yet:

* Fixed a bug with closing the paths in EZPlot, and made it a little more memory efficient, and no longer needing write access to the data buffers being passed to it.
* Trigger all drawing directly from the Csound callbacks, which actually makes for a faster scrolling plot and saves having to manage locks.
* Allow to specify an inspectable property to set the refresh rate for these plots, in an effort to gain control over how often the `drawRect:` method gets called.
* Also another little tweak to the iOS run script.

I think it's obvious that the EZPlot drawing code is woefully inefficient as is - it tries to draw a lot more line segments that are really needed (one for each sample in the buffer, two if you include the mirrors). So that takes a lot of CPU to do very little visible to the user. I'll try to improve on this tomorrow...
