### PR TITLE
Added defaults and presets

### DIFF
--- a/AudioKit/Operations/Analysis/AKTrackedAmplitude.h
+++ b/AudioKit/Operations/Analysis/AKTrackedAmplitude.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKTrackedAmplitude : AKControl
 /// Instantiates the tracked amplitude with all values
-/// @param input Input audio signal to track. [Default Value: ]
+/// @param input Input audio signal to track. 
 /// @param halfPowerPoint Half-power point (in Hz) of a special internal low-pass filter. [Default Value: 10]
 - (instancetype)initWithInput:(AKParameter *)input
                halfPowerPoint:(AKConstant *)halfPowerPoint;

--- a/AudioKit/Operations/FFT/AKFFTProcessor.h
+++ b/AudioKit/Operations/FFT/AKFFTProcessor.h
@@ -18,7 +18,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKFFTProcessor : AKFSignal
 /// Instantiates the fft processor with all values
-/// @param table Primary input is a table, usually a mono sound file. Updated at Control-rate. [Default Value: ]
+/// @param table Primary input is a table, usually a mono sound file. Updated at Control-rate. 
 /// @param frequencyRatio Grain frequency scaling (1=normal pitch, < 1 lower, > 1 higher; negative, backwards) Updated at Control-rate. [Default Value: 1]
 /// @param timeRatio Time Scaling ratio, < 1 stretches, > 1 contracts. Updated at Control-rate. [Default Value: 1]
 /// @param amplitude Amplitude of the output. Updated at Control-rate. [Default Value: 1]

--- a/AudioKit/Operations/Signal Generators/Granular Synthesis/AKGranularSynthesisTexture.h
+++ b/AudioKit/Operations/Signal Generators/Granular Synthesis/AKGranularSynthesisTexture.h
@@ -17,8 +17,8 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKGranularSynthesisTexture : AKAudio
 /// Instantiates the granular synthesis texture with all values
-/// @param grainTable The grain waveform. This can be just a sine wave or a sampled sound. [Default Value: ]
-/// @param windowTable The amplitude envelope used for the grains. [Default Value: ]
+/// @param grainTable The grain waveform. This can be just a sine wave or a sampled sound.
+/// @param windowTable The amplitude envelope used for the grains. 
 /// @param maximumGrainDuration Maximum grain duration in seconds. [Default Value: 0.5]
 /// @param averageGrainDuration Average grain duration in seconds. Updated at Control-rate. [Default Value: 0.4]
 /// @param maximumFrequencyDeviation Maximum pitch deviation from grainFrequency in Hz. Updated at Control-rate. [Default Value: 0.5]

--- a/AudioKit/Operations/Signal Generators/Granular Synthesis/AKGranularSynthesizer.h
+++ b/AudioKit/Operations/Signal Generators/Granular Synthesis/AKGranularSynthesizer.h
@@ -18,7 +18,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKGranularSynthesizer : AKAudio
 /// Instantiates the granular synthesizer with all values
-/// @param grainWaveform Table contain grain waveform. Updated at Control-rate. [Default Value: ]
+/// @param grainWaveform Table contain grain waveform. Updated at Control-rate.
 /// @param frequency Grain frequency in Hz Updated at Control-rate. [Default Value: ]
 /// @param windowWaveform Table containing window waveform. [Default Value: AKWindowTypeHamming]
 /// @param duration Grain duration in seconds. It also controls the duration of already active grains (actually the speed at which the window function is read). Updated at Control-rate. [Default Value: 0.2]

--- a/AudioKit/Operations/Signal Generators/Loopers/AKMonoSoundFileLooper.h
+++ b/AudioKit/Operations/Signal Generators/Loopers/AKMonoSoundFileLooper.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (AKConstant *)loopPlaysForwardAndThenBackwards;
 
 /// Instantiates the mono sound file looper with all values
-/// @param soundFile The sound file table. [Default Value: ]
+/// @param soundFile The sound file table. 
 /// @param frequencyRatio The frequency ratio. Updated at Control-rate. [Default Value: 1]
 /// @param amplitude The amplitude of the output [Default Value: 1]
 /// @param loopMode Can be no-looping, normal forward looping, or forward and backward looping. [Default Value: AKSoundFileLooperModeNormal]

--- a/AudioKit/Operations/Signal Generators/Loopers/AKStereoSoundFileLooper.h
+++ b/AudioKit/Operations/Signal Generators/Loopers/AKStereoSoundFileLooper.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (AKConstant *)loopPlaysForwardAndThenBackwards;
 
 /// Instantiates the stereo sound file looper with all values
-/// @param soundFile The sound file table. [Default Value: ]
+/// @param soundFile The sound file table. 
 /// @param frequencyRatio The frequency ratio. Updated at Control-rate. [Default Value: 1]
 /// @param amplitude The amplitude of the output [Default Value: 1]
 /// @param loopMode Can be no-looping, normal forward looping, or forward and backward looping. [Default Value: AKSoundFileLooperModeNormal]

--- a/AudioKit/Operations/Signal Generators/Loopers/AKTableLooper.h
+++ b/AudioKit/Operations/Signal Generators/Loopers/AKTableLooper.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (AKConstant *)loopPlaysForwardAndThenBackwards;
 
 /// Instantiates the table looper with all values
-/// @param table Sound source table, generally an AKSoundFile. [Default Value: ]
+/// @param table Sound source table, generally an AKSoundFile. 
 /// @param startTime Loop start point in seconds. Updated at Control-rate. [Default Value: 0]
 /// @param endTime Playback end position in seconds.  Defaults to end of table(0). Updated at Control-rate. [Default Value: 0]
 /// @param transpositionRatio Pitch control by way of transposition ratio. Updated at Control-rate. [Default Value: 1]

--- a/AudioKit/Operations/Signal Generators/Musical Controls/AKPortamento.h
+++ b/AudioKit/Operations/Signal Generators/Musical Controls/AKPortamento.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKPortamento : AKControl
 /// Instantiates the portamento with all values
-/// @param input The input signal at control-rate. Updated at Control-rate. [Default Value: ]
+/// @param input The input signal at control-rate. Updated at Control-rate. 
 /// @param halfTime Half-time of the function in seconds. Updated at Control-rate. [Default Value: 1]
 - (instancetype)initWithInput:(AKParameter *)input
                      halfTime:(AKParameter *)halfTime;

--- a/AudioKit/Operations/Signal Generators/Physical Models/Waveguide/AKBeatenPlate.h
+++ b/AudioKit/Operations/Signal Generators/Physical Models/Waveguide/AKBeatenPlate.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKBeatenPlate : AKAudio
 /// Instantiates the beaten plate with all values
-/// @param input The excitation noise. [Default Value: ]
+/// @param input The excitation noise. 
 /// @param frequency1 The inverse of delay time for the first of two parallel delay lines. [Default Value: 5000]
 /// @param frequency2 The inverse of delay time for the second of two parallel delay lines. [Default Value: 2000]
 /// @param cutoffFrequency1 The filter cutoff frequency in Hz for the first low-pass filter. Updated at Control-rate. [Default Value: 3000]

--- a/AudioKit/Operations/Signal Generators/Physical Models/Waveguide/AKSimpleWaveGuideModel.h
+++ b/AudioKit/Operations/Signal Generators/Physical Models/Waveguide/AKSimpleWaveGuideModel.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKSimpleWaveGuideModel : AKAudio
 /// Instantiates the simple wave guide model with all values
-/// @param input The excitation noise. [Default Value: ]
+/// @param input The excitation noise. 
 /// @param frequency The inverse of delay time. [Default Value: 440]
 /// @param cutoff Filter cut-off frequency in Hz Updated at Control-rate. [Default Value: 3000]
 /// @param feedback Feedback factor usually between 0 and 1 Updated at Control-rate. [Default Value: 0.8]

