### PR TITLE
Adding AK prefix to a bunch of classes

### DIFF
--- a/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit.xcodeproj/project.pbxproj
@@ -14,10 +14,10 @@
 		C4C8125B1AE5CA03003A8B73 /* Sekere.h in Headers */ = {isa = PBXBuildFile; fileRef = C4C812591AE5CA03003A8B73 /* Sekere.h */; };
 		C4C8125C1AE5CA03003A8B73 /* Sekere.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* Sekere.m */; };
 		C4C8125D1AE5CA03003A8B73 /* Sekere.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* Sekere.m */; };
-		C4FAE5F11AED6B2600FD71E2 /* AudioFilePlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = C4FAE5EF1AED6B2600FD71E2 /* AudioFilePlayer.h */; };
-		C4FAE5F21AED6B2600FD71E2 /* AudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AudioFilePlayer.m */; };
-		C4FAE5F31AED6B2600FD71E2 /* AudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AudioFilePlayer.m */; };
-		C4FAE5F41AED6B2600FD71E2 /* AudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AudioFilePlayer.m */; };
+		C4FAE5F11AED6B2600FD71E2 /* AKAudioFilePlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = C4FAE5EF1AED6B2600FD71E2 /* AKAudioFilePlayer.h */; };
+		C4FAE5F21AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */; };
+		C4FAE5F31AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */; };
+		C4FAE5F41AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */; };
 		EA08B5701AD8985F00949FD5 /* CsoundObj.m in Sources */ = {isa = PBXBuildFile; fileRef = EA08B56E1AD8985F00949FD5 /* CsoundObj.m */; };
 		EA08B5711AD8985F00949FD5 /* CsoundObj.m in Sources */ = {isa = PBXBuildFile; fileRef = EA08B56E1AD8985F00949FD5 /* CsoundObj.m */; };
 		EA321D1D1AEDCA5300DCCABD /* AKAudioFFTPlot.h in Headers */ = {isa = PBXBuildFile; fileRef = EA321D1B1AEDCA5300DCCABD /* AKAudioFFTPlot.h */; };
@@ -43,8 +43,8 @@
 		EA8E95B01AD3C6850057E979 /* AKStereoAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E940E1AD3C6840057E979 /* AKStereoAudio.m */; };
 		EA8E95B11AD3C6850057E979 /* AKSampler.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94111AD3C6840057E979 /* AKSampler.m */; };
 		EA8E95B21AD3C6850057E979 /* AKTools.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94131AD3C6840057E979 /* AKTools.m */; };
-		EA8E95B31AD3C6850057E979 /* Amplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* Amplifier.m */; };
-		EA8E95B41AD3C6850057E979 /* StereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* StereoAmplifier.m */; };
+		EA8E95B31AD3C6850057E979 /* AKAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* AKAmplifier.m */; };
+		EA8E95B41AD3C6850057E979 /* AKStereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */; };
 		EA8E95B51AD3C6850057E979 /* AKAudioAnalyzer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941C1AD3C6840057E979 /* AKAudioAnalyzer.m */; };
 		EA8E95B61AD3C6850057E979 /* BambooSticks.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* BambooSticks.m */; };
 		EA8E95B71AD3C6850057E979 /* Mandolin.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* Mandolin.m */; };
@@ -55,10 +55,10 @@
 		EA8E95BC1AD3C6850057E979 /* StruckMetalBar.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* StruckMetalBar.m */; };
 		EA8E95BD1AD3C6850057E979 /* Tambourine.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* Tambourine.m */; };
 		EA8E95BE1AD3C6850057E979 /* Vibraphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* Vibraphone.m */; };
-		EA8E95BF1AD3C6850057E979 /* Microphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* Microphone.m */; };
-		EA8E95C01AD3C6850057E979 /* ReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* ReverbProcessor.m */; };
-		EA8E95C11AD3C6850057E979 /* FMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* FMOscillatorInstrument.m */; };
-		EA8E95C21AD3C6850057E979 /* VCOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943A1AD3C6840057E979 /* VCOscillatorInstrument.m */; };
+		EA8E95BF1AD3C6850057E979 /* AKMicrophone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* AKMicrophone.m */; };
+		EA8E95C01AD3C6850057E979 /* AKReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* AKReverbProcessor.m */; };
+		EA8E95C11AD3C6850057E979 /* AKFMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* AKFMOscillatorInstrument.m */; };
+		EA8E95C21AD3C6850057E979 /* AKVCOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943A1AD3C6840057E979 /* AKVCOscillatorInstrument.m */; };
 		EA8E95C31AD3C6850057E979 /* AKAudioInputFFTPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943D1AD3C6840057E979 /* AKAudioInputFFTPlot.m */; };
 		EA8E95C41AD3C6850057E979 /* AKAudioInputPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943F1AD3C6840057E979 /* AKAudioInputPlot.m */; };
 		EA8E95C51AD3C6850057E979 /* AKAudioInputRollingWaveformPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94411AD3C6840057E979 /* AKAudioInputRollingWaveformPlot.m */; };
@@ -212,8 +212,8 @@
 		EA8E967A1AD3C8790057E979 /* AKStereoAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E940E1AD3C6840057E979 /* AKStereoAudio.m */; };
 		EA8E967B1AD3C8810057E979 /* AKSampler.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94111AD3C6840057E979 /* AKSampler.m */; };
 		EA8E967C1AD3C8810057E979 /* AKTools.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94131AD3C6840057E979 /* AKTools.m */; };
-		EA8E967D1AD3C88A0057E979 /* Amplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* Amplifier.m */; };
-		EA8E967E1AD3C88A0057E979 /* StereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* StereoAmplifier.m */; };
+		EA8E967D1AD3C88A0057E979 /* AKAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* AKAmplifier.m */; };
+		EA8E967E1AD3C88A0057E979 /* AKStereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */; };
 		EA8E967F1AD3C89F0057E979 /* AKAudioAnalyzer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941C1AD3C6840057E979 /* AKAudioAnalyzer.m */; };
 		EA8E96801AD3C89F0057E979 /* BambooSticks.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* BambooSticks.m */; };
 		EA8E96811AD3C89F0057E979 /* Mandolin.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* Mandolin.m */; };
@@ -224,10 +224,10 @@
 		EA8E96861AD3C89F0057E979 /* StruckMetalBar.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* StruckMetalBar.m */; };
 		EA8E96871AD3C89F0057E979 /* Tambourine.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* Tambourine.m */; };
 		EA8E96881AD3C89F0057E979 /* Vibraphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* Vibraphone.m */; };
-		EA8E96891AD3C9090057E979 /* Microphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* Microphone.m */; };
-		EA8E968A1AD3C9090057E979 /* ReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* ReverbProcessor.m */; };
-		EA8E968B1AD3C9090057E979 /* FMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* FMOscillatorInstrument.m */; };
-		EA8E968C1AD3C9090057E979 /* VCOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943A1AD3C6840057E979 /* VCOscillatorInstrument.m */; };
+		EA8E96891AD3C9090057E979 /* AKMicrophone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* AKMicrophone.m */; };
+		EA8E968A1AD3C9090057E979 /* AKReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* AKReverbProcessor.m */; };
+		EA8E968B1AD3C9090057E979 /* AKFMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* AKFMOscillatorInstrument.m */; };
+		EA8E968C1AD3C9090057E979 /* AKVCOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943A1AD3C6840057E979 /* AKVCOscillatorInstrument.m */; };
 		EA8E968D1AD3C92B0057E979 /* AKAudioInputFFTPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943D1AD3C6840057E979 /* AKAudioInputFFTPlot.m */; };
 		EA8E968E1AD3C92B0057E979 /* AKAudioInputPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943F1AD3C6840057E979 /* AKAudioInputPlot.m */; };
 		EA8E968F1AD3C92B0057E979 /* AKAudioInputRollingWaveformPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94411AD3C6840057E979 /* AKAudioInputRollingWaveformPlot.m */; };
@@ -423,12 +423,12 @@
 		EAA0F5171AE71C8F007CD7C9 /* AKDopplerEffect.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95351AD3C6840057E979 /* AKDopplerEffect.m */; };
 		EAA0F5181AE71C8F007CD7C9 /* AKSinusoidBursts.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94C31AD3C6840057E979 /* AKSinusoidBursts.m */; };
 		EAA0F5191AE71C8F007CD7C9 /* AKStick.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94F81AD3C6840057E979 /* AKStick.m */; };
-		EAA0F51A1AE71C8F007CD7C9 /* VCOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943A1AD3C6840057E979 /* VCOscillatorInstrument.m */; };
+		EAA0F51A1AE71C8F007CD7C9 /* AKVCOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943A1AD3C6840057E979 /* AKVCOscillatorInstrument.m */; };
 		EAA0F51B1AE71C8F007CD7C9 /* AKPhaseLockedVocoder.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94951AD3C6840057E979 /* AKPhaseLockedVocoder.m */; };
 		EAA0F51C1AE71C8F007CD7C9 /* AKResonantFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E954E1AD3C6840057E979 /* AKResonantFilter.m */; };
 		EAA0F51D1AE71C8F007CD7C9 /* AKCombFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E953A1AD3C6840057E979 /* AKCombFilter.m */; };
 		EAA0F51E1AE71C8F007CD7C9 /* AKDifference.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94A21AD3C6840057E979 /* AKDifference.m */; };
-		EAA0F51F1AE71C8F007CD7C9 /* FMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* FMOscillatorInstrument.m */; };
+		EAA0F51F1AE71C8F007CD7C9 /* AKFMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* AKFMOscillatorInstrument.m */; };
 		EAA0F5201AE71C8F007CD7C9 /* AKMoogVCF.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E954C1AD3C6840057E979 /* AKMoogVCF.m */; };
 		EAA0F5211AE71C8F007CD7C9 /* AKMandolin.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94DD1AD3C6840057E979 /* AKMandolin.m */; };
 		EAA0F5221AE71C8F007CD7C9 /* AKTrackedAmplitude.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94841AD3C6840057E979 /* AKTrackedAmplitude.m */; };
@@ -444,12 +444,12 @@
 		EAA0F52C1AE71C8F007CD7C9 /* AKScaledFFT.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94991AD3C6840057E979 /* AKScaledFFT.m */; };
 		EAA0F52D1AE71C8F007CD7C9 /* AKConstant.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94061AD3C6840057E979 /* AKConstant.m */; };
 		EAA0F52E1AE71C8F007CD7C9 /* AKAudioOutputRollingWaveformPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94471AD3C6840057E979 /* AKAudioOutputRollingWaveformPlot.m */; };
-		EAA0F52F1AE71C8F007CD7C9 /* Amplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* Amplifier.m */; };
+		EAA0F52F1AE71C8F007CD7C9 /* AKAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* AKAmplifier.m */; };
 		EAA0F5301AE71C8F007CD7C9 /* AKHighPassButterworthFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E955B1AD3C6840057E979 /* AKHighPassButterworthFilter.m */; };
 		EAA0F5311AE71C8F007CD7C9 /* AKSleighbells.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94F61AD3C6840057E979 /* AKSleighbells.m */; };
 		EAA0F5321AE71C8F007CD7C9 /* AKVCOscillator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94DA1AD3C6840057E979 /* AKVCOscillator.m */; };
 		EAA0F5331AE71C8F007CD7C9 /* AKBallWithinTheBoxReverb.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95601AD3C6840057E979 /* AKBallWithinTheBoxReverb.m */; };
-		EAA0F5341AE71C8F007CD7C9 /* ReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* ReverbProcessor.m */; };
+		EAA0F5341AE71C8F007CD7C9 /* AKReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* AKReverbProcessor.m */; };
 		EAA0F5351AE71C8F007CD7C9 /* AKSegmentArrayLoop.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95131AD3C6840057E979 /* AKSegmentArrayLoop.m */; };
 		EAA0F5361AE71C8F007CD7C9 /* AKCabasa.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94EA1AD3C6840057E979 /* AKCabasa.m */; };
 		EAA0F5371AE71C8F007CD7C9 /* AKFlute.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95031AD3C6840057E979 /* AKFlute.m */; };
@@ -508,7 +508,7 @@
 		EAA0F56C1AE71C8F007CD7C9 /* Vibraphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* Vibraphone.m */; };
 		EAA0F56D1AE71C8F007CD7C9 /* AKAudioInputPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943F1AD3C6840057E979 /* AKAudioInputPlot.m */; };
 		EAA0F56E1AE71C8F007CD7C9 /* AKCrossSynthesizedFFT.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E948D1AD3C6840057E979 /* AKCrossSynthesizedFFT.m */; };
-		EAA0F56F1AE71C8F007CD7C9 /* StereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* StereoAmplifier.m */; };
+		EAA0F56F1AE71C8F007CD7C9 /* AKStereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */; };
 		EAA0F5701AE71C8F007CD7C9 /* AKProduct.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94AC1AD3C6840057E979 /* AKProduct.m */; };
 		EAA0F5711AE71C8F007CD7C9 /* AKThreePoleLowpassFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95521AD3C6840057E979 /* AKThreePoleLowpassFilter.m */; };
 		EAA0F5721AE71C8F007CD7C9 /* AKDecimator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E953E1AD3C6840057E979 /* AKDecimator.m */; };
@@ -527,7 +527,7 @@
 		EAA0F57F1AE71C8F007CD7C9 /* AKBeatenPlate.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94FF1AD3C6840057E979 /* AKBeatenPlate.m */; };
 		EAA0F5801AE71C8F007CD7C9 /* AKVibrato.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94CF1AD3C6840057E979 /* AKVibrato.m */; };
 		EAA0F5811AE71C8F007CD7C9 /* AKStereoOutputPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94501AD3C6840057E979 /* AKStereoOutputPlot.m */; };
-		EAA0F5821AE71C8F007CD7C9 /* Microphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* Microphone.m */; };
+		EAA0F5821AE71C8F007CD7C9 /* AKMicrophone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* AKMicrophone.m */; };
 		EAA0F5831AE71C8F007CD7C9 /* AKOrchestra.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E93F71AD3C6840057E979 /* AKOrchestra.m */; };
 		EAA0F5841AE71C8F007CD7C9 /* AKFFT.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E948F1AD3C6840057E979 /* AKFFT.m */; };
 		EAA0F5851AE71C8F007CD7C9 /* AKCrunch.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94EC1AD3C6840057E979 /* AKCrunch.m */; };
