### PR TITLE
Added default peak scaling to AKAntiresonator

### DIFF
--- a/AudioKit/Operations/Signal Modifiers/Filters/AKAntiresonantFilter.m
+++ b/AudioKit/Operations/Signal Modifiers/Filters/AKAntiresonantFilter.m
@@ -3,6 +3,7 @@
 //  AudioKit
 //
 //  Auto-generated on 8/16/15.
+//  Customized by Daniel Clelland on 8/30/15 to include tival() and peak scaling.
 //  Copyright (c) 2015 Aurelius Prochazka. All rights reserved.
 //
 //  Implementation of Csound's areson:
@@ -116,6 +117,7 @@
     } else {
         [inputsString appendFormat:@"AKControl(%@)", _bandwidth];
     }
+    [inputsString appendString:@", 1, tival()"];
     return inputsString;
 }
 

--- a/Tests/TestProjects/Shared/Operation Tests/AKAntiresonantFilterTests.m
+++ b/Tests/TestProjects/Shared/Operation Tests/AKAntiresonantFilterTests.m
@@ -56,7 +56,7 @@
     [testInstrument playForDuration:testDuration];
     
     // Check output
-    XCTAssertEqualObjects([self md5ForOutputWithDuration:testDuration], @"6732f0f4e4b428dfcd2a043aa49b3c07");
+    XCTAssertEqualObjects([self md5ForOutputWithDuration:testDuration], @"1ed0bdfac7be5ace532d635186af071d");
 }
 
 


### PR DESCRIPTION
This also avoids this csound bug:
http://csound.1045644.n5.nabble.com/reson-areson-td5736604.html