--- a/AudioKit/Operations/Signal Generators/Subtractive Synthesis/AKAdditiveCosines.h
+++ b/AudioKit/Operations/Signal Generators/Subtractive Synthesis/AKAdditiveCosines.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKAdditiveCosines : AKAudio
 /// Instantiates the additive cosines with all values
-/// @param cosineTable A cosine table with at least 8192 points is recommended. [Default Value: ]
+/// @param cosineTable A cosine table with at least 8192 points is recommended. 
 /// @param harmonicsCount Total number of harmonics requested. Updated at Control-rate. [Default Value: 10]
 /// @param firstHarmonicIndex The lowest harmonic present. Updated at Control-rate. [Default Value: 1]
 /// @param partialMultiplier The multiplier in the series of amplitude coefficients. Updated at Control-rate. [Default Value: 1]

--- a/AudioKit/Operations/Signal Input and Output/AKMP3FileInput.h
+++ b/AudioKit/Operations/Signal Input and Output/AKMP3FileInput.h
@@ -15,7 +15,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKMP3FileInput : AKStereoAudio
 /// Instantiates the mp3 file input with all values
-/// @param filename Input MP3 Filename. [Default Value: ]
+/// @param filename Input MP3 Filename. 
 /// @param startTime Number of seconds into the file to start playback. [Default Value: 0]
 - (instancetype)initWithFilename:(NSString *)filename
                        startTime:(AKConstant *)startTime;

--- a/AudioKit/Operations/Signal Modifiers/Convolutions/AKConvolution.h
+++ b/AudioKit/Operations/Signal Modifiers/Convolutions/AKConvolution.h
@@ -16,8 +16,8 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKConvolution : AKAudio
 /// Instantiates the convolution with all values
-/// @param input Input to the convolution, usually audio. [Default Value: ]
-/// @param impulseResponseFilename File contain the impulse response audio.  Usually a very short impulse sound. [Default Value: ]
+/// @param input Input to the convolution, usually audio.
+/// @param impulseResponseFilename File contain the impulse response audio.  Usually a very short impulse sound. 
 - (instancetype)initWithInput:(AKParameter *)input
       impulseResponseFilename:(NSString *)impulseResponseFilename;
 

--- a/AudioKit/Operations/Signal Modifiers/Convolutions/AKStereoConvolution.h
+++ b/AudioKit/Operations/Signal Modifiers/Convolutions/AKStereoConvolution.h
@@ -16,8 +16,8 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKStereoConvolution : AKStereoAudio
 /// Instantiates the stereo convolution with all values
-/// @param input Input to the convolution, usually audio. [Default Value: ]
-/// @param impulseResponseFilename File contain the impulse response audio.  Usually a very short impulse sound. [Default Value: ]
+/// @param input Input to the convolution, usually audio.
+/// @param impulseResponseFilename File contain the impulse response audio.  Usually a very short impulse sound.
 - (instancetype)initWithInput:(AKParameter *)input
       impulseResponseFilename:(NSString *)impulseResponseFilename;
 

--- a/AudioKit/Operations/Signal Modifiers/Delays/AKMultitapDelay.h
+++ b/AudioKit/Operations/Signal Modifiers/Delays/AKMultitapDelay.h
@@ -16,8 +16,8 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKMultitapDelay : AKAudio
 /// Instantiates the multitap delay
-/// @param input Input signal to be delayed. [Default Value: ]
-/// @param firstEchoTime Time in seconds to delay the firsted delayed playback. [Default Value: ]
+/// @param input Input signal to be delayed.
+/// @param firstEchoTime Time in seconds to delay the firsted delayed playback.
 /// @param firstEchoGain The relative amplitude of the first echo. [Default Value: ]
 - (instancetype)initWithInput:(AKParameter *)input
                 firstEchoTime:(AKConstant *)firstEchoTime

--- a/AudioKit/Operations/Signal Modifiers/Effects/AKCompressor.h
+++ b/AudioKit/Operations/Signal Modifiers/Effects/AKCompressor.h
@@ -19,8 +19,8 @@ The running envelope is next converted to decibels, then passed through a mappin
 NS_ASSUME_NONNULL_BEGIN
 @interface AKCompressor : AKAudio
 /// Instantiates the compressor with all values
-/// @param input The input signal that will be compressed. [Default Value: ]
-/// @param controllingInput The signal that defines the compression. [Default Value: ]
+/// @param input The input signal that will be compressed.
+/// @param controllingInput The signal that defines the compression. 
 /// @param threshold Sets the lowest decibel level that will be allowed through. Normally 0 or less, but if higher the threshold will begin removing low-level signal energy such as background noise. Updated at Control-rate. [Default Value: 0]
 /// @param lowKnee Decibel break-point denoting where compression or expansion will begin. These set the boundaries of a soft-knee curve joining the low-amplitude 1:1 line and the higher-amplitude compression ratio line. Typical values are 48 and 60 db. If the two breakpoints are equal, a hard-knee (angled) map will result. Updated at Control-rate. [Default Value: 48]
 /// @param highKnee Decibel break-points denoting where compression or expansion will begin. These set the boundaries of a soft-knee curve joining the low-amplitude 1:1 line and the higher-amplitude compression ratio line. Typical values are 48 and 60 db. If the two breakpoints are equal, a hard-knee (angled) map will result. Updated at Control-rate. [Default Value: 60]

--- a/AudioKit/Operations/Signal Modifiers/Effects/AKDopplerEffect.h
+++ b/AudioKit/Operations/Signal Modifiers/Effects/AKDopplerEffect.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKDopplerEffect : AKAudio
 /// Instantiates the doppler effect with all values
-/// @param input Input signal at the sound source. [Default Value: ]
+/// @param input Input signal at the sound source. 
 /// @param sourcePosition Position of the source sound in meters. The distance between source and mic should not be changed faster than about 3/4 the speed of sound. Updated at Control-rate. [Default Value: 0]
 /// @param micPosition Position of the recording microphone in meters. The distance between source and mic should not be changed faster than about 3/4 the speed of sound. Updated at Control-rate. [Default Value: 0]
 /// @param smoothingFilterUpdateRate Rate of updating the position smoothing filter, in cycles/second. [Default Value: 6]

--- a/AudioKit/Operations/Signal Modifiers/Effects/AKFlanger.h
+++ b/AudioKit/Operations/Signal Modifiers/Effects/AKFlanger.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKFlanger : AKAudio
 /// Instantiates the flanger with all values
-/// @param input Input signal. [Default Value: ]
+/// @param input Input signal.
 /// @param delayTime Delay in seconds [Default Value: ]
 /// @param feedback Feedback amount (in normal tasks this should not exceed 1, even if bigger values are allowed) Updated at Control-rate. [Default Value: 0]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Effects/AKRingModulator.h
+++ b/AudioKit/Operations/Signal Modifiers/Effects/AKRingModulator.h
@@ -17,8 +17,8 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKRingModulator : AKAudio
 /// Instantiates the ring modulator with all values
-/// @param input Input audio signal [Default Value: ]
-/// @param carrier The carrier signal [Default Value: ]
+/// @param input Input audio signal
+/// @param carrier The carrier signal 
 - (instancetype)initWithInput:(AKParameter *)input
                       carrier:(AKParameter *)carrier;
 

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKCombFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKCombFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKCombFilter : AKAudio
 /// Instantiates the comb filter with all values
