### PR TITLE
Allow audio input to be turned on/off at any moment, expose AKSettings

### DIFF
--- a/AudioKit/Core Classes/AKFoundation.h
+++ b/AudioKit/Core Classes/AKFoundation.h
@@ -15,6 +15,7 @@
 #import "AKCompatibility.h"
 
 # pragma mark - Core Classes
+#import "AKSettings.h"
 #import "AKManager.h"
 #import "AKOrchestra.h"
 

--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -239,12 +239,12 @@ static AKManager *_sharedManager = nil;
 
 /// Enable Audio Input
 - (void)enableAudioInput {
-    [self.engine setUseAudioInput:YES];
+    AKSettings.settings.audioInputEnabled = YES;
 }
 
 /// Disable AudioInput
 - (void)disableAudioInput {
-    [self.engine setUseAudioInput:NO];
+    AKSettings.settings.audioInputEnabled = NO;
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -106,7 +106,7 @@ static AKManager *_sharedManager = nil;
         _engine.messageDelegate = self;
         
         _isRunning = NO;
-        _isLogging = AKSettings.settings.loggingEnabled;
+        _isLogging = AKSettings.shared.loggingEnabled;
 #ifdef TRAVIS_CI
         _testLog = [NSMutableArray array];
 #endif
@@ -122,7 +122,7 @@ static AKManager *_sharedManager = nil;
                     "--expression-opt ; Enable expression optimizations\n"
                     "-m0              ; Print raw amplitudes\n"
                     "-i %@            ; Request sound from the host audio input device",
-                    AKSettings.settings.audioOutput, AKSettings.settings.audioInput];
+                    AKSettings.shared.audioOutput, AKSettings.shared.audioInput];
         
         _csdFile = [NSString stringWithFormat:@"%@/AudioKit-%@.csd", NSTemporaryDirectory(), @(getpid())];
         _midi = [[AKMidi alloc] init];
@@ -239,12 +239,12 @@ static AKManager *_sharedManager = nil;
 
 /// Enable Audio Input
 - (void)enableAudioInput {
-    AKSettings.settings.audioInputEnabled = YES;
+    AKSettings.shared.audioInputEnabled = YES;
 }
 
 /// Disable AudioInput
 - (void)disableAudioInput {
-    AKSettings.settings.audioInputEnabled = NO;
+    AKSettings.shared.audioInputEnabled = NO;
 }
 
 // -----------------------------------------------------------------------------
