### PR TITLE
Bridge AKSettings to Soundpipe, various fixes

### DIFF
--- a/AudioKit/Common/Internals/AKSettings-Bridge.h
+++ b/AudioKit/Common/Internals/AKSettings-Bridge.h
@@ -1,0 +1,17 @@
+//
+//  AKSettings-Bridge.h
+//  AudioKit
+//
+//  Created by Stéphane Peter on 1/29/16.
+//  Copyright © 2016 AudioKit. All rights reserved.
+//
+
+#ifndef AKSettings_Bridge_h
+#define AKSettings_Bridge_h
+
+double  _AKSettings_sampleRate(void);
+short   _AKSettings_numberOfChannels(void);
+int     _AKSettings_audioInputEnabled(void);
+int     _AKSettings_playbackWhileMuted(void);
+
+#endif /* AKSettings_Bridge_h */

--- a/AudioKit/Common/Internals/AKSettings-Bridge.m
+++ b/AudioKit/Common/Internals/AKSettings-Bridge.m
@@ -1,0 +1,34 @@
+//
+//  AKSettings-Bridge.m
+//  AudioKit
+//
+//  Created by Stéphane Peter on 1/29/16.
+//  Copyright © 2016 AudioKit. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AudioKit/AudioKit-Swift.h>
+
+#import "AKSettings-Bridge.h"
+
+// Exports the AKSettings properties to vanilla C, for Soundpipe
+
+double _AKSettings_sampleRate(void)
+{
+    return AKSettings.sampleRate;
+}
+
+short _AKSettings_numberOfChannels(void)
+{
+    return AKSettings.numberOfChannels;
+}
+
+int _AKSettings_audioInputEnabled(void)
+{
+    return AKSettings.audioInputEnabled;
+}
+
+int _AKSettings_playbackWhileMuted(void)
+{
+    return AKSettings.playbackWhileMuted;
+}

--- a/AudioKit/Common/Internals/Soundpipe/modules/base.c
+++ b/AudioKit/Common/Internals/Soundpipe/modules/base.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <math.h>
 #include "soundpipe.h"
+#ifdef AUDIOKIT
+# include "AKSettings-Bridge.h"
+#endif
 
 int sp_create(sp_data **spp)
 {
@@ -13,7 +16,11 @@ int sp_create(sp_data **spp)
     SPFLOAT *out = malloc(sizeof(SPFLOAT) * sp->nchan);
     *out = 0;
     sp->out = out;
+#ifdef AUDIOKIT
+    sp->sr = _AKSettings_sampleRate();
+#else
     sp->sr = 44100;
+#endif
     sp->len = 5 * sp->sr;
     sp->pos = 0;
     sp->k = 1;
@@ -30,7 +37,11 @@ int sp_createn(sp_data **spp, int nchan)
     SPFLOAT *out = malloc(sizeof(SPFLOAT) * sp->nchan);
     *out = 0;
     sp->out = out;
+#ifdef AUDIOKIT
+    sp->sr = _AKSettings_sampleRate();
+#else
     sp->sr = 44100;
+#endif
     sp->len = 5 * sp->sr;
     sp->pos = 0;
     sp->k = 1;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSPKernel.hpp
@@ -116,8 +116,8 @@ public:
 
 private:
 
-    int channels = 2;
-    float sampleRate = 44100.0;
+    int channels = AKSettings.numberOfChannels;
+    float sampleRate = AKSettings.sampleRate;
 
     AudioBufferList *inBufferListPtr = nullptr;
     AudioBufferList *outBufferListPtr = nullptr;

--- a/AudioKit/OSX/AudioKit For OSX.xcodeproj/project.pbxproj
+++ b/AudioKit/OSX/AudioKit For OSX.xcodeproj/project.pbxproj
@@ -521,6 +521,8 @@
 		C4E8ED141C43A5BC0041965F /* AKConvolutionAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C4E8ED101C43A5BC0041965F /* AKConvolutionAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C4E8ED151C43A5BC0041965F /* AKConvolutionAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = C4E8ED111C43A5BC0041965F /* AKConvolutionAudioUnit.mm */; };
 		C4E8ED161C43A5BC0041965F /* AKConvolutionDSPKernel.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C4E8ED121C43A5BC0041965F /* AKConvolutionDSPKernel.hpp */; };
