### PR TITLE
AVSession and buffer settings

### DIFF
--- a/AudioKit/Common/Internals/AKMicrophoneRecorder.swift
+++ b/AudioKit/Common/Internals/AKMicrophoneRecorder.swift
@@ -28,7 +28,11 @@ public class AKMicrophoneRecorder {
         #if os(iOS)
         self.recordingSession = AVAudioSession.sharedInstance()
         do {
-            try recordingSession.setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions:AVAudioSessionCategoryOptions.DefaultToSpeaker)
+
+
+            //try recordingSession.setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions:AVAudioSessionCategoryOptions.DefaultToSpeaker)
+            try AKSettings.setSessionCategory(AKSettings.SessionCategory.PlayAndRecord, withOptions:AVAudioSessionCategoryOptions.DefaultToSpeaker)
+
             try recordingSession.setActive(true)
         } catch {
             print("lacking permission to record!\n")

--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -11,30 +11,139 @@ import AVFoundation
 
 /// Global settings for AudioKit
 @objc public class AKSettings: NSObject {
-    
+
+    /// Enum of available AVAudioSession Categories
+    public enum SessionCategory: String {
+        case Ambient = "AVAudioSessionCategoryAmbient"
+        case SoloAmbient = "AVAudioSessionCategorySoloAmbient"
+        case Playback = "AVAudioSessionCategoryPlayback"
+        case Record = "AVAudioSessionCategoryRecord"
+        case PlayAndRecord = "AVAudioSessionCategoryPlayAndRecord"
+        case AudioProcessing = "AVAudioSessionCategoryAudioProcessing"
+        case MultiRoute = "AVAudioSessionCategoryMultiRoute"
+    }
+
+    /// Enum of available buffer lengths
+    /// from Shortest: 2 power 5 samples (32 samples = 0.7 ms @ 44100 kz)
+    /// to Longest: 2 power 12 samples (4096 samples = 92.9 ms @ 44100 Hz)
+    public enum BufferLength: Int {
+        case Shortest = 5
+        case VeryShort = 6
+        case Short = 7
+        case Medium = 8
+        case Long = 9
+        case VeryLong = 10
+        case Huge = 11
+        case Longest = 12
+
+        /// The buffer Length expressed as number of samples
+        var samplesCount: AVAudioFrameCount {
+            return AVAudioFrameCount(pow(2.0,Double(self.rawValue)))
+        }
+
+        /// The buffer Length expressed as a duration in seconds
+        var duration: Double {
+            return Double(samplesCount) / AKSettings.sampleRate
+        }
+    }
+
+    /// Shortcut for AVAudioSession.sharedInstance()
+    public static let session = AVAudioSession.sharedInstance()
+
     /// The sample rate in Hertz
     public static var sampleRate: Double = 44100
-    
+
     /// Number of audio channels: 2 for stereo, 1 for mono
     public static var numberOfChannels: UInt32 = 2
-    
+
     /// Whether we should be listening to audio input (microphone)
     public static var audioInputEnabled: Bool = false
-    
+
     /// Whether to allow audio playback to override the mute setting
     public static var playbackWhileMuted: Bool = false
-    
+
     /// Global audio format AudioKit will default to
     public static var audioFormat: AVAudioFormat {
         return AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: numberOfChannels)
     }
-    
+
     /// Whether to DefaultToSpeaker when audio input is enabled
     public static var defaultToSpeaker: Bool = false
-    
+
     /// Global default rampTime value
     public static var rampTime: Double = 0.0002
 
     /// Allows AudioKit to send Notifications
     public static var notificationsEnabled: Bool = false
+
+    /// AudioKit buffer length is set using AKSettings.BufferLength
+    /// default is .Medium for a buffer set to 2 power 8 = 256 samples (58 ms)
+    public static var bufferLength: BufferLength = .Medium
+
+    /// AudioKit recording buffer length is set using AKSettings.BufferLength
+    /// default is .Medium for a buffer set to 2 power 8 = 256 samples (58 ms)
+    public static var recordingBufferLength: BufferLength = .Medium
+
+    /// Enable AudioKit AVAudioSession Category Management
+    public static var disableAVAudioSessionCategoryManagement: Bool = false
+
+
+
+    public static func setSessionCategory( category:SessionCategory, withOptions options: AVAudioSessionCategoryOptions? = nil ) throws {
+
+        if AKSettings.disableAVAudioSessionCategoryManagement == false {
+
+            print( "ask for category: \(category.rawValue)")
+            // Category
+            if options != nil {
+                do {
+                    try session.setCategory(category.rawValue, withOptions: options!)
+                } catch let error as NSError {
+                    print ("AKAsettings Error: Cannot set AVAudioSession Category to \(String(category)) with options: \(String(options!))")
+                    print ("AKAsettings Error: \(error))")
+                    throw error
+                }
+            }
+        } else {
+
+            do {
+                try session.setCategory(category.rawValue)
+            } catch let error as NSError {
+                print ("AKAsettings Error: Cannot set AVAudioSession Category to \(String(category))")
+                print ("AKAsettings Error: \(error))")
+                throw error
+            }
+        }
+
+        // Preferred IO Buffer Duration
+
+        do {
+            try session.setPreferredIOBufferDuration(bufferLength.duration)
+        } catch let error as NSError {
+            print ("AKAsettings Error: Cannot set Preferred IOBufferDuration  to \(bufferLength.duration) ( = \(bufferLength.samplesCount) samples)")
+            print ("AKAsettings Error: \(error))")
+            throw error
+        }
+
+        // Activate session
+        do {
+            try session.setActive(true)
+        } catch let error as NSError {
+            print ("AKAsettings Error: Cannot set AVAudioSession.setActive to true")
+            print ("AKAsettings Error: \(error))")
+            throw error
+        }
+
+        
+        // FOR DEBUG !
+        print ("AKSettings: asked for: \(category.rawValue)")
+        print ("AKSettings: Session.category is set to: \(session.category)")
+
+        if options != nil {
+            print ("AKSettings: asked for options: \(options!)")
+            print ("AKSettings: Session.category is set to: \(session.categoryOptions)")
+        }
+     }
 }
