### PR TITLE
Updated CocoaPods support

### DIFF
--- a/AudioKit.podspec.json
+++ b/AudioKit.podspec.json
@@ -9,6 +9,8 @@
 	"file": "LICENSE"
     },
     "homepage": "http://audiokit.io/",
+    "social_media_url": "http://twitter.com/AudioKitMan",
+    "documentation_url": "http://audiokit.io/docs/",
     "source": {
         "http": "https://github.com/audiokit/AudioKit/releases/download/v3.0.1/AudioKit.framework.zip"
     },

--- a/AudioKit.podspec.json
+++ b/AudioKit.podspec.json
@@ -1,37 +1,36 @@
 {
     "name": "AudioKit",
-    "version": "3.0",
+    "version": "3.0.1",
     "authors": {
         "Aurelius Prochazka": "audiokit@audiokit.io"
     },
     "license": {
-        "type": "MIT"
+        "type": "MIT",
+	"file": "LICENSE"
     },
     "homepage": "http://audiokit.io/",
     "source": {
-        "git": "https://github.com/audiokit/AudioKit.git",
-        "tag": "v3.0"
+        "http": "https://github.com/audiokit/AudioKit/releases/download/v3.0.1/AudioKit.framework.zip"
     },
     "summary": "Open-source audio synthesis, processing, & analysis platform.",
-    "source_files": [],
     "platforms": {
-        "osx": "10.10",
+        "osx": "10.11",
         "ios": "9.0",
-	   "tvos": "9.0"
+        "tvos": "9.0"
     },
-    "public_header_files": [
-        "AudioKit/AudioKit.h",
-        "AudioKit/Internals/**/*.h",
-        "AudioKit/Nodes/**/*.h"
+    "frameworks": [
+	"AVFoundation"
     ],
     "osx": {
-        "frameworks": "AudioKit"
+	"public_header_files": "OSX/AudioKit.framework/Versions/A/Headers/*.h",
+        "vendored_frameworks": "OSX/AudioKit.framework"
     },
     "ios": {
-        "frameworks": "AudioKit"
+	"public_header_files": "iOS/AudioKit.framework/Headers/*.h",
+        "vendored_frameworks": "iOS/AudioKit.framework"
     },
     "tvos": {
-    	"exclude_files": "AudioKit/MIDI/*",
-    	"frameworks": "AudioKit"
+	"public_header_files": "tvOS/AudioKit.framework/Headers/*.h",
+        "vendored_frameworks": "tvOS/AudioKit.framework"
     }
 }

--- a/Frameworks/build_packages.sh
+++ b/Frameworks/build_packages.sh
@@ -24,6 +24,7 @@ create_package()
 {
 	echo "Packaging AudioKit version $VERSION for $1 ..."
 	DIR="AudioKit-$1"
+	rm -f ${DIR}-${VERSION}.zip
 	mkdir -p "Carthage/$os"
 	cp -a "$DIR/AudioKit.framework" "Carthage/$os/"
 	cd $DIR
@@ -44,6 +45,8 @@ done
 # Create binary framework zip for Carthage, to be uploaded to Github along with release
 
 echo "Packaging AudioKit frameworks version $VERSION for Carthage ..."
+rm -f AudioKit.framework.zip
 cd Carthage
-zip -9yr ../AudioKit.framework.zip $PLATFORMS
+cp ../../LICENSE .
+zip -9yr ../AudioKit.framework.zip $PLATFORMS LICENSE
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ AudioKit V3
 [![Build Status](https://travis-ci.org/audiokit/AudioKit.svg)](https://travis-ci.org/audiokit/AudioKit)
 [![License](https://img.shields.io/cocoapods/l/AudioKit.svg?style=flat)](http://cocoadocs.org/docsets/AudioKit)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![CocoaPods compatible](https://img.shields.io/cocoapods/v/AudioKit.svg?style=flat)](https://github.com/CocoaPods/Specs/tree/master/Specs/AudioKit)
 
-
-*This document was last updated: January 27, 2016*
+*This document was last updated: January 29, 2016*
 
 AudioKit is an audio synthesis, processing, and analysis platform for OS X, iOS, and tvOS. This document serves as a one-page introduction to AudioKit, but we have much more information available on the AudioKit website at http://audiokit.io/
 
@@ -45,21 +45,17 @@ The examples rely on the frameworks being built so you can either download the p
 
 Hello World basically consists of just a few sections of code:
 
-Setting up AudioKit:
-
-    let audiokit = AKManager.sharedInstance
-
 Creating the sound, in this case an oscillator:
 
     var oscillator = AKOscillator()
 
 Telling AudioKit where to get its audio from (ie. the oscillator):
 
-    audiokit.audioOutput = oscillator
+    AudioKit.output = oscillator
 
 Starting AudioKit:
 
-        audiokit.start()
+    AudioKit.start()
 
 And then responding to the UI by changing the oscillator:
 
@@ -91,6 +87,12 @@ You can easily add the framework to your project by using [Carthage](https://git
 
 ```
 github "audiokit/AudioKit"
+```
+
+If you use CocoaPods, you can also easily get the latest AudioKit binary framework for your project. Use this in your `Podfile`:
+
+```
+pod 'AudioKit', '~> 3.0'
 ```
 
 ## About Us

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ AudioKit V3
 [![License](https://img.shields.io/cocoapods/l/AudioKit.svg?style=flat)](http://cocoadocs.org/docsets/AudioKit)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods compatible](https://img.shields.io/cocoapods/v/AudioKit.svg?style=flat)](https://github.com/CocoaPods/Specs/tree/master/Specs/AudioKit)
+[![Twitter Follow](https://img.shields.io/twitter/follow/AudioKitMan.svg?style=social)](http://twitter.com/AudioKitMan)
 
 *This document was last updated: January 29, 2016*
 


### PR DESCRIPTION
Small updates to the script that creates the frameworks zip for Carthage, so that the same file can also be used with CocoaPods. The new pod then will install our blessed binaries instead of copying and compiling the entire library. I still need to finish troubleshooting these odd issues with Bitcode, but this will work regardless.

Note that as is it will fail to validate until we push 3.0.1 and upload the binary file, but it worked when I was trying it with my own repo.

Also it would be a good idea to go and update the old pod spec for previous 2.x versions so that they refer to the AudioKitArchive repo now, if that's something we can do.