+		EA3B2C3F1C5C60BE008F481F /* AKSettings-Bridge.h in Headers */ = {isa = PBXBuildFile; fileRef = EA3B2C3D1C5C60BE008F481F /* AKSettings-Bridge.h */; };
+		EA3B2C401C5C60BE008F481F /* AKSettings-Bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3B2C3E1C5C60BE008F481F /* AKSettings-Bridge.m */; };
 		EA6949EB1C5A2F720035B5DF /* AKSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6949EA1C5A2F720035B5DF /* AKSettings.swift */; };
 		EA6949ED1C5AE1D70035B5DF /* AudioKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6949EC1C5AE1D70035B5DF /* AudioKit.swift */; };
 		EAF006671C4C78F900ECD392 /* AKMorphingOscillator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF006631C4C78F900ECD392 /* AKMorphingOscillator.swift */; };
@@ -1054,6 +1056,8 @@
 		C4E8ED101C43A5BC0041965F /* AKConvolutionAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKConvolutionAudioUnit.h; sourceTree = "<group>"; };
 		C4E8ED111C43A5BC0041965F /* AKConvolutionAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKConvolutionAudioUnit.mm; sourceTree = "<group>"; };
 		C4E8ED121C43A5BC0041965F /* AKConvolutionDSPKernel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKConvolutionDSPKernel.hpp; sourceTree = "<group>"; };
+		EA3B2C3D1C5C60BE008F481F /* AKSettings-Bridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AKSettings-Bridge.h"; sourceTree = "<group>"; };
+		EA3B2C3E1C5C60BE008F481F /* AKSettings-Bridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AKSettings-Bridge.m"; sourceTree = "<group>"; };
 		EA6949EA1C5A2F720035B5DF /* AKSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKSettings.swift; sourceTree = "<group>"; };
 		EA6949EC1C5AE1D70035B5DF /* AudioKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioKit.swift; sourceTree = "<group>"; };
 		EAF006631C4C78F900ECD392 /* AKMorphingOscillator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMorphingOscillator.swift; sourceTree = "<group>"; };
@@ -1260,6 +1264,8 @@
 			children = (
 				C42F36CF1C0582E6000E937C /* AudioKit.h */,
 				EA6949EA1C5A2F720035B5DF /* AKSettings.swift */,
+				EA3B2C3D1C5C60BE008F481F /* AKSettings-Bridge.h */,
+				EA3B2C3E1C5C60BE008F481F /* AKSettings-Bridge.m */,
 				EA6949EC1C5AE1D70035B5DF /* AudioKit.swift */,
 				C40C416F1C40E3EF009D870B /* AKTable.swift */,
 				C40C41701C40E3EF009D870B /* AudioKitHelpers.swift */,
@@ -2660,6 +2666,7 @@
 				C453839A1C3A5E4300A51738 /* AKCostelloReverbAudioUnit.h in Headers */,
 				C4B1907B1C3B340400C0F330 /* _kiss_fft_guts.h in Headers */,
 				C4B190791C3B340400C0F330 /* ini.h in Headers */,
+				EA3B2C3F1C5C60BE008F481F /* AKSettings-Bridge.h in Headers */,
 				C45383881C3A5E4300A51738 /* AKThreePoleLowpassFilterAudioUnit.h in Headers */,
 				C45383241C3A5E4300A51738 /* AKFrequencyTrackerAudioUnit.h in Headers */,
 				C45383691C3A5E4300A51738 /* AKLowPassButterworthFilterAudioUnit.h in Headers */,
@@ -3159,6 +3166,7 @@
 				C42FFBAA1C3CFC3000823BD4 /* AKBalancer.swift in Sources */,
 				C4E751ED1C23885400688A1B /* autoWah.swift in Sources */,
 				C45383741C3A5E4300A51738 /* AKModalResonanceFilterAudioUnit.mm in Sources */,