-/// @param input Input signal, usually audio. [Default Value: ]
+/// @param input Input signal, usually audio. 
 /// @param reverbDuration The time in seconds for a signal to decay to 1/1000, or 60dB from its original amplitude. Updated at Control-rate. [Default Value: 1]
 /// @param loopDuration Determines frequency response curve, loopDuration * sr/2 peaks spaced evenly between 0 and sr/2. [Default Value: 0.1]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKDCBlock.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKDCBlock.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKDCBlock : AKAudio
 /// Instantiates the dc block with all values
-/// @param input Input audio signal. [Default Value: ]
+/// @param input Input audio signal. 
 /// @param gain The gain of the filter, which defaults to 0.99. [Default Value: 0.99]
 - (instancetype)initWithInput:(AKParameter *)input
                          gain:(AKConstant *)gain;

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKDecimator.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKDecimator.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKDecimator : AKAudio
 /// Instantiates the decimator with all values
-/// @param input Audio to be decimated! [Default Value: ]
+/// @param input Audio to be decimated! 
 /// @param bitDepth The bit depth of signal output. Typically in range (1-24). Non-integer values are OK. Updated at Control-rate. [Default Value: 24]
 /// @param sampleRate The sample rate of signal output. Non-integer values are OK. Updated at Control-rate. [Default Value: 44100]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKDeclick.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKDeclick.h
@@ -15,7 +15,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKDeclick : AKAudio
 /// Instantiates the declick with all values
-/// @param input Input audio signal to be declicked [Default Value: ]
+/// @param input Input audio signal to be declicked 
 - (instancetype)initWithInput:(AKParameter *)input;
 
 /// Instantiates the declick with default values

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKEqualizerFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKEqualizerFilter.h
@@ -18,7 +18,7 @@ The amplitude response for this filter will be flat (=1) for gain=1. With gain b
 NS_ASSUME_NONNULL_BEGIN
 @interface AKEqualizerFilter : AKAudio
 /// Instantiates the equalizer filter with all values
-/// @param input Input signal. [Default Value: ]
+/// @param input Input signal. 
 /// @param centerFrequency Filter center frequency in Hz. Updated at Control-rate. [Default Value: 1000]
 /// @param bandwidth Peak/notch bandwidth in Hz. Updated at Control-rate. [Default Value: 100]
 /// @param gain Peak/notch gain. Updated at Control-rate. [Default Value: 10]

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHighPassFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHighPassFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKHighPassFilter : AKAudio
 /// Instantiates the high pass filter with all values
-/// @param input The input signal to be filtered [Default Value: ]
+/// @param input The input signal to be filtered 
 /// @param cutoffFrequency The response curve's half-power point, in Hertz. Half power is defined as peak power / root 2. Updated at Control-rate. [Default Value: 4000]
 - (instancetype)initWithInput:(AKParameter *)input
               cutoffFrequency:(AKParameter *)cutoffFrequency;

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
@@ -20,7 +20,7 @@ Unlike an FIR-based Hilbert Transformer, the output of AKHilbertTransformer does
 NS_ASSUME_NONNULL_BEGIN
 @interface AKHilbertTransformer : AKAudio
 // Instantiates the hilbert transformer with all values
-/// @param input The input audio Signal [Default Value: ]
+/// @param input The input audio Signal 
 /// @param frequency The frequency shifter frequency. Updated at Control-rate. [Default Value: 440]
 - (instancetype)initWithInput:(AKParameter *)input
                     frequency:(AKParameter *)frequency;

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
@@ -55,6 +55,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param input The control to be filtered
 + (instancetype)presetAlienSpaceshipFilterWithInput:(AKParameter *)input;
 
+/// Instantiates the low pass filter with an mosquito sound
+/// @param input The control to be filtered
+- (instancetype)initWithPresetMosquitoWithInput:(AKParameter *)input;
+
+/// Instantiates the low pass filter with an mosquito sound
+/// @param input The control to be filtered
++ (instancetype)presetMosquitoFilterWithInput:(AKParameter *)input;
+
 
 /// Filter cut-off frequency in Hz. [Default Value: 440]
 @property (nonatomic) AKParameter *frequency;

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AKHilbertTransformer : AKAudio
 /// Instantiates the hilbert transformer with all values
 /// @param input The input audio Signal [Default Value: ]
-/// @param frequency The frequency shifter frequency. Updated at Control-rate. [Default Value: ]
+/// @param frequency The frequency shifter frequency. Updated at Control-rate. [Default Value: 440]
 - (instancetype)initWithInput:(AKParameter *)input
                     frequency:(AKParameter *)frequency;
 
@@ -31,7 +31,21 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)filterWithInput:(AKParameter *)input
                       frequency:(AKParameter *)frequency;
 
+/// Instantiates the low pass filter with default values
+/// @param input The control to be filtered
+- (instancetype)initWithInput:(AKParameter *)input;
 
+/// Instantiates the low pass filter with default values
+/// @param input The control to be filtered
++ (instancetype)filterWithInput:(AKParameter *)input;
+
+/// Instantiates the low pass filter with default values
+/// @param input The control to be filtered
+- (instancetype)initWithPresetDefaultFilterWithInput:(AKParameter *)input;
+
+/// Instantiates the low pass filter with default values
+/// @param input The control to be filtered
++ (instancetype)presetDefaultFilterWithInput:(AKParameter *)input;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
@@ -47,6 +47,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param input The control to be filtered
 + (instancetype)presetDefaultFilterWithInput:(AKParameter *)input;
 
+/// Instantiates the low pass filter with an alien spaceship sound
+/// @param input The control to be filtered
+- (instancetype)initWithPresetAlienSpaceshipWithInput:(AKParameter *)input;
+
+/// Instantiates the low pass filter with an alien spaceship sound
+/// @param input The control to be filtered
++ (instancetype)presetAlienSpaceshipFilterWithInput:(AKParameter *)input;
+
+
 /// Filter cut-off frequency in Hz. [Default Value: 440]
 @property (nonatomic) AKParameter *frequency;
 

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.h
@@ -19,7 +19,7 @@ Unlike an FIR-based Hilbert Transformer, the output of AKHilbertTransformer does
 
 NS_ASSUME_NONNULL_BEGIN
 @interface AKHilbertTransformer : AKAudio
-/// Instantiates the hilbert transformer with all values
+// Instantiates the hilbert transformer with all values
 /// @param input The input audio Signal [Default Value: ]
 /// @param frequency The frequency shifter frequency. Updated at Control-rate. [Default Value: 440]
 - (instancetype)initWithInput:(AKParameter *)input
@@ -46,6 +46,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Instantiates the low pass filter with default values
 /// @param input The control to be filtered
 + (instancetype)presetDefaultFilterWithInput:(AKParameter *)input;
+
+/// Filter cut-off frequency in Hz. [Default Value: 440]
+@property (nonatomic) AKParameter *frequency;
+
+/// Set an optional cutoff frequency
+/// @param cutoffFrequency Filter cut-off frequency in Hz. [Default Value: 440]
+- (void)setOptionalFrequency:(AKParameter *)frequency;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
@@ -65,6 +65,9 @@
     return [[AKHilbertTransformer alloc] initWithInput:input];
 }
 
+- (void)setOptionalFrequency:(AKParameter *)frequency {
+    [self setFrequency:frequency];
+}
 
 - (void)setUpConnections
 {

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
@@ -38,6 +38,34 @@
 }
 
 
