### PR TITLE
setNeedsDisplay not needed

### DIFF
--- a/Examples/iOS/HelloWorld/HelloWorld/ViewController.swift
+++ b/Examples/iOS/HelloWorld/HelloWorld/ViewController.swift
@@ -30,7 +30,6 @@ class ViewController: UIViewController {
             oscillator.start()
             sender.setTitle("Stop Sine Wave at \(Int(oscillator.frequency))Hz", forState: .Normal)
         }
-        sender.setNeedsDisplay()
     }
 
 }


### PR DESCRIPTION
call to `setNeedsDisplay` is not needed in this example. This method is meant to trigger a `drawRect` refresh and has no affect in this example.