### PR TITLE
MIDIEnabled setting in AKSettings

### DIFF
--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -96,8 +96,10 @@ static AKManager *_sharedManager = nil;
 - (instancetype)init {
     self = [super init];
     if (self != nil) {
-        AKMidi *midi = [[AKMidi alloc] init];
-        [midi openMidiIn];
+        if (AKSettings.shared.MIDIEnabled) {
+            _midi = [[AKMidi alloc] init];
+            [_midi openMidiIn];
+        }
         
         _engine = [[CsoundObj alloc] init];
         [_engine addListener:self];
@@ -125,7 +127,6 @@ static AKManager *_sharedManager = nil;
                     AKSettings.shared.audioOutput, inputOption];
         
         _csdFile = [NSString stringWithFormat:@"%@/AudioKit-%@.csd", NSTemporaryDirectory(), @(getpid())];
-        _midi = [[AKMidi alloc] init];
         _sequences = [NSMutableDictionary dictionary];
         
         // Get notified when the application ends so we can a chance to do some cleanups
@@ -265,12 +266,12 @@ static AKManager *_sharedManager = nil;
 
 - (void)enableMidi
 {
-    [_midi openMidiIn];
+    [self.midi openMidiIn];
 }
 
 - (void)disableMidi
 {
-    [_midi closeMidiIn];
+    [self.midi closeMidiIn];
 }
 
 // -----------------------------------------------------------------------------

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic,readonly) UInt32 sampleRate, samplesPerControlPeriod;
 @property (nonatomic,readonly) UInt16 numberOfChannels;
 @property (nonatomic,readonly) float  zeroDBFullScaleValue;
+@property (nonatomic,readonly) BOOL MIDIEnabled;
 
 // The following properties can be changed dynamically after AudioKit has been initalized
 @property (nonatomic) BOOL loggingEnabled, messagesEnabled;

--- a/AudioKit/Core Classes/AKSettings.m
+++ b/AudioKit/Core Classes/AKSettings.m
@@ -37,6 +37,7 @@ static AKSettings *_settings = nil;
         _messagesEnabled = NO;
         _audioInputEnabled = NO;
         _playbackWhileMuted = NO;
+        _MIDIEnabled = YES;
         
         // Try to load from AudioKit.plist if found
         NSString *path = [[NSBundle mainBundle] pathForResource:@"AudioKit" ofType:@"plist"];
@@ -62,6 +63,8 @@ static AKSettings *_settings = nil;
                 _messagesEnabled = [dict[@"Prefix Csound Messages"] boolValue];
             if (dict[@"Playback While Muted"])
                 _playbackWhileMuted = [dict[@"Playback While Muted"] boolValue];
+            if (dict[@"MIDI Enabled"])
+                _MIDIEnabled = [dict[@"MIDI Enabled"] boolValue];
         }
     }
     return self;

--- a/AudioKit/Resources/AudioKit.plist
+++ b/AudioKit/Resources/AudioKit.plist
@@ -24,5 +24,7 @@
 	<false/>
 	<key>Perform To Disk</key>
 	<false/>
+	<key>MIDI Enabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Enabled by default, but can now be overridden in the plist.