+- (instancetype)initWithInput:(AKParameter *)input
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _frequency = akp(440);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)filterWithInput:(AKParameter *)input
+{
+    return [[AKHilbertTransformer alloc] initWithInput:input];
+}
+
+- (instancetype)initWithPresetDefaultFilterWithInput:(AKParameter *)input;
+{
+    return [self initWithInput:input];
+}
+
++ (instancetype)presetDefaultFilterWithInput:(AKParameter *)input;
+{
+    return [[AKHilbertTransformer alloc] initWithInput:input];
+}
+
+
 - (void)setUpConnections
 {
     self.state = @"connectable";

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
@@ -88,7 +88,7 @@
     if (self) {
         _input = input;
         // Default Values
-        _frequency = akp(1000);
+        _frequency = akp(9000);
         [self setUpConnections];
     }
     return self;

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
@@ -82,6 +82,23 @@
     return [[AKHilbertTransformer alloc] initWithPresetAlienSpaceshipWithInput:input];
 }
 
+- (instancetype)initWithPresetMosquitoWithInput:(AKParameter *)input;
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _frequency = akp(1000);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)presetMosquitoFilterWithInput:(AKParameter *)input;
+{
+    return [[AKHilbertTransformer alloc] initWithPresetMosquitoWithInput:input];
+}
+
 
 - (void)setOptionalFrequency:(AKParameter *)frequency {
     [self setFrequency:frequency];

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKHilbertTransformer.m
@@ -65,6 +65,24 @@
     return [[AKHilbertTransformer alloc] initWithInput:input];
 }
 
+- (instancetype)initWithPresetAlienSpaceshipWithInput:(AKParameter *)input;
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _frequency = akp(1000);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)presetAlienSpaceshipFilterWithInput:(AKParameter *)input;
+{
+    return [[AKHilbertTransformer alloc] initWithPresetAlienSpaceshipWithInput:input];
+}
+
+
 - (void)setOptionalFrequency:(AKParameter *)frequency {
     [self setFrequency:frequency];
 }

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKLowPassFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKLowPassFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKLowPassFilter : AKAudio
 /// Instantiates the low pass filter with all values
-/// @param input The control to be filtered [Default Value: ]
+/// @param input The control to be filtered 
 /// @param halfPowerPoint The response curve's half-power point, in Hertz. Half power is defined as peak power / root 2. Updated at Control-rate. [Default Value: 1000]
 - (instancetype)initWithInput:(AKParameter *)input
                halfPowerPoint:(AKParameter *)halfPowerPoint;

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKMoogLadder.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKMoogLadder.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKMoogLadder : AKAudio
 /// Instantiates the moog ladder with all values
-/// @param input Input signal [Default Value: ]
+/// @param input Input signal 
 /// @param cutoffFrequency Filter cutoff frequency Updated at Control-rate. [Default Value: 100]
 /// @param resonance Resonance, generally < 1, but not limited to it. Higher than 1 resonance values might cause aliasing, analogue synths generally allow resonances to be above 1. Updated at Control-rate. [Default Value: 0.5]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKMoogVCF.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKMoogVCF.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKMoogVCF : AKAudio
 /// Instantiates the moog vcf with all values
-/// @param input Input signal. [Default Value: ]
+/// @param input Input signal. 
 /// @param cutoffFrequency Filter cut-off frequency in Hz. [Default Value: 1000]
 /// @param resonance Amount of resonance. Self-oscillation occurs when this is approximately one. [Default Value: 0.5]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKResonantFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKResonantFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKResonantFilter : AKAudio
 /// Instantiates the resonant filter with all values
-/// @param input The input audio stream. [Default Value: ]
+/// @param input The input audio stream. 
 /// @param centerFrequency Center frequency of the filter, or frequency position of the peak response. Updated at Control-rate. [Default Value: 1000]
 /// @param bandwidth Bandwidth of the filter (the Hz difference between the upper and lower half-power points). Updated at Control-rate. [Default Value: 10]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKStringResonator.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKStringResonator.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKStringResonator : AKAudio
 /// Instantiates the string resonator with all values
-/// @param input The input audio signal. [Default Value: ]
+/// @param input The input audio signal.
 /// @param fundamentalFrequency The fundamental frequency of the string. Updated at Control-rate. [Default Value: 100]
 /// @param fdbgain feedback gain, between 0 and 1, of the internal delay line. A value close to 1 creates a slower decay and a more pronounced resonance. Small values may leave the input signal unaffected. Depending on the filter frequency, typical values are > .9. [Default Value: 0.95]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKThreePoleLowpassFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKThreePoleLowpassFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKThreePoleLowpassFilter : AKAudio
 /// Instantiates the three pole lowpass filter with all values
-/// @param input Signal that will be modified. [Default Value: ]
+/// @param input Signal that will be modified. 
 /// @param distortion Amount of distortion. Zero gives a clean output. kdist > 0 adds tanh() distortion controlled by the filter parameters, in such a way that both low cutoff and high resonance increase the distortion amount. Some experimentation is encouraged. Updated at Control-rate. [Default Value: 0.5]
 /// @param cutoffFrequency The filter cutoff frequency in Hz. Updated at Control-rate. [Default Value: 1500]
 /// @param resonance Amount of resonance. Self-oscillation occurs when approximately 1. Should usually be in the range 0 to 1, however, values slightly greater than 1 are possible for more sustained oscillation and an “overdrive” effect. Updated at Control-rate. [Default Value: 0.5]

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKThreePoleLowpassFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKThreePoleLowpassFilter.h
@@ -34,6 +34,38 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param input Signal that will be modified.
 + (instancetype)filterWithInput:(AKParameter *)input;
 
+/// Instantiates the three pole lowpass filter with default values
+/// @param input Signal that will be modified.
+- (instancetype)initWithPresetDefaultFilterWithInput:(AKParameter *)input;
+
+/// Instantiates the three pole lowpass filter with default values
+/// @param input Signal that will be modified.
++ (instancetype)presetDefaultFilterWithInput:(AKParameter *)input;
+
+/// Instantiates the three pole lowpass filter with a bright values
+/// @param input Signal that will be modified.
+- (instancetype)initWithPresetBrightFilterWithInput:(AKParameter *)input;
+
+/// Instantiates the three pole lowpass filter with a bright values
+/// @param input Signal that will be modified.
++ (instancetype)presetBrightFilterWithInput:(AKParameter *)input;
+
+/// Instantiates the three pole lowpass filter with a bright values
+/// @param input Signal that will be modified.
+- (instancetype)initWithPresetDullBassWithInput:(AKParameter *)input;
+
+/// Instantiates the three pole lowpass filter with a bright values
+/// @param input Signal that will be modified.
++ (instancetype)presetDullBassWithInput:(AKParameter *)input;
+
+/// Instantiates the three pole lowpass filter with a bright values
+/// @param input Signal that will be modified.
+- (instancetype)initWithPresetScreamWithInput:(AKParameter *)input;
+
+/// Instantiates the three pole lowpass filter with a bright values
+/// @param input Signal that will be modified.
++ (instancetype)presetScreamWithInput:(AKParameter *)input;
+
 /// Amount of distortion. Zero gives a clean output. kdist > 0 adds tanh() distortion controlled by the filter parameters, in such a way that both low cutoff and high resonance increase the distortion amount. Some experimentation is encouraged. [Default Value: 0.5]
 @property (nonatomic) AKParameter *distortion;
 

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKThreePoleLowpassFilter.m
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKThreePoleLowpassFilter.m
@@ -52,6 +52,73 @@
     return [[AKThreePoleLowpassFilter alloc] initWithInput:input];
 }
 
