### PR TITLE
Carthage support

### DIFF
--- a/AudioKit.xcworkspace/contents.xcworkspacedata
+++ b/AudioKit.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:AudioKit/OSX/AudioKit For OSX.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AudioKit/tvOS/AudioKit For tvOS.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AudioKit/iOS/AudioKit For iOS.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Frameworks/.gitignore
+++ b/Frameworks/.gitignore
@@ -1,3 +1,5 @@
 *.framework
 *.zip
 AudioKit-*
+Carthage
+

--- a/Frameworks/build_packages.sh
+++ b/Frameworks/build_packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Builds packages for release of the current versino of AudioKit.
+# Builds packages for release of the current version of AudioKit.
 #
 set -o pipefail
 
@@ -24,6 +24,8 @@ create_package()
 {
 	echo "Packaging AudioKit version $VERSION for $1 ..."
 	DIR="AudioKit-$1"
+	mkdir -p "Carthage/$os"
+	cp -a "$DIR/AudioKit.framework" "Carthage/$os/"
 	cd $DIR
 	mkdir -p Examples
 	cp -a ../../Examples/$1/* Examples/
@@ -38,4 +40,10 @@ for os in $PLATFORMS;
 do
 	create_package $os
 done
+
+# Create binary framework zip for Carthage, to be uploaded to Github along with release
+
+echo "Packaging AudioKit frameworks version $VERSION for Carthage ..."
+cd Carthage
+zip -9yr ../AudioKit.framework.zip $PLATFORMS
 

--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ AudioKit was created by the following team whose contributions are fully chronic
 * **Paul Batchelor**: The author of [Soundpipe](https://github.com/paulbatchelor/soundpipe), and [Sporth](https://github.com/paulbatchelor/sporth), which serve as two primary audio engines in AudioKit 3.
 * **Simon Gladman**: Longtime user of AudioKit, contributed his AudioKitParticles project to AudioKit 3.
 * **Stephane Peter**: Installation and configuration czar and code reviewer.
-* **Syed Haris Ali**: The author of EZAudio which is AudioKit's included waveform plotter and FFT analysis engine.
+* **Syed Haris Ali**: The author of [EZAudio](https://github.com/syedhali/EZAudio) which is AudioKit's included waveform plotter and FFT analysis engine.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ AudioKit V3
 
 [![Build Status](https://travis-ci.org/audiokit/AudioKit.svg)](https://travis-ci.org/audiokit/AudioKit)
 [![License](https://img.shields.io/cocoapods/l/AudioKit.svg?style=flat)](http://cocoadocs.org/docsets/AudioKit)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 
-*This document was last updated: January 20, 2016*
+*This document was last updated: January 27, 2016*
 
 AudioKit is an audio synthesis, processing, and analysis platform for OS X, iOS, and tvOS. This document serves as a one-page introduction to AudioKit, but we have much more information available on the AudioKit website at http://audiokit.io/
 
@@ -84,15 +85,23 @@ OS X Playgrounds are able to launch NSWindows that can be used to control the Au
 
 So far, the only testing that we do automatically through Travis is to ensure that all of the projects included with AudioKit build successfully.  AudioKit version 2 was heavily tested, but at the time of this writing AudioKit 3 does not have a test suite in place.  This is high on our priority list after an initial release.
 
+## Package Managers
+
+You can easily add the framework to your project by using [Carthage](https://github.com/Carthage/Carthage). Just use the following in your `Cartfile`:
+
+```
+github "audiokit/AudioKit"
+```
+
 ## About Us
 
 AudioKit was created by the following team whose contributions are fully chronicled in Github, and summarized below in alphabetical order by first name:
 
-* Aurelius Prochazka: Primary programmer of AudioKit. Lives for this stuff.  Your life line if you need help.
-* Jeff Cooper: Rearchitected all things MIDI, sampler, and sequencer related in AudioKit 3.
-* Matthew Fecher: Sound design, graphic design, and programming of the Swift Synth example.
-* Nicholas Arner: Longtime contributor to AudioKit and AudioKit's web site.
-* Paul Batchelor: The author of [Soundpipe](https://www.github.com/paulbatchelor/soundpipe), and [Sporth](http://www.github.com/paulbatchelor/sporth), which serve as two primary audio engines in AudioKit 3.
-* Simon Gladman: Longtime user of AudioKit, contributed his AudioKitParticles project to AudioKit 3.
-* Stephane Peter: Installation and configuration czar and code reviewer.
-* Syed Haris Ali: The author of EZAudio which is AudioKit's included waveform plotter and FFT analysis engine.
+* **Aurelius Prochazka**: Primary programmer of AudioKit. Lives for this stuff.  Your life line if you need help.
+* **Jeff Cooper**: Rearchitected all things MIDI, sampler, and sequencer related in AudioKit 3.
+* **Matthew Fecher**: Sound design, graphic design, and programming of the Swift Synth example.
+* **Nicholas Arner**: Longtime contributor to AudioKit and AudioKit's web site.
+* **Paul Batchelor**: The author of [Soundpipe](https://github.com/paulbatchelor/soundpipe), and [Sporth](https://github.com/paulbatchelor/sporth), which serve as two primary audio engines in AudioKit 3.
+* **Simon Gladman**: Longtime user of AudioKit, contributed his AudioKitParticles project to AudioKit 3.
+* **Stephane Peter**: Installation and configuration czar and code reviewer.
+* **Syed Haris Ali**: The author of EZAudio which is AudioKit's included waveform plotter and FFT analysis engine.


### PR DESCRIPTION
This adds the necessary support for Carthage, in the form of binary archives. As is, Carthage is not able to compile AudioKit properly (because of the location of the Xcode projects mostly), however it is able to fetch precompiled binaries as an alternative, and that works just fine.

Basically as part of the `build_archives.sh` script, a new `AudioKit.framework.zip` file is generated that needs to be uploaded to Github along the other zips for all releases. Then Carthage will automatically pick it up and recognize the architecture of each of the frameworks in there.

Next will be CocoaPods I guess, however this is obviously a better way to handle AudioKit since they use our blessed frameworks directly.