@@ -572,8 +572,8 @@
 		C45552471ADF152F000C8D42 /* AKRingModulator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRingModulator.m; sourceTree = "<group>"; };
 		C4C812591AE5CA03003A8B73 /* Sekere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sekere.h; sourceTree = "<group>"; };
 		C4C8125A1AE5CA03003A8B73 /* Sekere.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Sekere.m; sourceTree = "<group>"; };
-		C4FAE5EF1AED6B2600FD71E2 /* AudioFilePlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioFilePlayer.h; sourceTree = "<group>"; };
-		C4FAE5F01AED6B2600FD71E2 /* AudioFilePlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AudioFilePlayer.m; sourceTree = "<group>"; };
+		C4FAE5EF1AED6B2600FD71E2 /* AKAudioFilePlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioFilePlayer.h; sourceTree = "<group>"; };
+		C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioFilePlayer.m; sourceTree = "<group>"; };
 		EA08B56D1AD8985F00949FD5 /* CsoundObj.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CsoundObj.h; sourceTree = "<group>"; };
 		EA08B56E1AD8985F00949FD5 /* CsoundObj.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CsoundObj.m; sourceTree = "<group>"; };
 		EA15CDF41AE356B500BA279F /* AKCompatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKCompatibility.h; sourceTree = "<group>"; };
@@ -589,7 +589,7 @@
 		EA8E93F51AD3C6840057E979 /* AKManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKManager.m; sourceTree = "<group>"; };
 		EA8E93F61AD3C6840057E979 /* AKOrchestra.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKOrchestra.h; sourceTree = "<group>"; };
 		EA8E93F71AD3C6840057E979 /* AKOrchestra.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKOrchestra.m; sourceTree = "<group>"; };
-		EA8E93F81AD3C6840057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = "AudioKit/Resources/AudioKit.plist"; sourceTree = SOURCE_ROOT; };
+		EA8E93F81AD3C6840057E979 /* AudioKit.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AudioKit.plist; path = AudioKit/Resources/AudioKit.plist; sourceTree = SOURCE_ROOT; };
 		EA8E93FA1AD3C6840057E979 /* AKMidi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKMidi.h; sourceTree = "<group>"; };
 		EA8E93FB1AD3C6840057E979 /* AKMidi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKMidi.m; sourceTree = "<group>"; };
 		EA8E93FC1AD3C6840057E979 /* AKMidiListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKMidiListener.h; sourceTree = "<group>"; };
@@ -613,10 +613,10 @@
 		EA8E94111AD3C6840057E979 /* AKSampler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSampler.m; sourceTree = "<group>"; };
 		EA8E94121AD3C6840057E979 /* AKTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKTools.h; sourceTree = "<group>"; };
 		EA8E94131AD3C6840057E979 /* AKTools.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKTools.m; sourceTree = "<group>"; };
-		EA8E94161AD3C6840057E979 /* Amplifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Amplifier.h; sourceTree = "<group>"; };
-		EA8E94171AD3C6840057E979 /* Amplifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Amplifier.m; sourceTree = "<group>"; };
-		EA8E94181AD3C6840057E979 /* StereoAmplifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StereoAmplifier.h; sourceTree = "<group>"; };
-		EA8E94191AD3C6840057E979 /* StereoAmplifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StereoAmplifier.m; sourceTree = "<group>"; };
+		EA8E94161AD3C6840057E979 /* AKAmplifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAmplifier.h; sourceTree = "<group>"; };
+		EA8E94171AD3C6840057E979 /* AKAmplifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAmplifier.m; sourceTree = "<group>"; };
+		EA8E94181AD3C6840057E979 /* AKStereoAmplifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKStereoAmplifier.h; sourceTree = "<group>"; };
+		EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKStereoAmplifier.m; sourceTree = "<group>"; };
 		EA8E941B1AD3C6840057E979 /* AKAudioAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioAnalyzer.h; sourceTree = "<group>"; };
 		EA8E941C1AD3C6840057E979 /* AKAudioAnalyzer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioAnalyzer.m; sourceTree = "<group>"; };
 		EA8E941E1AD3C6840057E979 /* BambooSticks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BambooSticks.h; sourceTree = "<group>"; };
@@ -637,14 +637,14 @@
 		EA8E942D1AD3C6840057E979 /* Tambourine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Tambourine.m; sourceTree = "<group>"; };
 		EA8E942E1AD3C6840057E979 /* Vibraphone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vibraphone.h; sourceTree = "<group>"; };
 		EA8E942F1AD3C6840057E979 /* Vibraphone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Vibraphone.m; sourceTree = "<group>"; };
-		EA8E94311AD3C6840057E979 /* Microphone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Microphone.h; sourceTree = "<group>"; };
-		EA8E94321AD3C6840057E979 /* Microphone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Microphone.m; sourceTree = "<group>"; };
-		EA8E94341AD3C6840057E979 /* ReverbProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReverbProcessor.h; sourceTree = "<group>"; };
-		EA8E94351AD3C6840057E979 /* ReverbProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReverbProcessor.m; sourceTree = "<group>"; };
-		EA8E94371AD3C6840057E979 /* FMOscillatorInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FMOscillatorInstrument.h; sourceTree = "<group>"; };
-		EA8E94381AD3C6840057E979 /* FMOscillatorInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FMOscillatorInstrument.m; sourceTree = "<group>"; };
-		EA8E94391AD3C6840057E979 /* VCOscillatorInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VCOscillatorInstrument.h; sourceTree = "<group>"; };
-		EA8E943A1AD3C6840057E979 /* VCOscillatorInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VCOscillatorInstrument.m; sourceTree = "<group>"; };
+		EA8E94311AD3C6840057E979 /* AKMicrophone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKMicrophone.h; sourceTree = "<group>"; };
+		EA8E94321AD3C6840057E979 /* AKMicrophone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKMicrophone.m; sourceTree = "<group>"; };
+		EA8E94341AD3C6840057E979 /* AKReverbProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKReverbProcessor.h; sourceTree = "<group>"; };
+		EA8E94351AD3C6840057E979 /* AKReverbProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKReverbProcessor.m; sourceTree = "<group>"; };
+		EA8E94371AD3C6840057E979 /* AKFMOscillatorInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKFMOscillatorInstrument.h; sourceTree = "<group>"; };
+		EA8E94381AD3C6840057E979 /* AKFMOscillatorInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKFMOscillatorInstrument.m; sourceTree = "<group>"; };
+		EA8E94391AD3C6840057E979 /* AKVCOscillatorInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKVCOscillatorInstrument.h; sourceTree = "<group>"; };
+		EA8E943A1AD3C6840057E979 /* AKVCOscillatorInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKVCOscillatorInstrument.m; sourceTree = "<group>"; };
 		EA8E943C1AD3C6840057E979 /* AKAudioInputFFTPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioInputFFTPlot.h; sourceTree = "<group>"; };
 		EA8E943D1AD3C6840057E979 /* AKAudioInputFFTPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioInputFFTPlot.m; sourceTree = "<group>"; };
 		EA8E943E1AD3C6840057E979 /* AKAudioInputPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioInputPlot.h; sourceTree = "<group>"; };
@@ -994,8 +994,8 @@
 		C4FAE5EE1AED6B2600FD71E2 /* File Players */ = {
 			isa = PBXGroup;
 			children = (
-				C4FAE5EF1AED6B2600FD71E2 /* AudioFilePlayer.h */,
-				C4FAE5F01AED6B2600FD71E2 /* AudioFilePlayer.m */,
+				C4FAE5EF1AED6B2600FD71E2 /* AKAudioFilePlayer.h */,
+				C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */,
 			);
 			path = "File Players";
 			sourceTree = "<group>";
@@ -1132,10 +1132,10 @@
 		EA8E94151AD3C6840057E979 /* Amplifiers */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E94161AD3C6840057E979 /* Amplifier.h */,
-				EA8E94171AD3C6840057E979 /* Amplifier.m */,
-				EA8E94181AD3C6840057E979 /* StereoAmplifier.h */,
-				EA8E94191AD3C6840057E979 /* StereoAmplifier.m */,
+				EA8E94161AD3C6840057E979 /* AKAmplifier.h */,
+				EA8E94171AD3C6840057E979 /* AKAmplifier.m */,
+				EA8E94181AD3C6840057E979 /* AKStereoAmplifier.h */,
+				EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */,
 			);
 			path = Amplifiers;
 			sourceTree = "<group>";
@@ -1179,8 +1179,8 @@
 		EA8E94301AD3C6840057E979 /* Microphone */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E94311AD3C6840057E979 /* Microphone.h */,
-				EA8E94321AD3C6840057E979 /* Microphone.m */,
+				EA8E94311AD3C6840057E979 /* AKMicrophone.h */,
+				EA8E94321AD3C6840057E979 /* AKMicrophone.m */,
 			);
 			path = Microphone;
 			sourceTree = "<group>";
@@ -1188,8 +1188,8 @@
 		EA8E94331AD3C6840057E979 /* Processors */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E94341AD3C6840057E979 /* ReverbProcessor.h */,
-				EA8E94351AD3C6840057E979 /* ReverbProcessor.m */,
+				EA8E94341AD3C6840057E979 /* AKReverbProcessor.h */,
+				EA8E94351AD3C6840057E979 /* AKReverbProcessor.m */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -1197,10 +1197,10 @@
 		EA8E94361AD3C6840057E979 /* Synthesizers */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E94371AD3C6840057E979 /* FMOscillatorInstrument.h */,
-				EA8E94381AD3C6840057E979 /* FMOscillatorInstrument.m */,
-				EA8E94391AD3C6840057E979 /* VCOscillatorInstrument.h */,
-				EA8E943A1AD3C6840057E979 /* VCOscillatorInstrument.m */,
+				EA8E94371AD3C6840057E979 /* AKFMOscillatorInstrument.h */,
+				EA8E94381AD3C6840057E979 /* AKFMOscillatorInstrument.m */,
+				EA8E94391AD3C6840057E979 /* AKVCOscillatorInstrument.h */,
+				EA8E943A1AD3C6840057E979 /* AKVCOscillatorInstrument.m */,
 			);
 			path = Synthesizers;
 			sourceTree = "<group>";
@@ -1853,7 +1853,7 @@
 				EA95E9F11AD5EC50007FC41F /* AKSettings.h in Headers */,
 				EA321D1D1AEDCA5300DCCABD /* AKAudioFFTPlot.h in Headers */,
 				C4C8125B1AE5CA03003A8B73 /* Sekere.h in Headers */,
-				C4FAE5F11AED6B2600FD71E2 /* AudioFilePlayer.h in Headers */,
+				C4FAE5F11AED6B2600FD71E2 /* AKAudioFilePlayer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2011,13 +2011,13 @@
 				EA8E962E1AD3C6850057E979 /* AKDopplerEffect.m in Sources */,
 				EA8E95FC1AD3C6850057E979 /* AKSinusoidBursts.m in Sources */,
 				EA8E96141AD3C6850057E979 /* AKStick.m in Sources */,
-				EA8E95C21AD3C6850057E979 /* VCOscillatorInstrument.m in Sources */,
+				EA8E95C21AD3C6850057E979 /* AKVCOscillatorInstrument.m in Sources */,
 				EA8E95E71AD3C6850057E979 /* AKPhaseLockedVocoder.m in Sources */,
 				EA8E963A1AD3C6850057E979 /* AKResonantFilter.m in Sources */,
 				EA8E96301AD3C6850057E979 /* AKCombFilter.m in Sources */,
 				EA8E95ED1AD3C6850057E979 /* AKDifference.m in Sources */,
-				C4FAE5F21AED6B2600FD71E2 /* AudioFilePlayer.m in Sources */,
-				EA8E95C11AD3C6850057E979 /* FMOscillatorInstrument.m in Sources */,
+				C4FAE5F21AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */,
+				EA8E95C11AD3C6850057E979 /* AKFMOscillatorInstrument.m in Sources */,
 				EA8E96391AD3C6850057E979 /* AKMoogVCF.m in Sources */,
 				EA8E96071AD3C6850057E979 /* AKMandolin.m in Sources */,
 				EA8E95DF1AD3C6850057E979 /* AKTrackedAmplitude.m in Sources */,
@@ -2034,12 +2034,12 @@
 				EA8E95E91AD3C6850057E979 /* AKScaledFFT.m in Sources */,
 				EA8E95AC1AD3C6850057E979 /* AKConstant.m in Sources */,
 				EA8E95C81AD3C6850057E979 /* AKAudioOutputRollingWaveformPlot.m in Sources */,
-				EA8E95B31AD3C6850057E979 /* Amplifier.m in Sources */,
+				EA8E95B31AD3C6850057E979 /* AKAmplifier.m in Sources */,
 				EA8E96401AD3C6850057E979 /* AKHighPassButterworthFilter.m in Sources */,
 				EA8E96131AD3C6850057E979 /* AKSleighbells.m in Sources */,
 				EA8E96061AD3C6850057E979 /* AKVCOscillator.m in Sources */,
 				EA8E96421AD3C6850057E979 /* AKBallWithinTheBoxReverb.m in Sources */,
-				EA8E95C01AD3C6850057E979 /* ReverbProcessor.m in Sources */,
+				EA8E95C01AD3C6850057E979 /* AKReverbProcessor.m in Sources */,
 				EA8E96201AD3C6850057E979 /* AKSegmentArrayLoop.m in Sources */,
 				EA8E960D1AD3C6850057E979 /* AKCabasa.m in Sources */,
 				EA8E96191AD3C6850057E979 /* AKFlute.m in Sources */,
@@ -2099,7 +2099,7 @@
 				EA8E95BE1AD3C6850057E979 /* Vibraphone.m in Sources */,
 				EA8E95C41AD3C6850057E979 /* AKAudioInputPlot.m in Sources */,
 				EA8E95E31AD3C6850057E979 /* AKCrossSynthesizedFFT.m in Sources */,
-				EA8E95B41AD3C6850057E979 /* StereoAmplifier.m in Sources */,
+				EA8E95B41AD3C6850057E979 /* AKStereoAmplifier.m in Sources */,
 				EA8E95F21AD3C6850057E979 /* AKProduct.m in Sources */,
 				EA8E963C1AD3C6850057E979 /* AKThreePoleLowpassFilter.m in Sources */,
 				EA89F5741AEEE50900858344 /* AKAudioPlot.m in Sources */,
@@ -2119,7 +2119,7 @@
 				EA8E96171AD3C6850057E979 /* AKBeatenPlate.m in Sources */,
 				EA8E96011AD3C6850057E979 /* AKVibrato.m in Sources */,
 				EA8E95CC1AD3C6850057E979 /* AKStereoOutputPlot.m in Sources */,
-				EA8E95BF1AD3C6850057E979 /* Microphone.m in Sources */,
+				EA8E95BF1AD3C6850057E979 /* AKMicrophone.m in Sources */,
 				EA8E95A71AD3C6850057E979 /* AKOrchestra.m in Sources */,
 				EA8E95E41AD3C6850057E979 /* AKFFT.m in Sources */,
 				EA8E960E1AD3C6850057E979 /* AKCrunch.m in Sources */,
@@ -2199,7 +2199,7 @@
 				EA8E96F91AD3CA4C0057E979 /* AKDeclick.m in Sources */,
 				EA8E96FA1AD3CA4C0057E979 /* AKEqualizerFilter.m in Sources */,
 				EA8E96FB1AD3CA4C0057E979 /* AKHighPassFilter.m in Sources */,
-				C4FAE5F41AED6B2600FD71E2 /* AudioFilePlayer.m in Sources */,
+				C4FAE5F41AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */,
 				EA8E96FC1AD3CA4C0057E979 /* AKHilbertTransformer.m in Sources */,
 				EA8E96FD1AD3CA4C0057E979 /* AKLowPassFilter.m in Sources */,
 				EA8E96FE1AD3CA4C0057E979 /* AKMoogLadder.m in Sources */,
@@ -2270,16 +2270,16 @@
 				EA8E96911AD3C92B0057E979 /* AKAudioOutputPlot.m in Sources */,
 				EA8E96721AD3C85D0057E979 /* AKMidi.m in Sources */,
 				EA8E96A51AD3C9640057E979 /* AKRandomDistributionTableGenerator.m in Sources */,
-				EA8E968C1AD3C9090057E979 /* VCOscillatorInstrument.m in Sources */,
-				EA8E968B1AD3C9090057E979 /* FMOscillatorInstrument.m in Sources */,
+				EA8E968C1AD3C9090057E979 /* AKVCOscillatorInstrument.m in Sources */,
+				EA8E968B1AD3C9090057E979 /* AKFMOscillatorInstrument.m in Sources */,
 				EA8E96781AD3C8790057E979 /* AKFSignal.m in Sources */,
 				EA8E96A21AD3C9640057E979 /* AKFourierSeriesTableGenerator.m in Sources */,
 				EA8E969A1AD3C92B0057E979 /* EZAudioPlot.m in Sources */,
 				EA8E96761AD3C8790057E979 /* AKConstant.m in Sources */,
 				EA8E96921AD3C92B0057E979 /* AKAudioOutputRollingWaveformPlot.m in Sources */,
 				C4C8125D1AE5CA03003A8B73 /* Sekere.m in Sources */,
-				EA8E967D1AD3C88A0057E979 /* Amplifier.m in Sources */,
-				EA8E968A1AD3C9090057E979 /* ReverbProcessor.m in Sources */,
+				EA8E967D1AD3C88A0057E979 /* AKAmplifier.m in Sources */,
+				EA8E968A1AD3C9090057E979 /* AKReverbProcessor.m in Sources */,
 				EA8E968D1AD3C92B0057E979 /* AKAudioInputFFTPlot.m in Sources */,
 				EA8E96841AD3C89F0057E979 /* Sleighbells.m in Sources */,
 				EA8E96801AD3C89F0057E979 /* BambooSticks.m in Sources */,