@@ -350,7 +350,7 @@ static AKManager *_sharedManager = nil;
 #endif
     
     if (_isLogging) {
-        if (AKSettings.settings.messagesEnabled) {
+        if (AKSettings.shared.messagesEnabled) {
             NSLog(@"Csound(%d): %@", attr, msg);
         } else {
             NSLog(@"%@", msg);

--- a/AudioKit/Core Classes/AKOrchestra.m
+++ b/AudioKit/Core Classes/AKOrchestra.m
@@ -32,10 +32,10 @@
         _userDefinedOperations = [[NSMutableSet alloc] init];
         
         // Default Values (for tests that don't load the AudioKit.plist)
-        _sampleRate = AKSettings.settings.sampleRate;
-        _samplesPerControlPeriod = AKSettings.settings.samplesPerControlPeriod;
-        _numberOfChannels = AKSettings.settings.numberOfChannels;
-        _zeroDBFullScaleValue = AKSettings.settings.zeroDBFullScaleValue;
+        _sampleRate = AKSettings.shared.sampleRate;
+        _samplesPerControlPeriod = AKSettings.shared.samplesPerControlPeriod;
+        _numberOfChannels = AKSettings.shared.numberOfChannels;
+        _zeroDBFullScaleValue = AKSettings.shared.zeroDBFullScaleValue;
         
         _udoFiles = [[NSMutableSet alloc] init];
         _csound = [[AKManager sharedManager] engine];
@@ -50,12 +50,6 @@
 + (void)start
 {
     if (![[AKManager sharedManager] isRunning]) {
-        if (AKSettings.settings.audioInputEnabled) {
-            [[AKManager sharedManager] enableAudioInput];
-        }else{
-            [[AKManager sharedManager] disableAudioInput];
-        }
-        
         [[AKManager sharedManager] runOrchestra];
     }
 }

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -16,11 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (AKSettings *)settings;
 
-@property (nonatomic, readonly) NSString *audioInput, *audioOutput;
-@property (nonatomic, readonly) UInt32 sampleRate, samplesPerControlPeriod;
-@property (nonatomic, readonly) UInt16 numberOfChannels;
-@property (nonatomic, readonly) float zeroDBFullScaleValue;
-@property (nonatomic, readonly) BOOL loggingEnabled, audioInputEnabled, messagesEnabled;
+@property (nonatomic) NSString *audioInput, *audioOutput;
+@property (nonatomic) UInt32 sampleRate, samplesPerControlPeriod;
+@property (nonatomic) UInt16 numberOfChannels;
+@property (nonatomic) float  zeroDBFullScaleValue;
+@property (nonatomic) BOOL   loggingEnabled, messagesEnabled;
+@property (nonatomic) BOOL   audioInputEnabled, playbackWhileMuted;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -16,12 +16,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (AKSettings *)settings;
 
-@property (nonatomic) NSString *audioInput, *audioOutput;
-@property (nonatomic) UInt32 sampleRate, samplesPerControlPeriod;
-@property (nonatomic) UInt16 numberOfChannels;
-@property (nonatomic) float  zeroDBFullScaleValue;
-@property (nonatomic) BOOL   loggingEnabled, messagesEnabled;
-@property (nonatomic) BOOL   audioInputEnabled, playbackWhileMuted;
+// The following properties can only be changed from the plist
+@property (nonatomic,readonly) NSString *audioInput, *audioOutput;
+@property (nonatomic,readonly) UInt32 sampleRate, samplesPerControlPeriod;
+@property (nonatomic,readonly) UInt16 numberOfChannels;
+@property (nonatomic,readonly) float  zeroDBFullScaleValue;
+
+// The following properties can be changed dynamically after AudioKit has been initalized
+@property (nonatomic) BOOL loggingEnabled, messagesEnabled;
+@property (nonatomic) BOOL audioInputEnabled, playbackWhileMuted;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -14,7 +14,8 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKSettings : NSObject
 
-+ (AKSettings *)settings;
+/// Global singleton
++ (AKSettings *)shared;
 
 // The following properties can only be changed from the plist
 @property (nonatomic,readonly) NSString *audioInput, *audioOutput;

--- a/AudioKit/Core Classes/AKSettings.m
+++ b/AudioKit/Core Classes/AKSettings.m
@@ -7,6 +7,7 @@
 //
 
 #import "AKSettings.h"
+#import "AKManager.h"
 
 @implementation AKSettings
 
@@ -34,7 +35,8 @@ static AKSettings *_settings = nil;
         _zeroDBFullScaleValue = 1.0;
         _loggingEnabled = NO;
         _messagesEnabled = NO;
-        _audioInputEnabled = YES;
+        _audioInputEnabled = NO;
+        _playbackWhileMuted = NO;
         
         // Try to load from AudioKit.plist if found
         NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
@@ -58,9 +60,29 @@ static AKSettings *_settings = nil;
                 _audioInputEnabled = [dict[@"Enable Audio Input By Default"] boolValue];
             if (dict[@"Prefix Csound Messages"])
                 _messagesEnabled = [dict[@"Prefix Csound Messages"] boolValue];
+            if (dict[@"Playback While Muted"])
+                _playbackWhileMuted = [dict[@"Playback While Muted"] boolValue];
         }
     }
     return self;
+}
+
+#pragma mark - Property setters that trigger some sort of action
+
+- (void)setAudioInputEnabled:(BOOL)audioInputEnabled
+{
+    if (audioInputEnabled != _audioInputEnabled) {
+        _audioInputEnabled = audioInputEnabled;
+        [AKManager sharedManager].engine.useAudioInput = audioInputEnabled;
+    }
+}
+
+- (void)setPlaybackWhileMuted:(BOOL)playbackWhileMuted
+{
+    if (playbackWhileMuted != _playbackWhileMuted) {
+        _playbackWhileMuted = playbackWhileMuted;
+        [[AKManager sharedManager].engine resetSession];
+    }
 }
 
 @end

