### PR TITLE
CoreMidi packet fixes, virtual midi ports, and pitchbend support for AnalogSynthX

### DIFF
--- a/AudioKit/Common/Internals/AudioKitHelpers.swift
+++ b/AudioKit/Common/Internals/AudioKitHelpers.swift
@@ -81,6 +81,15 @@ extension Double {
             self = min * exp(log(max / min) * self);
         }
     }
+    
+    /// Calculate frequency from a floating point MIDI Note Number
+    ///
+    /// - returns: Frequency (Double) in Hz
+    ///
+    public func midiNoteToFrequency(aRef : Double = 440.0) -> Double {
+        return pow(2.0, (self - 69.0) / 12.0) * aRef
+    }
+
 }
 
 // MARK: - MIDI Helpers
@@ -92,10 +101,12 @@ extension Int {
     ///
     /// - returns: Frequency (Double) in Hz
     ///
-    public func midiNoteToFrequency() -> Double {
-        return pow(2.0, (Double(self) - 69.0) / 12.0) * 440.0
+    public func midiNoteToFrequency(aRef : Double = 440.0) -> Double {
+        return pow(2.0, (Double(self) - 69.0) / 12.0) * aRef
     }
 }
+
+
 
 /// Potential MIDI Status messages
 ///

--- a/AudioKit/Common/MIDI/AKMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI.swift
@@ -48,16 +48,25 @@ extension MIDIPacket: SequenceType {
             if AKMIDIEvent.isStatusByte(status) {
                 var data1: UInt8 = 0
                 var data2: UInt8 = 0
-                let mstat = AKMIDIEvent.statusFromValue(status)
+                var mstat = AKMIDIEvent.statusFromValue(status)
                 switch  mstat {
-                case .NoteOff: data1 = pop(); data2 = pop();
-                case .NoteOn: data1 = pop(); data2 = pop();
-                case .PolyphonicAftertouch: data1 = pop(); data2 = pop();
-                case .ControllerChange: data1 = pop(); data2 = pop();
-                case .ProgramChange: data1 = pop()
-                case .ChannelAftertouch:data1 = pop()
-                case .PitchWheel: data1 = pop(); data2 = pop();
-                case .SystemCommand: data1 = 0;
+                case .NoteOff,
+                .NoteOn,
+                .PolyphonicAftertouch,
+                .ControllerChange,
+                .PitchWheel:
+                    data1 = pop(); data2 = pop();
+
+                case .ProgramChange,
+                .ChannelAftertouch:
+                    data1 = pop()
+
+                case .SystemCommand: break
+                }
+
+                if mstat == .NoteOn && data2 == 0 {
+                    // turn noteOn with velocity 0 to noteOff
+                    mstat = .NoteOff
                 }
 
                 let chan = (status & 0xF)

--- a/AudioKit/Common/MIDI/AKMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI.swift
@@ -9,6 +9,110 @@
 import Foundation
 import CoreMIDI
 
+
+/** The returned generator will enumerate each value of the provided tuple. */
+func generatorForTuple(tuple: Any) -> AnyGenerator<Any> {
+    let children = Mirror(reflecting: tuple).children
+    return anyGenerator(children.generate().lazy.map { $0.value }.generate())
+}
+
+/**
+ Allows a MIDIPacket to be iterated through with a for statement.
+ This is necessary because MIDIPacket can contain multiple midi events,
+ but Swift makes this unnecessarily hard because the MIDIPacket struct uses a tuple
+ for the data field. Grrr!
+ 
+ Example usage:
+ let packet: MIDIPacket
+ for message in packet {
+ // message is a Message
+ }
+ */
+extension MIDIPacket: SequenceType {
+    public func generate() -> AnyGenerator<AKMIDIEvent> {
+        let generator = generatorForTuple(self.data)
+        var index: UInt16 = 0
+        
+        return anyGenerator {
+            if index >= self.length {
+                return nil
+            }
+            
+            func pop() -> UInt8 {
+                assert(index < self.length)
+                index++
+                return generator.next() as! UInt8
+            }
+            
+            let status = pop()
+            if AKMIDIEvent.isStatusByte(status) {
+                var data1: UInt8 = 0
+                var data2: UInt8 = 0
+                let mstat = AKMIDIEvent.statusFromValue(status)
+                switch  mstat {
+                case .NoteOff: data1 = pop(); data2 = pop();
+                case .NoteOn: data1 = pop(); data2 = pop();
+                case .PolyphonicAftertouch: data1 = pop(); data2 = pop();
+                case .ControllerChange: data1 = pop(); data2 = pop();
+                case .ProgramChange: data1 = pop()
+                case .ChannelAftertouch:data1 = pop()
+                case .PitchWheel: data1 = pop(); data2 = pop();
+                case .SystemCommand: data1 = 0;
+                }
+
+                let chan = (status & 0xF)
+                return AKMIDIEvent(status: mstat, channel: chan, byte1: data1, byte2: data2)
+            }
+            else if status == 0xF0 {
+                // sysex - guaranteed by coremidi to be the entire packet
+                index = self.length
+                return AKMIDIEvent(packet: self)
+            }
+            // TODO realtime messages
+            
+            return nil
+        }
+    }
+}
+
+extension MIDIPacketList: SequenceType {
+    public typealias Generator = MIDIPacketListGenerator
+    
+    public func generate() -> Generator {
+        return Generator(packetList: self)
+    }
+}
+
+/**
+ Generator for MIDIPacketList allowing iteration over its list of MIDIPacket objects.
+ */
+public struct MIDIPacketListGenerator : GeneratorType {
+    public typealias Element = MIDIPacket
+    
+    init(packetList: MIDIPacketList) {
+        let ptr = UnsafeMutablePointer<MIDIPacket>.alloc(1)
+        ptr.initialize(packetList.packet)
+        self.packet = ptr
+        self.count = packetList.numPackets
+    }
+    
+    public mutating func next() -> Element? {
+        guard self.packet != nil && self.index < self.count else { return nil }
+        
+        let lastPacket = self.packet!
+        self.packet = MIDIPacketNext(self.packet!)
+        self.index++
+        return lastPacket.memory
+    }
+    
+    // Extracted packet list info
+    var count: UInt32
+    var index: UInt32 = 0
+    
+    // Iteration state
+    var packet: UnsafeMutablePointer<MIDIPacket>?
+}
+
 /// MIDI input and output handler
 ///
 /// You add midi listeners like this:
@@ -29,7 +133,10 @@ public class AKMIDI {
     
     /// Array of MIDI In ports
     public var midiInPorts: [MIDIPortRef] = []
-    
+
+    // virtual midi destination (input)
+    public var virtInput = MIDIPortRef()
+
     /// MIDI Client Name
     var midiClientName: CFString = "MIDI Client"
     
@@ -46,6 +153,10 @@ public class AKMIDI {
     
     /// MIDI Out Port Reference
     public var midiOutPort = MIDIPortRef()
+
+    // virtual midi source (output)
+    public var virtOutput = MIDIPortRef()
+
     
     /// Array of MIDI Endpoints
     public var midiEndpoints: [MIDIEndpointRef] = []
@@ -67,28 +178,20 @@ public class AKMIDI {
             switch type{
                 case AKMIDIStatus.ControllerChange:
                     listener.midiController(Int(event.internalData[1]), value: Int(event.internalData[2]), channel: Int(event.channel))
-                    break
                 case AKMIDIStatus.ChannelAftertouch:
                     listener.midiAfterTouch(Int(event.internalData[1]), channel: Int(event.channel))
-                    break
                 case AKMIDIStatus.NoteOn:
                     listener.midiNoteOn(Int(event.internalData[1]), velocity: Int(event.internalData[2]), channel: Int(event.channel))
-                    break
                 case AKMIDIStatus.NoteOff:
                     listener.midiNoteOff(Int(event.internalData[1]), velocity: Int(event.internalData[2]), channel: Int(event.channel))
-                    break
                 case AKMIDIStatus.PitchWheel:
-                    listener.midiPitchWheel(Int(event.internalData[1]), channel: Int(event.channel))
-                    break
+                    listener.midiPitchWheel(Int(event.data), channel: Int(event.channel))
                 case AKMIDIStatus.PolyphonicAftertouch:
                     listener.midiAftertouchOnNote(Int(event.internalData[1]), pressure: Int(event.internalData[2]), channel: Int(event.channel))
-                    break
                 case AKMIDIStatus.ProgramChange:
                     listener.midiProgramChange(Int(event.internalData[1]), channel: Int(event.channel))
-                    break
                 case AKMIDIStatus.SystemCommand:
                     listener.midiSystemCommand(event.internalData)
-                    break
             }
         }
     }
@@ -108,16 +211,13 @@ public class AKMIDI {
         let midiPortPtr = UnsafeMutablePointer<MIDIPortRef>(srcConnRefCon)
         let midiPort = midiPortPtr.memory
         */
-        let numPackets = Int(packetList.memory.numPackets)
-        let packet = packetList.memory.packet as MIDIPacket
-        var packetPtr: UnsafeMutablePointer<MIDIPacket> = UnsafeMutablePointer.alloc(1)
-        packetPtr.initialize(packet)
-        for var i = 0; i < numPackets; ++i {
-            let event = AKMIDIEvent(packet: packetPtr.memory)
-            handleMidiMessage(event)
-            packetPtr = MIDIPacketNext(packetPtr)
+
+        for packet in packetList.memory {
+            // a coremidi packet may contain multiple midi events
+            for event in packet {
+                handleMidiMessage(event)
+            }
         }
-    
     }
 
     // MARK: - Initialization
@@ -139,6 +239,47 @@ public class AKMIDI {
             } else {
                 print("error creating client : \(result)")
             }
+        }
+    }
+    
+    public func createVirtualPorts(uniqueId: Int32 = 2000000) {
+        print("Creating virtual MIDI ports")
+
+        destroyVirtualPorts()
+        
+        var result = OSStatus(noErr)
+        result = MIDIDestinationCreateWithBlock(midiClient, midiClientName, &virtInput, MyMIDIReadBlock)
+        
+        if result == OSStatus(noErr) {
+            print("Created virt dest: \(midiClientName)");
+            MIDIObjectSetIntegerProperty(virtInput, kMIDIPropertyUniqueID, uniqueId)
+        }
+        else {
+            print("Error creatervirt dest: \(midiClientName) -- \(virtInput)");
+        }
+        
+        
+        result = MIDISourceCreate(midiClient, midiClientName, &virtOutput);
+        if result == OSStatus(noErr) {
+            print("Created virt source: \(midiClientName)")
+            MIDIObjectSetIntegerProperty(virtInput, kMIDIPropertyUniqueID, uniqueId + 1)
+        }
+        else {
+            print("Error creating virtual source: \(midiClientName) -- \(virtOutput)")
+        }
+
+    
+    }
+    
+    public func destroyVirtualPorts() {
+        if virtInput != 0 {
+            MIDIEndpointDispose(virtInput)
+            virtInput = 0
+        }
+
+        if virtOutput != 0 {
+            MIDIEndpointDispose(virtOutput)
+            virtOutput = 0
         }
     }
     
@@ -258,6 +399,10 @@ public class AKMIDI {
             } else {
                 print("error sending midi : \(result)")
             }
+        }
+
+        if virtOutput != 0 {
+            MIDIReceived(virtOutput, packetListPtr);
         }
         
         packetListPtr.destroy()

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -41,19 +41,19 @@ public struct AKMIDIEvent {
         }
         return 0
     }
-    private var data1: UInt8 {
+    var data1: UInt8 {
         return internalData[1]
     }
-    private var data2: UInt8 {
+    var data2: UInt8 {
         return internalData[2]
     }
-    private var data: UInt16 {
+    var data: UInt16 {
         let x = UInt16(internalData[1])
-        let y = UInt16(internalData[2] << 7)
+        let y = UInt16(internalData[2]) << 7
         return y + x
     }
     
-    private var bytes: NSData {
+    var bytes: NSData {
         return NSData(bytes: [internalData[0], internalData[1], internalData[2]] as [UInt8], length: 3)
     }
     
@@ -69,7 +69,7 @@ public struct AKMIDIEvent {
             if(packet.data.0 == AKMIDISystemCommand.Sysex.rawValue){ //if is sysex
                 internalData = [] //reset internalData
                 //voodoo
-                let mirrorData = Mirror(reflecting:packet.data)
+                let mirrorData = Mirror(reflecting:data)
                 var i = 0
                 for (_, value) in mirrorData.children{
                     internalData.append(UInt8(value as! UInt8))
@@ -133,7 +133,24 @@ public struct AKMIDIEvent {
         }
     }
     
+    static private let statusBit: UInt8 = 0b10000000
+    static private let dataMask: UInt8 = 0b01111111
+    static private let messageMask: UInt8 = 0b01110000
+    static private let channelMask: UInt8 = 0b00001111
+    
     // MARK: - Utility constructors for common MIDI events
+    static func isStatusByte(byte: UInt8) -> Bool {
+        return (byte & AKMIDIEvent.statusBit) == AKMIDIEvent.statusBit
+    }
+    static func isDataByte(byte: UInt8) -> Bool {
+        return (byte & AKMIDIEvent.statusBit) == 0
+    }
+
+    static func statusFromValue(byte: UInt8) -> AKMIDIStatus {
+        let status = byte >> 4
+        return AKMIDIStatus(rawValue: Int(status))!
+    }
+
     
     /// Create note on event
     static public func eventWithNoteOn(note: UInt8, velocity: UInt8, channel: UInt8 ) -> AKMIDIEvent {

--- a/AudioKit/Common/MIDI/AKMIDIListener.swift
+++ b/AudioKit/Common/MIDI/AKMIDIListener.swift
@@ -47,7 +47,7 @@ public protocol AKMIDIListener {
     func midiAfterTouch(pressure: Int, channel: Int)
     
     /// Receive pitch wheel value
-    /// - parameter pitchWheelValue: MIDI Pitch Wheel Value (0-127)
+    /// - parameter pitchWheelValue: MIDI Pitch Wheel Value (0-16383)
     /// - parameter channel:         MIDI Channel (1-16)
     func midiPitchWheel(pitchWheelValue: Int, channel: Int)
     
@@ -104,10 +104,10 @@ public extension AKMIDIListener{
     }
     
     /// Receive pitch wheel value
-    /// - parameter pitchWheelValue: MIDI Pitch Wheel Value (0-127)
+    /// - parameter pitchWheelValue: MIDI Pitch Wheel Value (0-16383)
     /// - parameter channel:         MIDI Channel (1-16)
     func midiPitchWheel(pitchWheelValue:Int, channel:Int){
-        print("channel: \(channel) pitchWheel: \(pitchWheelValue)")
+        print("channel: \(channel) pitchWheelC: \(pitchWheelValue)")
     }
     
     /// Receive program change

--- a/Examples/iOS/AnalogSynthX/AnalogSynthX/AudioSystem/Conductor.swift
+++ b/Examples/iOS/AnalogSynthX/AnalogSynthX/AudioSystem/Conductor.swift
@@ -23,6 +23,7 @@ class Conductor: AKMIDIListener {
     var reverb: AKCostelloReverb
     var reverbMixer: AKDryWetMixer
 
+    var midiBendRange : Double = 2.0
 
     init() {
         bitCrusher = AKBitCrusher(core)
@@ -40,11 +41,15 @@ class Conductor: AKMIDIListener {
         reverb.stop()
 
         reverbMixer = AKDryWetMixer(masterVolume, reverb, balance: 0.0)
-
+        
+        // uncomment this to allow background operation
+        // AKSettings.playbackWhileMuted = true
+        
         AudioKit.output = reverbMixer
         AudioKit.start()
 
         let midi = AKMIDI()
+        midi.createVirtualPorts()
         midi.openMIDIIn("Session 1")
         midi.addListener(self)
     }
@@ -54,6 +59,10 @@ class Conductor: AKMIDIListener {
     }
     func midiNoteOff(note: Int, velocity: Int, channel: Int) {
         core.stopNote(note)
+    }
+    func midiPitchWheel(pitchWheelValue: Int, channel: Int) {
+        let bendSemi =  (Double(pitchWheelValue - 8192) / 8192.0) * midiBendRange
+        core.globalbend = bendSemi
     }
 
 }

--- a/Examples/iOS/AnalogSynthX/AnalogSynthX/AudioSystem/CoreInstrument.swift
+++ b/Examples/iOS/AnalogSynthX/AnalogSynthX/AudioSystem/CoreInstrument.swift
@@ -34,12 +34,24 @@ class CoreInstrument: AKPolyphonicInstrument {
     var waveform1 = 0.0 { didSet { updateWaveform1() } }
     var waveform2 = 0.0 { didSet { updateWaveform2() } }
 
-
+    var globalbend : Double = 0.0 {
+        didSet {
+            for i in 0..<activeVoices.count {
+                let coreVoice = activeVoices[i] as! CoreVoice
+                let note = Double(activeNotes[i] + offset1) + globalbend
+                coreVoice.vco1.frequency = note.midiNoteToFrequency()
+                let note2 = Double(activeNotes[i] + offset2) + globalbend
+                coreVoice.vco2.frequency = note2.midiNoteToFrequency()
+                coreVoice.subOsc.frequency = (Double(activeNotes[i] - 12) + globalbend).midiNoteToFrequency()
+            }
+        }
+    }
+    
     var offset1 = 0 {
         didSet {
             for i in 0..<activeVoices.count {
                 let coreVoice = activeVoices[i] as! CoreVoice
-                let note = activeNotes[i] + offset1
+                let note = Double(activeNotes[i] + offset1) + globalbend
                 coreVoice.vco1.frequency = note.midiNoteToFrequency()
             }
         }
@@ -49,7 +61,7 @@ class CoreInstrument: AKPolyphonicInstrument {
         didSet {
             for i in 0..<activeVoices.count {
                 let coreVoice = activeVoices[i] as! CoreVoice
-                let note = activeNotes[i] + offset2
+                let note = Double(activeNotes[i] + offset2) + globalbend
                 coreVoice.vco2.frequency = note.midiNoteToFrequency()
             }
         }
@@ -207,10 +219,10 @@ class CoreInstrument: AKPolyphonicInstrument {
         coreVoice.fmOscillator.amplitude = commonAmplitude
         coreVoice.noise.amplitude        = commonAmplitude
         
-        coreVoice.vco1.frequency = (note + offset1).midiNoteToFrequency()
-        coreVoice.vco2.frequency = (note + offset2).midiNoteToFrequency()
+        coreVoice.vco1.frequency = (Double(note + offset1) + globalbend).midiNoteToFrequency()
+        coreVoice.vco2.frequency = (Double(note + offset2) + globalbend).midiNoteToFrequency()
 
-        coreVoice.subOsc.frequency = (note - 12).midiNoteToFrequency()
+        coreVoice.subOsc.frequency = (Double(note - 12) + globalbend).midiNoteToFrequency()
         coreVoice.fmOscillator.baseFrequency = note.midiNoteToFrequency()
         
         coreVoice.start()

--- a/Examples/iOS/AnalogSynthX/AnalogSynthX/SynthViewController.swift
+++ b/Examples/iOS/AnalogSynthX/AnalogSynthX/SynthViewController.swift
@@ -135,6 +135,7 @@ class SynthViewController: UIViewController {
         conductor.multiDelay.mix = 0.5 // Dry/Wet
         conductor.reverb.feedback = 0.88 // Amt
         conductor.reverbMixer.balance = 0.4 // Dry/Wet
+        conductor.midiBendRange = 2.0 // MIDI bend range in +/- semitones
         cutoffKnob.value = 0.36 // Cutoff Knob Position
         
         // ADSR


### PR DESCRIPTION
MIDI packet handling needed to be updated to handle multiple events inside of a packet (which is completely legal and common) as well as fixing the handling of multiple packets. Took the opportunity to use some handy borrowed code to iterate over the midi packet list and packet events.

Added virtual midi port creation/destruction functions to AKMIDI so that other apps can see us and send MIDI while we are running in the background. (Requires the AKSettings.playbackWhileMuted to be true in order for background operation to work, incidentally).

Also added pitchbend support to AnalogSynthX, with a default midi pitch bend range of +/-2. I'll leave it to someone else to expose that config parameter in the UI, and possibly add a UI pitchwheel control for setting the globalbend parameter on the instrument.