+				EA3B2C401C5C60BE008F481F /* AKSettings-Bridge.m in Sources */,
 				C4DA4BE41C248EC200AA3771 /* jitter.swift in Sources */,
 				C4B190CF1C3B340400C0F330 /* tenv2.c in Sources */,
 				C45383BA1C3A5E4300A51738 /* AKSquareWaveOscillator.swift in Sources */,
@@ -3295,6 +3303,7 @@
 					"DEBUG=1",
 					"NO_LIBSNDFILE=1",
 					"$(inherited)",
+					"AUDIOKIT=1",
 				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3317,7 +3326,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				GCC_PREPROCESSOR_DEFINITIONS = "NO_LIBSNDFILE=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NO_LIBSNDFILE=1",
+					"AUDIOKIT=1",
+				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 		C4E958FB1C0ADC5800516A6A /* kiss_fftr.h in Headers */ = {isa = PBXBuildFile; fileRef = C4E958F41C0ADC5800516A6A /* kiss_fftr.h */; };
 		C4E959081C0B847C00516A6A /* fft.c in Sources */ = {isa = PBXBuildFile; fileRef = C4E959071C0B847C00516A6A /* fft.c */; };
 		C4E9590E1C0B84FA00516A6A /* mincer.c in Sources */ = {isa = PBXBuildFile; fileRef = C4E9590D1C0B84FA00516A6A /* mincer.c */; };
+		EA3B2C371C5C43B6008F481F /* AKSettings-Bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3B2C361C5C43B6008F481F /* AKSettings-Bridge.m */; };
 		EA6949E21C59A9FC0035B5DF /* AKSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6949E11C59A9FC0035B5DF /* AKSettings.swift */; };
 		FE4423711C4B95B700BA7009 /* AKDrumSynths.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4423701C4B95B700BA7009 /* AKDrumSynths.swift */; };
 /* End PBXBuildFile section */
@@ -1047,6 +1048,8 @@
 		C4E958F51C0ADC5800516A6A /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
 		C4E959071C0B847C00516A6A /* fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fft.c; sourceTree = "<group>"; };
 		C4E9590D1C0B84FA00516A6A /* mincer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mincer.c; sourceTree = "<group>"; };
+		EA3B2C361C5C43B6008F481F /* AKSettings-Bridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AKSettings-Bridge.m"; sourceTree = "<group>"; };
+		EA3B2C381C5C4518008F481F /* AKSettings-Bridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AKSettings-Bridge.h"; sourceTree = "<group>"; };
 		EA6949E11C59A9FC0035B5DF /* AKSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKSettings.swift; sourceTree = "<group>"; };
 		FE4423701C4B95B700BA7009 /* AKDrumSynths.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKDrumSynths.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1330,6 +1333,8 @@
 			children = (
 				C40C411C1C40E2E1009D870B /* AudioKit.swift */,
 				EA6949E11C59A9FC0035B5DF /* AKSettings.swift */,
+				EA3B2C361C5C43B6008F481F /* AKSettings-Bridge.m */,
+				EA3B2C381C5C4518008F481F /* AKSettings-Bridge.h */,
 				C40C411D1C40E2E1009D870B /* AKTable.swift */,
 				C40C411E1C40E2E1009D870B /* AudioKitHelpers.swift */,
 				C40C41221C40E344009D870B /* CoreAudio */,
@@ -2812,6 +2817,7 @@
 				C4A9164E1C24F95E006C1A15 /* metronome.swift in Sources */,
 				C46301061C20C342009B44D9 /* switch.c in Sources */,
 				C4E958CD1C0ADBFD00516A6A /* pluck.c in Sources */,
+				EA3B2C371C5C43B6008F481F /* AKSettings-Bridge.m in Sources */,
 				C4537FD11C3A438D00A51738 /* AKLowPassButterworthFilterAudioUnit.mm in Sources */,
 				C4E958C81C0ADBFD00516A6A /* panst.c in Sources */,
 				C40AD69D1C463B2600B638AF /* AKMusicTrack+MIDI.swift in Sources */,
@@ -3304,6 +3310,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 					"NO_LIBSNDFILE=1",
+					"AUDIOKIT=1",
 				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3326,7 +3333,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREPROCESSOR_DEFINITIONS = "NO_LIBSNDFILE=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NO_LIBSNDFILE=1",