@@ -2302,14 +2302,14 @@
 				EA8E96A31AD3C9640057E979 /* AKHarmonicCosineTableGenerator.m in Sources */,
 				EA8E96881AD3C89F0057E979 /* Vibraphone.m in Sources */,
 				EA8E968E1AD3C92B0057E979 /* AKAudioInputPlot.m in Sources */,
-				EA8E967E1AD3C88A0057E979 /* StereoAmplifier.m in Sources */,
+				EA8E967E1AD3C88A0057E979 /* AKStereoAmplifier.m in Sources */,
 				EA8E969D1AD3C94F0057E979 /* AKPropertySlider.m in Sources */,
 				EA8E96A61AD3C9640057E979 /* AKTableGenerator.m in Sources */,
 				EA8E96731AD3C8620057E979 /* AKInstrument.m in Sources */,
 				EA8E969F1AD3C9580057E979 /* AKSoundFileTable.m in Sources */,
 				EA8E96751AD3C8790057E979 /* AKAudio.m in Sources */,
 				EA8E96961AD3C92B0057E979 /* AKStereoOutputPlot.m in Sources */,
-				EA8E96891AD3C9090057E979 /* Microphone.m in Sources */,
+				EA8E96891AD3C9090057E979 /* AKMicrophone.m in Sources */,
 				EA8E96711AD3C8430057E979 /* AKOrchestra.m in Sources */,
 				EA8E96791AD3C8790057E979 /* AKParameter.m in Sources */,
 			);
@@ -2377,13 +2377,13 @@
 				EAA0F5171AE71C8F007CD7C9 /* AKDopplerEffect.m in Sources */,
 				EAA0F5181AE71C8F007CD7C9 /* AKSinusoidBursts.m in Sources */,
 				EAA0F5191AE71C8F007CD7C9 /* AKStick.m in Sources */,
-				EAA0F51A1AE71C8F007CD7C9 /* VCOscillatorInstrument.m in Sources */,
+				EAA0F51A1AE71C8F007CD7C9 /* AKVCOscillatorInstrument.m in Sources */,
 				EAA0F51B1AE71C8F007CD7C9 /* AKPhaseLockedVocoder.m in Sources */,
 				EAA0F51C1AE71C8F007CD7C9 /* AKResonantFilter.m in Sources */,
 				EAA0F51D1AE71C8F007CD7C9 /* AKCombFilter.m in Sources */,
 				EAA0F51E1AE71C8F007CD7C9 /* AKDifference.m in Sources */,
-				C4FAE5F31AED6B2600FD71E2 /* AudioFilePlayer.m in Sources */,
-				EAA0F51F1AE71C8F007CD7C9 /* FMOscillatorInstrument.m in Sources */,
+				C4FAE5F31AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */,
+				EAA0F51F1AE71C8F007CD7C9 /* AKFMOscillatorInstrument.m in Sources */,
 				EAA0F5201AE71C8F007CD7C9 /* AKMoogVCF.m in Sources */,
 				EAA0F5211AE71C8F007CD7C9 /* AKMandolin.m in Sources */,
 				EAA0F5221AE71C8F007CD7C9 /* AKTrackedAmplitude.m in Sources */,
@@ -2400,12 +2400,12 @@
 				EAA0F52C1AE71C8F007CD7C9 /* AKScaledFFT.m in Sources */,
 				EAA0F52D1AE71C8F007CD7C9 /* AKConstant.m in Sources */,
 				EAA0F52E1AE71C8F007CD7C9 /* AKAudioOutputRollingWaveformPlot.m in Sources */,
-				EAA0F52F1AE71C8F007CD7C9 /* Amplifier.m in Sources */,
+				EAA0F52F1AE71C8F007CD7C9 /* AKAmplifier.m in Sources */,
 				EAA0F5301AE71C8F007CD7C9 /* AKHighPassButterworthFilter.m in Sources */,
 				EAA0F5311AE71C8F007CD7C9 /* AKSleighbells.m in Sources */,
 				EAA0F5321AE71C8F007CD7C9 /* AKVCOscillator.m in Sources */,
 				EAA0F5331AE71C8F007CD7C9 /* AKBallWithinTheBoxReverb.m in Sources */,
-				EAA0F5341AE71C8F007CD7C9 /* ReverbProcessor.m in Sources */,
+				EAA0F5341AE71C8F007CD7C9 /* AKReverbProcessor.m in Sources */,
 				EAA0F5351AE71C8F007CD7C9 /* AKSegmentArrayLoop.m in Sources */,
 				EAA0F5361AE71C8F007CD7C9 /* AKCabasa.m in Sources */,
 				EAA0F5371AE71C8F007CD7C9 /* AKFlute.m in Sources */,
@@ -2465,7 +2465,7 @@
 				EAA0F56C1AE71C8F007CD7C9 /* Vibraphone.m in Sources */,
 				EAA0F56D1AE71C8F007CD7C9 /* AKAudioInputPlot.m in Sources */,
 				EAA0F56E1AE71C8F007CD7C9 /* AKCrossSynthesizedFFT.m in Sources */,
-				EAA0F56F1AE71C8F007CD7C9 /* StereoAmplifier.m in Sources */,
+				EAA0F56F1AE71C8F007CD7C9 /* AKStereoAmplifier.m in Sources */,
 				EAA0F5701AE71C8F007CD7C9 /* AKProduct.m in Sources */,
 				EAA0F5711AE71C8F007CD7C9 /* AKThreePoleLowpassFilter.m in Sources */,
 				EA89F5751AEEE50900858344 /* AKAudioPlot.m in Sources */,
@@ -2485,7 +2485,7 @@
 				EAA0F57F1AE71C8F007CD7C9 /* AKBeatenPlate.m in Sources */,
 				EAA0F5801AE71C8F007CD7C9 /* AKVibrato.m in Sources */,
 				EAA0F5811AE71C8F007CD7C9 /* AKStereoOutputPlot.m in Sources */,
-				EAA0F5821AE71C8F007CD7C9 /* Microphone.m in Sources */,
+				EAA0F5821AE71C8F007CD7C9 /* AKMicrophone.m in Sources */,
 				EAA0F5831AE71C8F007CD7C9 /* AKOrchestra.m in Sources */,
 				EAA0F5841AE71C8F007CD7C9 /* AKFFT.m in Sources */,
 				EAA0F5851AE71C8F007CD7C9 /* AKCrunch.m in Sources */,

--- a/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		C45552431ADEFD8A000C8D42 /* AK3DBinauralAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = C45552401ADEFD8A000C8D42 /* AK3DBinauralAudio.m */; };
 		C45552481ADF152F000C8D42 /* AKRingModulator.m in Sources */ = {isa = PBXBuildFile; fileRef = C45552471ADF152F000C8D42 /* AKRingModulator.m */; };
 		C45552491ADF155A000C8D42 /* AKRingModulator.m in Sources */ = {isa = PBXBuildFile; fileRef = C45552471ADF152F000C8D42 /* AKRingModulator.m */; };
-		C4C8125B1AE5CA03003A8B73 /* Sekere.h in Headers */ = {isa = PBXBuildFile; fileRef = C4C812591AE5CA03003A8B73 /* Sekere.h */; };
-		C4C8125C1AE5CA03003A8B73 /* Sekere.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* Sekere.m */; };
-		C4C8125D1AE5CA03003A8B73 /* Sekere.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* Sekere.m */; };
+		C4C8125B1AE5CA03003A8B73 /* AKSekereInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = C4C812591AE5CA03003A8B73 /* AKSekereInstrument.h */; };
+		C4C8125C1AE5CA03003A8B73 /* AKSekereInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* AKSekereInstrument.m */; };
+		C4C8125D1AE5CA03003A8B73 /* AKSekereInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* AKSekereInstrument.m */; };
 		C4FAE5F11AED6B2600FD71E2 /* AKAudioFilePlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = C4FAE5EF1AED6B2600FD71E2 /* AKAudioFilePlayer.h */; };
 		C4FAE5F21AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */; };
 		C4FAE5F31AED6B2600FD71E2 /* AKAudioFilePlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */; };
@@ -46,15 +46,15 @@
 		EA8E95B31AD3C6850057E979 /* AKAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* AKAmplifier.m */; };
 		EA8E95B41AD3C6850057E979 /* AKStereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */; };
 		EA8E95B51AD3C6850057E979 /* AKAudioAnalyzer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941C1AD3C6840057E979 /* AKAudioAnalyzer.m */; };
-		EA8E95B61AD3C6850057E979 /* BambooSticks.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* BambooSticks.m */; };
-		EA8E95B71AD3C6850057E979 /* Mandolin.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* Mandolin.m */; };
-		EA8E95B81AD3C6850057E979 /* Marimba.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94231AD3C6840057E979 /* Marimba.m */; };
-		EA8E95B91AD3C6850057E979 /* PluckedString.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94251AD3C6840057E979 /* PluckedString.m */; };
-		EA8E95BA1AD3C6850057E979 /* Sleighbells.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94271AD3C6840057E979 /* Sleighbells.m */; };
-		EA8E95BB1AD3C6850057E979 /* Stick.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94291AD3C6840057E979 /* Stick.m */; };
-		EA8E95BC1AD3C6850057E979 /* StruckMetalBar.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* StruckMetalBar.m */; };
-		EA8E95BD1AD3C6850057E979 /* Tambourine.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* Tambourine.m */; };
-		EA8E95BE1AD3C6850057E979 /* Vibraphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* Vibraphone.m */; };
+		EA8E95B61AD3C6850057E979 /* AKBambooSticksInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* AKBambooSticksInstrument.m */; };
+		EA8E95B71AD3C6850057E979 /* AKMandolinInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* AKMandolinInstrument.m */; };
+		EA8E95B81AD3C6850057E979 /* AKMarimbaInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94231AD3C6840057E979 /* AKMarimbaInstrument.m */; };
+		EA8E95B91AD3C6850057E979 /* AKPluckedStringInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94251AD3C6840057E979 /* AKPluckedStringInstrument.m */; };
+		EA8E95BA1AD3C6850057E979 /* AKSleighbellsInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94271AD3C6840057E979 /* AKSleighbellsInstrument.m */; };
+		EA8E95BB1AD3C6850057E979 /* AKStickInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94291AD3C6840057E979 /* AKStickInstrument.m */; };
+		EA8E95BC1AD3C6850057E979 /* AKStruckMetalBarInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* AKStruckMetalBarInstrument.m */; };
+		EA8E95BD1AD3C6850057E979 /* AKTambourineInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* AKTambourineInstrument.m */; };
+		EA8E95BE1AD3C6850057E979 /* AKVibraphoneInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* AKVibraphoneInstrument.m */; };
 		EA8E95BF1AD3C6850057E979 /* AKMicrophone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* AKMicrophone.m */; };
 		EA8E95C01AD3C6850057E979 /* AKReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* AKReverbProcessor.m */; };
 		EA8E95C11AD3C6850057E979 /* AKFMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* AKFMOscillatorInstrument.m */; };
@@ -215,15 +215,15 @@
 		EA8E967D1AD3C88A0057E979 /* AKAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94171AD3C6840057E979 /* AKAmplifier.m */; };
 		EA8E967E1AD3C88A0057E979 /* AKStereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */; };
 		EA8E967F1AD3C89F0057E979 /* AKAudioAnalyzer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941C1AD3C6840057E979 /* AKAudioAnalyzer.m */; };
-		EA8E96801AD3C89F0057E979 /* BambooSticks.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* BambooSticks.m */; };
-		EA8E96811AD3C89F0057E979 /* Mandolin.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* Mandolin.m */; };
-		EA8E96821AD3C89F0057E979 /* Marimba.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94231AD3C6840057E979 /* Marimba.m */; };
-		EA8E96831AD3C89F0057E979 /* PluckedString.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94251AD3C6840057E979 /* PluckedString.m */; };
-		EA8E96841AD3C89F0057E979 /* Sleighbells.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94271AD3C6840057E979 /* Sleighbells.m */; };
-		EA8E96851AD3C89F0057E979 /* Stick.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94291AD3C6840057E979 /* Stick.m */; };
-		EA8E96861AD3C89F0057E979 /* StruckMetalBar.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* StruckMetalBar.m */; };
-		EA8E96871AD3C89F0057E979 /* Tambourine.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* Tambourine.m */; };
-		EA8E96881AD3C89F0057E979 /* Vibraphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* Vibraphone.m */; };
+		EA8E96801AD3C89F0057E979 /* AKBambooSticksInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* AKBambooSticksInstrument.m */; };
+		EA8E96811AD3C89F0057E979 /* AKMandolinInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* AKMandolinInstrument.m */; };
+		EA8E96821AD3C89F0057E979 /* AKMarimbaInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94231AD3C6840057E979 /* AKMarimbaInstrument.m */; };
+		EA8E96831AD3C89F0057E979 /* AKPluckedStringInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94251AD3C6840057E979 /* AKPluckedStringInstrument.m */; };
+		EA8E96841AD3C89F0057E979 /* AKSleighbellsInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94271AD3C6840057E979 /* AKSleighbellsInstrument.m */; };
+		EA8E96851AD3C89F0057E979 /* AKStickInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94291AD3C6840057E979 /* AKStickInstrument.m */; };
+		EA8E96861AD3C89F0057E979 /* AKStruckMetalBarInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* AKStruckMetalBarInstrument.m */; };
+		EA8E96871AD3C89F0057E979 /* AKTambourineInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* AKTambourineInstrument.m */; };
+		EA8E96881AD3C89F0057E979 /* AKVibraphoneInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* AKVibraphoneInstrument.m */; };
 		EA8E96891AD3C9090057E979 /* AKMicrophone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94321AD3C6840057E979 /* AKMicrophone.m */; };
 		EA8E968A1AD3C9090057E979 /* AKReverbProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94351AD3C6840057E979 /* AKReverbProcessor.m */; };
 		EA8E968B1AD3C9090057E979 /* AKFMOscillatorInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94381AD3C6840057E979 /* AKFMOscillatorInstrument.m */; };
@@ -379,7 +379,7 @@
 		EAA0F4EB1AE71C8F007CD7C9 /* AKSpectralVocoder.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E949B1AD3C6840057E979 /* AKSpectralVocoder.m */; };
 		EAA0F4EC1AE71C8F007CD7C9 /* AKVariableDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95301AD3C6840057E979 /* AKVariableDelay.m */; };
 		EAA0F4ED1AE71C8F007CD7C9 /* AKAudioAnalyzer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941C1AD3C6840057E979 /* AKAudioAnalyzer.m */; };
-		EAA0F4EE1AE71C8F007CD7C9 /* PluckedString.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94251AD3C6840057E979 /* PluckedString.m */; };
+		EAA0F4EE1AE71C8F007CD7C9 /* AKPluckedStringInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94251AD3C6840057E979 /* AKPluckedStringInstrument.m */; };
 		EAA0F4EF1AE71C8F007CD7C9 /* AKAssignment.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94A01AD3C6840057E979 /* AKAssignment.m */; };
 		EAA0F4F01AE71C8F007CD7C9 /* AKTablePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94521AD3C6840057E979 /* AKTablePlot.m */; };
 		EAA0F4F11AE71C8F007CD7C9 /* AKTools.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94131AD3C6840057E979 /* AKTools.m */; };
@@ -389,7 +389,7 @@
 		EAA0F4F51AE71C8F007CD7C9 /* AKADSREnvelope.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94B61AD3C6840057E979 /* AKADSREnvelope.m */; };
 		EAA0F4F61AE71C8F007CD7C9 /* AKMarimba.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94DF1AD3C6840057E979 /* AKMarimba.m */; };
 		EAA0F4F71AE71C8F007CD7C9 /* AKSimpleWaveGuideModel.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95051AD3C6840057E979 /* AKSimpleWaveGuideModel.m */; };
