### PR TITLE
Updated EZAudio source to 1.1.2, including the FFT class.

### DIFF
--- a/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit.xcodeproj/project.pbxproj
@@ -573,6 +573,10 @@
 		EAA0F5891AE71C8F007CD7C9 /* AKPhasor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94D81AD3C6840057E979 /* AKPhasor.m */; };
 		EAA0F58A1AE71C8F007CD7C9 /* AKNoise.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E950C1AD3C6840057E979 /* AKNoise.m */; };
 		EAA0F58B1AE71C8F007CD7C9 /* AKParameter+Operation.m in Sources */ = {isa = PBXBuildFile; fileRef = EA8E94811AD3C6840057E979 /* AKParameter+Operation.m */; };
+		EACF8E971B55E6720089700B /* EZAudioFFT.h in Headers */ = {isa = PBXBuildFile; fileRef = EACF8E951B55E6720089700B /* EZAudioFFT.h */; };
+		EACF8E981B55E6720089700B /* EZAudioFFT.m in Sources */ = {isa = PBXBuildFile; fileRef = EACF8E961B55E6720089700B /* EZAudioFFT.m */; };
+		EACF8E991B55E6720089700B /* EZAudioFFT.m in Sources */ = {isa = PBXBuildFile; fileRef = EACF8E961B55E6720089700B /* EZAudioFFT.m */; };
+		EACF8E9A1B55E6720089700B /* EZAudioFFT.m in Sources */ = {isa = PBXBuildFile; fileRef = EACF8E961B55E6720089700B /* EZAudioFFT.m */; };
 		EADE697B1B52687700996FE0 /* EZAudioUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = EADE69731B52687700996FE0 /* EZAudioUtilities.h */; };
 		EADE697C1B52687700996FE0 /* EZAudioUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = EADE69741B52687700996FE0 /* EZAudioUtilities.m */; };
 		EADE697D1B52687700996FE0 /* EZAudioUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = EADE69741B52687700996FE0 /* EZAudioUtilities.m */; };
@@ -1010,6 +1014,8 @@
 		EA9F18821AE789E0009D3DA6 /* libsndfile.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = libsndfile.framework; sourceTree = "<group>"; };
 		EAA0F5941AE71C8F007CD7C9 /* libAudioKit iOS Dynamic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libAudioKit iOS Dynamic.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EAA0F5951AE71CD1007CD7C9 /* CsoundLib.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CsoundLib.framework; sourceTree = "<group>"; };
+		EACF8E951B55E6720089700B /* EZAudioFFT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFFT.h; sourceTree = "<group>"; };
+		EACF8E961B55E6720089700B /* EZAudioFFT.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioFFT.m; sourceTree = "<group>"; };
 		EADE69731B52687700996FE0 /* EZAudioUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioUtilities.h; sourceTree = "<group>"; };
 		EADE69741B52687700996FE0 /* EZAudioUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioUtilities.m; sourceTree = "<group>"; };
 		EADE69751B52687700996FE0 /* EZAudioFloatData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFloatData.h; sourceTree = "<group>"; };
@@ -1381,6 +1387,8 @@
 				EADE69781B52687700996FE0 /* EZAudioFloatConverter.m */,
 				EADE69791B52687700996FE0 /* EZAudioDisplayLink.h */,
 				EADE697A1B52687700996FE0 /* EZAudioDisplayLink.m */,
+				EACF8E951B55E6720089700B /* EZAudioFFT.h */,
+				EACF8E961B55E6720089700B /* EZAudioFFT.m */,
 				EA8E945B1AD3C6840057E979 /* TPCircularBuffer.c */,
 				EA8E945C1AD3C6840057E979 /* TPCircularBuffer.h */,
 			);
@@ -1978,6 +1986,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4C627601B1B714900B7AD86 /* AKAdditiveCosines.h in Headers */,
+				EACF8E971B55E6720089700B /* EZAudioFFT.h in Headers */,
 				EADE697F1B52687700996FE0 /* EZAudioFloatData.h in Headers */,
 				EA95E9F11AD5EC50007FC41F /* AKSettings.h in Headers */,
 				C4258E461B3FAF7100D91B3D /* AKPitchShifterPedal.h in Headers */,
@@ -2222,6 +2231,7 @@
 				EADE69841B52687700996FE0 /* EZAudioFloatConverter.m in Sources */,
 				EA8E95F01AD3C6850057E979 /* AKMinimum.m in Sources */,
 				EA8E96431AD3C6850057E979 /* AKFlatFrequencyResponseReverb.m in Sources */,
+				EACF8E981B55E6720089700B /* EZAudioFFT.m in Sources */,
 				EA8E96341AD3C6850057E979 /* AKEqualizerFilter.m in Sources */,
 				EA8E96541AD3C6850057E979 /* AKNoteProperty.m in Sources */,
 				EA8E95AD1AD3C6850057E979 /* AKControl.m in Sources */,
@@ -2421,6 +2431,7 @@
 				EADE69861B52687700996FE0 /* EZAudioFloatConverter.m in Sources */,
 				EA8E96941AD3C92B0057E979 /* AKInstrumentPropertyPlot.m in Sources */,
 				EA8E967F1AD3C89F0057E979 /* AKAudioAnalyzer.m in Sources */,