--- a/AudioKit/Core Classes/AKSettings.m
+++ b/AudioKit/Core Classes/AKSettings.m
@@ -13,7 +13,7 @@
 
 static AKSettings *_settings = nil;
 
-+ (AKSettings *)settings
++ (AKSettings *)shared
 {
     @synchronized(self) {
         if (_settings == nil)

--- a/AudioKit/Core Classes/AKSettings.m
+++ b/AudioKit/Core Classes/AKSettings.m
@@ -73,7 +73,7 @@ static AKSettings *_settings = nil;
 {
     if (audioInputEnabled != _audioInputEnabled) {
         _audioInputEnabled = audioInputEnabled;
-        [AKManager sharedManager].engine.useAudioInput = audioInputEnabled;
+        [[AKManager sharedManager].engine resetSession];
     }
 }
 

--- a/AudioKit/Core Classes/AudioKit.plist
+++ b/AudioKit/Core Classes/AudioKit.plist
@@ -19,6 +19,8 @@
 	<key>Prefix Csound Messages</key>
 	<false/>
 	<key>Enable Audio Input By Default</key>
-	<true/>
+	<false/>
+	<key>Playback While Muted</key>
+	<false/>
 </dict>
 </plist>

--- a/AudioKit/Platforms/Common/CsoundObj.h
+++ b/AudioKit/Platforms/Common/CsoundObj.h
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSURL *outputURL;
 @property (assign) BOOL midiInEnabled;
-@property (assign) BOOL useAudioInput;
+@property (nonatomic, assign) BOOL useAudioInput;
 
 - (void)sendScore:(NSString *)score;
 
@@ -136,6 +136,9 @@ NS_ASSUME_NONNULL_BEGIN
 // Writable alternatives
 - (NSMutableData *)getMutableInSamples;
 - (NSMutableData *)getMutableOutSamples;
+
+// Reset the audio session, i.e. if we change audio I/O options
+- (void)resetSession;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AudioKit/Platforms/Common/CsoundObj.h
+++ b/AudioKit/Platforms/Common/CsoundObj.h
@@ -76,7 +76,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSURL *outputURL;
 @property (assign) BOOL midiInEnabled;
-@property (nonatomic, assign) BOOL useAudioInput;
 
 - (void)sendScore:(NSString *)score;
 

--- a/AudioKit/Platforms/Common/CsoundObj.m
+++ b/AudioKit/Platforms/Common/CsoundObj.m
@@ -76,7 +76,6 @@ OSStatus  Csound_Render(void *inRefCon,
         _bindings  = [[NSMutableArray alloc] init];
         _listeners = [[NSMutableArray alloc] init];
         _midiInEnabled = NO;
-        _useAudioInput = AKSettings.settings.audioInputEnabled;
     }
     
     return self;
@@ -457,7 +456,7 @@ OSStatus  Csound_Render(void *inRefCon,
 #if TARGET_OS_IPHONE
     for(frame=0;frame < inNumberFrames;frame++){
         @autoreleasepool {
-            if(obj.useAudioInput) {
+            if(AKSettings.settings.audioInputEnabled) {
                 for (k = 0; k < nchnls; k++){
                     buffer = (SInt32 *) ioData->mBuffers[k].mData;
                     spin[insmps++] =(1./coef)*buffer[frame];
@@ -503,7 +502,7 @@ OSStatus  Csound_Render(void *inRefCon,
             }
             
             /* performance */
-            if(obj.useAudioInput) {
+            if(AKSettings.settings.audioInputEnabled) {
                 for (k = 0; k < nchnls; k++){
                     buffer = (Float32 *) ioData->mBuffers[k].mData;
                     for(j=0; j < ksmps; j++){
@@ -674,7 +673,7 @@ OSStatus  Csound_Render(void *inRefCon,
                                      0,
                                      &enableIO,
                                      sizeof(enableIO));
-                if (self.useAudioInput) {
+                if (AKSettings.settings.audioInputEnabled) {
                     AudioUnitSetProperty(csAUHAL,
                                          kAudioOutputUnitProperty_EnableIO,
                                          kAudioUnitScope_Input,
@@ -687,7 +686,7 @@ OSStatus  Csound_Render(void *inRefCon,
                     UInt32 maxFPS;
                     UInt32 outsize;
                     int elem;
-                    for(elem = self.useAudioInput ? 1 : 0; elem >= 0; elem--){
+                    for(elem = AKSettings.settings.audioInputEnabled ? 1 : 0; elem >= 0; elem--){
                         outsize = sizeof(maxFPS);
                         AudioUnitGetProperty(csAUHAL,
                                              kAudioUnitProperty_MaximumFramesPerSlice,
@@ -882,14 +881,6 @@ OSStatus  Csound_Render(void *inRefCon,
         }
     }
 }
-
-- (void)setUseAudioInput:(BOOL)useAudioInput
-{
-    if (useAudioInput != _useAudioInput) {
-        _useAudioInput = useAudioInput;
-        [self resetSession];
-    }
-}
 #endif
 
 - (void)resetSession
@@ -898,7 +889,7 @@ OSStatus  Csound_Render(void *inRefCon,
     NSError *error;
     BOOL success;
     
-    if (self.useAudioInput) {
+    if (AKSettings.settings.audioInputEnabled) {
         success = [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord
                                                    withOptions:(AVAudioSessionCategoryOptionMixWithOthers |
                                                                 AVAudioSessionCategoryOptionDefaultToSpeaker)

--- a/AudioKit/Platforms/Common/CsoundObj.m
+++ b/AudioKit/Platforms/Common/CsoundObj.m
@@ -452,7 +452,7 @@ OSStatus  Csound_Render(void *inRefCon,
         AudioUnitRender(obj->_csAUHAL, ioActionFlags, inTimeStamp, 1, inNumberFrames, ioData);
         for(frame=0; frame < inNumberFrames; frame++){
             @autoreleasepool {
-                if(AKSettings.settings.audioInputEnabled) {
+                if(AKSettings.shared.audioInputEnabled) {
                     for (k = 0; k < nchnls; k++){
                         buffer = (SInt32 *) ioData->mBuffers[k].mData;
                         spin[insmps++] =(1./coef)*buffer[frame];
@@ -498,7 +498,7 @@ OSStatus  Csound_Render(void *inRefCon,
                 }
                 
                 /* performance */
-                if(AKSettings.settings.audioInputEnabled) {
+                if(AKSettings.shared.audioInputEnabled) {
                     for (k = 0; k < nchnls; k++){
                         buffer = (Float32 *) ioData->mBuffers[k].mData;
                         for(j=0; j < ksmps; j++){
@@ -894,12 +894,12 @@ OSStatus  Csound_Render(void *inRefCon,
         BOOL success;
 
         AVAudioSession *session = [AVAudioSession sharedInstance];
-        if (AKSettings.settings.audioInputEnabled) {
+        if (AKSettings.shared.audioInputEnabled) {
             success = [session setCategory:AVAudioSessionCategoryPlayAndRecord
                                withOptions:(AVAudioSessionCategoryOptionMixWithOthers |
                                             AVAudioSessionCategoryOptionDefaultToSpeaker)
                                      error:&error];
-        } else if (AKSettings.settings.playbackWhileMuted) {
+        } else if (AKSettings.shared.playbackWhileMuted) {
             success = [session setCategory:AVAudioSessionCategoryPlayback
                                withOptions:(AVAudioSessionCategoryOptionMixWithOthers |
                                             AVAudioSessionCategoryOptionDefaultToSpeaker)
@@ -944,7 +944,7 @@ OSStatus  Csound_Render(void *inRefCon,
             
             if (wasRunning)
                 [self stopAU:NO];
-            UInt32 enableInput = AKSettings.settings.audioInputEnabled;
+            UInt32 enableInput = AKSettings.shared.audioInputEnabled;
             if (AudioUnitSetProperty(_csAUHAL,
                                      kAudioOutputUnitProperty_EnableIO,
                                      kAudioUnitScope_Input,

--- a/AudioKit/Platforms/Common/CsoundObj.m
+++ b/AudioKit/Platforms/Common/CsoundObj.m
@@ -733,7 +733,8 @@ OSStatus  Csound_Render(void *inRefCon,
         
         while (!_ret && self.running) {
             @autoreleasepool {
-                [self updateAllValuesToCsound];
+                if (self.running)
+                    [self updateAllValuesToCsound];
                 
                 _ret = csoundPerformKsmps(_cs);
                 
@@ -749,7 +750,8 @@ OSStatus  Csound_Render(void *inRefCon,
                     }
                     
                 }
-                [self updateAllValuesFromCsound];
+                if (self.running)
+                    [self updateAllValuesFromCsound];
             }
         }
         

--- a/AudioKit/Utilities/Plots/AKAudioFFTPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioFFTPlot.m
@@ -161,7 +161,7 @@
 {
     _cs = csoundObj;
     
-    _sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
+    _sampleSize = AKSettings.shared.numberOfChannels * AKSettings.shared.samplesPerControlPeriod;
     
     void *samples = malloc(_sampleSize * sizeof(float));
     bzero(samples, _sampleSize * sizeof(float));

--- a/AudioKit/Utilities/Plots/AKAudioPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioPlot.m
@@ -77,7 +77,7 @@
 {
     _cs = csoundObj;
     
-    _sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
+    _sampleSize = AKSettings.shared.numberOfChannels * AKSettings.shared.samplesPerControlPeriod;
     
     void *samples = malloc(_sampleSize * sizeof(float));
     bzero(samples, _sampleSize * sizeof(float));

--- a/AudioKit/Utilities/Plots/AKAudioRollingWaveformPlot.m
+++ b/AudioKit/Utilities/Plots/AKAudioRollingWaveformPlot.m
@@ -45,7 +45,7 @@
 {
     _cs = csoundObj;
     
-    _sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
+    _sampleSize = AKSettings.shared.numberOfChannels * AKSettings.shared.samplesPerControlPeriod;
 }
 
 - (void)updateValuesFromCsound

--- a/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
+++ b/AudioKit/Utilities/Plots/AKStereoOutputPlot.m
@@ -84,7 +84,7 @@
 {
     cs = csoundObj;
 
-    sampleSize = AKSettings.settings.numberOfChannels * AKSettings.settings.samplesPerControlPeriod;
+    sampleSize = AKSettings.shared.numberOfChannels * AKSettings.shared.samplesPerControlPeriod;
     
     void *samples = malloc(sampleSize * sizeof(float));
     bzero(samples, sampleSize * sizeof(float));

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
@@ -34,6 +34,8 @@
     noteNamesWithSharps = @[@"C", @"C♯",@"D",@"D♯",@"E",@"F",@"F♯",@"G",@"G♯",@"A",@"A♯",@"B"];
     noteNamesWithFlats  = @[@"C", @"D♭",@"D",@"E♭",@"E",@"F",@"G♭",@"G",@"A♭",@"A",@"B♭",@"B"];
     
+    AKSettings.shared.audioInputEnabled = YES;
+    
     microphone = [[Microphone alloc] init];
     [AKOrchestra addInstrument:microphone];
     analyzer = [[AKAudioAnalyzer alloc] initWithAudioSource:microphone.auxilliaryOutput];

--- a/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/AnalysisViewController.swift
+++ b/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/AnalysisViewController.swift
@@ -26,6 +26,8 @@ class AnalysisViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        AKSettings.shared().audioInputEnabled = true
+        
         analyzer = AKAudioAnalyzer(audioSource: microphone.auxilliaryOutput)
 
         AKOrchestra.addInstrument(microphone)

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
@@ -37,7 +37,7 @@
     noteNamesWithSharps = @[@"C", @"C♯",@"D",@"D♯",@"E",@"F",@"F♯",@"G",@"G♯",@"A",@"A♯",@"B"];
     noteNamesWithFlats  = @[@"C", @"D♭",@"D",@"E♭",@"E",@"F",@"G♭",@"G",@"A♭",@"A",@"B♭",@"B"];
     
-    AKSettings.settings.audioInputEnabled = YES;
+    AKSettings.shared.audioInputEnabled = YES;
 
     microphone = [[Microphone alloc] init];
     [AKOrchestra addInstrument:microphone];

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
@@ -37,6 +37,8 @@
     noteNamesWithSharps = @[@"C", @"C♯",@"D",@"D♯",@"E",@"F",@"F♯",@"G",@"G♯",@"A",@"A♯",@"B"];
     noteNamesWithFlats  = @[@"C", @"D♭",@"D",@"E♭",@"E",@"F",@"G♭",@"G",@"A♭",@"A",@"B♭",@"B"];
     
+    AKSettings.settings.audioInputEnabled = YES;
+
     microphone = [[Microphone alloc] init];
     [AKOrchestra addInstrument:microphone];
     analyzer = [[AKAudioAnalyzer alloc] initWithAudioSource:microphone.auxilliaryOutput];

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.swift
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.swift
@@ -30,6 +30,8 @@ class AnalysisViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        AKSettings.shared().audioInputEnabled = true
+        
         analyzer = AKAudioAnalyzer(audioSource: microphone.auxilliaryOutput)
 
         AKOrchestra.addInstrument(microphone)


### PR DESCRIPTION
This one is focused on being able to turn on audio input at will during the lifetime of the app, i.e. not just when AudioKit is first initialized.

If only playback is enabled, then we use the more permissive `AVAudioSessionCategoryAmbient` category on iOS, to allow things such as the silent switch to be honored. The old behavior can be restored using the new setting "Playback While Muted", for apps that may require that.

As a side effect, I have changed the input setting to be OFF by default (as opposed to ON before), in the plist and the AKSettings defaults. To make this easier on the user, `AKSettings` is now part of AKFoundation and several of its properties are writable, including `audioInputEnabled`. This one must now be set explicitly in the programs (see what I did in `AudioKitDemo` where this is called only when first going to the analysis tab), or in the plist.

Note that this mostly affects iOS, even though the API is available on Mac too, where input is pretty much always available. The main advantage is avoiding the dreaded permissions dialog on iOS if not necessary.

Other changes:
* More cleanups in `CsoundObj.m`, including getting rid of duplicate or unused properties and methods
* The singleton for `AKSettings` is now accessed through a `shared` method (instead of the old `settings`) as it caused issues with Swift thinking it was actually a convenience constructor.
* Enabling/disabling of audio input is now mostly done through `AKSettings`, so `AKOrchestra` doesn't need to worry about that anymore.

I've updated all flavors of `AudioKitDemo` but any other examples you may have in the Examples repo might need to have audio input explicitly turned on if they need it.