-		EAA0F4F81AE71C8F007CD7C9 /* Mandolin.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* Mandolin.m */; };
+		EAA0F4F81AE71C8F007CD7C9 /* AKMandolinInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94211AD3C6840057E979 /* AKMandolinInstrument.m */; };
 		EAA0F4F91AE71C8F007CD7C9 /* AKDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E952C1AD3C6840057E979 /* AKDelay.m */; };
 		EAA0F4FA1AE71C8F007CD7C9 /* AKHighPassFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95441AD3C6840057E979 /* AKHighPassFilter.m */; };
 		EAA0F4FB1AE71C8F007CD7C9 /* AKStruckMetalBar.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94E31AD3C6840057E979 /* AKStruckMetalBar.m */; };
@@ -399,7 +399,7 @@
 		EAA0F4FF1AE71C8F007CD7C9 /* CsoundObj.m in Sources */ = {isa = PBXBuildFile; fileRef = EA08B56E1AD8985F00949FD5 /* CsoundObj.m */; };
 		EAA0F5001AE71C8F007CD7C9 /* AKMix.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E956B1AD3C6850057E979 /* AKMix.m */; };
 		EAA0F5011AE71C8F007CD7C9 /* AKResynthesizedAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94971AD3C6840057E979 /* AKResynthesizedAudio.m */; };
-		EAA0F5021AE71C8F007CD7C9 /* StruckMetalBar.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* StruckMetalBar.m */; };
+		EAA0F5021AE71C8F007CD7C9 /* AKStruckMetalBarInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942B1AD3C6840057E979 /* AKStruckMetalBarInstrument.m */; };
 		EAA0F5031AE71C8F007CD7C9 /* AKDCBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E953C1AD3C6840057E979 /* AKDCBlock.m */; };
 		EAA0F5041AE71C8F007CD7C9 /* AKJitter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E950A1AD3C6840057E979 /* AKJitter.m */; };
 		EAA0F5051AE71C8F007CD7C9 /* AKStringResonator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95501AD3C6840057E979 /* AKStringResonator.m */; };
@@ -459,9 +459,9 @@
 		EAA0F53B1AE71C8F007CD7C9 /* AKLine.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94B81AD3C6840057E979 /* AKLine.m */; };
 		EAA0F53C1AE71C8F007CD7C9 /* AKDroplet.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94EE1AD3C6840057E979 /* AKDroplet.m */; };
 		EAA0F53D1AE71C8F007CD7C9 /* AKInverse.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94A41AD3C6840057E979 /* AKInverse.m */; };
-		EAA0F53E1AE71C8F007CD7C9 /* Sleighbells.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94271AD3C6840057E979 /* Sleighbells.m */; };
+		EAA0F53E1AE71C8F007CD7C9 /* AKSleighbellsInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94271AD3C6840057E979 /* AKSleighbellsInstrument.m */; };
 		EAA0F53F1AE71C8F007CD7C9 /* AKTableValue.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94B21AD3C6840057E979 /* AKTableValue.m */; };
-		EAA0F5401AE71C8F007CD7C9 /* BambooSticks.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* BambooSticks.m */; };
+		EAA0F5401AE71C8F007CD7C9 /* AKBambooSticksInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E941F1AD3C6840057E979 /* AKBambooSticksInstrument.m */; };
 		EAA0F5411AE71C8F007CD7C9 /* AKMonoSoundFileLooper.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94C61AD3C6840057E979 /* AKMonoSoundFileLooper.m */; };
 		EAA0F5421AE71C8F007CD7C9 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = EA8E945B1AD3C6840057E979 /* TPCircularBuffer.c */; };
 		EAA0F5431AE71C8F007CD7C9 /* EZAudio.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94571AD3C6840057E979 /* EZAudio.m */; };
@@ -470,10 +470,10 @@
 		EAA0F5461AE71C8F007CD7C9 /* AKStereoConvolution.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95291AD3C6840057E979 /* AKStereoConvolution.m */; };
 		EAA0F5471AE71C8F007CD7C9 /* AKFileInput.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E951D1AD3C6840057E979 /* AKFileInput.m */; };
 		EAA0F5481AE71C8F007CD7C9 /* AKGuiro.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94F01AD3C6840057E979 /* AKGuiro.m */; };
-		EAA0F5491AE71C8F007CD7C9 /* Marimba.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94231AD3C6840057E979 /* Marimba.m */; };
+		EAA0F5491AE71C8F007CD7C9 /* AKMarimbaInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94231AD3C6840057E979 /* AKMarimbaInstrument.m */; };
 		EAA0F54A1AE71C8F007CD7C9 /* AKMaximum.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94A61AD3C6840057E979 /* AKMaximum.m */; };
 		EAA0F54B1AE71C8F007CD7C9 /* AKLog.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E951F1AD3C6840057E979 /* AKLog.m */; };
-		EAA0F54C1AE71C8F007CD7C9 /* Tambourine.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* Tambourine.m */; };
+		EAA0F54C1AE71C8F007CD7C9 /* AKTambourineInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942D1AD3C6840057E979 /* AKTambourineInstrument.m */; };
 		EAA0F54D1AE71C8F007CD7C9 /* AKBowedString.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95011AD3C6840057E979 /* AKBowedString.m */; };
 		EAA0F54E1AE71C8F007CD7C9 /* AKFloatPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94491AD3C6840057E979 /* AKFloatPlot.m */; };
 		EAA0F54F1AE71C8F007CD7C9 /* AKSandPaper.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94F21AD3C6840057E979 /* AKSandPaper.m */; };
@@ -489,7 +489,7 @@
 		EAA0F5591AE71C8F007CD7C9 /* AKLineTableGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94781AD3C6840057E979 /* AKLineTableGenerator.m */; };
 		EAA0F55A1AE71C8F007CD7C9 /* AKWindowTableGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E947E1AD3C6840057E979 /* AKWindowTableGenerator.m */; };
 		EAA0F55B1AE71C8F007CD7C9 /* AKPanner.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E956D1AD3C6850057E979 /* AKPanner.m */; };
-		EAA0F55C1AE71C8F007CD7C9 /* Stick.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94291AD3C6840057E979 /* Stick.m */; };
+		EAA0F55C1AE71C8F007CD7C9 /* AKStickInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94291AD3C6840057E979 /* AKStickInstrument.m */; };
 		EAA0F55D1AE71C8F007CD7C9 /* AKTrackedFrequencyFromFSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E948A1AD3C6840057E979 /* AKTrackedFrequencyFromFSignal.m */; };
 		EAA0F55E1AE71C8F007CD7C9 /* AKRingModulator.m in Sources */ = {isa = PBXBuildFile; fileRef = C45552471ADF152F000C8D42 /* AKRingModulator.m */; };
 		EAA0F55F1AE71C8F007CD7C9 /* AKReverb.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95661AD3C6850057E979 /* AKReverb.m */; };
@@ -503,9 +503,9 @@
 		EAA0F5671AE71C8F007CD7C9 /* AKVibes.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94E51AD3C6840057E979 /* AKVibes.m */; };
 		EAA0F5681AE71C8F007CD7C9 /* AKMP3FileInput.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E95231AD3C6840057E979 /* AKMP3FileInput.m */; };
 		EAA0F5691AE71C8F007CD7C9 /* AKMultitapDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E952E1AD3C6840057E979 /* AKMultitapDelay.m */; };
-		EAA0F56A1AE71C8F007CD7C9 /* Sekere.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* Sekere.m */; };
+		EAA0F56A1AE71C8F007CD7C9 /* AKSekereInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C8125A1AE5CA03003A8B73 /* AKSekereInstrument.m */; };
 		EAA0F56B1AE71C8F007CD7C9 /* AKHarmonicCosineTableGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94761AD3C6840057E979 /* AKHarmonicCosineTableGenerator.m */; };
-		EAA0F56C1AE71C8F007CD7C9 /* Vibraphone.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* Vibraphone.m */; };
+		EAA0F56C1AE71C8F007CD7C9 /* AKVibraphoneInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E942F1AD3C6840057E979 /* AKVibraphoneInstrument.m */; };
 		EAA0F56D1AE71C8F007CD7C9 /* AKAudioInputPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E943F1AD3C6840057E979 /* AKAudioInputPlot.m */; };
 		EAA0F56E1AE71C8F007CD7C9 /* AKCrossSynthesizedFFT.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E948D1AD3C6840057E979 /* AKCrossSynthesizedFFT.m */; };
 		EAA0F56F1AE71C8F007CD7C9 /* AKStereoAmplifier.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */; };