+- (instancetype)initWithPresetDefaultFilterWithInput:(AKParameter *)input;
+{
+    return [self initWithInput:input];
+}
+
++ (instancetype)presetDefaultFilterWithInput:(AKParameter *)input;
+{
+    return [[AKThreePoleLowpassFilter alloc] initWithInput:input];
+}
+
+- (instancetype)initWithPresetBrightFilterWithInput:(AKParameter *)input;
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _distortion = akp(1);
+        _cutoffFrequency = akp(9000);
+        _resonance = akp(1);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)presetBrightFilterWithInput:(AKParameter *)input;
+{
+    return [[AKThreePoleLowpassFilter alloc] initWithPresetBrightFilterWithInput:input];
+}
+
+- (instancetype)initWithPresetDullBassWithInput:(AKParameter *)input;
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _distortion = akp(0.9);
+        _cutoffFrequency = akp(150);
+        _resonance = akp(0.9);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)presetDullBassWithInput:(AKParameter *)input;
+{
+    return [[AKThreePoleLowpassFilter alloc] initWithPresetDullBassWithInput:input];
+}
+
+- (instancetype)initWithPresetScreamWithInput:(AKParameter *)input;
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _distortion = akp(0.9);
+        _cutoffFrequency = akp(1000);
+        _resonance = akp(1);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)presetScreamWithInput:(AKParameter *)input;
+{
+    return [[AKThreePoleLowpassFilter alloc] initWithPresetScreamWithInput:input];
+}
+
 - (void)setDistortion:(AKParameter *)distortion {
     _distortion = distortion;
     [self setUpConnections];

--- a/AudioKit/Operations/Signal Modifiers/Filters/AKVariableFrequencyResponseBandPassFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKVariableFrequencyResponseBandPassFilter.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (AKConstant *)scalingFactorRMS;
 
 /// Instantiates the variable frequency response band pass filter with all values
-/// @param input The input signal to be filtered. [Default Value: ]
+/// @param input The input signal to be filtered. 
 /// @param cutoffFrequency Cutoff or resonant frequency of the filter, measured in Hz. Updated at Control-rate. [Default Value: 1000]
 /// @param bandwidth Bandwidth of the filter (the Hz difference between the upper and lower half-power points). Updated at Control-rate. [Default Value: 10]
 /// @param scalingFactor There are three scaling factors possible, 'None' (Default, 0), 'Peak' or 1, and 'RMS' or 2.  All are accessibly through class function 'scalingFactor...'   'Peak' signifies a peak response factor of 1, i.e. all frequencies other than the cutoffFrequency are attenuated in accordance with the (normalized) response curve. 'RMS' raises the response factor so that its overall RMS value equals 1. This intended equalization of input and output power assumes all frequencies are physically present; hence it is most applicable to white noise.   [Default Value: 1]

--- a/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKBandPassButterworthFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKBandPassButterworthFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKBandPassButterworthFilter : AKAudio
 /// Instantiates the band pass butterworth filter with all values
-/// @param input Input signal to be filtered. [Default Value: ]
+/// @param input Input signal to be filtered. 
 /// @param centerFrequency Center frequency for each of the filters. Updated at Control-rate. [Default Value: 2000]
 /// @param bandwidth Bandwidth of the band-pass filters. Updated at Control-rate. [Default Value: 100]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKBandRejectButterworthFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKBandRejectButterworthFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKBandRejectButterworthFilter : AKAudio
 /// Instantiates the band reject butterworth filter with all values
-/// @param input Input signal to be filtered. [Default Value: ]
+/// @param input Input signal to be filtered. 
 /// @param centerFrequency Center frequency for each of the filters. Updated at Control-rate. [Default Value: 3000]
 /// @param bandwidth Bandwidth of the band-reject filters. Updated at Control-rate. [Default Value: 2000]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKHighPassButterworthFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKHighPassButterworthFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKHighPassButterworthFilter : AKAudio
 /// Instantiates the high pass butterworth filter with all values
-/// @param input Input signal to be filtered. [Default Value: ]
+/// @param input Input signal to be filtered. 
 /// @param cutoffFrequency Cutoff frequency for each of the filters. Updated at Control-rate. [Default Value: 500]
 - (instancetype)initWithInput:(AKParameter *)input
               cutoffFrequency:(AKParameter *)cutoffFrequency;

--- a/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKLowPassButterworthFilter.h
+++ b/AudioKit/Operations/Signal Modifiers/Filters/Butterworth Filters/AKLowPassButterworthFilter.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKLowPassButterworthFilter : AKAudio
 /// Instantiates the low pass butterworth filter with all values
-/// @param input Input signal to be filtered. [Default Value: ]
+/// @param input signal to be filtered. 
 /// @param cutoffFrequency Cutoff frequency for each of the filters. Updated at Control-rate. [Default Value: 1000]
 - (instancetype)initWithInput:(AKParameter *)input
               cutoffFrequency:(AKParameter *)cutoffFrequency;

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.h
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.h
@@ -50,6 +50,22 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param input Input to the reverberator.
 + (instancetype)presetDefaultReverbWithInput:(AKParameter *)input;
 
+/// Instantiates the reverb with a stuttering, disjointed sound
+/// @param input Input to the reverberator.
+- (instancetype)initWithPresetStutteringReverbWithInput:(AKParameter *)input;
+
+/// Instantiates the reverb with a stuttering, disjointed sound
+/// @param input Input to the reverberator.
++ (instancetype)presetStutteringReverbWithInput:(AKParameter *)input;
+
+/// Instantiates the reverb with a slow, plodding sound
+/// @param input Input to the reverberator.
+- (instancetype)initWithPresetPloddingReverbWithInput:(AKParameter *)input;
+
+/// Instantiates the reverb with a slow, plodding sound
+/// @param input Input to the reverberator.
++ (instancetype)presetPloddingReverbWithInput:(AKParameter *)input;
+
 /// Length of x-axis edge of the box in meters. [Default Value: 14.39]
 @property (nonatomic) AKConstant *lengthOfXAxisEdge;
 

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.h
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.h
@@ -42,6 +42,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param input The input audio signal.
 + (instancetype)reverbWithInput:(AKParameter *)input;
 
+/// Instantiates the reverb with default values
+/// @param input Input to the reverberator.
+- (instancetype)initWithPresetDefaultReverbWithInput:(AKParameter *)input;
+
+/// Instantiates the reverb with default values
+/// @param input Input to the reverberator.
++ (instancetype)presetDefaultReverbWithInput:(AKParameter *)input;
+
 /// Length of x-axis edge of the box in meters. [Default Value: 14.39]
 @property (nonatomic) AKConstant *lengthOfXAxisEdge;
 
@@ -84,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param zLocation The virtual z-coordinate of the source of sound (the input signal). Updated at Control-rate. [Default Value: 3]
 - (void)setOptionalZLocation:(AKParameter *)zLocation;
 
-/// Coefficient of diffusion at the walls, which regulates the amount of diffusion (0-1, where 0 = no diffusion, 1 = maximum diffusion, default= 1) [Default Value: 1]
+/// Coefficient of diffusion at the walls, which regulates the amount of diffusion (0-1, where 0 = no diffusion, 1 = maximum diffusion, default = 0.9) [Default Value: 1]
 @property (nonatomic) AKConstant *diffusion;
 
 /// Set an optional diffusion

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.h
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKBallWithinTheBoxReverb : AKStereoAudio
 /// Instantiates the ball within the box reverb with all values
-/// @param input The input audio signal. [Default Value: ]
+/// @param input The input audio signal. 
 /// @param lengthOfXAxisEdge Length of x-axis edge of the box in meters. [Default Value: 14.39]
 /// @param lengthOfYAxisEdge Length of y-axis edge of the box in meters. [Default Value: 11.86]
 /// @param lengthOfZAxisEdge Length of z-axis edge of the box in meters. [Default Value: 10]

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.m
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.m
@@ -69,6 +69,53 @@
     return [[AKBallWithinTheBoxReverb alloc] initWithInput:input];
 }
 
