### PR TITLE
MIDI / SoundFont tab in iOS AudioKitDemo

### DIFF
--- a/AudioKit/Platforms/Common/CsoundObj.m
+++ b/AudioKit/Platforms/Common/CsoundObj.m
@@ -643,7 +643,7 @@ OSStatus  Csound_Render(void *inRefCon,
         [self notifyListenersOfAboutToStart];
 
 #if TARGET_OS_IPHONE
-        char *argv[] = { "csound",
+        char *argv[] = { "csound", "-+rtmidi=null",
 # ifdef AK_TESTING
             "-+rtaudio=null",
 # else
@@ -651,7 +651,7 @@ OSStatus  Csound_Render(void *inRefCon,
 # endif            
                         (char*)[csdFilePath cStringUsingEncoding:NSASCIIStringEncoding]};
 #else
-        char *argv[] = { "csound", "-+ignore_csopts=0",
+        char *argv[] = { "csound", "-+ignore_csopts=0", "-+rtmidi=null",
 # ifdef AK_TESTING
                          "-+rtaudio=null",
 # else

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		EA9F18CC1AE7ACCA009D3DA6 /* libsndfile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA9F18951AE7A1F5009D3DA6 /* libsndfile.framework */; };
 		EA9F18CD1AE7ACCA009D3DA6 /* CsoundLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA9F18961AE7A1F5009D3DA6 /* CsoundLib.framework */; };
 		EAB29D6C1AD5121B000EA118 /* AKSoundFiles.bundle in Resources */ = {isa = PBXBuildFile; fileRef = EAB29D6B1AD5121B000EA118 /* AKSoundFiles.bundle */; };
+		EABBAEB71B7082EC000AB769 /* MIDIViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EABBAEB61B7082EC000AB769 /* MIDIViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,8 @@
 		EA9F18951AE7A1F5009D3DA6 /* libsndfile.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = libsndfile.framework; path = ../../../AudioKit/Platforms/iOS/libsndfile.framework; sourceTree = SOURCE_ROOT; };
 		EA9F18961AE7A1F5009D3DA6 /* CsoundLib.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CsoundLib.framework; path = ../../../AudioKit/Platforms/iOS/CsoundLib.framework; sourceTree = SOURCE_ROOT; };
 		EAB29D6B1AD5121B000EA118 /* AKSoundFiles.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AKSoundFiles.bundle; path = ../../../../AudioKit/Resources/AKSoundFiles.bundle; sourceTree = "<group>"; };
+		EABBAEB51B7082EC000AB769 /* MIDIViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MIDIViewController.h; path = MIDI/MIDIViewController.h; sourceTree = "<group>"; };
+		EABBAEB61B7082EC000AB769 /* MIDIViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MIDIViewController.m; path = MIDI/MIDIViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +148,7 @@
 				C4BACF431A90608000736291 /* Synthesis */,
 				C4BACD351A9002CA00736291 /* Processing */,
 				C4BACF471A9060A500736291 /* Analysis */,
+				EABBAEBA1B7082F9000AB769 /* MIDI */,
 				C4BACD091A8FFC3100736291 /* Supporting Files */,
 			);
 			path = AudioKitDemo;
@@ -221,6 +225,15 @@
 				EA8E97271AD3D15C0057E979 /* AVFoundation.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EABBAEBA1B7082F9000AB769 /* MIDI */ = {
+			isa = PBXGroup;
+			children = (
+				EABBAEB51B7082EC000AB769 /* MIDIViewController.h */,
+				EABBAEB61B7082EC000AB769 /* MIDIViewController.m */,
+			);
+			name = MIDI;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -344,6 +357,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4BACF401A90606300736291 /* ConvolutionInstrument.m in Sources */,
+				EABBAEB71B7082EC000AB769 /* MIDIViewController.m in Sources */,
 				C4BACD341A9002BE00736291 /* ProcessingViewController.m in Sources */,
 				C4BACF461A9060A100736291 /* AnalysisViewController.m in Sources */,
 				C4BACF541A91BB7100736291 /* FMSynthesizer.m in Sources */,

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/Base.lproj/Main.storyboard
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8164.2" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8135.1"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <mutableArray key="Courier.ttc">
+            <string>Courier</string>
+            <string>Courier</string>
+        </mutableArray>
+    </customFonts>
     <scenes>
         <!--Synthesis Examples-->
         <scene sceneID="hNz-n2-bh7">
@@ -20,7 +27,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eF6-mp-Am6" userLabel="Tambourine View">
                                 <rect key="frame" x="0.0" y="305" width="600" height="180"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tambourine" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cRT-Wb-nMb">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Tambourine" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cRT-Wb-nMb">
                                         <rect key="frame" x="20" y="20" width="93" height="21"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -46,7 +53,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="drm-p8-ykz" userLabel="FM Synthesizer View">
                                 <rect key="frame" x="0.0" y="90" width="600" height="180"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FM Synthesizer" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QPw-i9-3jB">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="FM Synthesizer" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QPw-i9-3jB">
                                         <rect key="frame" x="20" y="20" width="122" height="21"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -69,7 +76,7 @@
                                     <outletCollection property="gestureRecognizers" destination="Oty-7W-TVm" appends="YES" id="FGN-xD-k2O"/>
                                 </connections>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="And many more ..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJu-ZW-4a9">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="And many more ..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJu-ZW-4a9">
                                 <rect key="frame" x="230" y="506" width="141" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -112,6 +119,90 @@
             </objects>
             <point key="canvasLocation" x="1464" y="-424"/>
         </scene>
+        <!--MIDI-->
+        <scene sceneID="9eG-eg-Lfx">
+            <objects>
+                <viewController title="MIDI" id="jNI-8Z-wPL" customClass="MIDIViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="8UD-49-EwV"/>
+                        <viewControllerLayoutGuide type="bottom" id="8YA-FK-R9U"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Bt8-XG-jKu">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PnE-Ml-EnP">
+                                <rect key="frame" x="0.0" y="28" width="600" height="216"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="jNI-8Z-wPL" id="YIG-Ro-xPg"/>
+                                    <outlet property="delegate" destination="jNI-8Z-wPL" id="Itb-1S-7fo"/>
+                                </connections>
+                            </pickerView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IxE-6O-Scf">
+                                <rect key="frame" x="0.0" y="252" width="600" height="51"/>
+                                <color key="backgroundColor" red="0.090196078431372548" green="0.6705882352941176" blue="0.094117647058823528" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="600" id="qjh-bV-RxZ"/>
+                                    <constraint firstAttribute="height" constant="51" id="rLE-5s-CFW"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                <state key="normal" title="Play Note">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="qjh-bV-RxZ"/>
+                                    </mask>
+                                </variation>
+                                <connections>
+                                    <action selector="playNote:" destination="jNI-8Z-wPL" eventType="touchUpInside" id="4hd-z5-LFA"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MIDI Messages" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KED-wZ-qA9">
+                                <rect key="frame" x="0.0" y="319" width="600" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="yqb-Wc-J8c"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="aTp-8m-hcr">
+                                <rect key="frame" x="0.0" y="348" width="600" height="203"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="jNI-8Z-wPL" id="sFK-nZ-Dya"/>
+                                    <outlet property="delegate" destination="jNI-8Z-wPL" id="QWG-9H-lPZ"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="PnE-Ml-EnP" firstAttribute="top" secondItem="8UD-49-EwV" secondAttribute="bottom" constant="8" id="2eU-Mf-ThE"/>
+                            <constraint firstItem="aTp-8m-hcr" firstAttribute="top" secondItem="KED-wZ-qA9" secondAttribute="bottom" constant="8" id="Eky-iK-H4b"/>
+                            <constraint firstItem="IxE-6O-Scf" firstAttribute="width" secondItem="Bt8-XG-jKu" secondAttribute="width" id="Fe5-g4-Nnh"/>
+                            <constraint firstItem="PnE-Ml-EnP" firstAttribute="width" secondItem="Bt8-XG-jKu" secondAttribute="width" id="Gyr-Tl-oPq"/>
+                            <constraint firstItem="IxE-6O-Scf" firstAttribute="centerX" secondItem="Bt8-XG-jKu" secondAttribute="centerX" id="Hoz-3r-ZF9"/>
+                            <constraint firstItem="aTp-8m-hcr" firstAttribute="width" secondItem="Bt8-XG-jKu" secondAttribute="width" id="Td6-Gp-NoQ"/>
+                            <constraint firstItem="aTp-8m-hcr" firstAttribute="centerX" secondItem="Bt8-XG-jKu" secondAttribute="centerX" id="X3O-Gu-gIt"/>
+                            <constraint firstItem="IxE-6O-Scf" firstAttribute="top" secondItem="PnE-Ml-EnP" secondAttribute="bottom" constant="8" id="gAg-jw-ufn"/>
+                            <constraint firstItem="KED-wZ-qA9" firstAttribute="width" secondItem="Bt8-XG-jKu" secondAttribute="width" id="hqm-Be-GnA"/>
+                            <constraint firstItem="KED-wZ-qA9" firstAttribute="top" secondItem="IxE-6O-Scf" secondAttribute="bottom" constant="16" id="hrZ-nA-4sz"/>
+                            <constraint firstItem="KED-wZ-qA9" firstAttribute="centerX" secondItem="Bt8-XG-jKu" secondAttribute="centerX" id="ifo-UC-RgU"/>
+                            <constraint firstItem="PnE-Ml-EnP" firstAttribute="centerX" secondItem="Bt8-XG-jKu" secondAttribute="centerX" id="oZa-Na-sTc"/>
+                            <constraint firstItem="8YA-FK-R9U" firstAttribute="top" secondItem="aTp-8m-hcr" secondAttribute="bottom" id="zvt-IN-BdR"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="MIDI" id="vsL-Iw-OUO"/>
+                    <connections>
+                        <outlet property="_messagesTable" destination="aTp-8m-hcr" id="rXn-ui-rF1"/>
+                        <outlet property="_presetsPicker" destination="PnE-Ml-EnP" id="kDJ-9y-4mr"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="njy-bQ-JHN" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-164" y="833"/>
+        </scene>
         <!--Processing-->
         <scene sceneID="wg7-f3-ORb">
             <objects>
@@ -124,7 +215,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="QVJ-9n-cWO">
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="QVJ-9n-cWO">
                                 <rect key="frame" x="146" y="121" width="307" height="29"/>
                                 <segments>
                                     <segment title="Piano Bass Drum Loop"/>
@@ -134,7 +225,7 @@
                                     <action selector="fileChanged:" destination="8rJ-Kc-sve" eventType="valueChanged" id="k4b-Rv-Dlq"/>
                                 </connections>
                             </segmentedControl>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Source" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v6H-Y2-a9w">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Source" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v6H-Y2-a9w">
                                 <rect key="frame" x="146" y="92" width="307" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -143,7 +234,7 @@
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="Sug-eB-ocK" customClass="AKPropertySlider">
                                 <rect key="frame" x="28" y="495" width="544" height="31"/>
                             </slider>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Wet" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="d6X-yd-ZWW">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="Wet" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="d6X-yd-ZWW">
                                 <rect key="frame" x="540" y="466" width="30" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -152,7 +243,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 </variation>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Mix" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="SSS-lz-x0g">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="Mix" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="SSS-lz-x0g">
                                 <rect key="frame" x="286" y="466" width="29" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -161,7 +252,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 </variation>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Impulse Response" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="qZC-Kx-pbt">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="Impulse Response" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="qZC-Kx-pbt">
                                 <rect key="frame" x="227" y="376" width="146" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -179,7 +270,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 </variation>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Stairwell" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="044-kr-T70">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="Stairwell" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="044-kr-T70">
                                 <rect key="frame" x="504" y="376" width="66" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -224,7 +315,7 @@
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="1gV-x8-nYO" customClass="AKPropertySlider">
                                 <rect key="frame" x="28" y="405" width="544" height="31"/>
                             </slider>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Speed" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="g1k-aG-Wgo">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="Speed" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="g1k-aG-Wgo">
                                 <rect key="frame" x="276" y="166" width="51" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -233,7 +324,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 </variation>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="-2" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="aXo-Hy-XAZ">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="-2" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="aXo-Hy-XAZ">
                                 <rect key="frame" x="31" y="166" width="17" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -257,7 +348,7 @@
                                     <action selector="speedChanged:" destination="8rJ-Kc-sve" eventType="valueChanged" id="V9K-XE-HrJ"/>
                                 </connections>
                             </slider>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Pitch" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="kYn-jz-Pnd">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="Pitch" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="kYn-jz-Pnd">
                                 <rect key="frame" x="279" y="286" width="41" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -266,7 +357,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 </variation>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="0" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="RVs-Pz-arc">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="0" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="RVs-Pz-arc">
                                 <rect key="frame" x="29" y="286" width="10" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -275,7 +366,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 </variation>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="3" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="ze6-7D-22b">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="3" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="ze6-7D-22b">
                                 <rect key="frame" x="559" y="286" width="10" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -293,7 +384,7 @@
                                     <action selector="togglePitchMaintenance:" destination="8rJ-Kc-sve" eventType="valueChanged" id="AL0-tA-wiv"/>
                                 </connections>
                             </switch>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Preserve Pitch" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FPZ-yF-FNq">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Preserve Pitch" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FPZ-yF-FNq">
                                 <rect key="frame" x="331" y="252" width="87" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -379,7 +470,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4Nw-L8-lE0" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="750" y="360"/>
+            <point key="canvasLocation" x="651" y="788"/>
         </scene>
         <!--Analysis-->
         <scene sceneID="aQY-eb-ozn">
@@ -419,7 +510,7 @@
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" text="Amplitude:" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="eFn-8d-mbv">
+                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" misplaced="YES" text="Amplitude:" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="eFn-8d-mbv">
                                         <rect key="frame" x="20" y="92" width="87" height="22"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
@@ -439,13 +530,13 @@
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="C" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YHv-cP-GZq">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="C" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YHv-cP-GZq">
                                         <rect key="frame" x="381" y="124" width="13" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio Input Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="51w-TT-UpA">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Audio Input Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="51w-TT-UpA">
                                         <rect key="frame" x="20" y="156" width="130" height="22"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -484,7 +575,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tracked Frequency Intrument Property Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NnL-Z0-WZf">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Tracked Frequency Intrument Property Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NnL-Z0-WZf">
                                         <rect key="frame" x="22" y="439" width="330" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -503,13 +594,13 @@
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="connectPoints" value="NO"/>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Normalized Frequency Float Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lr1-e6-b7A">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Normalized Frequency Float Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lr1-e6-b7A">
                                         <rect key="frame" x="20" y="580" width="251" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio Input FFT Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RmN-65-Hyj">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Audio Input FFT Plot" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RmN-65-Hyj">
                                         <rect key="frame" x="20" y="721" width="158" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -539,7 +630,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rolling Input Waveform" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4H-RM-6J2">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Rolling Input Waveform" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4H-RM-6J2">
                                         <rect key="frame" x="20" y="862" width="179" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -654,6 +745,7 @@
                         <segue destination="670-Qj-8iE" kind="relationship" relationship="viewControllers" id="u7Y-xg-7CH"/>
                         <segue destination="8rJ-Kc-sve" kind="relationship" relationship="viewControllers" id="lzU-1b-eKA"/>
                         <segue destination="K54-1r-bYN" kind="relationship" relationship="viewControllers" id="Z6R-ug-kqQ"/>
+                        <segue destination="jNI-8Z-wPL" kind="relationship" relationship="viewControllers" id="1N2-v6-fqz"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HuB-VB-40B" sceneMemberID="firstResponder"/>

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/MIDI/MIDIViewController.h
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/MIDI/MIDIViewController.h
@@ -1,0 +1,13 @@
+//
+//  MIDIViewController.h
+//  AudioKitDemo
+//
+//  Created by Stéphane Peter on 8/3/15.
+//  Copyright © 2015 Aurelius Prochazka. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface MIDIViewController : UIViewController
+
+@end

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/MIDI/MIDIViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/MIDI/MIDIViewController.m
@@ -109,7 +109,6 @@
         [self logMessage:[NSString stringWithFormat:@"Note OFF: %@, velocity = %@, channel %@",
                           notif.userInfo[@"note"], notif.userInfo[@"velocity"], notif.userInfo[@"channel"]]];
     });
-    //    [_instrument stop];
 }
 
 - (void)midiPitchWheel:(NSNotification *)notif