@@ -570,8 +570,8 @@
 		C45552401ADEFD8A000C8D42 /* AK3DBinauralAudio.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AK3DBinauralAudio.m; sourceTree = "<group>"; };
 		C45552461ADF152F000C8D42 /* AKRingModulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKRingModulator.h; sourceTree = "<group>"; };
 		C45552471ADF152F000C8D42 /* AKRingModulator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRingModulator.m; sourceTree = "<group>"; };
-		C4C812591AE5CA03003A8B73 /* Sekere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sekere.h; sourceTree = "<group>"; };
-		C4C8125A1AE5CA03003A8B73 /* Sekere.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Sekere.m; sourceTree = "<group>"; };
+		C4C812591AE5CA03003A8B73 /* AKSekereInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSekereInstrument.h; sourceTree = "<group>"; };
+		C4C8125A1AE5CA03003A8B73 /* AKSekereInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSekereInstrument.m; sourceTree = "<group>"; };
 		C4FAE5EF1AED6B2600FD71E2 /* AKAudioFilePlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioFilePlayer.h; sourceTree = "<group>"; };
 		C4FAE5F01AED6B2600FD71E2 /* AKAudioFilePlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioFilePlayer.m; sourceTree = "<group>"; };
 		EA08B56D1AD8985F00949FD5 /* CsoundObj.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CsoundObj.h; sourceTree = "<group>"; };
@@ -619,24 +619,24 @@
 		EA8E94191AD3C6840057E979 /* AKStereoAmplifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKStereoAmplifier.m; sourceTree = "<group>"; };
 		EA8E941B1AD3C6840057E979 /* AKAudioAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioAnalyzer.h; sourceTree = "<group>"; };
 		EA8E941C1AD3C6840057E979 /* AKAudioAnalyzer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKAudioAnalyzer.m; sourceTree = "<group>"; };
-		EA8E941E1AD3C6840057E979 /* BambooSticks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BambooSticks.h; sourceTree = "<group>"; };
-		EA8E941F1AD3C6840057E979 /* BambooSticks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BambooSticks.m; sourceTree = "<group>"; };
-		EA8E94201AD3C6840057E979 /* Mandolin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Mandolin.h; sourceTree = "<group>"; };
-		EA8E94211AD3C6840057E979 /* Mandolin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Mandolin.m; sourceTree = "<group>"; };
-		EA8E94221AD3C6840057E979 /* Marimba.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Marimba.h; sourceTree = "<group>"; };
-		EA8E94231AD3C6840057E979 /* Marimba.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Marimba.m; sourceTree = "<group>"; };
-		EA8E94241AD3C6840057E979 /* PluckedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PluckedString.h; sourceTree = "<group>"; };
-		EA8E94251AD3C6840057E979 /* PluckedString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PluckedString.m; sourceTree = "<group>"; };
-		EA8E94261AD3C6840057E979 /* Sleighbells.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sleighbells.h; sourceTree = "<group>"; };
-		EA8E94271AD3C6840057E979 /* Sleighbells.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Sleighbells.m; sourceTree = "<group>"; };
-		EA8E94281AD3C6840057E979 /* Stick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Stick.h; sourceTree = "<group>"; };
-		EA8E94291AD3C6840057E979 /* Stick.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Stick.m; sourceTree = "<group>"; };
-		EA8E942A1AD3C6840057E979 /* StruckMetalBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StruckMetalBar.h; sourceTree = "<group>"; };
-		EA8E942B1AD3C6840057E979 /* StruckMetalBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StruckMetalBar.m; sourceTree = "<group>"; };
-		EA8E942C1AD3C6840057E979 /* Tambourine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Tambourine.h; sourceTree = "<group>"; };
-		EA8E942D1AD3C6840057E979 /* Tambourine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Tambourine.m; sourceTree = "<group>"; };
-		EA8E942E1AD3C6840057E979 /* Vibraphone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vibraphone.h; sourceTree = "<group>"; };
-		EA8E942F1AD3C6840057E979 /* Vibraphone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Vibraphone.m; sourceTree = "<group>"; };
+		EA8E941E1AD3C6840057E979 /* AKBambooSticksInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKBambooSticksInstrument.h; sourceTree = "<group>"; };
+		EA8E941F1AD3C6840057E979 /* AKBambooSticksInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKBambooSticksInstrument.m; sourceTree = "<group>"; };
+		EA8E94201AD3C6840057E979 /* AKMandolinInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKMandolinInstrument.h; sourceTree = "<group>"; };
+		EA8E94211AD3C6840057E979 /* AKMandolinInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKMandolinInstrument.m; sourceTree = "<group>"; };
+		EA8E94221AD3C6840057E979 /* AKMarimbaInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKMarimbaInstrument.h; sourceTree = "<group>"; };
+		EA8E94231AD3C6840057E979 /* AKMarimbaInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKMarimbaInstrument.m; sourceTree = "<group>"; };
+		EA8E94241AD3C6840057E979 /* AKPluckedStringInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPluckedStringInstrument.h; sourceTree = "<group>"; };
+		EA8E94251AD3C6840057E979 /* AKPluckedStringInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKPluckedStringInstrument.m; sourceTree = "<group>"; };
+		EA8E94261AD3C6840057E979 /* AKSleighbellsInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSleighbellsInstrument.h; sourceTree = "<group>"; };
+		EA8E94271AD3C6840057E979 /* AKSleighbellsInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSleighbellsInstrument.m; sourceTree = "<group>"; };
+		EA8E94281AD3C6840057E979 /* AKStickInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKStickInstrument.h; sourceTree = "<group>"; };
+		EA8E94291AD3C6840057E979 /* AKStickInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKStickInstrument.m; sourceTree = "<group>"; };
+		EA8E942A1AD3C6840057E979 /* AKStruckMetalBarInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKStruckMetalBarInstrument.h; sourceTree = "<group>"; };
+		EA8E942B1AD3C6840057E979 /* AKStruckMetalBarInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKStruckMetalBarInstrument.m; sourceTree = "<group>"; };
+		EA8E942C1AD3C6840057E979 /* AKTambourineInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKTambourineInstrument.h; sourceTree = "<group>"; };
+		EA8E942D1AD3C6840057E979 /* AKTambourineInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKTambourineInstrument.m; sourceTree = "<group>"; };
+		EA8E942E1AD3C6840057E979 /* AKVibraphoneInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKVibraphoneInstrument.h; sourceTree = "<group>"; };
+		EA8E942F1AD3C6840057E979 /* AKVibraphoneInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKVibraphoneInstrument.m; sourceTree = "<group>"; };
 		EA8E94311AD3C6840057E979 /* AKMicrophone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKMicrophone.h; sourceTree = "<group>"; };
 		EA8E94321AD3C6840057E979 /* AKMicrophone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKMicrophone.m; sourceTree = "<group>"; };
 		EA8E94341AD3C6840057E979 /* AKReverbProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKReverbProcessor.h; sourceTree = "<group>"; };
@@ -1152,26 +1152,26 @@
 		EA8E941D1AD3C6840057E979 /* Emulations */ = {
 			isa = PBXGroup;
 			children = (
-				EA8E941E1AD3C6840057E979 /* BambooSticks.h */,
-				EA8E941F1AD3C6840057E979 /* BambooSticks.m */,
-				EA8E94201AD3C6840057E979 /* Mandolin.h */,
-				EA8E94211AD3C6840057E979 /* Mandolin.m */,
-				EA8E94221AD3C6840057E979 /* Marimba.h */,
-				EA8E94231AD3C6840057E979 /* Marimba.m */,
-				EA8E94241AD3C6840057E979 /* PluckedString.h */,
-				EA8E94251AD3C6840057E979 /* PluckedString.m */,
-				C4C812591AE5CA03003A8B73 /* Sekere.h */,
-				C4C8125A1AE5CA03003A8B73 /* Sekere.m */,
-				EA8E94261AD3C6840057E979 /* Sleighbells.h */,
-				EA8E94271AD3C6840057E979 /* Sleighbells.m */,
-				EA8E94281AD3C6840057E979 /* Stick.h */,
-				EA8E94291AD3C6840057E979 /* Stick.m */,
-				EA8E942A1AD3C6840057E979 /* StruckMetalBar.h */,
-				EA8E942B1AD3C6840057E979 /* StruckMetalBar.m */,
-				EA8E942C1AD3C6840057E979 /* Tambourine.h */,
-				EA8E942D1AD3C6840057E979 /* Tambourine.m */,
-				EA8E942E1AD3C6840057E979 /* Vibraphone.h */,
-				EA8E942F1AD3C6840057E979 /* Vibraphone.m */,
+				EA8E941E1AD3C6840057E979 /* AKBambooSticksInstrument.h */,
+				EA8E941F1AD3C6840057E979 /* AKBambooSticksInstrument.m */,
+				EA8E94201AD3C6840057E979 /* AKMandolinInstrument.h */,
+				EA8E94211AD3C6840057E979 /* AKMandolinInstrument.m */,
+				EA8E94221AD3C6840057E979 /* AKMarimbaInstrument.h */,
+				EA8E94231AD3C6840057E979 /* AKMarimbaInstrument.m */,
+				EA8E94241AD3C6840057E979 /* AKPluckedStringInstrument.h */,
+				EA8E94251AD3C6840057E979 /* AKPluckedStringInstrument.m */,
+				C4C812591AE5CA03003A8B73 /* AKSekereInstrument.h */,
+				C4C8125A1AE5CA03003A8B73 /* AKSekereInstrument.m */,
+				EA8E94261AD3C6840057E979 /* AKSleighbellsInstrument.h */,
+				EA8E94271AD3C6840057E979 /* AKSleighbellsInstrument.m */,
+				EA8E94281AD3C6840057E979 /* AKStickInstrument.h */,
+				EA8E94291AD3C6840057E979 /* AKStickInstrument.m */,
+				EA8E942A1AD3C6840057E979 /* AKStruckMetalBarInstrument.h */,
+				EA8E942B1AD3C6840057E979 /* AKStruckMetalBarInstrument.m */,
+				EA8E942C1AD3C6840057E979 /* AKTambourineInstrument.h */,
+				EA8E942D1AD3C6840057E979 /* AKTambourineInstrument.m */,
+				EA8E942E1AD3C6840057E979 /* AKVibraphoneInstrument.h */,
+				EA8E942F1AD3C6840057E979 /* AKVibraphoneInstrument.m */,
 			);
 			path = Emulations;
 			sourceTree = "<group>";
@@ -1852,7 +1852,7 @@
 			files = (
 				EA95E9F11AD5EC50007FC41F /* AKSettings.h in Headers */,
 				EA321D1D1AEDCA5300DCCABD /* AKAudioFFTPlot.h in Headers */,
-				C4C8125B1AE5CA03003A8B73 /* Sekere.h in Headers */,
+				C4C8125B1AE5CA03003A8B73 /* AKSekereInstrument.h in Headers */,
 				C4FAE5F11AED6B2600FD71E2 /* AKAudioFilePlayer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1967,7 +1967,7 @@
 				EA8E95EA1AD3C6850057E979 /* AKSpectralVocoder.m in Sources */,
 				EA8E962C1AD3C6850057E979 /* AKVariableDelay.m in Sources */,
 				EA8E95B51AD3C6850057E979 /* AKAudioAnalyzer.m in Sources */,
-				EA8E95B91AD3C6850057E979 /* PluckedString.m in Sources */,
+				EA8E95B91AD3C6850057E979 /* AKPluckedStringInstrument.m in Sources */,
 				EA8E95EC1AD3C6850057E979 /* AKAssignment.m in Sources */,
 				EA8E95CD1AD3C6850057E979 /* AKTablePlot.m in Sources */,
 				EA8E95B21AD3C6850057E979 /* AKTools.m in Sources */,
@@ -1977,7 +1977,7 @@
 				EA8E95F61AD3C6850057E979 /* AKADSREnvelope.m in Sources */,
 				EA8E96081AD3C6850057E979 /* AKMarimba.m in Sources */,
 				EA8E961A1AD3C6850057E979 /* AKSimpleWaveGuideModel.m in Sources */,
-				EA8E95B71AD3C6850057E979 /* Mandolin.m in Sources */,
+				EA8E95B71AD3C6850057E979 /* AKMandolinInstrument.m in Sources */,
 				EA8E962A1AD3C6850057E979 /* AKDelay.m in Sources */,
 				EA8E96351AD3C6850057E979 /* AKHighPassFilter.m in Sources */,
 				EA8E960A1AD3C6850057E979 /* AKStruckMetalBar.m in Sources */,
@@ -1987,7 +1987,7 @@
 				EA08B5701AD8985F00949FD5 /* CsoundObj.m in Sources */,
 				EA8E96471AD3C6850057E979 /* AKMix.m in Sources */,
 				EA8E95E81AD3C6850057E979 /* AKResynthesizedAudio.m in Sources */,
-				EA8E95BC1AD3C6850057E979 /* StruckMetalBar.m in Sources */,
+				EA8E95BC1AD3C6850057E979 /* AKStruckMetalBarInstrument.m in Sources */,
 				EA8E96311AD3C6850057E979 /* AKDCBlock.m in Sources */,
 				EA8E961C1AD3C6850057E979 /* AKJitter.m in Sources */,
 				EA8E963B1AD3C6850057E979 /* AKStringResonator.m in Sources */,
@@ -2050,9 +2050,9 @@
 				EA8E95F71AD3C6850057E979 /* AKLine.m in Sources */,
 				EA8E960F1AD3C6850057E979 /* AKDroplet.m in Sources */,
 				EA8E95EE1AD3C6850057E979 /* AKInverse.m in Sources */,
-				EA8E95BA1AD3C6850057E979 /* Sleighbells.m in Sources */,
+				EA8E95BA1AD3C6850057E979 /* AKSleighbellsInstrument.m in Sources */,
 				EA8E95F51AD3C6850057E979 /* AKTableValue.m in Sources */,
-				EA8E95B61AD3C6850057E979 /* BambooSticks.m in Sources */,
+				EA8E95B61AD3C6850057E979 /* AKBambooSticksInstrument.m in Sources */,
 				EA8E95FD1AD3C6850057E979 /* AKMonoSoundFileLooper.m in Sources */,
 				EA8E95D11AD3C6850057E979 /* TPCircularBuffer.c in Sources */,
 				EA8E95CF1AD3C6850057E979 /* EZAudio.m in Sources */,
@@ -2061,10 +2061,10 @@
 				EA8E96291AD3C6850057E979 /* AKStereoConvolution.m in Sources */,
 				EA8E96241AD3C6850057E979 /* AKFileInput.m in Sources */,
 				EA8E96101AD3C6850057E979 /* AKGuiro.m in Sources */,
-				EA8E95B81AD3C6850057E979 /* Marimba.m in Sources */,
+				EA8E95B81AD3C6850057E979 /* AKMarimbaInstrument.m in Sources */,
 				EA8E95EF1AD3C6850057E979 /* AKMaximum.m in Sources */,
 				EA8E96251AD3C6850057E979 /* AKLog.m in Sources */,
-				EA8E95BD1AD3C6850057E979 /* Tambourine.m in Sources */,
+				EA8E95BD1AD3C6850057E979 /* AKTambourineInstrument.m in Sources */,
 				EA8E96181AD3C6850057E979 /* AKBowedString.m in Sources */,
 				EA8E95C91AD3C6850057E979 /* AKFloatPlot.m in Sources */,
 				EA8E96111AD3C6850057E979 /* AKSandPaper.m in Sources */,
@@ -2080,7 +2080,7 @@
 				EA8E95DA1AD3C6850057E979 /* AKLineTableGenerator.m in Sources */,
 				EA8E95DD1AD3C6850057E979 /* AKWindowTableGenerator.m in Sources */,
 				EA8E96481AD3C6850057E979 /* AKPanner.m in Sources */,
-				EA8E95BB1AD3C6850057E979 /* Stick.m in Sources */,
+				EA8E95BB1AD3C6850057E979 /* AKStickInstrument.m in Sources */,
 				EA8E95E21AD3C6850057E979 /* AKTrackedFrequencyFromFSignal.m in Sources */,
 				C45552481ADF152F000C8D42 /* AKRingModulator.m in Sources */,
 				EA8E96451AD3C6850057E979 /* AKReverb.m in Sources */,
@@ -2094,9 +2094,9 @@
 				EA8E960B1AD3C6850057E979 /* AKVibes.m in Sources */,
 				EA8E96271AD3C6850057E979 /* AKMP3FileInput.m in Sources */,
 				EA8E962B1AD3C6850057E979 /* AKMultitapDelay.m in Sources */,
-				C4C8125C1AE5CA03003A8B73 /* Sekere.m in Sources */,
+				C4C8125C1AE5CA03003A8B73 /* AKSekereInstrument.m in Sources */,
 				EA8E95D91AD3C6850057E979 /* AKHarmonicCosineTableGenerator.m in Sources */,
-				EA8E95BE1AD3C6850057E979 /* Vibraphone.m in Sources */,
+				EA8E95BE1AD3C6850057E979 /* AKVibraphoneInstrument.m in Sources */,
 				EA8E95C41AD3C6850057E979 /* AKAudioInputPlot.m in Sources */,
 				EA8E95E31AD3C6850057E979 /* AKCrossSynthesizedFFT.m in Sources */,
 				EA8E95B41AD3C6850057E979 /* AKStereoAmplifier.m in Sources */,
@@ -2256,13 +2256,13 @@
 				EA8E96A01AD3C9580057E979 /* AKTable.m in Sources */,
 				EA8E96941AD3C92B0057E979 /* AKInstrumentPropertyPlot.m in Sources */,
 				EA8E967F1AD3C89F0057E979 /* AKAudioAnalyzer.m in Sources */,
-				EA8E96831AD3C89F0057E979 /* PluckedString.m in Sources */,
+				EA8E96831AD3C89F0057E979 /* AKPluckedStringInstrument.m in Sources */,
 				EA8E96971AD3C92B0057E979 /* AKTablePlot.m in Sources */,
 				EA8E967C1AD3C8810057E979 /* AKTools.m in Sources */,
 				EA8E96A11AD3C9640057E979 /* AKExponentialTableGenerator.m in Sources */,
 				EA8E967A1AD3C8790057E979 /* AKStereoAudio.m in Sources */,
-				EA8E96811AD3C89F0057E979 /* Mandolin.m in Sources */,
-				EA8E96861AD3C89F0057E979 /* StruckMetalBar.m in Sources */,
+				EA8E96811AD3C89F0057E979 /* AKMandolinInstrument.m in Sources */,
+				EA8E96861AD3C89F0057E979 /* AKStruckMetalBarInstrument.m in Sources */,
 				EA8E96951AD3C92B0057E979 /* AKPlotView.m in Sources */,
 				EA8E969C1AD3C94F0057E979 /* AKPropertyLabel.m in Sources */,
 				C45552491ADF155A000C8D42 /* AKRingModulator.m in Sources */,
@@ -2277,30 +2277,30 @@
 				EA8E969A1AD3C92B0057E979 /* EZAudioPlot.m in Sources */,
 				EA8E96761AD3C8790057E979 /* AKConstant.m in Sources */,
 				EA8E96921AD3C92B0057E979 /* AKAudioOutputRollingWaveformPlot.m in Sources */,
-				C4C8125D1AE5CA03003A8B73 /* Sekere.m in Sources */,
+				C4C8125D1AE5CA03003A8B73 /* AKSekereInstrument.m in Sources */,
 				EA8E967D1AD3C88A0057E979 /* AKAmplifier.m in Sources */,
 				EA8E968A1AD3C9090057E979 /* AKReverbProcessor.m in Sources */,
 				EA8E968D1AD3C92B0057E979 /* AKAudioInputFFTPlot.m in Sources */,
-				EA8E96841AD3C89F0057E979 /* Sleighbells.m in Sources */,
-				EA8E96801AD3C89F0057E979 /* BambooSticks.m in Sources */,
+				EA8E96841AD3C89F0057E979 /* AKSleighbellsInstrument.m in Sources */,
+				EA8E96801AD3C89F0057E979 /* AKBambooSticksInstrument.m in Sources */,
 				EA8E969B1AD3C92B0057E979 /* TPCircularBuffer.c in Sources */,
 				EA8E96991AD3C92B0057E979 /* EZAudio.m in Sources */,
 				EA89F5761AEEE50900858344 /* AKAudioPlot.m in Sources */,
 				EA8E96901AD3C92B0057E979 /* AKAudioOutputFFTPlot.m in Sources */,
-				EA8E96821AD3C89F0057E979 /* Marimba.m in Sources */,
-				EA8E96871AD3C89F0057E979 /* Tambourine.m in Sources */,
+				EA8E96821AD3C89F0057E979 /* AKMarimbaInstrument.m in Sources */,
+				EA8E96871AD3C89F0057E979 /* AKTambourineInstrument.m in Sources */,
 				EA8E96931AD3C92B0057E979 /* AKFloatPlot.m in Sources */,
 				EA8E96701AD3C8400057E979 /* AKManager.m in Sources */,
 				EA8E96981AD3C92B0057E979 /* AEFloatConverter.m in Sources */,
 				EA8E96771AD3C8790057E979 /* AKControl.m in Sources */,
 				EA8E96A41AD3C9640057E979 /* AKLineTableGenerator.m in Sources */,
 				EA8E96A71AD3C9640057E979 /* AKWindowTableGenerator.m in Sources */,
-				EA8E96851AD3C89F0057E979 /* Stick.m in Sources */,
+				EA8E96851AD3C89F0057E979 /* AKStickInstrument.m in Sources */,
 				EA8E968F1AD3C92B0057E979 /* AKAudioInputRollingWaveformPlot.m in Sources */,
 				EA8E967B1AD3C8810057E979 /* AKSampler.m in Sources */,
 				EA8E96741AD3C8660057E979 /* AKInstrumentProperty.m in Sources */,
 				EA8E96A31AD3C9640057E979 /* AKHarmonicCosineTableGenerator.m in Sources */,
-				EA8E96881AD3C89F0057E979 /* Vibraphone.m in Sources */,
+				EA8E96881AD3C89F0057E979 /* AKVibraphoneInstrument.m in Sources */,
 				EA8E968E1AD3C92B0057E979 /* AKAudioInputPlot.m in Sources */,
 				EA8E967E1AD3C88A0057E979 /* AKStereoAmplifier.m in Sources */,
 				EA8E969D1AD3C94F0057E979 /* AKPropertySlider.m in Sources */,
@@ -2333,7 +2333,7 @@
 				EAA0F4EB1AE71C8F007CD7C9 /* AKSpectralVocoder.m in Sources */,
 				EAA0F4EC1AE71C8F007CD7C9 /* AKVariableDelay.m in Sources */,
 				EAA0F4ED1AE71C8F007CD7C9 /* AKAudioAnalyzer.m in Sources */,
-				EAA0F4EE1AE71C8F007CD7C9 /* PluckedString.m in Sources */,
+				EAA0F4EE1AE71C8F007CD7C9 /* AKPluckedStringInstrument.m in Sources */,
 				EAA0F4EF1AE71C8F007CD7C9 /* AKAssignment.m in Sources */,
 				EAA0F4F01AE71C8F007CD7C9 /* AKTablePlot.m in Sources */,
 				EAA0F4F11AE71C8F007CD7C9 /* AKTools.m in Sources */,
@@ -2343,7 +2343,7 @@
 				EAA0F4F51AE71C8F007CD7C9 /* AKADSREnvelope.m in Sources */,
 				EAA0F4F61AE71C8F007CD7C9 /* AKMarimba.m in Sources */,
 				EAA0F4F71AE71C8F007CD7C9 /* AKSimpleWaveGuideModel.m in Sources */,
-				EAA0F4F81AE71C8F007CD7C9 /* Mandolin.m in Sources */,
+				EAA0F4F81AE71C8F007CD7C9 /* AKMandolinInstrument.m in Sources */,
 				EAA0F4F91AE71C8F007CD7C9 /* AKDelay.m in Sources */,
 				EAA0F4FA1AE71C8F007CD7C9 /* AKHighPassFilter.m in Sources */,
 				EAA0F4FB1AE71C8F007CD7C9 /* AKStruckMetalBar.m in Sources */,
@@ -2353,7 +2353,7 @@
 				EAA0F4FF1AE71C8F007CD7C9 /* CsoundObj.m in Sources */,
 				EAA0F5001AE71C8F007CD7C9 /* AKMix.m in Sources */,
 				EAA0F5011AE71C8F007CD7C9 /* AKResynthesizedAudio.m in Sources */,
-				EAA0F5021AE71C8F007CD7C9 /* StruckMetalBar.m in Sources */,
+				EAA0F5021AE71C8F007CD7C9 /* AKStruckMetalBarInstrument.m in Sources */,
 				EAA0F5031AE71C8F007CD7C9 /* AKDCBlock.m in Sources */,
 				EAA0F5041AE71C8F007CD7C9 /* AKJitter.m in Sources */,
 				EAA0F5051AE71C8F007CD7C9 /* AKStringResonator.m in Sources */,
@@ -2416,9 +2416,9 @@
 				EAA0F53B1AE71C8F007CD7C9 /* AKLine.m in Sources */,
 				EAA0F53C1AE71C8F007CD7C9 /* AKDroplet.m in Sources */,
 				EAA0F53D1AE71C8F007CD7C9 /* AKInverse.m in Sources */,
-				EAA0F53E1AE71C8F007CD7C9 /* Sleighbells.m in Sources */,
+				EAA0F53E1AE71C8F007CD7C9 /* AKSleighbellsInstrument.m in Sources */,
 				EAA0F53F1AE71C8F007CD7C9 /* AKTableValue.m in Sources */,
-				EAA0F5401AE71C8F007CD7C9 /* BambooSticks.m in Sources */,
+				EAA0F5401AE71C8F007CD7C9 /* AKBambooSticksInstrument.m in Sources */,
 				EAA0F5411AE71C8F007CD7C9 /* AKMonoSoundFileLooper.m in Sources */,
 				EAA0F5421AE71C8F007CD7C9 /* TPCircularBuffer.c in Sources */,
 				EAA0F5431AE71C8F007CD7C9 /* EZAudio.m in Sources */,
@@ -2427,10 +2427,10 @@
 				EAA0F5461AE71C8F007CD7C9 /* AKStereoConvolution.m in Sources */,
 				EAA0F5471AE71C8F007CD7C9 /* AKFileInput.m in Sources */,
 				EAA0F5481AE71C8F007CD7C9 /* AKGuiro.m in Sources */,
-				EAA0F5491AE71C8F007CD7C9 /* Marimba.m in Sources */,
+				EAA0F5491AE71C8F007CD7C9 /* AKMarimbaInstrument.m in Sources */,
 				EAA0F54A1AE71C8F007CD7C9 /* AKMaximum.m in Sources */,
 				EAA0F54B1AE71C8F007CD7C9 /* AKLog.m in Sources */,
-				EAA0F54C1AE71C8F007CD7C9 /* Tambourine.m in Sources */,
+				EAA0F54C1AE71C8F007CD7C9 /* AKTambourineInstrument.m in Sources */,
 				EAA0F54D1AE71C8F007CD7C9 /* AKBowedString.m in Sources */,
 				EAA0F54E1AE71C8F007CD7C9 /* AKFloatPlot.m in Sources */,
 				EAA0F54F1AE71C8F007CD7C9 /* AKSandPaper.m in Sources */,
@@ -2446,7 +2446,7 @@
 				EAA0F5591AE71C8F007CD7C9 /* AKLineTableGenerator.m in Sources */,
 				EAA0F55A1AE71C8F007CD7C9 /* AKWindowTableGenerator.m in Sources */,
 				EAA0F55B1AE71C8F007CD7C9 /* AKPanner.m in Sources */,
-				EAA0F55C1AE71C8F007CD7C9 /* Stick.m in Sources */,
+				EAA0F55C1AE71C8F007CD7C9 /* AKStickInstrument.m in Sources */,
 				EAA0F55D1AE71C8F007CD7C9 /* AKTrackedFrequencyFromFSignal.m in Sources */,
 				EAA0F55E1AE71C8F007CD7C9 /* AKRingModulator.m in Sources */,
 				EAA0F55F1AE71C8F007CD7C9 /* AKReverb.m in Sources */,
@@ -2460,9 +2460,9 @@
 				EAA0F5671AE71C8F007CD7C9 /* AKVibes.m in Sources */,
 				EAA0F5681AE71C8F007CD7C9 /* AKMP3FileInput.m in Sources */,
 				EAA0F5691AE71C8F007CD7C9 /* AKMultitapDelay.m in Sources */,
-				EAA0F56A1AE71C8F007CD7C9 /* Sekere.m in Sources */,
+				EAA0F56A1AE71C8F007CD7C9 /* AKSekereInstrument.m in Sources */,
 				EAA0F56B1AE71C8F007CD7C9 /* AKHarmonicCosineTableGenerator.m in Sources */,
-				EAA0F56C1AE71C8F007CD7C9 /* Vibraphone.m in Sources */,
+				EAA0F56C1AE71C8F007CD7C9 /* AKVibraphoneInstrument.m in Sources */,
 				EAA0F56D1AE71C8F007CD7C9 /* AKAudioInputPlot.m in Sources */,
 				EAA0F56E1AE71C8F007CD7C9 /* AKCrossSynthesizedFFT.m in Sources */,
 				EAA0F56F1AE71C8F007CD7C9 /* AKStereoAmplifier.m in Sources */,

--- a/AudioKit/Core Classes/AKFoundation.h
+++ b/AudioKit/Core Classes/AKFoundation.h
@@ -217,8 +217,8 @@
 // Utilities - Instruments
 
 // Utilities - Instruments - Amplifiers
-#import "Amplifier.h"
-#import "StereoAmplifier.h"
+#import "AKAmplifier.h"
+#import "AKStereoAmplifier.h"
 
 // Utilities - Instruments - Analyzers
 #import "AKAudioAnalyzer.h"
@@ -236,17 +236,17 @@
 #import "Vibraphone.h"
 
 // Utilities - Instruments - File Players
-#import "AudioFilePlayer.h"
+#import "AKAudioFilePlayer.h"
 
 // Utilities - Instruments - Microphone
-#import "Microphone.h"
+#import "AKMicrophone.h"
 
 // Utilities - Instruments - Processors
-#import "ReverbProcessor.h"
+#import "AKReverbProcessor.h"
 
 // Utilities - Instruments - Synthesizers
-#import "FMOscillatorInstrument.h"
-#import "VCOscillatorInstrument.h"
+#import "AKFMOscillatorInstrument.h"
+#import "AKVCOscillatorInstrument.h"
 
 // Utilities - Plots
 #import "AKAudioInputFFTPlot.h"

--- a/AudioKit/Core Classes/AKFoundation.h
+++ b/AudioKit/Core Classes/AKFoundation.h
@@ -224,16 +224,16 @@
 #import "AKAudioAnalyzer.h"
 
 // Utilities - Instruments - Emulations
-#import "BambooSticks.h"
-#import "Mandolin.h"
-#import "Marimba.h"
-#import "PluckedString.h"
-#import "Sekere.h"
-#import "Sleighbells.h"
-#import "Stick.h"
-#import "StruckMetalBar.h"
-#import "Tambourine.h"
-#import "Vibraphone.h"
+#import "AKBambooSticksInstrument.h"
+#import "AKMandolinInstrument.h"
+#import "AKMarimbaInstrument.h"
+#import "AKPluckedStringInstrument.h"
+#import "AKSekereInstrument.h"
+#import "AKSleighbellsInstrument.h"
+#import "AKStickInstrument.h"
+#import "AKStruckMetalBarInstrument.h"
+#import "AKTambourineInstrument.h"
+#import "AKVibraphoneInstrument.h"
 
 // Utilities - Instruments - File Players
 #import "AKAudioFilePlayer.h"

--- a/AudioKit/Utilities/Instruments/Amplifiers/AKAmplifier.h
+++ b/AudioKit/Utilities/Instruments/Amplifiers/AKAmplifier.h
@@ -1,5 +1,5 @@
 //
-//  StereoAmplifier.h
+//  AKAmplifier.h
 //  AudioKit
 //
 //  Created by Aurelius Prochazka on 3/20/15.
@@ -8,13 +8,13 @@
 
 #import "AKFoundation.h"
 
-/** A stereo amplification system with amplitude control.  
+/** A monophonic amplification system with amplitude control.  
  This instrument is intended to be used as the last instrument in a processing chain.
  */
-@interface StereoAmplifier : AKInstrument
+@interface AKAmplifier : AKInstrument
 
 @property (nonatomic) AKInstrumentProperty *amplitude;
 
-- (instancetype)initWithAudioSource:(AKStereoAudio *)audioSource;
+- (instancetype)initWithAudioSource:(AKAudio *)audioSource;
 
 @end

--- a/AudioKit/Utilities/Instruments/Amplifiers/AKAmplifier.m
+++ b/AudioKit/Utilities/Instruments/Amplifiers/AKAmplifier.m
@@ -1,16 +1,16 @@
 //
-//  StereoAmplifier.m
+//  Amplifier.m
 //  AudioKit
 //
 //  Created by Aurelius Prochazka on 3/20/15.
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "StereoAmplifier.h"
+#import "AKAmplifier.h"
 
-@implementation StereoAmplifier
+@implementation AKAmplifier
 
-- (instancetype)initWithAudioSource:(AKStereoAudio *)audioSource
+- (instancetype)initWithAudioSource:(AKAudio *)audioSource
 {
     self = [super init];
     if (self) {
@@ -19,7 +19,7 @@
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:2.0];
 
         // Audio Output
-        [self setStereoAudioOutput:[audioSource scaledBy:_amplitude]];
+        [self setAudioOutput:[audioSource scaledBy:_amplitude]];
 
         // Reset Inputs
         [self resetParameter:audioSource];

--- a/AudioKit/Utilities/Instruments/Amplifiers/AKStereoAmplifier.h
+++ b/AudioKit/Utilities/Instruments/Amplifiers/AKStereoAmplifier.h
@@ -1,5 +1,5 @@
 //
-//  Amplifier.h
+//  AKStereoAmplifier.h
 //  AudioKit
 //
 //  Created by Aurelius Prochazka on 3/20/15.
@@ -8,13 +8,13 @@
 
 #import "AKFoundation.h"
 
-/** A monophonic amplification system with amplitude control.  
+/** A stereo amplification system with amplitude control.  
  This instrument is intended to be used as the last instrument in a processing chain.
  */
-@interface Amplifier : AKInstrument
+@interface AKStereoAmplifier : AKInstrument
 
 @property (nonatomic) AKInstrumentProperty *amplitude;
 
-- (instancetype)initWithAudioSource:(AKAudio *)audioSource;
+- (instancetype)initWithAudioSource:(AKStereoAudio *)audioSource;
 
 @end

--- a/AudioKit/Utilities/Instruments/Amplifiers/AKStereoAmplifier.m
+++ b/AudioKit/Utilities/Instruments/Amplifiers/AKStereoAmplifier.m
@@ -1,16 +1,16 @@
 //
-//  Amplifier.m
+//  StereoAmplifier.m
 //  AudioKit
 //
 //  Created by Aurelius Prochazka on 3/20/15.
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Amplifier.h"
+#import "AKStereoAmplifier.h"
 
-@implementation Amplifier
+@implementation AKStereoAmplifier
 
-- (instancetype)initWithAudioSource:(AKAudio *)audioSource
+- (instancetype)initWithAudioSource:(AKStereoAudio *)audioSource
 {
     self = [super init];
     if (self) {
@@ -19,7 +19,7 @@
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:2.0];
 
         // Audio Output
-        [self setAudioOutput:[audioSource scaledBy:_amplitude]];
+        [self setStereoAudioOutput:[audioSource scaledBy:_amplitude]];
 
         // Reset Inputs
         [self resetParameter:audioSource];

--- a/AudioKit/Utilities/Instruments/Emulations/AKBambooSticksInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKBambooSticksInstrument.h
@@ -1,5 +1,5 @@
 //
-//  Sleighbells.h
+//  BambooSticks.h
 //  AudioKitPlayground
 //
 //  Created by Nicholas Arner on 3/21/15.
@@ -8,8 +8,8 @@
 
 #import "AKFoundation.h"
 
-/// An instrument that wraps the sleighbells physical model
-@interface Sleighbells : AKInstrument
+/// An instrument that wraps the bamboo sticks physical model
+@interface AKBambooSticksInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
@@ -19,11 +19,10 @@
 
 @end
 
-@interface SleighbellsNote : AKNote
+@interface AKBambooSticksNote : AKNote
 
 // Note properties
-@property AKNoteProperty *intensity;
-@property AKNoteProperty *dampingFactor;
+@property AKNoteProperty *count;
 @property AKNoteProperty *mainResonantFrequency;
 @property AKNoteProperty *firstResonantFrequency;
 @property AKNoteProperty *secondResonantFrequency;

--- a/AudioKit/Utilities/Instruments/Emulations/AKBambooSticksInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKBambooSticksInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "BambooSticks.h"
+#import "AKBambooSticksInstrument.h"
 
-@implementation BambooSticks
+@implementation AKBambooSticksInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        BambooSticksNote *note = [[BambooSticksNote alloc] init];
+        AKBambooSticksNote *note = [[AKBambooSticksNote alloc] init];
 
         // Instrument Properties
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
@@ -43,7 +43,7 @@
 // -----------------------------------------------------------------------------
 
 
-@implementation BambooSticksNote
+@implementation AKBambooSticksNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKMandolinInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKMandolinInstrument.h
@@ -1,5 +1,5 @@
 //
-//  Vibraphone.h
+//  Mandolin.h
 //  AudioKit
 //
 //  Created by Nicholas Arner on 3/20/15.
@@ -8,24 +8,25 @@
 
 #import "AKFoundation.h"
 
-/// An instrument that wraps the vibraphone physical model
-@interface Vibraphone : AKInstrument
+/// An instrument that wraps the mandolin physical model
+@interface AKMandolinInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
+@property AKInstrumentProperty *bodySize;
+@property AKInstrumentProperty *pairedStringDetuning;
 
-// Audio outlet for global effects processing (choose mono or stereo accordingly)
+
+// Audio outlet for global effects processing
 @property (readonly) AKAudio *auxilliaryOutput;
 
 @end
 
-@interface VibraphoneNote : AKNote
+@interface AKMandolinNote : AKNote
 
 // Note properties
 @property AKNoteProperty *frequency;
+@property AKNoteProperty *pluckPosition;
 @property AKNoteProperty *amplitude;
-@property AKNoteProperty *stickHardness;
-@property AKNoteProperty *strikePosition;
-
 
 @end

--- a/AudioKit/Utilities/Instruments/Emulations/AKMandolinInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKMandolinInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Mandolin.h"
+#import "AKMandolinInstrument.h"
 
-@implementation Mandolin
+@implementation AKMandolinInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        MandolinNote *note = [[MandolinNote alloc] init];
+        AKMandolinNote *note = [[AKMandolinNote alloc] init];
 
         // Instrument Properties
         _bodySize = [self createPropertyWithValue:0.5 minimum:0.0 maximum:1.0];
@@ -45,7 +45,7 @@
 // -----------------------------------------------------------------------------
 
 
-@implementation MandolinNote
+@implementation AKMandolinNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKMarimbaInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKMarimbaInstrument.h
@@ -9,7 +9,7 @@
 #import "AKFoundation.h"
 
 /// An instrument that wraps the marimba physical model
-@interface Marimba : AKInstrument
+@interface AKMarimbaInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
@@ -23,7 +23,7 @@
 
 @end
 
-@interface MarimbaNote : AKNote
+@interface AKMarimbaNote : AKNote
 
 // Note properties
 @property AKNoteProperty *frequency;

--- a/AudioKit/Utilities/Instruments/Emulations/AKMarimbaInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKMarimbaInstrument.m
@@ -1,48 +1,53 @@
 //
-//  Vibraphone.m
+//  Marimba.m
 //  AudioKit
 //
 //  Created by Nicholas Arner on 3/20/15.
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Vibraphone.h"
+#import "AKMarimbaInstrument.h"
 
-@implementation Vibraphone
+@implementation AKMarimbaInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        VibraphoneNote *note = [[VibraphoneNote alloc] init];
+        AKMarimbaNote *note = [[AKMarimbaNote alloc] init];
 
         // Instrument Properties
-        _amplitude = [self createPropertyWithValue:0.5 minimum:0.0 maximum:1.0];
-
+        _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
+        _vibratoFrequency = [self createPropertyWithValue:0.0 minimum:0.0 maximum:12.0];
+        _vibratoAmplitude = [self createPropertyWithValue:0.0 minimum:0.0 maximum:1.0];
+        
         // Instrument Definition
-        AKVibes *vibes = [AKVibes vibes];
-        vibes.frequency      = note.frequency;
-        vibes.amplitude      = note.amplitude;
-        vibes.stickHardness  = note.stickHardness;
-        vibes.strikePosition = note.strikePosition;
+        AKMarimba *marimba = [AKMarimba marimba];
+        marimba.frequency        = note.frequency;
+        marimba.amplitude        = note.amplitude;
+        marimba.stickHardness    = note.stickHardness;
+        marimba.strikePosition   = note.strikePosition;
+        marimba.vibratoFrequency = _vibratoFrequency;
+        marimba.vibratoAmplitude = _vibratoAmplitude;
+    
+        [self setAudioOutput:[marimba scaledBy:_amplitude]];
 
-        [self setAudioOutput:[vibes scaledBy:_amplitude]];
-
-        // Output to global effects processing
+        // Output to global effects processing (choose mono or stereo accordingly)
         _auxilliaryOutput = [AKAudio globalParameter];
-        [self assignOutput:_auxilliaryOutput to:vibes];
+        //_auxilliaryOutput = [AKStereoAudio globalParameter];
+        [self assignOutput:_auxilliaryOutput to:marimba];
     }
     return self;
 }
 @end
 
 // -----------------------------------------------------------------------------
-#  pragma mark - Vibraphone Note
+#  pragma mark - Marimba Note
 // -----------------------------------------------------------------------------
 
 
-@implementation VibraphoneNote
+@implementation AKMarimbaNote
 
 - (instancetype)init
 {
@@ -56,11 +61,13 @@
         _stickHardness.isContinuous = NO;
         _strikePosition = [self createPropertyWithValue:0.2 minimum:0 maximum:1];
         _strikePosition.isContinuous = NO;
-
+        
         // Optionally set a default note duration
         self.duration.value = 1.0;
     }
     return self;
 }
+
+
 
 @end

--- a/AudioKit/Utilities/Instruments/Emulations/AKPluckedStringInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKPluckedStringInstrument.h
@@ -9,7 +9,7 @@
 #import "AKFoundation.h"
 
 /// An instrument that wraps the plucked string physical model
-@interface PluckedString : AKInstrument
+@interface AKPluckedStringInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
@@ -20,7 +20,7 @@
 
 @end
 
-@interface PluckedStringNote : AKNote
+@interface AKPluckedStringNote : AKNote
 
 // Note properties
 @property AKNoteProperty *frequency;

--- a/AudioKit/Utilities/Instruments/Emulations/AKPluckedStringInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKPluckedStringInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "PluckedString.h"
+#import "AKPluckedStringInstrument.h"
 
-@implementation PluckedString
+@implementation AKPluckedStringInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        PluckedStringNote *note = [[PluckedStringNote alloc] init];
+        AKPluckedStringNote *note = [[AKPluckedStringNote alloc] init];
 
         // Instrument Properties
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
@@ -44,7 +44,7 @@
 // -----------------------------------------------------------------------------
 
 
-@implementation PluckedStringNote
+@implementation AKPluckedStringNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKSekereInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKSekereInstrument.h
@@ -8,7 +8,7 @@
 
 #import "AKFoundation.h"
 
-@interface Sekere : AKInstrument
+@interface AKSekereInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
@@ -18,7 +18,7 @@
 
 @end
 
-@interface SekereNote : AKNote
+@interface AKSekereNote : AKNote
 
 // Note properties
 @property AKNoteProperty *count;

--- a/AudioKit/Utilities/Instruments/Emulations/AKSekereInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKSekereInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Sekere.h"
+#import "AKSekereInstrument.h"
 
-@implementation Sekere
+@implementation AKSekereInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        SekereNote *note = [[SekereNote alloc] init];
+        AKSekereNote *note = [[AKSekereNote alloc] init];
 
         // Instrument Properties
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
@@ -41,7 +41,7 @@
 // -----------------------------------------------------------------------------
 
 
-@implementation SekereNote
+@implementation AKSekereNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKSleighbellsInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKSleighbellsInstrument.h
@@ -1,5 +1,5 @@
 //
-//  BambooSticks.h
+//  Sleighbells.h
 //  AudioKitPlayground
 //
 //  Created by Nicholas Arner on 3/21/15.
@@ -8,8 +8,8 @@
 
 #import "AKFoundation.h"
 
-/// An instrument that wraps the bamboo sticks physical model
-@interface BambooSticks : AKInstrument
+/// An instrument that wraps the sleighbells physical model
+@interface AKSleighbellsInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
@@ -19,10 +19,11 @@
 
 @end
 
-@interface BambooSticksNote : AKNote
+@interface AKSleighbellsNote : AKNote
 
 // Note properties
-@property AKNoteProperty *count;
+@property AKNoteProperty *intensity;
+@property AKNoteProperty *dampingFactor;
 @property AKNoteProperty *mainResonantFrequency;
 @property AKNoteProperty *firstResonantFrequency;
 @property AKNoteProperty *secondResonantFrequency;

--- a/AudioKit/Utilities/Instruments/Emulations/AKSleighbellsInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKSleighbellsInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Sleighbells.h"
+#import "AKSleighbellsInstrument.h"
 
-@implementation Sleighbells
+@implementation AKSleighbellsInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        SleighbellsNote *note = [[SleighbellsNote alloc] init];
+        AKSleighbellsNote *note = [[AKSleighbellsNote alloc] init];
 
         // Instrument Properties
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
@@ -45,7 +45,7 @@
 // -----------------------------------------------------------------------------
 
 
-@implementation SleighbellsNote
+@implementation AKSleighbellsNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKStickInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKStickInstrument.h
@@ -9,7 +9,7 @@
 #import "AKFoundation.h"
 
 /// An instrument that wraps the stick physical model
-@interface Stick : AKInstrument
+@interface AKStickInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
@@ -19,7 +19,7 @@
 
 @end
 
-@interface StickNote : AKNote
+@interface AKStickNote : AKNote
 
 // Note properties
 @property AKNoteProperty *intensity;

--- a/AudioKit/Utilities/Instruments/Emulations/AKStickInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKStickInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Stick.h"
+#import "AKStickInstrument.h"
 
-@implementation Stick
+@implementation AKStickInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        StickNote *note = [[StickNote alloc] init];
+        AKStickNote *note = [[AKStickNote alloc] init];
 
         // Instrument Properties
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
@@ -41,7 +41,7 @@
 // -----------------------------------------------------------------------------
 
 
-@implementation StickNote
+@implementation AKStickNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKStruckMetalBarInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKStruckMetalBarInstrument.h
@@ -9,7 +9,7 @@
 #import "AKFoundation.h"
 
 /// An instrument that wraps the struck metal bar physical model
-@interface StruckMetalBar : AKInstrument
+@interface AKStruckMetalBarInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
@@ -19,7 +19,7 @@
 
 @end
 
-@interface StruckMetalBarNote : AKNote
+@interface AKStruckMetalBarNote : AKNote
 
 // Note properties
 @property AKNoteProperty *decayTime;

--- a/AudioKit/Utilities/Instruments/Emulations/AKStruckMetalBarInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKStruckMetalBarInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "StruckMetalBar.h"
+#import "AKStruckMetalBarInstrument.h"
 
-@implementation StruckMetalBar
+@implementation AKStruckMetalBarInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        StruckMetalBarNote *note = [[StruckMetalBarNote alloc] init];
+        AKStruckMetalBarNote *note = [[AKStruckMetalBarNote alloc] init];
 
         // Instrument Properties
         _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
@@ -46,7 +46,7 @@
 #  pragma mark - StruckMetalBar Note
 // -----------------------------------------------------------------------------
 
-@implementation StruckMetalBarNote
+@implementation AKStruckMetalBarNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKTambourineInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKTambourineInstrument.h
@@ -9,11 +9,11 @@
 #import "AKFoundation.h"
 
 /// An instrument that wraps the tambourine physical model
-@interface Tambourine : AKInstrument
+@interface AKTambourineInstrument : AKInstrument
 @property AKInstrumentProperty *amplitude;
 @end
 
-@interface TambourineNote : AKNote
+@interface AKTambourineNote : AKNote
 
 // Note properties
 @property AKNoteProperty *dampingFactor;

--- a/AudioKit/Utilities/Instruments/Emulations/AKTambourineInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKTambourineInstrument.m
@@ -6,9 +6,9 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Tambourine.h"
+#import "AKTambourineInstrument.h"
 
-@implementation Tambourine
+@implementation AKTambourineInstrument
 
 - (instancetype)init
 {
@@ -16,7 +16,7 @@
     if (self) {
         _amplitude = [self createPropertyWithValue:0.5 minimum:0.0 maximum:1.0];
         
-        TambourineNote *note = [[TambourineNote alloc] init];
+        AKTambourineNote *note = [[AKTambourineNote alloc] init];
         AKTambourine *tambourine = [AKTambourine tambourine];
         tambourine.dampingFactor           = note.dampingFactor;
         tambourine.intensity               = note.intensity;
@@ -33,7 +33,7 @@
 #  pragma mark - Tambourine Note
 // -----------------------------------------------------------------------------
 
-@implementation TambourineNote
+@implementation AKTambourineNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Emulations/AKVibraphoneInstrument.h
+++ b/AudioKit/Utilities/Instruments/Emulations/AKVibraphoneInstrument.h
@@ -1,5 +1,5 @@
 //
-//  Mandolin.h
+//  Vibraphone.h
 //  AudioKit
 //
 //  Created by Nicholas Arner on 3/20/15.
@@ -8,25 +8,24 @@
 
 #import "AKFoundation.h"
 
-/// An instrument that wraps the mandolin physical model
-@interface Mandolin : AKInstrument
+/// An instrument that wraps the vibraphone physical model
+@interface AKVibraphoneInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
-@property AKInstrumentProperty *bodySize;
-@property AKInstrumentProperty *pairedStringDetuning;
 
-
-// Audio outlet for global effects processing
+// Audio outlet for global effects processing (choose mono or stereo accordingly)
 @property (readonly) AKAudio *auxilliaryOutput;
 
 @end
 
-@interface MandolinNote : AKNote
+@interface AKVibraphoneNote : AKNote
 
 // Note properties
 @property AKNoteProperty *frequency;
-@property AKNoteProperty *pluckPosition;
 @property AKNoteProperty *amplitude;
+@property AKNoteProperty *stickHardness;
+@property AKNoteProperty *strikePosition;
+
 
 @end

--- a/AudioKit/Utilities/Instruments/Emulations/AKVibraphoneInstrument.m
+++ b/AudioKit/Utilities/Instruments/Emulations/AKVibraphoneInstrument.m
@@ -1,53 +1,48 @@
 //
-//  Marimba.m
+//  Vibraphone.m
 //  AudioKit
 //
 //  Created by Nicholas Arner on 3/20/15.
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Marimba.h"
+#import "AKVibraphoneInstrument.h"
 
-@implementation Marimba
+@implementation AKVibraphoneInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        MarimbaNote *note = [[MarimbaNote alloc] init];
+        AKVibraphoneNote *note = [[AKVibraphoneNote alloc] init];
 
         // Instrument Properties
-        _amplitude = [self createPropertyWithValue:1.0 minimum:0.0 maximum:1.0];
-        _vibratoFrequency = [self createPropertyWithValue:0.0 minimum:0.0 maximum:12.0];
-        _vibratoAmplitude = [self createPropertyWithValue:0.0 minimum:0.0 maximum:1.0];
-        
-        // Instrument Definition
-        AKMarimba *marimba = [AKMarimba marimba];
-        marimba.frequency        = note.frequency;
-        marimba.amplitude        = note.amplitude;
-        marimba.stickHardness    = note.stickHardness;
-        marimba.strikePosition   = note.strikePosition;
-        marimba.vibratoFrequency = _vibratoFrequency;
-        marimba.vibratoAmplitude = _vibratoAmplitude;
-    
-        [self setAudioOutput:[marimba scaledBy:_amplitude]];
+        _amplitude = [self createPropertyWithValue:0.5 minimum:0.0 maximum:1.0];
 
-        // Output to global effects processing (choose mono or stereo accordingly)
+        // Instrument Definition
+        AKVibes *vibes = [AKVibes vibes];
+        vibes.frequency      = note.frequency;
+        vibes.amplitude      = note.amplitude;
+        vibes.stickHardness  = note.stickHardness;
+        vibes.strikePosition = note.strikePosition;
+
+        [self setAudioOutput:[vibes scaledBy:_amplitude]];
+
+        // Output to global effects processing
         _auxilliaryOutput = [AKAudio globalParameter];
-        //_auxilliaryOutput = [AKStereoAudio globalParameter];
-        [self assignOutput:_auxilliaryOutput to:marimba];
+        [self assignOutput:_auxilliaryOutput to:vibes];
     }
     return self;
 }
 @end
 
 // -----------------------------------------------------------------------------
-#  pragma mark - Marimba Note
+#  pragma mark - Vibraphone Note
 // -----------------------------------------------------------------------------
 
 
-@implementation MarimbaNote
+@implementation AKVibraphoneNote
 
 - (instancetype)init
 {
@@ -61,13 +56,11 @@
         _stickHardness.isContinuous = NO;
         _strikePosition = [self createPropertyWithValue:0.2 minimum:0 maximum:1];
         _strikePosition.isContinuous = NO;
-        
+
         // Optionally set a default note duration
         self.duration.value = 1.0;
     }
     return self;
 }