+				EACF8E9A1B55E6720089700B /* EZAudioFFT.m in Sources */,
 				EA8E96831AD3C89F0057E979 /* AKPluckedStringInstrument.m in Sources */,
 				EA8E96971AD3C92B0057E979 /* AKTablePlot.m in Sources */,
 				EA8E967C1AD3C8810057E979 /* AKTools.m in Sources */,
@@ -2620,6 +2631,7 @@
 				EADE69851B52687700996FE0 /* EZAudioFloatConverter.m in Sources */,
 				EAA0F5531AE71C8F007CD7C9 /* AKMinimum.m in Sources */,
 				EAA0F5541AE71C8F007CD7C9 /* AKFlatFrequencyResponseReverb.m in Sources */,
+				EACF8E991B55E6720089700B /* EZAudioFFT.m in Sources */,
 				EAA0F5551AE71C8F007CD7C9 /* AKEqualizerFilter.m in Sources */,
 				EAA0F5571AE71C8F007CD7C9 /* AKNoteProperty.m in Sources */,
 				EAA0F5581AE71C8F007CD7C9 /* AKControl.m in Sources */,

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudio.h
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudio.h
@@ -49,6 +49,7 @@
 #pragma mark - Utility Components
 //------------------------------------------------------------------------------
 
+#import "EZAudioFFT.h"
 #import "EZAudioFloatConverter.h"
 #import "EZAudioFloatData.h"
 #import "EZAudioUtilities.h"

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioFFT.h
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioFFT.h
@@ -1,0 +1,392 @@
+//
+//  EZAudioFFT.h
+//  EZAudio
+//
+//  Created by Syed Haris Ali on 7/10/15.
+//  Copyright (c) 2015 Syed Haris Ali. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import <Accelerate/Accelerate.h>
+
+@class EZAudioFFT;
+
+//------------------------------------------------------------------------------
+#pragma mark - EZAudioFFTDelegate
+//------------------------------------------------------------------------------
+
+/**
+ The EZAudioFFTDelegate provides event callbacks for the EZAudioFFT (and subclasses such as the EZAudioFFTRolling) whenvever the FFT is computed.
+ */
+@protocol EZAudioFFTDelegate <NSObject>
+
+@optional
+
+///-----------------------------------------------------------
+/// @name Getting FFT Output Data
+///-----------------------------------------------------------
+
+/**
+ Triggered when the EZAudioFFT computes an FFT from a buffer of input data. Provides an array of float data representing the computed FFT.
+ @param fft        The EZAudioFFT instance that triggered the event.
+ @param fftData    A float pointer representing the float array of FFT data.
+ @param bufferSize A vDSP_Length (unsigned long) representing the length of the float array.
+ */
+- (void)        fft:(EZAudioFFT *)fft
+ updatedWithFFTData:(float *)fftData
+         bufferSize:(vDSP_Length)bufferSize;
+
+@end
+
+//------------------------------------------------------------------------------
+#pragma mark - EZAudioFFT
+//------------------------------------------------------------------------------
+
+/**
+ The EZAudioFFT provides a base class to quickly calculate the FFT of incoming audio data using the Accelerate framework. In addition, the EZAudioFFT contains an EZAudioFFTDelegate to receive an event anytime an FFT is computed.
+ */
+@interface EZAudioFFT : NSObject
+
+//------------------------------------------------------------------------------
+#pragma mark - Initializers
+//------------------------------------------------------------------------------
+
+///-----------------------------------------------------------
+/// @name Initializers
+///-----------------------------------------------------------
+
+/**
+ Initializes an EZAudioFFT (or subclass) instance with a maximum buffer size and sample rate. The sample rate is used specifically to calculate the `maxFrequency` property. If you don't care about the `maxFrequency` property then you can set the sample rate to 0.
+ @param maximumBufferSize A vDSP_Length (unsigned long) representing the maximum length of the incoming audio data.
+ @param sampleRate        A float representing the sample rate of the incoming audio data.
+ 
+ @return A newly created EZAudioFFT (or subclass) instance.
+ */
+- (instancetype)initWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                               sampleRate:(float)sampleRate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Initializes an EZAudioFFT (or subclass) instance with a maximum buffer size, sample rate, and EZAudioFFTDelegate. The sample rate is used specifically to calculate the `maxFrequency` property. If you don't care about the `maxFrequency` property then you can set the sample rate to 0. The EZAudioFFTDelegate will act as a receive to get an event whenever the FFT is calculated.
+ @param maximumBufferSize A vDSP_Length (unsigned long) representing the maximum length of the incoming audio data.
+ @param sampleRate        A float representing the sample rate of the incoming audio data.
+ @param delegate          An EZAudioFFTDelegate to receive an event whenever the FFT is calculated.
+ @return A newly created EZAudioFFT (or subclass) instance.
+ */
+- (instancetype)initWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                               sampleRate:(float)sampleRate
+                                 delegate:(id<EZAudioFFTDelegate>)delegate;
+
+//------------------------------------------------------------------------------
+#pragma mark - Class Initializers
+//------------------------------------------------------------------------------
+
+///-----------------------------------------------------------
+/// @name Class Initializers
+///-----------------------------------------------------------
+
+/**
+ Class method to initialize an EZAudioFFT (or subclass) instance with a maximum buffer size and sample rate. The sample rate is used specifically to calculate the `maxFrequency` property. If you don't care about the `maxFrequency` property then you can set the sample rate to 0.
+ @param maximumBufferSize A vDSP_Length (unsigned long) representing the maximum length of the incoming audio data.
+ @param sampleRate        A float representing the sample rate of the incoming audio data.
+ @return A newly created EZAudioFFT (or subclass) instance.
+ */
++ (instancetype)fftWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                              sampleRate:(float)sampleRate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Class method to initialize an EZAudioFFT (or subclass) instance with a maximum buffer size, sample rate, and EZAudioFFTDelegate. The sample rate is used specifically to calculate the `maxFrequency` property. If you don't care about the `maxFrequency` property then you can set the sample rate to 0. The EZAudioFFTDelegate will act as a receive to get an event whenever the FFT is calculated.
+ @param maximumBufferSize A vDSP_Length (unsigned long) representing the maximum length of the incoming audio data.
+ @param sampleRate        A float representing the sample rate of the incoming audio data.
+ @param delegate          An EZAudioFFTDelegate to receive an event whenever the FFT is calculated.
+ @return A newly created EZAudioFFT (or subclass) instance.
+ */
++ (instancetype)fftWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                              sampleRate:(float)sampleRate
+                                delegate:(id<EZAudioFFTDelegate>)delegate;
+
+//------------------------------------------------------------------------------
+#pragma mark - Properties
+//------------------------------------------------------------------------------
+
+///-----------------------------------------------------------
+/// @name Properties
+///-----------------------------------------------------------
+
+/**
+ An EZAudioFFTDelegate to receive an event whenever the FFT is calculated.
+ */
+@property (weak, nonatomic) id<EZAudioFFTDelegate> delegate;
+
+//------------------------------------------------------------------------------
+
+/**
+ A COMPLEX_SPLIT data structure used to hold the FFT's imaginary and real components.
+ */
+@property (readonly, nonatomic) COMPLEX_SPLIT complexSplit;
+
+//------------------------------------------------------------------------------
+
+/**
+ A float array containing the last calculated FFT data.
+ */
+@property (readonly, nonatomic) float *fftData;
+
+//------------------------------------------------------------------------------
+
+/**
+ An FFTSetup data structure used to internally calculate the FFT using Accelerate.
+ */
+@property (readonly, nonatomic) FFTSetup fftSetup;
+
+//------------------------------------------------------------------------------
+
+/**
+ A float array containing the last calculated inverse FFT data (the time domain signal).
+ */
+@property (readonly, nonatomic) float *inversedFFTData;
+
+//------------------------------------------------------------------------------
+
+/**
+ A float representing the frequency with the highest energy is the last FFT calculation.
+ */
+@property (readonly, nonatomic) float maxFrequency;
+
+//------------------------------------------------------------------------------
+
+/**
+ A vDSP_Length (unsigned long) representing the index of the frequency with the highest energy is the last FFT calculation.
+ */
+@property (readonly, nonatomic) vDSP_Length maxFrequencyIndex;
+
+//------------------------------------------------------------------------------
+
+/**
+ A float representing the magnitude of the frequency with the highest energy is the last FFT calculation.
+ */
+@property (readonly, nonatomic) float maxFrequencyMagnitude;
+
+//------------------------------------------------------------------------------
+
+/**
+ A vDSP_Length (unsigned long) representing the maximum buffer size. This is the maximum length the incoming audio data in the `computeFFTWithBuffer:withBufferSize` method can be.
+ */
+@property (readonly, nonatomic) vDSP_Length maximumBufferSize;
+
+//------------------------------------------------------------------------------
+
+/**
+ A float representing the sample rate of the incoming audio data.
+ */
+@property (readwrite, nonatomic) float sampleRate;
+
+//------------------------------------------------------------------------------
+#pragma mark - Actions
+//------------------------------------------------------------------------------
+
+///-----------------------------------------------------------
+/// @name Computing The FFT
+///-----------------------------------------------------------
+
+/**
+ Computes the FFT for a float array representing an incoming audio signal. This will trigger the EZAudioFFTDelegate method `fft:updatedWithFFTData:bufferSize:`.
+ @param buffer     A float array representing the audio data.
+ @param bufferSize The length of the float array of audio data.
+ @return A float array containing the computed FFT data. The length of the output will be half the incoming buffer (half the `bufferSize` argument).
+ */
+- (float *)computeFFTWithBuffer:(float *)buffer withBufferSize:(UInt32)bufferSize;
+
+//------------------------------------------------------------------------------
+
+/**
+ Provides the frequency corresponding to an index in the last computed FFT data.
+ @param index A vDSP_Length (unsigned integer) representing the index of the frequency bin value you'd like to get
+ @return A float representing the frequency value at that index.
+ */
+- (float)frequencyAtIndex:(vDSP_Length)index;
+
+//------------------------------------------------------------------------------
+
+/**
+ Provides the magnitude of the frequenecy corresponding to an index in the last computed FFT data.
+ @param index A vDSP_Length (unsigned integer) representing the index of the frequency bin value you'd like to get
+ @return A float representing the frequency magnitude value at that index.
+ */
+- (float)frequencyMagnitudeAtIndex:(vDSP_Length)index;
+
+@end
+
+//------------------------------------------------------------------------------
+#pragma mark - EZAudioFFTRolling
+//------------------------------------------------------------------------------
+
+/**
+ The EZAudioFFTRolling, a subclass of EZAudioFFT, provides a class to calculate an FFT for an incoming audio signal while maintaining a history of audio data to allow much higher resolution FFTs. For instance, the EZMicrophone typically provides 512 frames at a time, but you would probably want to provide 2048 or 4096 frames for a decent looking FFT if you're trying to extract precise frequency components. You will typically be using this class for variable length FFTs instead of the EZAudioFFT base class.
+ */
+@interface EZAudioFFTRolling : EZAudioFFT
+
+//------------------------------------------------------------------------------
+#pragma mark - Initializers
+//------------------------------------------------------------------------------
+
+///-----------------------------------------------------------
+/// @name Initializers
+///-----------------------------------------------------------
+
+/**
+ Initializes an EZAudioFFTRolling instance with a window size and a sample rate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT and a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property). The history buffer size in this case is the `windowSize` * 8, which is pretty good for most cases.
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @return A newly created EZAudioFFTRolling instance.
+ */
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                        sampleRate:(float)sampleRate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Initializes an EZAudioFFTRolling instance with a window size, a sample rate, and an EZAudioFFTDelegate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT, a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property), and an EZAudioFFTDelegate to receive a callback anytime the FFT is calculated. The history buffer size in this case is the `windowSize` * 8, which is pretty good for most cases.
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @param delegate          An EZAudioFFTDelegate to receive an event whenever the FFT is calculated.
+ @return A newly created EZAudioFFTRolling instance.
+ */
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                        sampleRate:(float)sampleRate
+                          delegate:(id<EZAudioFFTDelegate>)delegate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Initializes an EZAudioFFTRolling instance with a window size, a history buffer size, and a sample rate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT, a history buffer size representing the maximum length of the sliding window's underlying circular buffer, and a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property).
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param historyBufferSize A vDSP_Length (unsigned long) representing the length of the history buffer. This should be AT LEAST the size of the window. A recommended value for this would be at least 8x greater than the `windowSize` argument.
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @return A newly created EZAudioFFTRolling instance.
+ */
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                 historyBufferSize:(vDSP_Length)historyBufferSize
+                        sampleRate:(float)sampleRate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Initializes an EZAudioFFTRolling instance with a window size, a history buffer size, a sample rate, and an EZAudioFFTDelegate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT, a history buffer size representing the maximum length of the sliding window's underlying circular buffer, a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property), and an EZAudioFFTDelegate to receive a callback anytime the FFT is calculated.
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param historyBufferSize A vDSP_Length (unsigned long) representing the length of the history buffer. This should be AT LEAST the size of the window. A recommended value for this would be at least 8x greater than the `windowSize` argument.
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @param delegate          An EZAudioFFTDelegate to receive an event whenever the FFT is calculated.
+ @return A newly created EZAudioFFTRolling instance.
+ */
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                 historyBufferSize:(vDSP_Length)historyBufferSize
+                        sampleRate:(float)sampleRate
+                          delegate:(id<EZAudioFFTDelegate>)delegate;
+
+//------------------------------------------------------------------------------
+#pragma mark - Class Initializers
+//------------------------------------------------------------------------------
+
+///-----------------------------------------------------------
+/// @name Class Initializers
+///-----------------------------------------------------------
+
+/**
+ Class method to initialize an EZAudioFFTRolling instance with a window size and a sample rate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT and a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property). The history buffer size in this case is the `windowSize` * 8, which is pretty good for most cases.
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @return A newly created EZAudioFFTRolling instance.
+ */
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                       sampleRate:(float)sampleRate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Class method to initialize an EZAudioFFTRolling instance with a window size, a sample rate, and an EZAudioFFTDelegate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT, a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property), and an EZAudioFFTDelegate to receive a callback anytime the FFT is calculated. The history buffer size in this case is the `windowSize` * 8, which is pretty good for most cases.
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @param delegate          An EZAudioFFTDelegate to receive an event whenever the FFT is calculated.
+ @return A newly created EZAudioFFTRolling instance.
+ */
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                       sampleRate:(float)sampleRate
+                         delegate:(id<EZAudioFFTDelegate>)delegate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Class method to initialize an EZAudioFFTRolling instance with a window size, a history buffer size, and a sample rate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT, a history buffer size representing the maximum length of the sliding window's underlying circular buffer, and a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property).
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param historyBufferSize A vDSP_Length (unsigned long) representing the length of the history buffer. This should be AT LEAST the size of the window. A recommended value for this would be at least 8x greater than the `windowSize` argument.
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @return A newly created EZAudioFFTRolling instance.
+ */
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                historyBufferSize:(vDSP_Length)historyBufferSize
+                       sampleRate:(float)sampleRate;
+
+//------------------------------------------------------------------------------
+
+/**
+ Class method to initialize an EZAudioFFTRolling instance with a window size, a history buffer size, a sample rate, and an EZAudioFFTDelegate. The EZAudioFFTRolling has an internal EZPlotHistoryInfo data structure that writes audio data to a circular buffer and manages sliding windows of audio data to support efficient, large FFT calculations. Here you provide a window size that represents how many audio sample will be used to calculate the FFT, a history buffer size representing the maximum length of the sliding window's underlying circular buffer, a float representing the sample rate of the incoming audio (can be 0 if you don't care about the `maxFrequency` property), and an EZAudioFFTDelegate to receive a callback anytime the FFT is calculated.
+ @param windowSize        A vDSP_Length (unsigned long) representing the size of the window (i.e. the resolution) of data that should be used to calculate the FFT. A typical value for this would be something like 1024 - 4096 (or higher for an even higher resolution FFT).
+ @param historyBufferSize A vDSP_Length (unsigned long) representing the length of the history buffer. This should be AT LEAST the size of the window. A recommended value for this would be at least 8x greater than the `windowSize` argument.
+ @param sampleRate        A float representing the sample rate of the incoming audio signal.
+ @param delegate          An EZAudioFFTDelegate to receive an event whenever the FFT is calculated.
+ @return A newly created EZAudioFFTRolling instance.
+ */
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                historyBufferSize:(vDSP_Length)historyBufferSize
+                       sampleRate:(float)sampleRate
+                         delegate:(id<EZAudioFFTDelegate>)delegate;
+
+//------------------------------------------------------------------------------
+#pragma mark - Properties
+//------------------------------------------------------------------------------
+
+///-----------------------------------------------------------
+/// @name Properties
+///-----------------------------------------------------------
+
+/**
+ A vDSP_Length (unsigned long) representing the length of the FFT window.
+ */
+@property (readonly, nonatomic) vDSP_Length windowSize;
+
+//------------------------------------------------------------------------------
+
+/**
+ A float array representing the audio data in the internal circular buffer used to perform the FFT. This will increase as more data is appended to the internal circular buffer via the `computeFFTWithBuffer:withBufferSize:` method. The length of this array is the `timeDomainBufferSize` property.
+ */
+@property (readonly, nonatomic) float *timeDomainData;
+
+//------------------------------------------------------------------------------
+
+/**
+ A UInt32 representing the length of the audio data used to perform the FFT.
+ */
+@property (readonly, nonatomic) UInt32 timeDomainBufferSize;
+
+@end

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioFFT.m
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioFFT.m
@@ -1,0 +1,444 @@
+//
+//  EZAudioFFT.m
+//  EZAudio
+//
+//  Created by Syed Haris Ali on 7/10/15.
+//  Copyright (c) 2015 Syed Haris Ali. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import "EZAudioFFT.h"
+#import "EZAudioUtilities.h"
+
+//------------------------------------------------------------------------------
+#pragma mark - Data Structures
+//------------------------------------------------------------------------------
+
+typedef struct EZAudioFFTInfo
+{
+    FFTSetup       fftSetup;
+    COMPLEX_SPLIT  complexA;
+    float         *outFFTData;
+    vDSP_Length    outFFTDataLength;
+    float         *inversedFFTData;
+    vDSP_Length    maxFrequencyIndex;
+    float          maxFrequencyMangitude;
+    float          maxFrequency;
+} EZAudioFFTInfo;
+
+//------------------------------------------------------------------------------
+#pragma mark - EZAudioFFT (Interface Extension)
+//------------------------------------------------------------------------------
+
+@interface EZAudioFFT ()
+@property (assign,    nonatomic) EZAudioFFTInfo *info;
+@property (readwrite, nonatomic) vDSP_Length     maximumBufferSize;
+@end
+
+//------------------------------------------------------------------------------
+#pragma mark - EZAudioFFT (Implementation)
+//------------------------------------------------------------------------------
+
+@implementation EZAudioFFT
+
+//------------------------------------------------------------------------------
+#pragma mark - Dealloc
+//------------------------------------------------------------------------------
+
+- (void)dealloc
+{
+    vDSP_destroy_fftsetup(self.info->fftSetup);
+    free(self.info->complexA.realp);
+    free(self.info->complexA.imagp);
+    free(self.info->outFFTData);
+    free(self.info->inversedFFTData);
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Initializers
+//------------------------------------------------------------------------------
+
+- (instancetype)initWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                               sampleRate:(float)sampleRate
+{
+    return [self initWithMaximumBufferSize:maximumBufferSize
+                                sampleRate:sampleRate
+                                  delegate:nil];
+}
+
+//------------------------------------------------------------------------------
+
+- (instancetype)initWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                               sampleRate:(float)sampleRate
+                                 delegate:(id<EZAudioFFTDelegate>)delegate
+{
+    self = [super init];
+    if (self)
+    {
+        self.maximumBufferSize = (vDSP_Length)maximumBufferSize;
+        self.sampleRate = sampleRate;
+        self.delegate = delegate;
+        [self setup];
+    }
+    return self;
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Class Initializers
+//------------------------------------------------------------------------------
+
++ (instancetype)fftWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                              sampleRate:(float)sampleRate
+{
+    return [[self alloc] initWithMaximumBufferSize:maximumBufferSize
+                                        sampleRate:sampleRate];
+}
+
+//------------------------------------------------------------------------------
+
++ (instancetype)fftWithMaximumBufferSize:(vDSP_Length)maximumBufferSize
+                              sampleRate:(float)sampleRate
+                                delegate:(id<EZAudioFFTDelegate>)delegate
+{
+    return [[self alloc] initWithMaximumBufferSize:maximumBufferSize
+                                        sampleRate:sampleRate
+                                          delegate:delegate];
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Setup
+//------------------------------------------------------------------------------
+
+- (void)setup
+{
+    NSAssert(self.maximumBufferSize > 0, @"Expected FFT buffer size to be greater than 0!");
+    
+    //
+    // Initialize FFT
+    //
+    float maximumBufferSizeBytes = self.maximumBufferSize * sizeof(float);
+    self.info = (EZAudioFFTInfo *)calloc(1, sizeof(EZAudioFFTInfo));
+    vDSP_Length log2n = log2f(self.maximumBufferSize);
+    self.info->fftSetup = vDSP_create_fftsetup(log2n, FFT_RADIX2);
+    long nOver2 = maximumBufferSizeBytes / 2;
+    size_t maximumSizePerComponentBytes = nOver2 * sizeof(float);
+    self.info->complexA.realp = (float *)malloc(maximumSizePerComponentBytes);
+    self.info->complexA.imagp = (float *)malloc(maximumSizePerComponentBytes);
+    self.info->outFFTData = (float *)malloc(maximumSizePerComponentBytes);
+    memset(self.info->outFFTData, 0, maximumSizePerComponentBytes);
+    self.info->inversedFFTData = (float *)malloc(maximumSizePerComponentBytes);
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Actions
+//------------------------------------------------------------------------------
+
+- (float *)computeFFTWithBuffer:(float *)buffer withBufferSize:(UInt32)bufferSize
+{
+    if (buffer == NULL)
+    {
+        return NULL;
+    }
+    
+    //
+    // Calculate real + imaginary components and normalize
+    //
+    vDSP_Length log2n = log2f(bufferSize);
+    long nOver2 = bufferSize / 2;
+    float mFFTNormFactor = 10.0 / (2 * bufferSize);
+    vDSP_ctoz((COMPLEX*)buffer, 2, &(self.info->complexA), 1, nOver2);
+    vDSP_fft_zrip(self.info->fftSetup, &(self.info->complexA), 1, log2n, FFT_FORWARD);
+    vDSP_vsmul(self.info->complexA.realp, 1, &mFFTNormFactor, self.info->complexA.realp, 1, nOver2);
+    vDSP_vsmul(self.info->complexA.imagp, 1, &mFFTNormFactor, self.info->complexA.imagp, 1, nOver2);
+    vDSP_zvmags(&(self.info->complexA), 1, self.info->outFFTData, 1, nOver2);
+    vDSP_fft_zrip(self.info->fftSetup, &(self.info->complexA), 1, log2n, FFT_INVERSE);
+    vDSP_ztoc(&(self.info->complexA), 1, (COMPLEX *) self.info->inversedFFTData , 2, nOver2);
+    self.info->outFFTDataLength = nOver2;
+    
+    //
+    // Calculate max freq
+    //
+    if (self.sampleRate > 0.0f)
+    {
+        vDSP_maxvi(self.info->outFFTData, 1, &self.info->maxFrequencyMangitude, &self.info->maxFrequencyIndex, nOver2);
+        self.info->maxFrequency = [self frequencyAtIndex:self.info->maxFrequencyIndex];
+    }
+    
+    //
+    // Notify delegate
+    //
+    if ([self.delegate respondsToSelector:@selector(fft:updatedWithFFTData:bufferSize:)])
+    {
+        [self.delegate fft:self
+        updatedWithFFTData:self.info->outFFTData
+                bufferSize:nOver2];
+    }
+    
+    //
+    // Return the FFT
+    //
+    return self.info->outFFTData;
+}
+
+//------------------------------------------------------------------------------
+
+- (float)frequencyAtIndex:(vDSP_Length)index
+{
+    if (!(self.info->outFFTData == NULL || self.sampleRate == 0.0f))
+    {
+        float nyquistMaxFreq = self.sampleRate / 2.0;
+        return ((float)index / (float)self.info->outFFTDataLength) * nyquistMaxFreq;
+    }
+    return NSNotFound;
+}
+
+//------------------------------------------------------------------------------
+
+- (float)frequencyMagnitudeAtIndex:(vDSP_Length)index
+{
+    if (self.info->outFFTData != NULL)
+    {
+        return self.info->outFFTData[index];
+    }
+    return NSNotFound;
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Getters
+//------------------------------------------------------------------------------
+
+- (COMPLEX_SPLIT)complexSplit
+{
+    return self.info->complexA;
+}
+
+//------------------------------------------------------------------------------
+
+- (float *)fftData
+{
+    return self.info->outFFTData;
+}
+
+//------------------------------------------------------------------------------
+
+- (FFTSetup)fftSetup
+{
+    return self.info->fftSetup;
+}
+
+//------------------------------------------------------------------------------
+
+- (float *)inversedFFTData
+{
+    return self.info->inversedFFTData;
+}
+
+//------------------------------------------------------------------------------
+
+- (vDSP_Length)maxFrequencyIndex
+{
+    return self.info->maxFrequencyIndex;
+}
+
+//------------------------------------------------------------------------------
+
+- (float)maxFrequencyMagnitude
+{
+    return self.info->maxFrequencyMangitude;
+}
+
+//------------------------------------------------------------------------------
+
+- (float)maxFrequency
+{
+    return self.info->maxFrequency;
+}
+
+@end
+
+//------------------------------------------------------------------------------
+#pragma mark - EZAudioFFTRolling
+//------------------------------------------------------------------------------
+
+@interface EZAudioFFTRolling ()
+@property (assign,    nonatomic) EZPlotHistoryInfo *historyInfo;
+@property (readwrite, nonatomic) vDSP_Length        windowSize;
+
+@end
+
+@implementation EZAudioFFTRolling
+
+//------------------------------------------------------------------------------
+#pragma mark - Dealloc
+//------------------------------------------------------------------------------
+
+- (void)dealloc
+{
+    [EZAudioUtilities freeHistoryInfo:self.historyInfo];
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Initialization
+//------------------------------------------------------------------------------
+
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                        sampleRate:(float)sampleRate
+{
+    return [self initWithWindowSize:windowSize
+                  historyBufferSize:windowSize * 8
+                         sampleRate:sampleRate
+                           delegate:nil];
+}
+
+//------------------------------------------------------------------------------
+
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                        sampleRate:(float)sampleRate
+                          delegate:(id<EZAudioFFTDelegate>)delegate
+{
+    return [self initWithWindowSize:windowSize
+                  historyBufferSize:windowSize * 8
+                         sampleRate:sampleRate
+                           delegate:delegate];
+}
+
+//------------------------------------------------------------------------------
+
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                 historyBufferSize:(vDSP_Length)historyBufferSize
+                        sampleRate:(float)sampleRate
+{
+    return [self initWithWindowSize:windowSize
+                  historyBufferSize:historyBufferSize
+                         sampleRate:sampleRate
+                           delegate:nil];
+}
+
+//------------------------------------------------------------------------------
+
+- (instancetype)initWithWindowSize:(vDSP_Length)windowSize
+                 historyBufferSize:(vDSP_Length)historyBufferSize
+                        sampleRate:(float)sampleRate
+                          delegate:(id<EZAudioFFTDelegate>)delegate
+{
+    self = [super initWithMaximumBufferSize:historyBufferSize
+                                 sampleRate:sampleRate];
+    if (self)
+    {
+        self.delegate = delegate;
+        self.windowSize = windowSize;
+        
+        //
+        // Allocate an appropriately sized history buffer in bytes
+        //
+        self.historyInfo = [EZAudioUtilities historyInfoWithDefaultLength:(UInt32)windowSize
+                                                            maximumLength:(UInt32)historyBufferSize];
+    }
+    return self;
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Class Initializers
+//------------------------------------------------------------------------------
+
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                       sampleRate:(float)sampleRate
+{
+    return [[self alloc] initWithWindowSize:windowSize
+                                 sampleRate:sampleRate];
+}
+
+//------------------------------------------------------------------------------
+
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                       sampleRate:(float)sampleRate
+                         delegate:(id<EZAudioFFTDelegate>)delegate
+{
+    return [[self alloc] initWithWindowSize:windowSize
+                                 sampleRate:sampleRate
+                                   delegate:delegate];
+}
+
+//------------------------------------------------------------------------------
+
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                historyBufferSize:(vDSP_Length)historyBufferSize
+                       sampleRate:(float)sampleRate
+{
+    return [[self alloc] initWithWindowSize:windowSize
+                          historyBufferSize:historyBufferSize
+                                 sampleRate:sampleRate];
+}
+
+//------------------------------------------------------------------------------
+
++ (instancetype)fftWithWindowSize:(vDSP_Length)windowSize
+                historyBufferSize:(vDSP_Length)historyBufferSize
+                       sampleRate:(float)sampleRate
+                         delegate:(id<EZAudioFFTDelegate>)delegate
+{
+    return [[self alloc] initWithWindowSize:windowSize
+                          historyBufferSize:historyBufferSize
+                                 sampleRate:sampleRate
+                                   delegate:delegate];
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Actions
+//------------------------------------------------------------------------------
+
+- (float *)computeFFTWithBuffer:(float *)buffer
+                 withBufferSize:(UInt32)bufferSize
+{
+    if (buffer == NULL)
+    {
+        return NULL;
+    }
+    
+    //
+    // Append buffer to history window
+    //
+    [EZAudioUtilities appendBuffer:buffer
+                    withBufferSize:bufferSize
+                     toHistoryInfo:self.historyInfo];
+    
+    //
+    // Call super to calculate the FFT of the window
+    //
+    return [super computeFFTWithBuffer:self.historyInfo->buffer
+                        withBufferSize:self.historyInfo->bufferSize];
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Getters
+//------------------------------------------------------------------------------
+
+- (UInt32)timeDomainBufferSize
+{
+    return self.historyInfo->bufferSize;
+}
+
+//------------------------------------------------------------------------------
+
+- (float *)timeDomainData
+{
+    return self.historyInfo->buffer;
+}
+
+@end

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioUtilities.h
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioUtilities.h
@@ -381,6 +381,13 @@ typedef NSRect EZRect;
 + (float)SGN:(float)value;
 
 //------------------------------------------------------------------------------
+#pragma mark - Music Utilities
+//------------------------------------------------------------------------------
+
++ (NSString *)noteNameStringForFrequency:(float)frequency
+                           includeOctave:(BOOL)includeOctave;
+
+//------------------------------------------------------------------------------
 #pragma mark - OSStatus Utility
 //------------------------------------------------------------------------------
 

--- a/AudioKit/Utilities/Plots/EZAudio/EZAudioUtilities.m
+++ b/AudioKit/Utilities/Plots/EZAudio/EZAudioUtilities.m
@@ -27,6 +27,22 @@
 
 @import Accelerate;
 
+static float    const  EZAudioUtilitiesFixedNoteA       = 440.0f;
+static int      const  EZAudioUtilitiesFixedNoteAIndex  = 9;
+static int      const  EZAudioUtilitiesFixedNoteAOctave = 4;
+static float    const  EZAudioUtilitiesEQFrequencyRatio = 1.059463094359f;
+static int      const  EZAudioUtilitiesNotesLength      = 12;
+static NSString * const EZAudioUtilitiesNotes[EZAudioUtilitiesNotesLength] =
+{
+    @"C", @"C#",
+    @"D", @"D#",
+    @"E",
+    @"F", @"F#",
+    @"G", @"G#",
+    @"A", @"A#",
+    @"B"
+};
+
 BOOL __shouldExitOnCheckResultFail = YES;
 
 @implementation EZAudioUtilities
@@ -55,15 +71,29 @@ BOOL __shouldExitOnCheckResultFail = YES;
                                       numberOfChannels:(UInt32)channels
                                            interleaved:(BOOL)interleaved
 {
-    AudioBufferList *audioBufferList = (AudioBufferList*)malloc(sizeof(AudioBufferList) + sizeof(AudioBuffer) * (channels-1));
-    UInt32 outputBufferSize = 32 * frames; // 32 KB
-    audioBufferList->mNumberBuffers = interleaved ? 1 : channels;
-    for(int i = 0; i < audioBufferList->mNumberBuffers; i++)
+    unsigned nBuffers;
+    unsigned bufferSize;
+    unsigned channelsPerBuffer;
+    if (interleaved)
     {
-        audioBufferList->mBuffers[i].mNumberChannels = channels;
-        audioBufferList->mBuffers[i].mDataByteSize = channels * outputBufferSize;
-        audioBufferList->mBuffers[i].mData = (float *)malloc(channels * sizeof(float) *outputBufferSize);
-        memset(audioBufferList->mBuffers[i].mData, 0, frames);
+        nBuffers = 1;
+        bufferSize = sizeof(float) * frames * channels;
+        channelsPerBuffer = channels;
+    }
+    else
+    {
+        nBuffers = channels;
+        bufferSize = sizeof(float) * frames;
+        channelsPerBuffer = 1;
+    }
+    
+    AudioBufferList *audioBufferList = (AudioBufferList *)malloc(sizeof(AudioBufferList) + sizeof(AudioBuffer) * (channels-1));
+    audioBufferList->mNumberBuffers = nBuffers;
+    for(unsigned i = 0; i < nBuffers; i++)
+    {
+        audioBufferList->mBuffers[i].mNumberChannels = channelsPerBuffer;
+        audioBufferList->mBuffers[i].mDataByteSize = bufferSize;
+        audioBufferList->mBuffers[i].mData = calloc(bufferSize, 1);
     }
     return audioBufferList;
 }
@@ -431,11 +461,11 @@ BOOL __shouldExitOnCheckResultFail = YES;
 
 //------------------------------------------------------------------------------
 
-+(float)MAP:(float)value
-    leftMin:(float)leftMin
-    leftMax:(float)leftMax
-   rightMin:(float)rightMin
-   rightMax:(float)rightMax
++ (float)MAP:(float)value
+     leftMin:(float)leftMin
+     leftMax:(float)leftMax
+    rightMin:(float)rightMin
+    rightMax:(float)rightMax
 {
     float leftSpan    = leftMax  - leftMin;
     float rightSpan   = rightMax - rightMin;
@@ -445,8 +475,7 @@ BOOL __shouldExitOnCheckResultFail = YES;
 
 //------------------------------------------------------------------------------
 
-+(float)RMS:(const float *)buffer
-     length:(int)bufferSize
++(float)RMS:(const float *)buffer   length:(int)bufferSize
 {
     float *squared = calloc(bufferSize, sizeof(float));
     vDSP_vsq(buffer, 1, squared, 1, bufferSize);
@@ -458,9 +487,40 @@ BOOL __shouldExitOnCheckResultFail = YES;
 
 //------------------------------------------------------------------------------
 
-+(float)SGN:(float)value
++ (float)SGN:(float)value
 {
     return value < 0 ? -1.0f : ( value > 0 ? 1.0f : 0.0f);
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Music Utilities
+//------------------------------------------------------------------------------
+
++ (NSString *)noteNameStringForFrequency:(float)frequency
+                           includeOctave:(BOOL)includeOctave
+{
+    NSMutableString *noteName = [NSMutableString string];
+    int halfStepsFromFixedNote = roundf(log(frequency / EZAudioUtilitiesFixedNoteA) / log(EZAudioUtilitiesEQFrequencyRatio));
+    int halfStepsModOctaves = halfStepsFromFixedNote % EZAudioUtilitiesNotesLength;
+    int indexOfNote = EZAudioUtilitiesFixedNoteAIndex + halfStepsModOctaves;
+    float octaves = halfStepsFromFixedNote / EZAudioUtilitiesNotesLength;
+    if (indexOfNote >= EZAudioUtilitiesNotesLength)
+    {
+        indexOfNote -= EZAudioUtilitiesNotesLength;
+        octaves += 1;
+    }
+    else if (indexOfNote < 0)
+    {
+        indexOfNote += EZAudioUtilitiesNotesLength;
+        octaves = -1;
+    }
+    [noteName appendString:EZAudioUtilitiesNotes[indexOfNote]];
+    if (includeOctave)
+    {
+        int noteOctave = EZAudioUtilitiesFixedNoteAOctave + octaves;
+        [noteName appendFormat:@"%i", noteOctave];
+    }
+    return noteName;
 }
 
 //------------------------------------------------------------------------------
@@ -637,7 +697,7 @@ BOOL __shouldExitOnCheckResultFail = YES;
     memmove(historyInfo->buffer, historyBuffer, bytes);
     if (targetBytes <= availableBytes)
     {
-        TPCircularBufferConsume(&historyInfo->circularBuffer, targetBytes);
+        TPCircularBufferConsume(&historyInfo->circularBuffer, availableBytes - targetBytes);
     }
 }
 


### PR DESCRIPTION
This should fix the issue with the rolling waveforms not sliding properly, and I also included their new FFT code that we may want to use to rewrite out own FFT plots.