+
+

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -128,10 +128,7 @@ public typealias AKCallback = Void -> Void
 
                 #if os(iOS)
                     if AKSettings.defaultToSpeaker {
-
-                        try AVAudioSession.sharedInstance().setCategory(
-                            AVAudioSessionCategoryPlayAndRecord,
-                            withOptions: AVAudioSessionCategoryOptions.DefaultToSpeaker)
+                        try AKSettings.setSessionCategory(AKSettings.SessionCategory.PlayAndRecord, withOptions: AVAudioSessionCategoryOptions.DefaultToSpeaker)
 
                         // listen to AVAudioEngineConfigurationChangeNotification
                         // and restart the engine if it's stopped.
@@ -142,19 +139,24 @@ public typealias AKCallback = Void -> Void
                             object: engine)
 
                     } else {
-                        try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord)
+
+                         try AKSettings.setSessionCategory(AKSettings.SessionCategory.PlayAndRecord)
 
                     }
                 #else
                     // tvOS
-                    try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord)
+
+                    try AKSettings.setSessionCategory(AKSettings.SessionCategory.PlayAndRecord)
 
                 #endif
 
                 } else if AKSettings.playbackWhileMuted {
-                    try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback)
+
+                try AKSettings.setSessionCategory(AKSettings.SessionCategory.Playback)
+
                 } else {
-                    try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryAmbient)
+                    try AKSettings.setSessionCategory(AKSettings.SessionCategory.Ambient)
+
                 }
             #if os(iOS)
                 try AVAudioSession.sharedInstance().setActive(true)


### PR DESCRIPTION
- Now you can disable any AVAudioSession category setting from AudioKit.
- Added a bufferLength and a recordingBufferLength AKSettings
properties.

Successfully tested in a minimal recorder app with my iPhone4S

Will probably be improved, as AVSession handling is far to be perfect.
But couldn’t wait to share as it works really fine here.