-
-
 
 @end

--- a/AudioKit/Utilities/Instruments/File Players/AKAudioFilePlayer.h
+++ b/AudioKit/Utilities/Instruments/File Players/AKAudioFilePlayer.h
@@ -1,5 +1,5 @@
 //
-//  AudioFilePlayer.h
+//  AKAudioFilePlayer.h
 //  Objective-C Sound Example
 //
 //  Created by Aurelius Prochazka on 6/16/12.
@@ -8,7 +8,7 @@
 
 #import "AKFoundation.h"
 
-@interface AudioFilePlayer : AKInstrument
+@interface AKAudioFilePlayer : AKInstrument
 
 @property (readonly) AKAudio *auxilliaryOutput;
 

--- a/AudioKit/Utilities/Instruments/File Players/AKAudioFilePlayer.m
+++ b/AudioKit/Utilities/Instruments/File Players/AKAudioFilePlayer.m
@@ -6,9 +6,9 @@
 //  Copyright (c) 2012 Hear For Yourself. All rights reserved.
 //
 
-#import "AudioFilePlayer.h"
+#import "AKAudioFilePlayer.h"
 
-@implementation AudioFilePlayer
+@implementation AKAudioFilePlayer
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Microphone/AKMicrophone.h
+++ b/AudioKit/Utilities/Instruments/Microphone/AKMicrophone.h
@@ -1,5 +1,5 @@
 //
