### PR TITLE
Renamed the TRAVIS_CI macro to the more generic AK_TESTING.

### DIFF
--- a/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit.xcodeproj/project.pbxproj
@@ -2526,7 +2526,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"TRAVIS_CI=1",
+					"AK_TESTING=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;

--- a/AudioKit/Core Classes/AKManager.h
+++ b/AudioKit/Core Classes/AKManager.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Determines whether or not to log
 @property BOOL isLogging;
 
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
 /// Place to put lines of testing logs
 @property NSMutableArray *testLog;
 #endif

--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -103,7 +103,7 @@ static AKManager *_sharedManager = nil;
         
         _isRunning = NO;
         _isLogging = AKSettings.shared.loggingEnabled;
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
         _testLog = [NSMutableArray array];
 #endif
         _totalRunDuration = 10000000;
@@ -114,7 +114,7 @@ static AKManager *_sharedManager = nil;
         _orchestra = [[AKOrchestra alloc] init];
         
         NSString *inputOption = [NSString stringWithFormat:@"-i %@", AKSettings.shared.audioInput];
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
         inputOption = @"";
 #endif
 
@@ -198,7 +198,7 @@ static AKManager *_sharedManager = nil;
 
 - (void)runOrchestra
 {
-# ifdef TRAVIS_CI
+#ifdef AK_TESTING
     return;
 #else
     if(_isRunning) {
@@ -343,7 +343,7 @@ static AKManager *_sharedManager = nil;
 
 - (void)messageReceivedFrom:(CsoundObj *)csoundObj attr:(int)attr message:(NSString *)msg
 {
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
     if ([msg rangeOfString:@"AKTEST"].location != NSNotFound) {
         [_testLog addObject:[msg stringByReplacingOccurrencesOfString:@"AKTEST" withString:@""]];
         return;

--- a/AudioKit/Platforms/Common/CsoundObj.m
+++ b/AudioKit/Platforms/Common/CsoundObj.m
@@ -62,7 +62,7 @@ OSStatus  Csound_Render(void *inRefCon,
 
 @property (strong) NSMutableArray *listeners;
 
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
 @property (strong) NSMutableArray *orcMessages;
 @property (strong) NSMutableArray *scoMessages;
 #endif
@@ -95,7 +95,7 @@ OSStatus  Csound_Render(void *inRefCon,
 
 - (void)sendScore:(NSString *)score
 {
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
     [_scoMessages addObject:score];
 #else
     if (_cs) {
@@ -115,7 +115,7 @@ OSStatus  Csound_Render(void *inRefCon,
 
 - (void)updateOrchestra:(NSString *)orchestraString
 {
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
     [_orcMessages addObject:orchestraString];
 #else
     if (_cs) {
@@ -583,7 +583,7 @@ OSStatus  Csound_Render(void *inRefCon,
                          "-o",     (char*)[paths[1] cStringUsingEncoding:NSASCIIStringEncoding]};
         int ret = csoundCompile(_cs, 4, argv);
         
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
         for (NSString *message in _orcMessages) {
             csoundCompileOrc(_cs, [message cStringUsingEncoding:NSASCIIStringEncoding]);
         }
@@ -626,7 +626,7 @@ OSStatus  Csound_Render(void *inRefCon,
         
 #if TARGET_OS_IPHONE
         char *argv[] = { "csound",
-# ifdef TRAVIS_CI
+# ifdef AK_TESTING
             "-+rtaudio=null",
 # else
             "-+rtaudio=coreaudio",
@@ -634,7 +634,7 @@ OSStatus  Csound_Render(void *inRefCon,
                         (char*)[csdFilePath cStringUsingEncoding:NSASCIIStringEncoding]};
 #else
         char *argv[] = { "csound", "-+ignore_csopts=0",
-# ifdef TRAVIS_CI
+# ifdef AK_TESTING
                          "-+rtaudio=null",
 # else
                          "-+rtaudio=coreaudio",
@@ -1005,7 +1005,7 @@ OSStatus  Csound_Render(void *inRefCon,
 
 - (void)setUpForTest
 {
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
     NSLog(@"Setting up Csound for test...");
     _scoMessages = [[NSMutableArray alloc] init];
     _orcMessages = [[NSMutableArray alloc] init];
@@ -1016,7 +1016,7 @@ OSStatus  Csound_Render(void *inRefCon,
 
 - (void)teardownForTest
 {
-#ifdef TRAVIS_CI
+#ifdef AK_TESTING
     NSLog(@"Tearing down Csound for test...");
     [[AKManager sharedManager] cleanup];
     csoundDestroy(_cs);

--- a/Tests/AudioKitTest/AudioKitTest.xcodeproj/project.pbxproj
+++ b/Tests/AudioKitTest/AudioKitTest.xcodeproj/project.pbxproj
@@ -411,7 +411,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"TRAVIS_CI=1",
+					"AK_TESTING=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Tests/TestProjects/OSXObjectiveCAudioKit/OSXObjectiveCAudioKit.xcodeproj/project.pbxproj
+++ b/Tests/TestProjects/OSXObjectiveCAudioKit/OSXObjectiveCAudioKit.xcodeproj/project.pbxproj
@@ -579,7 +579,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"TRAVIS_CI=1",
+					"AK_TESTING=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Tests/TestProjects/iOSObjectiveCAudioKit/iOSObjectiveCAudioKit.xcodeproj/project.pbxproj
+++ b/Tests/TestProjects/iOSObjectiveCAudioKit/iOSObjectiveCAudioKit.xcodeproj/project.pbxproj
@@ -710,7 +710,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"TRAVIS_CI=1",
+					"AK_TESTING=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;


### PR DESCRIPTION
Pretty simple, just renamed the macro in all places it was being used.
