### PR TITLE
Making Csound wait time a parameter for some slower simulators

### DIFF
--- a/AudioKit/Core Classes/AKManager.m
+++ b/AudioKit/Core Classes/AKManager.m
@@ -214,12 +214,12 @@ static AKManager *_sharedManager = nil;
     [self.engine play:_csdFile];
     if (_isLogging) NSLog(@"Starting \n\n%@\n", [AKManager stringFromFile:_csdFile]);
     
-    // Pause to allow Csound to start, warn if nothing happens after 1 second
+    // Pause to allow Csound to start, warn if nothing happens after allotted time
     int cycles = 0;
     while(!_isRunning) {
         cycles++;
-        if (cycles > 100) {
-            if (_isLogging) NSLog(@"Csound has not started in 1 second.");
+        if (cycles > 100 * AKSettings.shared.maximumWaitTime) {
+            NSLog(@"Csound has not started in %0.1f seconds.", AKSettings.shared.maximumWaitTime);
             break;
         }
         [NSThread sleepForTimeInterval:0.01];

--- a/AudioKit/Core Classes/AKSettings.h
+++ b/AudioKit/Core Classes/AKSettings.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic,readonly) UInt16 numberOfChannels;
 @property (nonatomic,readonly) float  zeroDBFullScaleValue;
 @property (nonatomic,readonly) BOOL MIDIEnabled;
+@property (nonatomic,readonly) float maximumWaitTime;
 
 // The following properties can be changed dynamically after AudioKit has been initalized
 @property (nonatomic) BOOL loggingEnabled, messagesEnabled;

--- a/AudioKit/Core Classes/AKSettings.m
+++ b/AudioKit/Core Classes/AKSettings.m
@@ -34,6 +34,7 @@ static AKSettings *_settings = nil;
         _numberOfChannels = 2;
         _zeroDBFullScaleValue = 1.0;
         _loggingEnabled = NO;
+        _maximumWaitTime = 1.0;
         _messagesEnabled = NO;
         _audioInputEnabled = NO;
         _playbackWhileMuted = NO;
@@ -61,6 +62,8 @@ static AKSettings *_settings = nil;
                 _audioInputEnabled = [dict[@"Enable Audio Input By Default"] boolValue];
             if (dict[@"Prefix Csound Messages"])
                 _messagesEnabled = [dict[@"Prefix Csound Messages"] boolValue];
+            if (dict[@"Maximum Time To Wait For Csound To Start"])
+                _maximumWaitTime = [dict[@"Maximum Time To Wait For Csound To Start"] floatValue];
             if (dict[@"Playback While Muted"])
                 _playbackWhileMuted = [dict[@"Playback While Muted"] boolValue];
             if (dict[@"MIDI Enabled"])

--- a/AudioKit/Resources/AudioKit.plist
+++ b/AudioKit/Resources/AudioKit.plist
@@ -18,6 +18,8 @@
 	<false/>
 	<key>Prefix Csound Messages</key>
 	<false/>
+	<key>Maximum Time To Wait For Csound To Start</key>
+	<real>1</real>
 	<key>Enable Audio Input By Default</key>
 	<false/>
 	<key>Playback While Muted</key>


### PR DESCRIPTION
This seems to work fine, just making a pull request so I can do travis testing.