+					"AUDIOKIT=1",
+				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Tracking Amplitude.xcplaygroundpage/Contents.swift
+++ b/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Tracking Amplitude.xcplaygroundpage/Contents.swift
@@ -25,13 +25,13 @@ AudioKit.output = trackedAmplitude
 AudioKit.start()
 oscillatorNode.start()
 
-AKPla//: And here's where we monitor the results of tracking the amplitude.
-ygroundLoop(every: 0.1) {
+//: And here's where we monitor the results of tracking the amplitude.
+AKPlaygroundLoop(every: 0.1) {
     let amp = trackedAmplitude.amplitude
 }
 
-XCPla//: This keeps the playground running so that audio can play for a long time
-ygroundPage.currentPage.needsIndefiniteExecution = true
+//: This keeps the playground running so that audio can play for a long time
+XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
 
 
 //: You can experiment with this playground by changing the volume function to a phasor or another well-known function to see how well the amplitude tracker can track.  Also, you could change the sound source from an oscillator to a noise generator, or any constant sound source (some things like a physical model would not work because the output has an envelope to its volume).  Instead of just plotting our results, we could use the value to drive other sounds or update an app's user interface.

--- a/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Tracking Amplitude.xcplaygroundpage/timeline.xctimeline
+++ b/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Tracking Amplitude.xcplaygroundpage/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1374&amp;EndingColumnNumber=12&amp;EndingLineNumber=29&amp;StartingColumnNumber=9&amp;StartingLineNumber=29&amp;Timestamp=475727741.671525"
+         documentLocation = "#CharacterRangeLen=3&amp;CharacterRangeLoc=1374&amp;EndingColumnNumber=12&amp;EndingLineNumber=29&amp;StartingColumnNumber=9&amp;StartingLineNumber=29&amp;Timestamp=475836981.501151"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Tracking Frequency.xcplaygroundpage/Contents.swift
+++ b/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Tracking Frequency.xcplaygroundpage/Contents.swift
@@ -29,15 +29,15 @@ AudioKit.start()
 
 oscillatorNode.start()
 
-AKPla//: And here's where we monitor the results of tracking the amplitude.
-ygroundLoop(every: 0.1) {
+//: And here's where we monitor the results of tracking the amplitude.
+AKPlaygroundLoop(every: 0.1) {
     let amp = tracker.amplitude
     let freq = tracker.frequency
 
 }
 
-XCPla//: This keeps the playground running so that audio can play for a long time
-ygroundPage.currentPage.needsIndefiniteExecution = true
+//: This keeps the playground running so that audio can play for a long time
+XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
 
 
 //: [TOC](Table%20Of%20Contents) | [Previous](@previous) | [Next](@next)

--- a/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
+++ b/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
@@ -495,6 +495,8 @@
 		C4E8ED1D1C43A5ED0041965F /* AKConvolutionAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C4E8ED191C43A5ED0041965F /* AKConvolutionAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C4E8ED1E1C43A5ED0041965F /* AKConvolutionAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = C4E8ED1A1C43A5ED0041965F /* AKConvolutionAudioUnit.mm */; };
 		C4E8ED1F1C43A5ED0041965F /* AKConvolutionDSPKernel.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C4E8ED1B1C43A5ED0041965F /* AKConvolutionDSPKernel.hpp */; };
+		EA3B2C3B1C5C5FF8008F481F /* AKSettings-Bridge.h in Headers */ = {isa = PBXBuildFile; fileRef = EA3B2C391C5C5FF8008F481F /* AKSettings-Bridge.h */; };
+		EA3B2C3C1C5C5FF8008F481F /* AKSettings-Bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3B2C3A1C5C5FF8008F481F /* AKSettings-Bridge.m */; };
 		EA6949E91C5A2F610035B5DF /* AKSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6949E81C5A2F610035B5DF /* AKSettings.swift */; };
 		EA6949EF1C5AE1EA0035B5DF /* AudioKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6949EE1C5AE1EA0035B5DF /* AudioKit.swift */; };
 		EAF006721C4C7A2300ECD392 /* oscmorph.c in Sources */ = {isa = PBXBuildFile; fileRef = EAF006711C4C7A2300ECD392 /* oscmorph.c */; };