+- (instancetype)initWithPresetStutteringReverbWithInput:(AKParameter *)input;
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _lengthOfXAxisEdge = akp(80);
+        _lengthOfYAxisEdge = akp(80);
+        _lengthOfZAxisEdge = akp(80);
+        _xLocation = akp(20);
+        _yLocation = akp(20);
+        _zLocation = akp(20);
+        _diffusion = akp(0.9);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)presetStutteringReverbWithInput:(AKParameter *)input;
+{
+    return [[AKBallWithinTheBoxReverb alloc] initWithPresetStutteringReverbWithInput:input];
+}
+
+- (instancetype)initWithPresetPloddingReverbWithInput:(AKParameter *)input;
+{
+    self = [super initWithString:[self operationName]];
+    if (self) {
+        _input = input;
+        // Default Values
+        _lengthOfXAxisEdge = akp(30);
+        _lengthOfYAxisEdge = akp(40);
+        _lengthOfZAxisEdge = akp(20);
+        _xLocation = akp(6);
+        _yLocation = akp(4);
+        _zLocation = akp(3);
+        _diffusion = akp(0.9);
+        [self setUpConnections];
+    }
+    return self;
+}
+
++ (instancetype)presetPloddingReverbWithInput:(AKParameter *)input;
+{
+    return [[AKBallWithinTheBoxReverb alloc] initWithPresetPloddingReverbWithInput:input];
+}
+
+
 + (instancetype)reverbWithInput:(AKParameter *)input
 {
     return [[AKBallWithinTheBoxReverb alloc] initWithInput:input];

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.m
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKBallWithinTheBoxReverb.m
@@ -53,10 +53,20 @@
         _xLocation = akp(6);
         _yLocation = akp(4);
         _zLocation = akp(3);
-        _diffusion = akp(1);
+        _diffusion = akp(0.9);
         [self setUpConnections];
     }
     return self;
+}
+
+- (instancetype)initWithPresetDefaultReverbWithInput:(AKParameter *)input
+{
+    return [self initWithInput:input];
+}
+
++ (instancetype)presetDefaultReverbWithInput:(AKParameter *)input
+{
+    return [[AKBallWithinTheBoxReverb alloc] initWithInput:input];
 }
 
 + (instancetype)reverbWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKFlatFrequencyResponseReverb.h
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKFlatFrequencyResponseReverb.h
@@ -42,19 +42,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Instantiates the flat frequency response reverb with 'metallic' sound
 /// @param input The input signal to be reverberated.
-- (instancetype)initMetallicReverbWithInput:(AKParameter *)input;
+- (instancetype)initWithPresetMetallicReverbWithInput:(AKParameter *)input;
 
 /// Instantiates the flat frequency response reverb with a 'metallic' sound
 /// @param input The input signal to be reverberated.
-+ (instancetype)metallicReverbWithInput:(AKParameter *)input;
++ (instancetype)presetMetallicReverbWithInput:(AKParameter *)input;
 
 /// Instantiates the flat frequency response reverb with 'stuttering' sound
 /// @param input The input signal to be reverberated.
-- (instancetype)initStutteringReverbWithInput:(AKParameter *)input;
+- (instancetype)initWithPresetStutteringReverbWithInput:(AKParameter *)input;
 
 /// Instantiates the flat frequency response reverb with a 'stuttering' sound
 /// @param input The input signal to be reverberated.
-+ (instancetype)stutteringReverbWithInput:(AKParameter *)input;
++ (instancetype)presetStutteringReverbWithInput:(AKParameter *)input;
 
 
 /// The duration in seconds for a signal to decay to 1/1000, or 60dB down from its original amplitude. [Default Value: 0.5]

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKFlatFrequencyResponseReverb.m
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKFlatFrequencyResponseReverb.m
@@ -59,7 +59,7 @@
     return [[AKFlatFrequencyResponseReverb alloc] initWithInput:input];
 }
 
