### PR TITLE
Develop

### DIFF
--- a/AudioKit/Common/Internals/AKAudioFile.swift
+++ b/AudioKit/Common/Internals/AKAudioFile.swift
@@ -13,16 +13,16 @@ import AVFoundation
 
 /// Audio file, inherits from AVAudioFile and adds functionality
 public class AKAudioFile: AVAudioFile {
-    
+
     // MARK: - embedded enums
-    
+
     /**
      BaseDirectory enum
 
      - Temp: Temp Directory.
      - Documents: Documents Directory
      - Resources: Resources Directory (Shouldn't be used for writing / recording files).
-     
+
      Ex: let directory = AKAudioFile.BaseDirectory.Temp
 
      */
@@ -49,7 +49,7 @@ public class AKAudioFile: AVAudioFile {
         case mp4
         case m4a
         case caf
-        
+
         // Returns a Uniform Type identifier for each audio file format
         private var UTI: CFString {
             switch self {
@@ -60,13 +60,13 @@ public class AKAudioFile: AVAudioFile {
             case caf: return AVFileTypeCoreAudioFormat
             }
         }
-        
+
         // Returns available Export Formats as an Array of Strings
         static var arrayOfStrings: [String] {
             return ["wav", "aif", "mp4", "m4a", "caf"]
         }
     }
-    
+
     // MARK: - private vars
 
     // Used for exporting, can be accessed with public .avAsset property
@@ -74,8 +74,8 @@ public class AKAudioFile: AVAudioFile {
         let avAssetUrl = NSURL(fileURLWithPath:self.url.absoluteString)
         return  AVURLAsset(URL: avAssetUrl)
     }()
-    
-    
+
+
     // MARK: - super.inits !
 
     /**
@@ -95,10 +95,10 @@ public class AKAudioFile: AVAudioFile {
     /**
      Super.init inherited from AVAudioFile superclass
 
-     - Parameters: 
-        - fileURL: NSURL of the file.
-        - format: The processing commonFormat to use when reading from the file.
-        - interleaved: Bool (Whether to use an interleaved processing format.)
+     - Parameters:
+     - fileURL: NSURL of the file.
+     - format: The processing commonFormat to use when reading from the file.
+     - interleaved: Bool (Whether to use an interleaved processing format.)
 
      - Throws: NSError if init failed .
 
@@ -106,9 +106,9 @@ public class AKAudioFile: AVAudioFile {
 
      */
     public override init(forReading fileURL: NSURL,
-                          commonFormat format: AVAudioCommonFormat,
-                          interleaved: Bool) throws {
-        
+                                    commonFormat format: AVAudioCommonFormat,
+                                                 interleaved: Bool) throws {
+
         try super.init(forReading: fileURL, commonFormat: format, interleaved: interleaved)
     }
 
@@ -116,10 +116,10 @@ public class AKAudioFile: AVAudioFile {
      Super.init inherited from AVAudioFile superclass
 
      - Parameters:
-        - fileURL: NSURL of the file.
-        - settings: The format of the file to create.
-        - format: The processing commonFormat to use when writing.
-        - interleaved: Bool (Whether to use an interleaved processing format.)
+     - fileURL: NSURL of the file.
+     - settings: The format of the file to create.
+     - format: The processing commonFormat to use when writing.
+     - interleaved: Bool (Whether to use an interleaved processing format.)
 
      - Throws: NSError if init failed .
 
@@ -133,13 +133,13 @@ public class AKAudioFile: AVAudioFile {
      Note: It seems that Apple's AVAudioFile class has a bug with .wav files. They cannot be set
      with a floating Point encoding. As a consequence, such files will fail to record properly.
      So it's better to use .caf (or .aif) files for recording purpose.
-     
+
      */
 
     public override init(forWriting fileURL: NSURL,
-                          settings: [String : AnyObject],
-                          commonFormat format: AVAudioCommonFormat,
-                          interleaved: Bool) throws {
+                                    settings: [String : AnyObject],
+                                    commonFormat format: AVAudioCommonFormat,
+                                                 interleaved: Bool) throws {
         try super.init(forWriting: fileURL,
                        settings: settings,
                        commonFormat: format,
@@ -151,18 +151,18 @@ public class AKAudioFile: AVAudioFile {
      Super.init inherited from AVAudioFile superclass
 
      - Parameters:
-        - fileURL: NSURL of the file.
-        - settings: The settings of the file to create.
+     - fileURL: NSURL of the file.
+     - settings: The settings of the file to create.
 
      - Throws: NSError if init failed .
 
      - Returns: An initialized AKAudioFile for writing, or nil if init failed.
-     
+
      From Apple doc: The file type to create is inferred from the file extension of fileURL.
      This method will overwrite a file at the specified URL if a file already exists.
 
      The file is opened for writing using the standard format, AVAudioPCMFormatFloat32.
-     
+
      Note: It seems that Apple's AVAudioFile class has a bug with .wav files. They cannot be set
      with a floating Point encoding. As a consequence, such files will fail to record properly.
      So it's better to use .caf (or .aif) files for recording purpose.
@@ -187,16 +187,16 @@ public class AKAudioFile: AVAudioFile {
 
      - Returns: An initialized AKAudioFile for reading, or nil if init failed.
 
-    */
+     */
     public convenience init(readFileName name: String,
-                            baseDir: BaseDirectory = .Resources) throws {
-        
+                                         baseDir: BaseDirectory = .Resources) throws {
+
         let filePath: String
         let fileNameWithExtension = name
-        
+
         switch baseDir {
         case .Temp:
-            filePath =  (NSTemporaryDirectory() as String) + "/" + name
+            filePath =  (NSTemporaryDirectory() as String) + name
         case .Documents:
             filePath =  (NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]) + "/" + name
         case .Resources:
@@ -209,26 +209,19 @@ public class AKAudioFile: AVAudioFile {
                 throw NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist, userInfo: nil)
             }
             filePath = path!
-            
-        }
-        let fileManager = NSFileManager.defaultManager()
-        if fileManager.fileExistsAtPath(filePath) {
-            let fileUrl = NSURL(string: filePath)
-            
-            do {
-                try self.init(forReading: fileUrl!)
-            } catch let error as NSError {
-                print ("Error !!! AKAudioFile: \"\(name)\" doesn't seem to be a valid AudioFile !...")
-                print(error.localizedDescription)
-                throw error
-            }
-            
-        } else {
-            print( "ERROR: AKAudioFile cannot find \"\(name)\"!... aka \(name)")
-            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotOpenFile, userInfo: nil)
-        }
-    }
 
+        }
+        let fileUrl = NSURL(fileURLWithPath: filePath)
+        do {
+            try self.init(forReading: fileUrl)
+        } catch let error as NSError {
+            print ("Error !!! AKAudioFile: \"\(name)\" doesn't seem to be a valid AudioFile !...")
+            print(error.localizedDescription)
+            throw error
+        }
+
+
+    }
 
     /**
      Converts an AVAudioFile to an AKAudioFile for reading.
@@ -239,7 +232,7 @@ public class AKAudioFile: AVAudioFile {
      - Throws: NSError if init failed .
 
      - Returns: An initialized AKAudioFile for reading, or nil if init failed.
-     
+
      */
     public convenience init(readAVAudioFile avAudioFile: AVAudioFile) throws {
         try self.init(forReading: avAudioFile.url)
@@ -254,7 +247,7 @@ public class AKAudioFile: AVAudioFile {
      - Throws: NSError if init failed .
 
      - Returns: An initialized AKAudioFile for writing, or nil if init failed.
-     
+
      */
     public convenience init(writeAVAudioFile avAudioFile: AVAudioFile) throws {
         var avSettings = avAudioFile.processingFormat.settings
@@ -262,8 +255,8 @@ public class AKAudioFile: AVAudioFile {
         avSettings["AVLinearPCMIsNonInterleaved"] = NSNumber(bool: false)
         try self.init(forWriting: avAudioFile.url, settings: avSettings)
     }
-    
-    
+
+
     /**
      Creates file for recording / writing purpose
      Default is a .caf AKAudioFile with AudioKit settings
@@ -272,12 +265,12 @@ public class AKAudioFile: AVAudioFile {
 
 
      - Parameters:
-        - name: the name of the file without its extension (String).
-        - ext: the extension of the file without "." (String).
-        - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
-        - settings: The settings of the file to create.
-        - format: The processing commonFormat to use when writing.
-        - interleaved: Bool (Whether to use an interleaved processing format.)
+     - name: the name of the file without its extension (String).
+     - ext: the extension of the file without "." (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+     - settings: The settings of the file to create.
+     - format: The processing commonFormat to use when writing.
+     - interleaved: Bool (Whether to use an interleaved processing format.)
 
 
      - Throws: NSError if init failed .
@@ -290,26 +283,22 @@ public class AKAudioFile: AVAudioFile {
      Note: It seems that Apple's AVAudioFile class has a bug with .wav files. They cannot be set
      with a floating Point encoding. As a consequence, such files will fail to record properly.
      So it's better to use .caf (or .aif) files for recording purpose.
-     
+
      Example of use: to create a temp .caf file with a unique name for recording:
      let recordFile = AKAudioFile()
-     
+
      */
     public convenience init(writeIn baseDir: BaseDirectory = .Temp,
-        name: String = "",
-        ext: String = "caf",
-        settings: [String : AnyObject] = AKSettings.audioFormat.settings,
-        commonFormat format: AVAudioCommonFormat = AKSettings.audioFormat.commonFormat,
-        interleaved: Bool = AKSettings.audioFormat.interleaved) throws {
-        
+                                    name: String = "") throws {
+
         let fileNameWithExtension: String
         // Create a unique file name if fileName == ""
         if name == "" {
-            fileNameWithExtension =  NSUUID().UUIDString + "." + ext
+            fileNameWithExtension =  NSUUID().UUIDString + ".caf"
         } else {
-            fileNameWithExtension = name + "." + ext
+            fileNameWithExtension = name + ".caf"
         }
-        
+
         var filePath: String
         switch baseDir {
         case .Temp:
@@ -320,31 +309,39 @@ public class AKAudioFile: AVAudioFile {
             print( "ERROR AKAudioFile: cannot create a file in applications resources!...")
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil)
         }
-        
+
         let nsurl = NSURL(string: filePath)
         guard nsurl != nil else {
             print( "ERROR AKAudioFile: directory \"\(filePath)\" isn't valid!...")
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil)
         }
+
+        // Directory exists ?
         let directoryPath = nsurl!.URLByDeletingLastPathComponent
-        // Check if directory exists
+
         let fileManager = NSFileManager.defaultManager()
         if fileManager.fileExistsAtPath((directoryPath?.absoluteString)!) == false {
             print( "ERROR AKAudioFile: directory \"\(directoryPath)\" doesn't exists!...")
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil)
         }
-        
+
         // AVLinearPCMIsNonInterleaved cannot be set to false (ignored but throw a warning)
-        var  fixedSettings =  settings
+        var  fixedSettings =  AKSettings.audioFormat.settings
+
         fixedSettings[ AVLinearPCMIsNonInterleaved] =  NSNumber(bool: false)
-        
-        
-        try self.init(forWriting: nsurl!, settings: fixedSettings, commonFormat: format, interleaved: interleaved)
+
+        do {
+            try self.init(forWriting: nsurl!, settings: fixedSettings)
+        } catch let error as NSError {
+            print( "ERROR AKAudioFile: Couldn't create an AKAudioFile...")
+            print( "Error: \(error)")
+            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil)
+        }
     }
 
-    
+
     // MARK: - Public AKAudioFileFormat Properties
-    
+
     /// The number of samples can be accessed by .length property,
     /// but samplesCount has a less ambiguous meaning
     public var samplesCount: Int64 {
@@ -352,7 +349,7 @@ public class AKAudioFile: AVAudioFile {
             return self.length
         }
     }
-    
+
     /// strange that sampleRate is a Double and not an Integer !...
     public var sampleRate: Double {
         get {
@@ -365,28 +362,28 @@ public class AKAudioFile: AVAudioFile {
             return self.fileFormat.channelCount
         }
     }
-    
+
     /// Duration in seconds
     public var duration: Double {
         get {
             return Double(samplesCount) / (sampleRate)
         }
     }
-    
+
     /// true if Audio Samples are interleaved
     public var interleaved: Bool {
         get {
             return self.fileFormat.interleaved
         }
     }
-    
+
     /// true if file format is "deinterleaved native-endian float (AVAudioPCMFormatFloat32)", otherwise false
     public var standard: Bool {
         get {
             return self.fileFormat.standard
         }
     }
-    
+
     /**  commonFormatString translates commonFormat in an human readable string.
      enum AVAudioCommonFormat : UInt {
      case OtherFormat
@@ -395,10 +392,10 @@ public class AKAudioFile: AVAudioFile {
      case PCMFormatInt16
      case PCMFormatInt32
      }  */
-    
+
     public var commonFormatString: String {
         get {
-            
+
             switch self.fileFormat.commonFormat.rawValue {
             case 1 :
                 return "PCMFormatFloat32"
@@ -413,40 +410,40 @@ public class AKAudioFile: AVAudioFile {
             }
         }
     }
-    
+
     /// the directory path as a NSURL object
     public var directoryPath: NSURL {
         get {
             return self.url.URLByDeletingLastPathComponent!
         }
     }
-    
+
     /// the file name with extension as a String
     public var fileNamePlusExtension: String {
         get {
             return self.url.lastPathComponent!
         }
     }
-    
+
     /// the file name without extension as a String
     public var fileName: String {
         get {
             return (self.url.URLByDeletingPathExtension?.lastPathComponent!)!
         }
     }
-    
+
     /// the file extension as a String (without ".")
     public var fileExt: String {
         get {
             return (self.url.pathExtension!)
         }
     }
-    
+
     /// Returns an AVAsset from the AKAudioFile
     public var avAsset: AVURLAsset {
         return internalAVAsset
     }
-    
+
     /// As The description doesn't provide so much informations, I appended the
     /// fileFormat String. (But may be it is a bad practice... let me know :-)
     override public var description: String {
@@ -454,8 +451,79 @@ public class AKAudioFile: AVAudioFile {
             return super.description + "\n" + String(self.fileFormat)
         }
     }
-    
-    
+
+    /// returns audio data as an Array of float Arrays
+    /// If stereo:
+    ///     - arraysOfFloats[0] will contain an Array of left channel samples as Floats
+    ///     - arraysOfFloats[1] will contains an Array of right channel samples as Floats
+    public lazy var arraysOfFloats: [[Float]] = {
+        var arrays:[[Float]] = []
+
+        if self.samplesCount > 0 {
+            let buf = self.pcmBuffer
+
+            for channel in 0..<self.channelCount {
+                let floatArray = Array(UnsafeBufferPointer(start: buf.floatChannelData[Int(channel)], count:Int(buf.frameLength)))
+                arrays.append(floatArray)
+            }
+        } else {
+            print("Warning AKAudioFile arraysOfFloats: self.samplesCount = 0")
+        }
+
+        return arrays
+    }()
+
+
+    /// returns audio data as an AVAudioPCMBuffer
+    public lazy var pcmBuffer: AVAudioPCMBuffer = {
+
+        let buffer =  AVAudioPCMBuffer(PCMFormat: self.processingFormat, frameCapacity: (AVAudioFrameCount( self.length)))
+
+        do {
+            try self.readIntoBuffer(buffer)
+        } catch let error as NSError {
+            print ("error cannot readIntBuffer, Error: \(error)")
+        }
+
+        return buffer
+
+    }()
+
+    ///
+    /// returns the peak level expressed in dB ( -> Float).
+    public lazy var maxLevel: Float = {
+        var maxLev:Float = 0
+
+        let buffer = self.pcmBuffer
+
+        if self.samplesCount > 0 {
+            for c in 0..<Int(self.channelCount){
+                let floats = UnsafeBufferPointer(start: buffer.floatChannelData[c], count:Int(buffer.frameLength))
+                let cmax = floats.maxElement()
+                let cmin = floats.minElement()
+
+                // positive max
+                if cmax != nil {
+                    maxLev  = max(cmax!, maxLev)
+                }
+
+                // negative max
+                if cmin != nil {
+                    maxLev  = max(abs(cmin!), maxLev)
+                }
+            }
+        }
+
+        if maxLev == 0
+        {
+            return FLT_MIN
+        } else {
+            return (10 * log10(maxLev))
+        }
+    }()
+
+
+
     // MARK: - Exporting utility method
 
 
@@ -464,52 +532,52 @@ public class AKAudioFile: AVAudioFile {
      Can export from wav/aif to wav/aif/m4a/mp4
      Can export from m4a/mp4 to m4a/mp4
      Exporting from mp4/m4a to wav/aif is not supported.
-     
+
      inTime and outTime can be set to extract only a portion of the current AKAudioFile.
      If outTime is zero, it will be set to the file's duration (no end trimming)
 
 
      - Parameters:
-        - name: the name of the file without its extension (String).
-        - ext: the output file formal as an ExportFormat enum value (.aif, .wav, .m4a, .mp4, .caf)
-        - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
-        - callBack: AKCallback function that will be triggered when export completed.
-        - inTime: start range time value in seconds
-        - outTime: end range time value in seconds.
+     - name: the name of the file without its extension (String).
+     - ext: the output file formal as an ExportFormat enum value (.aif, .wav, .m4a, .mp4, .caf)
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+     - callBack: AKCallback function that will be triggered when export completed.
+     - inTime: start range time value in seconds
+     - outTime: end range time value in seconds.
 
      - Throws: NSError if init failed .
 
      - Returns: An AKAudioFile ExportSession object, or nil if init failed.
-     
+
      As soon as callback has been triggered, you can use ExportSession.status to check if export succeeded or not. If export succeeded, you can get the exported AKAudioFile using ExportSession.exportedAudioFile. ExportSession.progress lets you monitor export progress.
-     
+
      See playground for an example of use.
-     
+
      */
     public func export(
-                    name: String,
-                    ext: ExportFormat,
-                    baseDir: BaseDirectory,
-                    callBack: (AKCallback),
-                    inTime: Double = 0,
-                    outTime: Double  = 0 ) throws -> ExportSession {
-        
+        name: String,
+        ext: ExportFormat,
+        baseDir: BaseDirectory,
+        callBack: (AKCallback),
+        inTime: Double = 0,
+        outTime: Double  = 0 ) throws -> ExportSession {
+
         let fromFileExt = fileExt.lowercaseString
-        
+
         // Only mp4, m4a, .wav, .aif can be exported...
         guard   ExportFormat.arrayOfStrings.contains(fromFileExt) else {
             print( "ERROR: AKAudioFile  \".\(fromFileExt)\" is not supported for export!...")
             throw NSError(domain: NSURLErrorDomain, code: NSFileWriteUnsupportedSchemeError, userInfo: nil)
         }
-        
-        
+
+
         // Compressed formats cannot be exported to PCM
         let fromFileFormatIsCompressed: Bool  = (fromFileExt == "m4a" || fromFileExt == "mp4")
         let outFileFormatIsCompressed: Bool  = (ext == .mp4 || ext == .m4a )
-        
+
         // set avExportPreset
         var avExportPreset: String
-        
+
         if fromFileFormatIsCompressed {
             if !outFileFormatIsCompressed {
                 print( "ERROR AKAudioFile: cannot convert from .\(fileExt) to .\(String(ext))!...")
@@ -524,8 +592,8 @@ public class AKAudioFile: AVAudioFile {
                 avExportPreset = AVAssetExportPresetPassthrough
             }
         }
-        
-        
+
+
         return try ExportSession(fileName: name,
                                  baseDir: baseDir,
                                  callBack: callBack,
@@ -535,7 +603,7 @@ public class AKAudioFile: AVAudioFile {
                                  from: inTime,
                                  to: outTime)
     }
-    
+
     /**
 
      ExportSession wraps an AVAssetExportSession. It is returned by AKAudioFile.export().
@@ -547,35 +615,41 @@ public class AKAudioFile: AVAudioFile {
 
      */
     public class ExportSession {
-        
+
         private var outputAudioFile: AKAudioFile?
         private var exporter: AVAssetExportSession
         private var callBack: AKCallback
-        
+
         public init(fileName: String, baseDir: BaseDirectory,
                     callBack: AKCallback,
                     presetName: String,
                     file: AKAudioFile,
                     outputFileExtension: ExportFormat,
                     from inTime: Double,
-                    to outTime: Double) throws {
-            
+                         to outTime: Double) throws {
+
             self.callBack = callBack
-            let asset = file.avAsset
-            
+
+            let assetUrl = file.url
+            let asset  = AVURLAsset(URL: assetUrl)
+
+            // let asset = file.avAsset
+
             let process = AVAssetExportSession(asset: asset, presetName:presetName)
-            
+
             guard process != nil else {
                 print( "ERROR AKAudioFile export: cannot create an AVAssetExportSession!...")
                 throw NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
             }
             exporter = process!
-            
+
             guard file.samplesCount > 0 else {
                 print( "ERROR AKAudioFile export: cannot export an empty file !...")
                 throw NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
             }
-            
+
+
+
             var filePath: String
             switch baseDir {
             case .Temp:
@@ -586,7 +660,7 @@ public class AKAudioFile: AVAudioFile {
                 print( "ERROR AKAudioFile export: cannot create a file in applications resources!...")
                 throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil)
             }
-            
+
             let nsurl = NSURL(string: filePath)
             guard nsurl != nil else {
                 print( "ERROR AKAudioFile export: directory \"\(filePath)\" isn't valid!...")
@@ -599,7 +673,7 @@ public class AKAudioFile: AVAudioFile {
                 print( "ERROR AKAudioFile export: directory \"\(directoryPath)\" doesn't exists!...")
                 throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil)
             }
-            
+
             // Check if out file exists
             if fileManager.fileExistsAtPath((nsurl?.absoluteString)!) {
                 // Then delete file
@@ -613,25 +687,23 @@ public class AKAudioFile: AVAudioFile {
                 }
                 print ("AKAudioFile export: Output file has been deleted !")
             }
-            
-            // must translate url as a fileUrl
-            exporter.outputURL = NSURL(fileURLWithPath: filePath)
-            
+
+            exporter.outputURL = NSURL.fileURLWithPath(filePath)
             // Sets the output file encoding (avoid .wav encoded as m4a...)
             exporter.outputFileType = outputFileExtension.UTI as String
-            
+
             // In and OUT times triming settings
             let inFrame: Int64
             let outFrame: Int64
-            
+
             if outTime == 0 {
                 outFrame = file.samplesCount
             } else {
                 outFrame = min(file.samplesCount, Int64(outTime * file.sampleRate))
             }
-            
+
             inFrame = abs(min(file.samplesCount, Int64(inTime * file.sampleRate)))
-            
+
             if (outFrame <= inFrame) {
                 print( "ERROR AKAudioFile export: In time must be less than Out time!...")
                 throw NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
@@ -640,11 +712,11 @@ public class AKAudioFile: AVAudioFile {
             let stopTime = CMTimeMake(outFrame, Int32(file.sampleRate))
             let timeRange = CMTimeRangeFromTimeToTime(startTime, stopTime)
             exporter.timeRange = timeRange
-            
+
             // Everything is fine, we can export...
             exporter.exportAsynchronouslyWithCompletionHandler(internalCompletionHandler)
         }
-        
+
         private func internalCompletionHandler () {
             switch exporter.status {
             case  AVAssetExportSessionStatus.Failed:
@@ -663,21 +735,21 @@ public class AKAudioFile: AVAudioFile {
                     print("ERROR AKAudioFile export: Couldn't create AKAudioFile with url: \"\(url)\" !...")
                     print(error.localizedDescription)
                 }
-                
+
                 callBack()
             }
         }
-        
+
         /// True if export succeeded...
         public var succeeded: Bool {
             return exporter.status == .Completed
         }
-        
+
         /// True if export failed...
         public var failed: Bool {
             return exporter.status == .Failed
         }
-        
+
         /** status returns current exporter status:
          enum AVAssetExportSessionStatus : Int {
          case Unknown
@@ -691,27 +763,301 @@ public class AKAudioFile: AVAudioFile {
         public var status: AVAssetExportSessionStatus {
             return exporter.status
         }
-        
+
         /// Progress of export process as a Float from 0 to 1,
         /// a value of 1 means 100% completed.
         public var progress: Float {
             return exporter.progress
         }
-        
+
         /// Returns the exported file as an AKAudioFile if export suceeded.
         public var exportedAudioFile: AKAudioFile? {
             return outputAudioFile
         }
-        
+
         /// Return the error as a NSError if an error occured...
         public var error: NSError? {
             return exporter.error
         }
-        
+
         /// To cancel export
         public func cancelExport() {
             exporter.cancelExport()
         }
     }
-    
 }
+
+
+extension AKAudioFile {
+
+    /*
+    Convenience init to instantiate a file from Floats Arrays.
+    To create a stereo file, you pass [leftChannelFloats, rightChannelFloats]
+    where leftChannelFloats and rightChannelFloats are 2 arrays of FLoat values.
+    Arrays must both have the same number of Floats.
+     
+     - Parameters:
+        - floatsArrays:[[Float]] An array of Arrays of floats
+        - name: the name of the file without its extension (String).
+        - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+
+     - Throws: NSError if failed .
+     
+     Returns a .caf AKAudioFile set to AudioKit settings (32 bits float @ 44100 Hz)
+     */
+    public convenience init(createFileFromFloats floatsArrays:[[Float]],
+                                                 baseDir: BaseDirectory = .Temp,
+                                                 name: String = "") throws {
+
+        let channelCount = floatsArrays.count
+        var fixedSettings = AKSettings.audioFormat.settings
+
+        fixedSettings[AVNumberOfChannelsKey] = channelCount
+
+        try self.init(writeIn: baseDir, name: name)
+
+
+        // create buffer for floats
+        let format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: AVAudioChannelCount (channelCount))
+        let buffer = AVAudioPCMBuffer(PCMFormat: format, frameCapacity:  AVAudioFrameCount(floatsArrays[0].count))
+
+        // Fill the buffers
+
+        for channel in 0..<channelCount {
+            let channelNData = buffer.floatChannelData[channel]
+            for f in 0..<Int(buffer.frameCapacity) {
+                channelNData[f] = floatsArrays[channel][f]
+            }
+        }
+
+        // set the buffer frameLength
+        buffer.frameLength = buffer.frameCapacity
+
+        // Write the buffer in file
+        do {
+            try self.writeFromBuffer(buffer)
+        } catch let error as NSError {
+            print( "ERROR AKAudioFile: cannot writeFromBuffer Error: \(error)")
+            throw error
+        }
+
+    }
+
+    /*
+     Convenience init to instantiate a file from an AVAudioPCMBuffer.
+
+     - Parameters:
+     - buffer: the :AVAudioPCMBuffer that will be used to fill the AKAudioFile
+     - name: the name of the file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+
+     - Throws: NSError if failed .
+
+     Returns a .caf AKAudioFile set to AudioKit settings (32 bits float @ 44100 Hz)
+     */
+
+    public convenience init(fromAVAudioPCMBuffer buffer:AVAudioPCMBuffer,
+                                                 baseDir: BaseDirectory = .Temp,
+                                                 name: String = "") throws {
+
+        try self.init(writeIn: baseDir,
+                      name: name)
+
+        // Write the buffer in file
+        do {
+            try self.writeFromBuffer(buffer)
+        } catch let error as NSError {
+            print( "ERROR AKAudioFile: cannot writeFromBuffer Error: \(error)")
+            throw error
+        }
+        
+    }
+
+
+
+    /*
+    Returns an AKAudioFile with audio data of the current AKAudioFile normalized to have a peak of newMaxLevel dB.
+
+    - Parameters:
+    - name: the name of the file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+     - newMaxLevel: max level targeted as a Float value (default if 0 dB)
+
+    - Throws: NSError if failed .
+
+    - Returns: An AKAudioFile, or nil if init failed.*/
+    public func normalize( baseDir: BaseDirectory = .Temp,
+                           name:String = "", newMaxLevel:Float = 0.0 ) throws -> AKAudioFile {
+
+        let level = self.maxLevel
+        var outputFile = try AKAudioFile (writeIn: baseDir, name: name)
+
+        if self.samplesCount == 0
+        {
+            print( "WARNING AKAudioFile: cannot normalize an empty file")
+             return try AKAudioFile(forReading: outputFile.url)
+        }
+
+        if level == FLT_MIN {
+            print( "WARNING AKAudioFile: cannot normalize a silent file")
+            return try AKAudioFile(forReading: outputFile.url)
+        }
+
+
+
+        let gainFactor = Float( pow(10.0, newMaxLevel/10.0) / pow(10.0, level / 10.0))
+
+        let arrays = self.arraysOfFloats
+
+        var newArrays:[[Float]] = []
+        for array in arrays {
+            let newArray = array.map{$0 * gainFactor}
+            newArrays.append(newArray)
+        }
+
+        outputFile = try AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
+        return try AKAudioFile(forReading: outputFile.url)
+    }
+
+
+    /*
+     Returns an AKAudioFile with audio reversed (will playback in reverse from end to beginning).
+
+     - Parameters:
+     - name: the name of the file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+
+     - Throws: NSError if failed .
+
+     - Returns: An AKAudioFile, or nil if init failed.*/
+    public func reverse( baseDir: BaseDirectory = .Temp,
+                         name:String = "" ) throws -> AKAudioFile {
+
+        var outputFile = try AKAudioFile (writeIn: baseDir, name: name)
+
+        if self.samplesCount == 0
+        {
+            return try AKAudioFile(forReading: outputFile.url)
+        }
+        
+        
+        let arrays = self.arraysOfFloats
+        
+        var newArrays:[[Float]] = []
+        for array in arrays {
+            newArrays.append(Array(array.reverse()))
+        }
+        outputFile = try AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
+        return try AKAudioFile(forReading: outputFile.url)
+    }
+
+
+    /*
+     Returns an AKAudioFile with appended audio data from another AKAudioFile.
+     - Parameters:
+     - file: an AKAudioFile that will be used to append audio from.
+     - name: the name of the file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+
+     - Throws: NSError if failed .
+
+     - Returns: An AKAudioFile, or nil if init failed.*/
+    public func append( file:AKAudioFile,
+                        baseDir: BaseDirectory = .Temp,
+                        name:String  = "") throws -> AKAudioFile {
+
+        if self.fileFormat != file.fileFormat {
+            print( "ERROR AKAudioFile: appended file must be of the same format!")
+            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo:nil)
+        }
+
+        let outputFile = try AKAudioFile (writeIn: baseDir, name: name)
+
+
+        let myBuffer = self.pcmBuffer
+
+        // Write the buffer in file
+        do {
+            try outputFile.writeFromBuffer(myBuffer)
+        } catch let error as NSError {
+            print( "ERROR AKAudioFile: cannot writeFromBuffer Error: \(error)")
+            throw error
+        }
+
+        let appendedBuffer = file.pcmBuffer
+
+        do {
+            try outputFile.writeFromBuffer(appendedBuffer)
+        } catch let error as NSError {
+            print( "ERROR AKAudioFile: cannot writeFromBuffer Error: \(error)")
+            throw error
+        }
+
+        return try AKAudioFile(forReading: outputFile.url)
+    }
+
+
+    /*
+     Returns an AKAudioFile that will contain a range of samples from the current AKAudioFile
+     - Parameters:
+     - from: the starting sampleFrame for extraction.
+     - to: the ending sampleFrame for extraction
+     - name: the name of the file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+
+     - Throws: NSError if failed .
+
+     - Returns: An AKAudioFile, or nil if init failed.*/
+    public func extract(from:Int64,to:Int64, baseDir: BaseDirectory = .Temp,
+                        name:String = "") throws -> AKAudioFile {
+        if from < 0 || to > Int64(self.samplesCount) || to <= from {
+            print( "ERROR AKAudioFile: cannot extract, not a valid range !")
+            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo:nil)
+        }
+
+
+        let arrays = self.arraysOfFloats
+
+        var newArrays:[[Float]] = []
+
+        for array in arrays {
+            let extract = Array(array[Int(from)..<Int(to)])
+            newArrays.append(extract)
+        }
+
+        let newFile = try AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
+        return try AKAudioFile(forReading: newFile.url)
+    }
+
+    /*
+     Returns a silent AKAudioFile with a length set in samples. 
+     For a silent file of one second, set samples value to 44100...
+     - Parameters:
+     - samples: the number of samples to generate ( equals length in seconds multiplied by sample rate)
+     - name: the name of the file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
+
+     - Throws: NSError if failed .
+
+     - Returns: An AKAudioFile, or nil if init failed.*/
+    static public func silent(samples:Int64,
+                              baseDir: BaseDirectory = .Temp,
+                              name:String = "") throws -> AKAudioFile {
+
+        if samples < 0 {
+            print( "ERROR AKAudioFile: cannot create silent AKAUdioFile with negative samples count !")
+            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo:nil)
+        } else if samples == 0 {
+            let emptyFile = try AKAudioFile(writeIn: baseDir, name: name)
+            // we return it as a file for reading
+            return try AKAudioFile(forReading: emptyFile.url)
+        }
+
+        let array = [Float](count:Int(samples), repeatedValue: 0.0)
+        let silentFile = try AKAudioFile(createFileFromFloats: [array,array], baseDir: baseDir, name: name)
+
+        return try AKAudioFile(forReading: silentFile.url)
+    }
+
+}
+

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -163,7 +163,19 @@ public class AKAudioPlayer: AKNode, AKToggleable {
     /// the safest way to proceed is to use an AKAudioFile
     public init(file: AKAudioFile, completionHandler: AKCallback? = nil) throws {
 
-        self.internalAudioFile = file
+        let readFile:AKAudioFile
+
+        // Open the file for reading to avoid a crash when setting frame position
+        // if the file was instantiated for writing
+        do {
+            readFile = try AKAudioFile(forReading: file.url)
+
+        } catch let error as NSError {
+            print ("AKAudioPlayer Error: cannot open file \(file.fileNamePlusExtension) for reading!...")
+            print ("Error: \(error)")
+            throw error
+        }
+        self.internalAudioFile = readFile
         self.completionHandler = completionHandler
 
         super.init()
@@ -173,11 +185,9 @@ public class AKAudioPlayer: AKNode, AKToggleable {
         let format = AVAudioFormat(standardFormatWithSampleRate: self.internalAudioFile.sampleRate, channels: self.internalAudioFile.channelCount)
         AudioKit.engine.connect(internalPlayer, to: mixer, format: format)
         self.avAudioNode = mixer
-
         internalPlayer.volume = 1.0
-
+        
         initialize()
-
     }
 
     /*

--- a/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/AKAudioFile Demo.xcplaygroundpage/Contents.swift
+++ b/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/AKAudioFile Demo.xcplaygroundpage/Contents.swift
@@ -47,7 +47,7 @@ if drumloop != nil{
     // and so on...
 }
 
-//: The benefit of AKAudioFile versus AVAudioFile is that you can easily trim and export it. First, you must set a callback function that will be triggered upon export has been completed.
+//: AKAudioFile can easily be trimmed and exported. First, you must set a callback function that will be triggered upon export has been completed.
 func myExportCallBack(){
     print ("myExportCallBack has been triggered. It means that export ended")
     if myExport!!.succeeded
@@ -73,7 +73,7 @@ func myExportCallBack(){
 }
 
 //: Then, we can extract from 1 to 2 seconds of drumloop, as an mp4 file that will be written in documents directory. If the destination file exists, it will be overwritten.
-let myExport = try? drumloop?.export("drumloopExported",
+let myExport = try? drumloop?.export("exported",
                                      ext: .m4a, baseDir: .Documents,
                                      callBack: myExportCallBack,
                                      inTime: 1, outTime: 2)
@@ -87,28 +87,11 @@ let mySecondWorkingFile = try? AKAudioFile()
 
 //: If you set no parameter, an AKAudioFile is created in temp directory, set to match AudioKit AKSettings (a stereo empty 32 bits float wav file at 44.1 kHz, with a unique name identifier :
 if myWorkingFile != nil && mySecondWorkingFile != nil {
-    print ("myWorkingFile name is \(myWorkingFile!.fileNamePlusExtension)")
-    print ("mySecondWorkingFile name is \(mySecondWorkingFile!.fileNamePlusExtension)")
+    let myWorkingFileName1 = myWorkingFile!.fileNamePlusExtension
+    let mySecondWorkingFileName = mySecondWorkingFile!.fileNamePlusExtension
 }
 
-//: But you can create a custom AKAudioFile too :
-let custom16bitsLinearSettings:[String : AnyObject] = [
-    AVSampleRateKey : NSNumber(float: Float(AKSettings.sampleRate)),
-    AVLinearPCMIsFloatKey: NSNumber(bool: false),
-    AVFormatIDKey : NSNumber(int: Int32(kAudioFormatLinearPCM)),
-    AVNumberOfChannelsKey : NSNumber(int: Int32(AKSettings.numberOfChannels)),
-    AVLinearPCMIsNonInterleaved: NSNumber(bool: false),
-    AVLinearPCMIsBigEndianKey: NSNumber(bool: false),
-    AVLinearPCMBitDepthKey: NSNumber(int: Int32(16)) ]
-
-
-let customFile = try? AKAudioFile(writeIn:.Documents, name: "customFile", ext: "aif", settings:custom16bitsLinearSettings)
-if customFile != nil {
-    let customFileSettings = customFile!.fileFormat.settings
-    print("customFileSettings: \(customFileSettings)")
-}
-//: Check AKAudioFile.swift to learn more about its properties and methods...
-
+//: But the benefits of using AKAudioFile instead of AVAudioFile, is that you can normalize, reverse them or extract samples as float arrays. You can even perform audio edits very easily. Have a look to AKAudioFile Part 2... 
 
 XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
 

--- a/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/AKAudioFile part2.xcplaygroundpage/Contents.swift
+++ b/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/AKAudioFile part2.xcplaygroundpage/Contents.swift
@@ -1,0 +1,73 @@
+//: [TOC](Table%20Of%20Contents) | [Previous](@previous) | [Next](@next)
+//:
+//: ---
+//:
+//: ## AKAudioFile part 2 : Audio editing !...
+//: ### Let's have some fun with our drum loop
+
+import XCPlayground
+import AudioKit
+
+//: First we load the drumloop
+
+let loop = try? AKAudioFile(readFileName: "drumloop.wav", baseDir: .Resources)
+
+//: You may have noticed that the drumloop doesn't loop so well. Let's fix this...
+let fixedLoop = try? loop!.extract(0, to: Int64(3.42 * 44100))
+
+//: Now out drumloop is one bar long and perfectly loops. Let's extract the kick, the snare and hihat into sisteenth note long files :
+let oneBarLength = fixedLoop!.samplesCount
+
+let oneSixteenthLength = oneBarLength / 16
+
+let kick = try?  fixedLoop!.extract(0, to: oneSixteenthLength)
+let snare = try? fixedLoop!.extract(oneSixteenthLength * 4, to: oneSixteenthLength * 5)
+let hihat = try? fixedLoop!.extract(oneSixteenthLength * 2, to: oneSixteenthLength * 3)
+
+//: Notice that we don't provide any name or location for those files (in fact, I don't care...) If no name / location are set, files will be created in temp directory with a unique name. But you could choose name and location if you wish. Let's check this:
+
+let kickFileName = kick!.fileNamePlusExtension
+let kickFilePath = kick!.directoryPath
+
+//: I love hihat, so we gonna normalize our Hihat sample so it will play as loud as other instruments...
+let normalizedHihat = try? hihat!.normalize()
+
+//: Why not making some new files by reversing them
+let reverseKick = try? kick!.reverse()
+let reverseSnare = try? snare!.reverse()
+let reverseHihat = try? normalizedHihat!.reverse()
+
+// A sixteenth note silence could be handy...
+let silence = try?  AKAudioFile.silent(oneSixteenthLength)
+
+//: Now, we put all them in an array so we can later randomly pick samples. Some are doubled so they'll have more luck to be picked.
+
+let samplesBox: [AKAudioFile] = [kick!, snare!, kick!, snare!, kick!, snare!, normalizedHihat!, reverseKick! , reverseSnare!, reverseHihat!, silence!, silence!, silence!, silence!, silence! ]
+
+//: Now, we'll play the original loop three times,
+let twoTimesLoop =  try? fixedLoop!.append(fixedLoop!)
+var sequence = try? twoTimesLoop!.append(fixedLoop!)
+//: Next, we append a random sequence of 16 sixteenth of audio to build our random drum solo...
+
+for i in 0..<16 {
+    let newSampleIndex = randomInt(0..<samplesBox.count)
+    let newSound = samplesBox[newSampleIndex]
+    print ("picked sample #\(newSampleIndex) name: \(newSound.fileNamePlusExtension)")
+    var newFile = try? sequence!.append(newSound)
+    sequence = newFile!
+}
+
+//: Each time you'll run this playground, the resulting audioFile will be different. Let's listen to our edited audiofile: Original Loop 3 times, followed by the "drum solo of the day"...
+
+
+let sequencePlayer = try? AKAudioPlayer(file: sequence!)
+sequencePlayer!.looping = true
+
+AudioKit.output = sequencePlayer!
+AudioKit.start()
+sequencePlayer!.play()
+
+
+XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
+
+//: [TOC](Table%20Of%20Contents) | [Previous](@previous) | [Next](@next)


### PR DESCRIPTION
AKAudioFile Update:

Fixed AKAudioPlayer: Now, the played file is opened « for reading »
It avoids a stupid crash when AKAudioPlayer try to set the
FramePosition if the file was instantiated « forWriting »

Fixed AKAudioFile:
Opening a file from resources worked in playgrounds, but not in an app
(!):  Fixed !
Exporting a file then worked in apps, but not in playground: Fixed !

Changed convenience writeIn init. Removed file extension, settings and
interleaved in init fields
Now, the file is ALWAYS a .caf set with AKSettings format.
As you still can instantiate the old / hard way (using NSURL and
manually set settings and format), user can create an AKAudioFile for
writing with his custom settings if he wishes to.
Then, it is not necessary to provide init fields that could lead to
errors (like creating a .m4a with linearPCM, for example…). We assume
the default AKAudioFile for writing should always be a.caf stereo file
set with AudioKit settings and format.

Added new lazy properties:

.pcmBuffer -> return  file’s samples as an AVAudioPCMBuffer
.arraysOfFloats -> return  file’s samples as [[Float]]
.maxLevel -> return the file’s peak value in dB.

Added a new Inits :

init(createFileFromFloats floatsArrays:[[Float]],
baseDir: BaseDirectory = .Temp,
name: String) throws { …

That lets you create an AKAudioFile from scratch, using array(s) of
floats

added init from AVAudioPCMBuffer.

So now, you can get the samples as floats Arrays, play with them, and
create an AKAudioFile set with the new floats values. (cool :-)

Added 3 new methods that return new AKAudioFiles:

.normalize() with an optional newMaxLevel init field, that let’s you
set the new maxLevel  expressed in dB.
.reverse(): returns an AKAudioFile with reversed samples
.append(file:AKAudioFile): returns a new AKAudioFile with with audio
samples appended from another file.
.extract(from inSample, to outSample): returns a new AKAudioFile with a
range of audio samples

and a static method :
.silent() that lets user generate silent AKAudioFile from any duration.

What is cool now:
- You can now convert convert an mp3 / m4a / mp4 audioFile to
.caf/.wav/.aif PCM file (it was not possible using AVAssetExportSession)

- you can now do some basic audio edits: extract a part of a file,
reverse it, append it to another file, add some silence, normalize,
convert to m4a… So we have a fully programmable audio editor.

\o/