@@ -1001,6 +1003,8 @@
 		C4E8ED191C43A5ED0041965F /* AKConvolutionAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKConvolutionAudioUnit.h; sourceTree = "<group>"; };
 		C4E8ED1A1C43A5ED0041965F /* AKConvolutionAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKConvolutionAudioUnit.mm; sourceTree = "<group>"; };
 		C4E8ED1B1C43A5ED0041965F /* AKConvolutionDSPKernel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKConvolutionDSPKernel.hpp; sourceTree = "<group>"; };
+		EA3B2C391C5C5FF8008F481F /* AKSettings-Bridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AKSettings-Bridge.h"; sourceTree = "<group>"; };
+		EA3B2C3A1C5C5FF8008F481F /* AKSettings-Bridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AKSettings-Bridge.m"; sourceTree = "<group>"; };
 		EA6949E81C5A2F610035B5DF /* AKSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKSettings.swift; sourceTree = "<group>"; };
 		EA6949EE1C5AE1EA0035B5DF /* AudioKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioKit.swift; sourceTree = "<group>"; };
 		EAF006711C4C7A2300ECD392 /* oscmorph.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = oscmorph.c; sourceTree = "<group>"; };
@@ -2242,6 +2246,8 @@
 			isa = PBXGroup;
 			children = (
 				EA6949E81C5A2F610035B5DF /* AKSettings.swift */,
+				EA3B2C391C5C5FF8008F481F /* AKSettings-Bridge.h */,
+				EA3B2C3A1C5C5FF8008F481F /* AKSettings-Bridge.m */,
 				EA6949EE1C5AE1EA0035B5DF /* AudioKit.swift */,
 				C40C41E21C40E5C2009D870B /* AKTable.swift */,
 				C40C41E31C40E5C2009D870B /* AudioKitHelpers.swift */,
@@ -2530,6 +2536,7 @@
 				C45381DA1C3A5CBD00A51738 /* AKModalResonanceFilterDSPKernel.hpp in Headers */,
 				C40C42371C40E5C2009D870B /* TPCircularBuffer.h in Headers */,
 				C45381E91C3A5CBD00A51738 /* AKStringResonatorAudioUnit.h in Headers */,
+				EA3B2C3B1C5C5FF8008F481F /* AKSettings-Bridge.h in Headers */,
 				C45381A11C3A5CBD00A51738 /* AKTanhDistortionAudioUnit.h in Headers */,
 				C45381F51C3A5CBD00A51738 /* AKToneFilterAudioUnit.h in Headers */,
 				C4B191FA1C3B342800C0F330 /* CUI.h in Headers */,
@@ -2794,6 +2801,7 @@
 				C484438E1C311C59007BE794 /* AKStereoOperation.swift in Sources */,
 				C4B192511C3B342800C0F330 /* tbvcf.c in Sources */,
 				C4B192A61C3B342800C0F330 /* tabread.c in Sources */,
+				EA3B2C3C1C5C5FF8008F481F /* AKSettings-Bridge.m in Sources */,
 				C45381C11C3A5CBD00A51738 /* AKFormantFilterAudioUnit.mm in Sources */,
 				C4B192951C3B342800C0F330 /* pluck.c in Sources */,
 				C4B1920E1C3B342800C0F330 /* bitcrush.c in Sources */,
@@ -3138,6 +3146,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 					"NO_LIBSNDFILE=1",
+					"AUDIOKIT=1",
 				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3158,7 +3167,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREPROCESSOR_DEFINITIONS = "NO_LIBSNDFILE=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NO_LIBSNDFILE=1",
+					"AUDIOKIT=1",
+				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
Mostly added a new `AUDIOKIT` macro to all the libraries so we can have AK-specific code in sub libraries like Soundpipe and EZAudio without being too invasive.

Also added some C bridging functions so that the AKSettings values can be accessed from there as well, for consistency's sake.

Also noticed a couple of weird things in some playgrounds.