-- (instancetype)initMetallicReverbWithInput:(AKParameter *)input
+- (instancetype)initWithPresetMetallicReverbWithInput:(AKParameter *)input;
 {
     self = [super initWithString:[self operationName]];
     if (self) {
@@ -72,12 +72,12 @@
     return self;
 }
 
-+ (instancetype)metallicReverbWithInput:(AKParameter *)input
++ (instancetype)presetMetallicReverbWithInput:(AKParameter *)input;
 {
-    return [[AKFlatFrequencyResponseReverb alloc] initMetallicReverbWithInput:input];
+    return [[AKFlatFrequencyResponseReverb alloc] initWithPresetMetallicReverbWithInput:input];
 }
 
-- (instancetype)initStutteringReverbWithInput:(AKParameter *)input
+- (instancetype)initWithPresetStutteringReverbWithInput:(AKParameter *)input;
 {
     self = [super initWithString:[self operationName]];
     if (self) {
@@ -90,9 +90,9 @@
     return self;
 }
 
-+ (instancetype)stutteringReverbWithInput:(AKParameter *)input
++ (instancetype)presetStutteringReverbWithInput:(AKParameter *)input;
 {
-    return [[AKFlatFrequencyResponseReverb alloc] initStutteringReverbWithInput:input];
+    return [[AKFlatFrequencyResponseReverb alloc] initWithPresetStutteringReverbWithInput:input];
 }
 
 - (void)setReverbDuration:(AKParameter *)reverbDuration {

--- a/AudioKit/Operations/Signal Modifiers/Reverbs/AKParallelCombLowPassFilterReverb.h
+++ b/AudioKit/Operations/Signal Modifiers/Reverbs/AKParallelCombLowPassFilterReverb.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKParallelCombLowPassFilterReverb : AKAudio
 /// Instantiates the parallel comb low pass filter reverb with all values
-/// @param input Audio signal to be reverberated. [Default Value: ]
+/// @param input Audio signal to be reverberated. 
 /// @param duration Length of reverbation in seconds. Updated at Control-rate. [Default Value: 1]
 /// @param highFrequencyDiffusivity A value between 0 and 1.  At 0, all frequencies decay with the same speed.  At 1, high frequencies decay faster than lower ones. Updated at Control-rate. [Default Value: 0.5]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AK3DBinauralAudio.h
+++ b/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AK3DBinauralAudio.h
@@ -18,7 +18,7 @@ Artifact-free user-defined trajectories are made possible using an interpolation
 NS_ASSUME_NONNULL_BEGIN
 @interface AK3DBinauralAudio : AKStereoAudio
 /// Instantiates the 3 d binaural audio with all values
-/// @param input  Input/source signal. [Default Value: ]
+/// @param input  Input/source signal. 
 /// @param azimuth Azimuth angle in degrees. Positive values represent position on the right, negative values are positions on the left. Updated at Control-rate. [Default Value: 0]
 /// @param elevation Elevation angle in degrees. Positive values represent position above horizontal, negative values are positions below horizontal (minimum: -40). Updated at Control-rate. [Default Value: 0]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKBalance.h
+++ b/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKBalance.h
@@ -17,8 +17,8 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface AKBalance : AKAudio
 /// Instantiates the balance with all values
-/// @param input Input audio signal [Default Value: ]
-/// @param comparatorAudioSource The comparator signal [Default Value: ]
+/// @param input Input audio signal
+/// @param comparatorAudioSource The comparator signal
 /// @param halfPowerPoint Half-power point (in Hz) of a special internal low-pass filter. The default value is 10. [Default Value: 10]
 - (instancetype)initWithInput:(AKParameter *)input
         comparatorAudioSource:(AKParameter *)comparatorAudioSource

--- a/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKPanner.h
+++ b/AudioKit/Operations/Signal Modifiers/Volume and Spatialization/AKPanner.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (AKConstant *)panMethodForEqualPowerAlternate;
 
 /// Instantiates the panner with all values
-/// @param input Source signal. [Default Value: ]
+/// @param input Source signal. 
 /// @param pan From hard left (-1) to middle (0) to hard right (1). [Default Value: 0]
 /// @param panMethod AKPanMethod can be EqualPower, SquareRoot, Linear, AltEqualPower [Default Value: AKPanMethodEqualPower]
 - (instancetype)initWithInput:(AKParameter *)input

--- a/Playgrounds/Playgrounds/PresetPlayground.m
+++ b/Playgrounds/Playgrounds/PresetPlayground.m
@@ -15,7 +15,7 @@
 - (void)run
 {
     [super run];
-
+    
     //Set up the source file we want to use for testing
     NSString *filename = [AKManager pathToSoundFile:@"PianoBassDrumLoop" ofType:@"wav"];
     AKFileInput *defaultStereo = [[AKFileInput alloc] initWithFilename:filename];
@@ -24,32 +24,30 @@
     testStereo.loop = YES;
     AKFileInput *presetStereo = [[AKFileInput alloc] initWithFilename:filename];
     presetStereo.loop = YES;
-
+    
     AKMix *defaultAudio = [[AKMix alloc] initMonoAudioFromStereoInput:defaultStereo];
     AKMix *testAudio    = [[AKMix alloc] initMonoAudioFromStereoInput:testStereo];
     AKMix *presetAudio = [[AKMix alloc] initMonoAudioFromStereoInput:presetStereo];
-
+    
     AKInstrument *defaultInstrument = [AKInstrument instrumentWithNumber:1];
     AKInstrument *testInstrument    = [AKInstrument instrumentWithNumber:2];
     AKInstrument *presetInstrument  = [AKInstrument instrumentWithNumber:3];
-
+    
     // Here we just instantiate the current sensible default
-    AKVariableFrequencyResponseBandPassFilter *defaultOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithInput:defaultAudio];
+    AKHilbertTransformer *defaultOperation = [[AKHilbertTransformer alloc] initWithInput:defaultAudio];
     [defaultInstrument setAudioOutput:defaultOperation];
-
+    
     // Here we instead create a new instrument based on default but with new parameters
     //  GENERATOR TEMPLATE
     //    AKTambourine *testOperation = [AKTambourine tambourine];
     //    testOperation.dampingFactor = akp(0.6);
     //    [testInstrument setAudioOutput:testOperation];
-
+    
     //  MODIFIER TEMPLATE
-    AKVariableFrequencyResponseBandPassFilter *testOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithInput:testAudio   ];
-    testOperation.cutoffFrequency = akp(200);
-    testOperation.bandwidth = akp(1);
-    testOperation.scalingFactor = akp(2);
+    AKHilbertTransformer *testOperation = [[AKHilbertTransformer alloc] initWithInput:testAudio];
+    testOperation.frequency = akp(100);
     [testInstrument setAudioOutput:testOperation];
-
+    
     // Once you create the preset, you can use it here to make sure it sounds the same as the presetInstrument
     //    AKBambooSticks *presetOperation = [AKBambooSticks presetDefaultSticks];
     //    AKBambooSticks *presetOperation = [AKBambooSticks presetFewSticks];
@@ -75,7 +73,7 @@
     //    AKTambourine *presetOperation = [AKTambourine presetDefaultTambourine];
     //    AKTambourine *presetOperation = [AKTambourine presetOpenTambourine];
     //    AKTambourine *presetOperation = [AKTambourine presetClosedTambourine];
-
+    
     ///// May 17th
     //    AKMandolin *presetOperation = [AKMandolin presetDetunedMandolin];
     //    AKMandolin *presetOperation = [AKMandolin presetSmallMandolin];
@@ -90,8 +88,8 @@
     //    AKVCOscillator *presetOperation = [AKVCOscillator presetSquareWithPWMOscillator];
     //    AKVCOscillator *presetOperation = [AKVCOscillator presetUnnormalizedPulseOscillator];
     //    AKVCOscillator *presetOperation = [AKVCOscillator presetIntegratedSawtoothOscillator];
-
-
+    
+    
     ///// May 20th
     //     AKMarimba *presetOperation = [AKMarimba presetDryMutedMarimba];
     //     AKMarimba *presetOperation = [AKMarimba presetGentleMarimba];
@@ -99,28 +97,28 @@
     //     AKPluckedString *presetOperation = [AKPluckedString presetDecayingPluckedString];
     //     AKPluckedString *presetOperation = [AKPluckedString presetRoundedPluckedString];
     //     AKPluckedString *presetOperation = [AKPluckedString presetSnappyPluckedString];
-
+    
     ///// May 21st
     //     AKStruckMetalBar *presetOperation = [AKStruckMetalBar presetThickDullMetalBar];
     //     AKStruckMetalBar *presetOperation = [AKStruckMetalBar presetIntenseDecayingMetalBar];
     //     AKStruckMetalBar *presetOperation = [AKStruckMetalBar presetSmallHollowMetalBar];
     //     AKStruckMetalBar *presetOperation = [AKStruckMetalBar presetSmallTinklingMetalBar];
-
+    
     //     AKVibes *presetOperation = [AKVibes presetTinyVibes];
     //     AKVibes *presetOperation = [AKVibes presetGentleVibes];
-
+    
     //     AKBowedString *presetOperation = [AKBowedString presetWhistlingBowedString];
     //     AKBowedString *presetOperation = [AKBowedString presetTrainWhislteBowedString];
     //     AKBowedString *presetOperation = [AKBowedString presetCelloBowedString];
     //     AKBowedString *presetOperation = [AKBowedString presetFeedbackBowedString];
     //     AKBowedString *presetOperation = [AKBowedString presetFogHornBowedString];
-
+    
     ///// May 22nd
     //    AKFlute *presetOperation = [AKFlute presetMicFeedbackFlute];
     //    AKFlute *presetOperation = [AKFlute presetShipsHornFlute];
     //    AKFlute *presetOperation = [AKFlute presetSciFiNoiseFlute];
     //    AKFlute *presetOperation = [AKFlute presetScreamingFlute];
-
+    
     ///// May 24th
     //    AKReverb *presetOperation = [AKReverb presetSmallHallReverbWithInput:presetAudio];
     //    AKReverb *presetOperation = [AKReverb presetLargeHallReverbWithInput:presetAudio];
@@ -139,7 +137,7 @@
     //
     //    AKMoogLadder *presetOperation = [AKMoogLadder presetBassHeavyFilterWithInput:presetAudio];
     //    AKMoogLadder *presetOperation = [AKMoogLadder presetUnderwaterFilterWithInput:presetAudio];
-
+    
     ///// May 25th
     //    AKMoogVCF *presetOperation = [AKMoogVCF presetHighTrebleFilterWithInput:presetAudio];
     //    AKMoogVCF *presetOperation = [AKMoogVCF presetFoggyBottomFilterWithInput:presetAudio];
@@ -166,39 +164,45 @@
     //
     //    AKLowPassButterworthFilter *presetOperation = [AKLowPassButterworthFilter presetBassHeavyFilterWithInput:presetAudio];
     //    AKLowPassButterworthFilter *presetOperation = [AKLowPassButterworthFilter presetMildBassFilterWithInput:presetAudio];
-
+    
     ///// May 26th
     //    AKEqualizerFilter *presetOperation = [AKEqualizerFilter presetNarrowHighFrequencyNotchFilterWithInput:presetAudio];
     //    AKEqualizerFilter *presetOperation = [AKEqualizerFilter presetNarrowLowFrequencyNotchFilterWithInput:presetAudio];
     //    AKEqualizerFilter *presetOperation = [AKEqualizerFilter presetWideHighFrequencyNotchFilterWithInput:presetAudio];
     // AKEqualizerFilter *presetOperation = [AKEqualizerFilter presetWideLowFrequencyNotchFilterWithInput:presetAudio];
-
-
+    
+    
     ///// May 27th
-    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetMuffledFilterWithInput:presetAudio];
+//    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetMuffledFilterWithInput:presetAudio];
+    
+    //    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetLargeMuffledFilterWithInput:presetAudio];
+    
+    //    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetTreblePeakFilterWithInput:presetAudio];
+    
+    //    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetBassPeakFilterWithInput:presetAudio];
+    
+    
+    
+    ///// May 30th
+    AKHilbertTransformer *presetOperation = [[AKHilbertTransformer alloc] initWithPresetAlienSpaceshipWithInput:presetAudio];
+//    AKHilbertTransformer *presetOperation = [[AKHilbertTransformer alloc] initWithPresetMosquitoWithInput:presetAudio];
 
-//    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetLargeMuffledFilterWithInput:presetAudio];
-
-//    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetTreblePeakFilterWithInput:presetAudio];
-
-//    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetBassPeakFilterWithInput:presetAudio];
-
-
+    
     [presetInstrument setAudioOutput:presetOperation];
-
+    
     [AKOrchestra addInstrument:defaultInstrument];
     [AKOrchestra addInstrument:testInstrument];
     [AKOrchestra addInstrument:presetInstrument];
-
+    
     AKNote *note = [[AKNote alloc] init];
     note.duration.value = 4.0;
     AKPhrase *phrase = [[AKPhrase alloc] init];
     [phrase addNote:note];
-
+    
     // As you are changing the testInstrument, you probably want to hear it
     // This will play the phrase once for each save
     [presetInstrument playPhrase:phrase];
-
+    
     [self addButtonWithTitle:@"Play Default" block:^{
         [defaultInstrument playPhrase:phrase];
     }];
@@ -208,10 +212,10 @@
     [self addButtonWithTitle:@"Play Preset" block:^{
         [presetInstrument playPhrase:phrase];
     }];
-
+    
     [self addAudioOutputPlot];
     [self addAudioOutputFFTPlot];
-
+    
 }
 
 @end