-//  Microphone.h
+//  AKMicrophone.h
 //  AudioKit
 //
 //  Created by Aurelius Prochazka on 4/4/15.
@@ -8,7 +8,7 @@
 
 #import "AKFoundation.h"
 
-@interface Microphone : AKInstrument
+@interface AKMicrophone : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;

--- a/AudioKit/Utilities/Instruments/Microphone/AKMicrophone.m
+++ b/AudioKit/Utilities/Instruments/Microphone/AKMicrophone.m
@@ -6,9 +6,9 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "Microphone.h"
+#import "AKMicrophone.h"
 
-@implementation Microphone
+@implementation AKMicrophone
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Processors/AKReverbProcessor.h
+++ b/AudioKit/Utilities/Instruments/Processors/AKReverbProcessor.h
@@ -1,5 +1,5 @@
 //
-//  ReverbProcessor.h
+//  AKReverbProcessor.h
 //  AudioKit
 //
 //  Created by Aurelius Prochazka on 3/20/15.
@@ -9,7 +9,7 @@
 #import "AKFoundation.h"
 
 /// A reverb processor and end point (outputs to the DAC)
-@interface ReverbProcessor : AKInstrument
+@interface AKReverbProcessor : AKInstrument
 
 @property (nonatomic) AKInstrumentProperty *feedback;
 

