### PR TITLE
Update AKAudioPlayer.totalFrameCount upon reloadFile()

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -108,17 +108,6 @@ public class AKAudioPlayer: AKNode, AKToggleable {
         internalPlayer.volume = 1.0
     }
     
-    /// Reload the file from the disk
-    public func reloadFile() {
-        let url = NSURL.fileURLWithPath(internalFile, isDirectory: false)
-        let audioFile = try! AVAudioFile(forReading: url)
-        let audioFormat = audioFile.processingFormat
-        let audioFrameCount = UInt32(audioFile.length)
-        audioFileBuffer = AVAudioPCMBuffer(PCMFormat: audioFormat,
-                                           frameCapacity: audioFrameCount)
-        try! audioFile.readIntoBuffer(audioFileBuffer)
-    }
-    
     /// Start playback
     public func start() {
         if (!internalPlayer.playing && !paused) || playhead == duration {
@@ -196,4 +185,14 @@ public class AKAudioPlayer: AKNode, AKToggleable {
         reloadFile()
     }
     
+    /// Reload the file from the disk
+    public func reloadFile() {
+        let url = NSURL.fileURLWithPath(internalFile, isDirectory: false)
+        let audioFile = try! AVAudioFile(forReading: url)
+        let audioFormat = audioFile.processingFormat
+        let audioFrameCount = UInt32(audioFile.length)
+        audioFileBuffer = AVAudioPCMBuffer(PCMFormat: audioFormat,
+                                           frameCapacity: audioFrameCount)
+        try! audioFile.readIntoBuffer(audioFileBuffer)
+    }
 }

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -194,5 +194,6 @@ public class AKAudioPlayer: AKNode, AKToggleable {
         audioFileBuffer = AVAudioPCMBuffer(PCMFormat: audioFormat,
                                            frameCapacity: audioFrameCount)
         try! audioFile.readIntoBuffer(audioFileBuffer)
+        totalFrameCount = Int64(audioFrameCount)
     }
 }


### PR DESCRIPTION
**What's in this pull request**

`AKAudioPlayer.totalFrameCount` is updated when the file is replaced.

`AKAudioPlayer.duration` is derived from `totalFrameCount` which was only set during the initialization phase of `AKAudioPlayer`. 

When replacing the file for `AKAudioPlayer` (via `replaceFile(_:)`), the `totalFrameCount`, and subsequently `duration` held the lingering value associated with the initial file given, which was no longer accurate.

See [this repository](https://github.com/jsbean/AKAudioPlayer-UpdateTotalFrameCount) for an iOS application with unit test demonstrating this change.