@@ -126,7 +125,8 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         [self logMessage:[NSString stringWithFormat:@"Program Change: %@, channel %@",
                           notif.userInfo[@"program"], notif.userInfo[@"channel"]]];
-        [_presetsPicker selectRow:program inComponent:1 animated:YES];
+        [_presetsPicker selectRow:program inComponent:0 animated:YES];
+        [self pickerView:_presetsPicker didSelectRow:program inComponent:0]; // Doesn't get called automatically
     });
 }
 
@@ -147,7 +147,7 @@
             forComponent:(NSInteger)component
 {
     AKSoundFontPreset *preset = _presets[row];
-    return preset.name;
+    return [NSString stringWithFormat:@"%@: %@",@(row),preset.name];
 }
 
 - (void)pickerView:(UIPickerView *)pickerView

--- a/Examples/iOS/AudioKitDemo/AudioKitDemo/MIDI/MIDIViewController.m
+++ b/Examples/iOS/AudioKitDemo/AudioKitDemo/MIDI/MIDIViewController.m
@@ -1,0 +1,191 @@
+//
+//  MIDIViewController.m
+//  AudioKitDemo
+//
+//  Created by Stéphane Peter on 8/3/15.
+//  Copyright © 2015 Aurelius Prochazka. All rights reserved.
+//
+
+#import "MIDIViewController.h"
+#import "AKFoundation.h"
+
+@interface MIDIViewController () <UITableViewDataSource, UITableViewDelegate, UIPickerViewDataSource, UIPickerViewDelegate>
+
+@end
+
+@implementation MIDIViewController {
+    IBOutlet UIPickerView *_presetsPicker;
+    IBOutlet UITableView *_messagesTable;
+    
+    AKSoundFont *_soundFont;
+    AKMidiInstrument *_instrument;
+    AKSoundFontPresetPlayer *_presetPlayer;
+    AKSoundFontPreset *_selectedPreset;
+    NSMutableArray *_log;
+    NSArray *_presets;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    _log = [NSMutableArray array];
+    [[AKManager sharedManager] setIsLogging:YES];
+    _instrument = [[AKMidiInstrument alloc] init];
+    _instrument.instrumentNumber = 1;
+    [AKOrchestra addInstrument:_instrument];
+    
+    _soundFont = [[AKSoundFont alloc] initWithFilename:[AKManager pathToSoundFile:@"GeneralMidi" ofType:@"sf2"]];
+    
+    [_soundFont fetchPresets:^(AKSoundFont *font) {
+        _presets = font.presets;
+        [_presetsPicker reloadAllComponents];
+        [_presetsPicker selectRow:0 inComponent:0 animated:NO];
+        [self pickerView:_presetsPicker didSelectRow:0 inComponent:0]; // Doesn't get called automatically
+    }];
+
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self
+               selector:@selector(midiNoteOn:)
+                   name:AKMidiNoteOnNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(midiNoteOff:)
+                   name:AKMidiNoteOffNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(midiPitchWheel:)
+                   name:AKMidiPitchWheelNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(midiProgramChange:)
+                   name:AKMidiProgramChangeNotification
+                 object:nil];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (IBAction)playNote:(id)sender
+{
+    AKMidiEvent *noteon = [AKMidiEvent eventWithNoteOn:60 channel:1 velocity:100];
+    AKMidiEvent *noteoff = [AKMidiEvent eventWithNoteOff:60 channel:1 velocity:100];
+    
+    [[AKManager sharedManager].midi sendEvent:noteon];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [[AKManager sharedManager].midi sendEvent:noteoff];
+    });
+
+}
+
+// ----------------------------------
+// Handling of received MIDI messages
+// ----------------------------------
+
+- (void)logMessage:(NSString *)msg
+{
+    [_log addObject:msg];
+    [_messagesTable reloadData];
+    [_messagesTable scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:_log.count-1 inSection:0]
+                          atScrollPosition:UITableViewScrollPositionBottom animated:YES];
+}
+
+- (void)midiNoteOn:(NSNotification *)notif
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self logMessage:[NSString stringWithFormat:@"Note ON: %@, velocity = %@, channel %@",
+                          notif.userInfo[@"note"], notif.userInfo[@"velocity"], notif.userInfo[@"channel"]]];
+    });
+}
+
+- (void)midiNoteOff:(NSNotification *)notif
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self logMessage:[NSString stringWithFormat:@"Note OFF: %@, velocity = %@, channel %@",
+                          notif.userInfo[@"note"], notif.userInfo[@"velocity"], notif.userInfo[@"channel"]]];
+    });
+    //    [_instrument stop];
+}
+
+- (void)midiPitchWheel:(NSNotification *)notif
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self logMessage:[NSString stringWithFormat:@"Pitch Wheel: %@, channel %@",
+                          notif.userInfo[@"pitchWheel"], notif.userInfo[@"channel"]]];
+    });
+}
+
+- (void)midiProgramChange:(NSNotification *)notif
+{
+    NSUInteger program = [notif.userInfo[@"program"] unsignedIntegerValue] - 1;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self logMessage:[NSString stringWithFormat:@"Program Change: %@, channel %@",
+                          notif.userInfo[@"program"], notif.userInfo[@"channel"]]];
+        [_presetsPicker selectRow:program inComponent:1 animated:YES];
+    });
+}
+
+#pragma mark - Picker View delegates
+
+- (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView
+{
+    return 1;
+}
+
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
+{
+    return _presets.count;
+}
+
+- (NSString *)pickerView:(UIPickerView *)pickerView
+             titleForRow:(NSInteger)row
+            forComponent:(NSInteger)component
+{
+    AKSoundFontPreset *preset = _presets[row];
+    return preset.name;
+}
+
+- (void)pickerView:(UIPickerView *)pickerView
+      didSelectRow:(NSInteger)row
+       inComponent:(NSInteger)component
+{
+    _selectedPreset = _presets[row];
+    
+    _instrument = [[AKMidiInstrument alloc] init];
+    _instrument.instrumentNumber = 1;
+    
+    _presetPlayer = [[AKSoundFontPresetPlayer alloc] initWithSoundFontPreset:_selectedPreset];
+    _presetPlayer.noteNumber = _instrument.note.notenumber;
+    [_instrument enableParameterLog:@"nn" parameter:_instrument.note.notenumber timeInterval:100];
+    _presetPlayer.velocity = _instrument.note.velocity;
+    
+    [_instrument setStereoAudioOutput:_presetPlayer];
+    [AKOrchestra updateInstrument:_instrument];
+    [_instrument startListeningOnAllMidiChannels];
+
+}
+
+#pragma mark - Table View delegates
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    return _log.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"LogCell"];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"LogCell"];
+    }
+    cell.textLabel.text = _log[indexPath.row];
+    return cell;
+}
+
+@end


### PR DESCRIPTION
This is mostly a port of the current OS X demo app, to add the MIDI and sound font for testing on that platform. It will need more polish, including a tab bar icon.

The good news is that it is working for me. I do not experience crashes when playing the keyboard on iOS either with this code. There seems to be a little bit of occasional audio distortion, but that's another issue.

So whatever is triggering the "many notes" crashes must be somewhere else, maybe in the way that the MIDI playground currently sends the events?