--- a/AudioKit/Utilities/Instruments/Processors/AKReverbProcessor.m
+++ b/AudioKit/Utilities/Instruments/Processors/AKReverbProcessor.m
@@ -6,9 +6,9 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "ReverbProcessor.h"
+#import "AKReverbProcessor.h"
 
-@implementation ReverbProcessor
+@implementation AKReverbProcessor
 
 - (instancetype)initWithAudioSource:(AKAudio *)audioSource
 {

--- a/AudioKit/Utilities/Instruments/Synthesizers/AKFMOscillatorInstrument.h
+++ b/AudioKit/Utilities/Instruments/Synthesizers/AKFMOscillatorInstrument.h
@@ -1,5 +1,5 @@
 //
-//  FMOscillatorInstrument.h
+//  AKFMOscillatorInstrument.h
 //  AudioKit
 //
 //  Created by Aurelius Prochazka on 3/20/15.
@@ -9,13 +9,13 @@
 #import "AKFoundation.h"
 
 /// A synth that uses FM Synthesis to generate sounds, with frequency and amplitude defined
-@interface FMOscillatorInstrument : AKInstrument
+@interface AKFMOscillatorInstrument : AKInstrument
 
 // Instrument Properties
 @property AKInstrumentProperty *amplitude;
 @end
 
-@interface FMOscillatorNote : AKNote
+@interface AKFMOscillatorNote : AKNote
 
 // Note properties
 @property AKNoteProperty *frequency;

--- a/AudioKit/Utilities/Instruments/Synthesizers/AKFMOscillatorInstrument.m
+++ b/AudioKit/Utilities/Instruments/Synthesizers/AKFMOscillatorInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "FMOscillatorInstrument.h"
+#import "AKFMOscillatorInstrument.h"
 
-@implementation FMOscillatorInstrument
+@implementation AKFMOscillatorInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         // Note Properties
-        FMOscillatorNote *note = [[FMOscillatorNote alloc] init];
+        AKFMOscillatorNote *note = [[AKFMOscillatorNote alloc] init];
 
         // Instrument Properties
         _amplitude = [self createPropertyWithValue:0.5 minimum:0.0 maximum:1.0];
@@ -36,7 +36,7 @@
 // -----------------------------------------------------------------------------
 
 
-@implementation FMOscillatorNote
+@implementation AKFMOscillatorNote
 
 - (instancetype)init
 {

--- a/AudioKit/Utilities/Instruments/Synthesizers/AKVCOscillatorInstrument.h
+++ b/AudioKit/Utilities/Instruments/Synthesizers/AKVCOscillatorInstrument.h
@@ -1,5 +1,5 @@
 //
-//  VCOscillatorInstrument.h
+//  AKVCOscillatorInstrument.h
 //  AudioKitPlayground
 //
 //  Created by Aurelius Prochazka on 3/22/15.
@@ -9,13 +9,13 @@
 #import "AKFoundation.h"
 
 /// An instrument for the Voltage-controlled oscillator operation
-@interface VCOscillatorInstrument : AKInstrument
+@interface AKVCOscillatorInstrument : AKInstrument
 @property AKInstrumentProperty *amplitude;
 @end
 
 
 
-@interface VCOscillatorNote : AKNote
+@interface AKVCOscillatorNote : AKNote
 @property AKNoteProperty *frequency;
 @property AKNoteProperty *waveformType;
 @end

--- a/AudioKit/Utilities/Instruments/Synthesizers/AKVCOscillatorInstrument.m
+++ b/AudioKit/Utilities/Instruments/Synthesizers/AKVCOscillatorInstrument.m
@@ -6,16 +6,16 @@
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 
-#import "VCOscillatorInstrument.h"
+#import "AKVCOscillatorInstrument.h"
 
-@implementation VCOscillatorInstrument
+@implementation AKVCOscillatorInstrument
 
 - (instancetype)init
 {
     self = [super init];
     if (self) {
         _amplitude = [[AKInstrumentProperty alloc] initWithValue:0.5 minimum:0 maximum:1];
-        VCOscillatorNote *note = [[VCOscillatorNote alloc] init];
+        AKVCOscillatorNote *note = [[AKVCOscillatorNote alloc] init];
         AKVCOscillator *vco = [AKVCOscillator oscillator];
         vco.amplitude = _amplitude;
         vco.frequency = note.frequency;
@@ -28,7 +28,7 @@
 @end
 
 
-@implementation VCOscillatorNote
+@implementation AKVCOscillatorNote
 
 - (instancetype)init
 {

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
@@ -11,7 +11,7 @@
 
 @implementation AnalysisViewController
 {
-    Microphone *microphone;
+    AKMicrophone *microphone;
     AKAudioAnalyzer *analyzer;
     
     IBOutlet NSTextField *frequencyLabel;
@@ -36,7 +36,7 @@
     
     AKSettings.shared.audioInputEnabled = YES;
     
-    microphone = [[Microphone alloc] init];
+    microphone = [[AKMicrophone alloc] init];
     [AKOrchestra addInstrument:microphone];
     analyzer = [[AKAudioAnalyzer alloc] initWithAudioSource:microphone.auxilliaryOutput];
     [AKOrchestra addInstrument:analyzer];

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo/Processing/ProcessingViewController.m
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo/Processing/ProcessingViewController.m
@@ -23,14 +23,14 @@
     float pitchToMaintain;
     
     ConvolutionInstrument *convolver;
-    AudioFilePlayer *audioFilePlayer;
+    AKAudioFilePlayer *audioFilePlayer;
     
     BOOL isPlaying;
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    audioFilePlayer = [[AudioFilePlayer alloc] init];
+    audioFilePlayer = [[AKAudioFilePlayer alloc] init];
     [AKOrchestra addInstrument:audioFilePlayer];
     
     convolver = [[ConvolutionInstrument alloc] initWithInput:audioFilePlayer.auxilliaryOutput];

--- a/Examples/OSX/AudioKitDemo/AudioKitDemo/Synthesis/SynthesisViewController.m
+++ b/Examples/OSX/AudioKitDemo/AudioKitDemo/Synthesis/SynthesisViewController.m
@@ -16,13 +16,13 @@
     IBOutlet NSView *fmSynthesizerTouchView;
     IBOutlet NSView *tambourineTouchView;
     
-    Tambourine *tambourine;
+    AKTambourineInstrument *tambourine;
     FMSynthesizer *fmSynthesizer;
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    tambourine = [[Tambourine alloc] init];
+    tambourine = [[AKTambourineInstrument alloc] init];
     [AKOrchestra addInstrument:tambourine];
     
     fmSynthesizer = [[FMSynthesizer alloc] init];
@@ -37,8 +37,8 @@
     
     float intensity = scaledY*4000 + 20;
     float dampingFactor = scaledX / 2.0;
-    TambourineNote *note = [[TambourineNote alloc] initWithIntensity:intensity
-                                                       dampingFactor:dampingFactor];
+    AKTambourineNote *note = [[AKTambourineNote alloc] initWithIntensity:intensity
+                                                           dampingFactor:dampingFactor];
     [tambourine playNote:note];
 }
 

--- a/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/AnalysisViewController.swift
+++ b/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/AnalysisViewController.swift
@@ -14,7 +14,7 @@ class AnalysisViewController: NSViewController {
     @IBOutlet var noteNameWithFlatsLabel: NSTextField!
     
     var analyzer: AKAudioAnalyzer!
-    let microphone = Microphone()
+    let microphone = AKMicrophone()
 
     let noteFrequencies = [16.35,17.32,18.35,19.45,20.6,21.83,23.12,24.5,25.96,27.5,29.14,30.87]
     let noteNamesWithSharps = ["C", "C♯","D","D♯","E","F","F♯","G","G♯","A","A♯","B"]

--- a/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/ProcessingViewController.swift
+++ b/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/ProcessingViewController.swift
@@ -18,7 +18,7 @@ class ProcessingViewController: NSViewController {
     var pitchToMaintain: Float = 1.0
     
     var conv: ConvolutionInstrument!
-    let audioFilePlayer = AudioFilePlayer()
+    let audioFilePlayer = AKAudioFilePlayer()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/SynthesisViewController.swift
+++ b/Examples/OSX/Swift/AudioKitDemo/AudioKitDemo/SynthesisViewController.swift
@@ -12,7 +12,7 @@ class SynthesisViewController: NSViewController {
     @IBOutlet var fmSynthesizerTouchView: NSView!
     @IBOutlet var tambourineTouchView: NSView!
     
-    let tambourine    = Tambourine()
+    let tambourine    = AKTambourineInstrument()
     let fmSynthesizer = FMSynthesizer()
     
     override func viewDidLoad() {
@@ -31,7 +31,7 @@ class SynthesisViewController: NSViewController {
         let intensity = Float(scaledY*4000 + 20)
         let dampingFactor = Float(scaledX / 2.0)
         
-        let note = TambourineNote(intensity: intensity, dampingFactor: dampingFactor)
+        let note = AKTambourineNote(intensity: intensity, dampingFactor: dampingFactor)
         tambourine.playNote(note)
     }
     

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.m
@@ -11,7 +11,7 @@
 
 @implementation AnalysisViewController
 {
-    Microphone *microphone;
+    AKMicrophone *microphone;
     AKAudioAnalyzer *analyzer;
     
     IBOutlet UILabel *frequencyLabel;
@@ -39,7 +39,7 @@
     
     AKSettings.shared.audioInputEnabled = YES;
 
-    microphone = [[Microphone alloc] init];
+    microphone = [[AKMicrophone alloc] init];
     [AKOrchestra addInstrument:microphone];
     analyzer = [[AKAudioAnalyzer alloc] initWithAudioSource:microphone.auxilliaryOutput];
     [AKOrchestra addInstrument:analyzer];

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Processing/ProcessingViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Processing/ProcessingViewController.m
@@ -24,14 +24,14 @@
     float pitchToMaintain;
 
     ConvolutionInstrument *convolver;
-    AudioFilePlayer *audioFilePlayer;
+    AKAudioFilePlayer *audioFilePlayer;
 
     BOOL isPlaying;
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    audioFilePlayer = [[AudioFilePlayer alloc] init];
+    audioFilePlayer = [[AKAudioFilePlayer alloc] init];
     [AKOrchestra addInstrument:audioFilePlayer];
 
     convolver = [[ConvolutionInstrument alloc] initWithInput:audioFilePlayer.auxilliaryOutput];

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Synthesis/SynthesisViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Synthesis/SynthesisViewController.m
@@ -16,14 +16,14 @@
     IBOutlet UIView *fmSynthesizerTouchView;
     IBOutlet UIView *tambourineTouchView;
     
-    Tambourine *tambourine;
+    AKTambourineInstrument *tambourine;
     FMSynthesizer *fmSynthesizer;
 }
 
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    tambourine = [[Tambourine alloc] init];
+    tambourine = [[AKTambourineInstrument alloc] init];
     [AKOrchestra addInstrument:tambourine];
 
     fmSynthesizer = [[FMSynthesizer alloc] init];
@@ -38,8 +38,8 @@
     
     float intensity = scaledY*4000 + 20;
     float dampingFactor = scaledX / 2.0;
-    TambourineNote *note = [[TambourineNote alloc] initWithIntensity:intensity
-                                                       dampingFactor:dampingFactor];
+    AKTambourineNote *note = [[AKTambourineNote alloc] initWithIntensity:intensity
+                                                           dampingFactor:dampingFactor];
     [tambourine playNote:note];
 }
 

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.swift
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Analysis/AnalysisViewController.swift
@@ -15,7 +15,7 @@ class AnalysisViewController: UIViewController {
     @IBOutlet var frequencyPlot: AKInstrumentPropertyPlot!
     @IBOutlet var normalizedFrequencyPlot: AKFloatPlot!
     
-    let microphone = Microphone()
+    let microphone = AKMicrophone()
     var analyzer: AKAudioAnalyzer!
 
     let noteFrequencies = [16.35,17.32,18.35,19.45,20.6,21.83,23.12,24.5,25.96,27.5,29.14,30.87]

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Processing/ProcessingViewController.swift
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Processing/ProcessingViewController.swift
@@ -21,7 +21,7 @@ class ProcessingViewController: UIViewController {
     var pitchToMaintain: Float = 1.0
     
     var conv: ConvolutionInstrument!
-    let audioFilePlayer = AudioFilePlayer()
+    let audioFilePlayer = AKAudioFilePlayer()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Synthesis/SynthesisViewController.swift
+++ b/Examples/iOS/Swift/AudioKitDemo/AudioKitDemo/Synthesis/SynthesisViewController.swift
@@ -12,7 +12,7 @@ class SynthesisViewController: UIViewController {
     @IBOutlet var fmSynthesizerTouchView: UIView!
     @IBOutlet var tambourineTouchView: UIView!
     
-    let tambourine    = Tambourine()
+    let tambourine    = AKTambourineInstrument()
     let fmSynthesizer = FMSynthesizer()
     
     override func viewDidLoad() {
@@ -32,7 +32,7 @@ class SynthesisViewController: UIViewController {
         let intensity = Float(scaledY*4000 + 20)
         let dampingFactor = Float(scaledX / 2.0)
         
-        let note = TambourineNote(intensity: intensity, dampingFactor: dampingFactor)
+        let note = AKTambourineNote(intensity: intensity, dampingFactor: dampingFactor)
         tambourine.playNote(note)
     }
     


### PR DESCRIPTION
As we start building the framework, a good practice is to make sure that all public classes in the library have unique names, and the best way to do this is to make sure they all use the AK prefix. The main holdouts so far are classes in the Utilities/Instruments group.

This patch changes those I could without introducing clashes with already existing names. This is actually a problem that we need to address, but it might be better to hash it out between @aure  and @narner to figure out the best way to resolve this.

Basically, you'll see that for instance we have a `Mandolin` class in Utilities, but we can't rename it to `AKMandolin` because there's already such a class under Operations. This applies to a bunch of those instruments (pretty much all remaining classes without the prefix).

So we need to agree on how best to handle this if we're going to keep these non-prefixed classes as public and part of the library. Either chuck them out if they're really just examples, or find some better way to rename them that still includes the prefix. One thing is sure is that we can't have a public `Mandolin` class as part of the framework, since it's very likely to conflict with similar classes in apps.
