### PR TITLE
Travis CI beta support for Xcode 6.3 / OS X 10.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: beta-xcode6.3
 
 env:
 - LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8

--- a/Tests/travis.sh
+++ b/Tests/travis.sh
@@ -10,7 +10,10 @@ xcodebuild -project Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj       -sdk 
 xcodebuild -project Examples/iOS/HelloWorld/HelloWorld.xcodeproj           -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO build | xcpretty -c || exit 4
 xcodebuild -project Examples/iOS/Swift/AudioKitDemo/AudioKitDemo.xcodeproj -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO build | xcpretty -c || exit 5
 xcodebuild -project Examples/iOS/Swift/HelloWorld/HelloWorld.xcodeproj     -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO build | xcpretty -c || exit 6
-cp Playgrounds/Playgrounds/DefaultPlayground.m Playgrounds/AudioKitPlayground/AudioKitPlayground/Playground.m || exit 7
-xcodebuild -workspace Playgrounds/AudioKitPlayground/AudioKitPlayground.xcworkspace -scheme AudioKitPlayground -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO build | xcpretty -c || exit 8
-pod lib lint --quick AudioKit.podspec.json || exit 9
+xcodebuild -project Examples/OSX/AudioKitDemo/AudioKitDemo.xcodeproj build | xcpretty -c || exit 7
+xcodebuild -project Examples/OSX/HelloWorld/HelloWorld.xcodeproj  build | xcpretty -c || exit 8
+
+cp Playgrounds/Playgrounds/DefaultPlayground.m Playgrounds/AudioKitPlayground/AudioKitPlayground/Playground.m || exit 9
+xcodebuild -workspace Playgrounds/AudioKitPlayground/AudioKitPlayground.xcworkspace -scheme AudioKitPlayground -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO build | xcpretty -c || exit 10
+pod lib lint --quick AudioKit.podspec.json || exit 11
 


### PR DESCRIPTION
So it turns out that there is currently beta support for the newer platforms on Travis, which in turns allows us to run more OS X tests. Seems to be working better than the regular VMs right now, so this turns it on.
