### PR TITLE
Maximum note allocation

### DIFF
--- a/AudioKit/Core Classes/AKOrchestra.m
+++ b/AudioKit/Core Classes/AKOrchestra.m
@@ -116,6 +116,14 @@
         }
     }
     
+    if (instrument.maximumNoteAllocation) {
+        [instrumentString appendFormat:@"maxalloc %@, %@\n", @(instrument.instrumentNumber), @(instrument.maximumNoteAllocation)];
+    }
+    
+    if (instrument.maximumProcessorAllocation) {
+        [instrumentString appendFormat:@"cpuprc %@, %f\n", @(instrument.instrumentNumber), instrument.maximumProcessorAllocation];
+    }
+    
     [instrumentString appendFormat:@"instr %@\n", @(instrument.instrumentNumber)];
     [instrumentString appendString:[NSString stringWithFormat:@"%@\n", stringForCSD]];
     [instrumentString appendString:@"endin\n"];

--- a/AudioKit/Core Classes/AKOrchestra.m
+++ b/AudioKit/Core Classes/AKOrchestra.m
@@ -120,10 +120,6 @@
         [instrumentString appendFormat:@"maxalloc %@, %@\n", @(instrument.instrumentNumber), @(instrument.maximumNoteAllocation)];
     }
     
-    if (instrument.maximumProcessorAllocation) {
-        [instrumentString appendFormat:@"cpuprc %@, %f\n", @(instrument.instrumentNumber), instrument.maximumProcessorAllocation];
-    }
-    
     [instrumentString appendFormat:@"instr %@\n", @(instrument.instrumentNumber)];
     [instrumentString appendString:[NSString stringWithFormat:@"%@\n", stringForCSD]];
     [instrumentString appendString:@"endin\n"];

--- a/AudioKit/Instruments/AKInstrument.h
+++ b/AudioKit/Instruments/AKInstrument.h
@@ -204,10 +204,5 @@ NS_ASSUME_NONNULL_BEGIN
 /// See http://www.csounds.com/manual/html/maxalloc.html for more info.
 @property NSUInteger maximumNoteAllocation;
 
-/// Set a limit to the amount of CPU usage per note. Note which exceed this limit will be deallocated.
-/// Range from 0.0 to 1.0. Defaults to zero, which is equivalent to setting no limit.
-/// See http://www.csounds.com/manual/html/cpuprc.html for more info.
-@property float maximumProcessorAllocation;
-
 @end
 NS_ASSUME_NONNULL_END

--- a/AudioKit/Instruments/AKInstrument.h
+++ b/AudioKit/Instruments/AKInstrument.h
@@ -195,5 +195,19 @@ NS_ASSUME_NONNULL_BEGIN
 /// Stop all notes created by the instrument
 - (void)stop;
 
+// -----------------------------------------------------------------------------
+#  pragma mark - Resource allocation
+// -----------------------------------------------------------------------------
+
+/// Set a limit to the number of notes to allocate at any one time. Note which exceed this limit will be deallocated.
+/// Defaults to zero, which is equivalent to setting no limit.
+/// See http://www.csounds.com/manual/html/maxalloc.html for more info.
+@property NSUInteger maximumNoteAllocation;
+
+/// Set a limit to the amount of CPU usage per note. Note which exceed this limit will be deallocated.
+/// Range from 0.0 to 1.0. Defaults to zero, which is equivalent to setting no limit.
+/// See http://www.csounds.com/manual/html/cpuprc.html for more info.
+@property float maximumProcessorAllocation;
+
 @end
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This is kind of experimental - added a maximumNoteAllocation attribute to AKInstrument.

I was running into a problem where adding too many notes to an instrument caused the CPU to hit 100% and Csound to stop making any noise. This allows you to set a hard limit on number of notes in order to avoid this scenario.

Not as good as proper polyphony (i.e. with a FIFO stack, where old notes get silenced first), but perhaps better than nothing.