--- a/Playgrounds/Playgrounds/PresetPlayground.m
+++ b/Playgrounds/Playgrounds/PresetPlayground.m
@@ -34,7 +34,7 @@
     AKInstrument *presetInstrument  = [AKInstrument instrumentWithNumber:3];
     
     // Here we just instantiate the current sensible default
-    AKHilbertTransformer *defaultOperation = [[AKHilbertTransformer alloc] initWithInput:defaultAudio];
+    AKThreePoleLowpassFilter *defaultOperation = [[AKThreePoleLowpassFilter alloc] initWithInput:defaultAudio];
     [defaultInstrument setAudioOutput:defaultOperation];
     
     // Here we instead create a new instrument based on default but with new parameters
@@ -44,8 +44,10 @@
     //    [testInstrument setAudioOutput:testOperation];
     
     //  MODIFIER TEMPLATE
-    AKHilbertTransformer *testOperation = [[AKHilbertTransformer alloc] initWithInput:testAudio];
-    testOperation.frequency = akp(100);
+    AKThreePoleLowpassFilter *testOperation = [[AKThreePoleLowpassFilter alloc] initWithInput:testAudio];
+    testOperation.distortion = akp(0.9);
+    testOperation.cutoffFrequency = akp(1000);
+    testOperation.resonance = akp(1);
     [testInstrument setAudioOutput:testOperation];
     
     // Once you create the preset, you can use it here to make sure it sounds the same as the presetInstrument
@@ -173,7 +175,7 @@
     
     
     ///// May 27th
-//    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetMuffledFilterWithInput:presetAudio];
+    //    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetMuffledFilterWithInput:presetAudio];
     
     //    AKVariableFrequencyResponseBandPassFilter *presetOperation = [[AKVariableFrequencyResponseBandPassFilter alloc] initWithPresetLargeMuffledFilterWithInput:presetAudio];
     
@@ -184,10 +186,13 @@
     
     
     ///// May 30th
-    AKHilbertTransformer *presetOperation = [[AKHilbertTransformer alloc] initWithPresetAlienSpaceshipWithInput:presetAudio];
-//    AKHilbertTransformer *presetOperation = [[AKHilbertTransformer alloc] initWithPresetMosquitoWithInput:presetAudio];
+    //    AKHilbertTransformer *presetOperation = [[AKHilbertTransformer alloc] initWithPresetAlienSpaceshipWithInput:presetAudio];
+    //    AKHilbertTransformer *presetOperation = [[AKHilbertTransformer alloc] initWithPresetMosquitoWithInput:presetAudio];
+    //    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetBrightFilterWithInput:presetAudio];
+    //    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetBrightFilterWithInput:presetAudio];
+    //    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetDullBassWithInput:presetAudio];
+    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetScreamWithInput:presetAudio];
 
-    
     [presetInstrument setAudioOutput:presetOperation];
     
     [AKOrchestra addInstrument:defaultInstrument];

--- a/Playgrounds/Playgrounds/PresetPlayground.m
+++ b/Playgrounds/Playgrounds/PresetPlayground.m
@@ -34,7 +34,7 @@
     AKInstrument *presetInstrument  = [AKInstrument instrumentWithNumber:3];
     
     // Here we just instantiate the current sensible default
-    AKThreePoleLowpassFilter *defaultOperation = [[AKThreePoleLowpassFilter alloc] initWithInput:defaultAudio];
+    AKBallWithinTheBoxReverb *defaultOperation = [[AKBallWithinTheBoxReverb alloc] initWithInput:defaultAudio];
     [defaultInstrument setAudioOutput:defaultOperation];
     
     // Here we instead create a new instrument based on default but with new parameters
@@ -44,10 +44,7 @@
     //    [testInstrument setAudioOutput:testOperation];
     
     //  MODIFIER TEMPLATE
-    AKThreePoleLowpassFilter *testOperation = [[AKThreePoleLowpassFilter alloc] initWithInput:testAudio];
-    testOperation.distortion = akp(0.9);
-    testOperation.cutoffFrequency = akp(1000);
-    testOperation.resonance = akp(1);
+    AKBallWithinTheBoxReverb *testOperation = [[AKBallWithinTheBoxReverb alloc] initWithInput:testAudio];
     [testInstrument setAudioOutput:testOperation];
     
     // Once you create the preset, you can use it here to make sure it sounds the same as the presetInstrument
@@ -191,8 +188,12 @@
     //    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetBrightFilterWithInput:presetAudio];
     //    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetBrightFilterWithInput:presetAudio];
     //    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetDullBassWithInput:presetAudio];
-    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetScreamWithInput:presetAudio];
-
+    //    AKThreePoleLowpassFilter *presetOperation = [[AKThreePoleLowpassFilter alloc] initWithPresetScreamWithInput:presetAudio];
+    
+    
+    //    AKBallWithinTheBoxReverb *presetOperation = [[AKBallWithinTheBoxReverb alloc] initWithPresetStutteringReverbWithInput:presetAudio];
+    AKBallWithinTheBoxReverb *presetOperation = [[AKBallWithinTheBoxReverb alloc] initWithPresetPloddingReverbWithInput:presetAudio];
+    
     [presetInstrument setAudioOutput:presetOperation];
     
     [AKOrchestra addInstrument:defaultInstrument];


### PR DESCRIPTION
-Added a sensible default for the AKHilbertTransform
-Exposed frequency as a property 
-Allow the user to set that property with a 'setOptional' method
-Added 'alien spaceship' and 'mosquito' presets for AKHilbertTransform
-Added presets for AKThreePoleLowpassFilter
-Fixed presets that didn't conform to preset/initWithPreset pattern on AKFlatFrequencyResponseReverb
-Added presets for AKBallInTheBoxReverb