### PR TITLE
Now Record throws ! :-)

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -75,7 +75,7 @@ import AVFoundation
     
     /// AudioKit buffer length is set using AKSettings.BufferLength
     /// default is .Medium for a buffer set to 2 power 8 = 256 samples (58 ms)
-    public static var bufferLength: BufferLength = .Medium
+    public static var bufferLength: BufferLength = .Longest
     
     /// AudioKit recording buffer length is set using AKSettings.BufferLength
     /// default is .Medium for a buffer set to 2 power 8 = 256 samples (58 ms)

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+Async Processing.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+Async Processing.swift
@@ -1,0 +1,365 @@
+//
+//  AKAudioFile+processing Async.swift
+//  AudioKit For iOS
+//
+//  Created by Laurent Veliscek and Brandon Barber on 12/07/2016.
+//  Copyright © 2016 AudioKit. All rights reserved.
+//
+//
+//  IMPORTANT: Any AKAudioFile process will output a .caf AKAudioFile
+//  set with a PCM Linear Encoding (no compression)
+//  But it can be applied to any readable file (.wav, .m4a, .mp3...)
+//
+
+
+import Foundation
+import AVFoundation
+
+
+
+extension AKAudioFile {
+
+
+    // MARK: - embedded enum
+
+    /// Enum of Status returned from the status property
+    /// of any AKAudioFile Async AKAudioFile process.
+    public enum ProcessStatus {
+        case Failed
+        case Processing
+        case Succeeded
+    }
+    /// Enum of Process Types stored as a property
+    /// in any AKAudioFile Async AKAudioFile process.
+    public enum ProcessType {
+        case Normalize
+        case Reverse
+        case Append
+    }
+
+    // MARK: - Async Process Objects
+
+    /*
+    Returned from normalize_Async()
+    
+    As soon as completionHandler has been triggered,
+    you can check status (.Failed or .Succeeded)
+     
+    If .Succeeded, the resulting AKAudioFile is the
+    process.processedFile property.
+
+    If .Failed, you mau check the error thrown using
+    process.error property.
+     
+    If needed, you can get the source AKAudioFile using
+    process.sourceFile property and get the process type
+    using process.processType
+
+    */
+    public class NormalizeProcess {
+
+        public var status:ProcessStatus = .Processing
+        public var processedFile: AKAudioFile?
+        public var error:NSError?
+        public let sourceFile:AKAudioFile
+        public let processType:ProcessType = .Normalize
+
+        init (  sourceFile:AKAudioFile, baseDir: BaseDirectory,
+                name: String,
+                newMaxLevel: Float,
+                completionCallBack:AKCallback) {
+            self.sourceFile = sourceFile
+            dispatch_async(AudioKit.AKAudioFileProcessQueue) {
+                do {
+                    self.processedFile = try sourceFile.normalize(baseDir, name: name, newMaxLevel: newMaxLevel)
+                } catch let error as NSError {
+                    self.status = .Failed
+                    print( "ERROR AKAudioFile: Normalize: \(error)")
+                    self.error = error
+                }
+                print( "AKAudioFile: Normalizing \"\(self.sourceFile.fileNamePlusExtension)\" -> \"\(self.processedFile!.fileNamePlusExtension)\" completed!")
+                self.status = .Succeeded
+                completionCallBack()
+            }
+        }
+    }
+
+    /*
+     Returned from reverse_Async()
+
+     As soon as completionHandler has been triggered,
+     you can check status (.Failed or .Succeeded)
+
+     If .Succeeded, the resulting AKAudioFile is the
+     process.processedFile property.
+
+     If .Failed, you mau check the error thrown using
+     process.error property.
+
+     If needed, you can get the source AKAudioFile using
+     process.sourceFile property.
+     
+     */
+    public class ReverseProcess {
+
+        public var status:ProcessStatus = .Processing
+        public var processedFile: AKAudioFile?
+        public var error:NSError?
+        public let sourceFile:AKAudioFile
+        public let processType:ProcessType = .Reverse
+
+        init (  sourceFile:AKAudioFile, baseDir: BaseDirectory,
+                name: String,
+                completionCallBack:AKCallback) {
+            self.sourceFile = sourceFile
+            dispatch_async(AudioKit.AKAudioFileProcessQueue) {
+                do {
+                    self.processedFile = try sourceFile.reverse(baseDir, name: name)
+                } catch let error as NSError {
+                    self.status = .Failed
+                    print( "ERROR AKAudioFile: Reverse: \(error)")
+                    self.error = error
+                }
+                print( "AKAudioFile: Reversing \"\(self.sourceFile.fileNamePlusExtension)\" -> \"\(self.processedFile!.fileNamePlusExtension)\" completed!")
+                self.status = .Succeeded
+                completionCallBack()
+            }
+        }
+    }
+
+
+    /*
+     Returned from append_Async()
+
+     As soon as completionHandler has been triggered,
+     you can check status (.Failed or .Succeeded)
+
+     If .Succeeded, the resulting AKAudioFile is the
+     process.processedFile property.
+
+     If .Failed, you mau check the error thrown using
+     process.error property.
+
+     If needed, you can get the source AKAudioFile using
+     process.sourceFile property.
+
+     */
+    public class AppendProcess {
+
+        public var status:ProcessStatus = .Processing
+        public var processedFile: AKAudioFile?
+        public var error:NSError?
+        public let sourceFile:AKAudioFile
+        public let processType:ProcessType = .Append
+
+        init (  sourceFile:AKAudioFile,
+                file: AKAudioFile,
+                baseDir: BaseDirectory,
+                name: String  = "",
+                completionCallBack:AKCallback) {
+            self.sourceFile = sourceFile
+            dispatch_async(AudioKit.AKAudioFileProcessQueue) {
+            do {
+                self.processedFile = try sourceFile.append(file, baseDir: baseDir, name: name)
+            } catch let error as NSError {
+                self.status = .Failed
+                print( "ERROR AKAudioFile: Append: \(error)")
+                self.error = error
+                }
+                print( "AKAudioFile: Appending to \"\(self.sourceFile.fileNamePlusExtension)\" -> \"\(self.processedFile!.fileNamePlusExtension)\" completed!")
+                self.status = .Succeeded
+                completionCallBack()
+            }
+        }
+    }
+    
+
+
+    /*
+     Returned from extract_Async()
+
+     As soon as completionHandler has been triggered,
+     you can check status (.Failed or .Succeeded)
+
+     If .Succeeded, the resulting AKAudioFile is the
+     process.processedFile property.
+
+     If .Failed, you mau check the error thrown using
+     process.error property.
+
+     If needed, you can get the source AKAudioFile using
+     process.sourceFile property.
+
+     */
+    public class ExtractProcess {
+
+        public var status:ProcessStatus = .Processing
+        public var processedFile: AKAudioFile?
+        public var error:NSError?
+        public let sourceFile:AKAudioFile
+        public let processType:ProcessType = .Append
+
+        init (  sourceFile:AKAudioFile,
+                from: Int64,
+                to: Int64,
+                baseDir: BaseDirectory,
+                name: String  = "",
+                completionCallBack:AKCallback) {
+            self.sourceFile = sourceFile
+            dispatch_async(AudioKit.AKAudioFileProcessQueue) {
+                do {
+                    self.processedFile = try sourceFile.extract(from, to:to, baseDir: baseDir, name: name)
+                } catch let error as NSError {
+                    self.status = .Failed
+                    print( "ERROR AKAudioFile: Extract: \(error)")
+                    self.error = error
+                }
+                print( "AKAudioFile: Extracting from \"\(self.sourceFile.fileNamePlusExtension)\" -> \"\(self.processedFile!.fileNamePlusExtension)\" completed!")
+                self.status = .Succeeded
+                completionCallBack()
+            }
+        }
+    }
+    
+    
+
+
+
+    // MARK: - Async Process functions
+
+    /**
+     Process the current AKAudioFile in background to return an
+     AKAudioFile reversed (will play backward)
+
+     - Parameters:
+     - name: the name of resulting the file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp (Default is .Temp)
+      - completionCallBack : AKCallback that will be triggered as soon as
+     process has been completed or failed.
+
+     - Returns: A ReverseProcess Object.
+
+     Notice that completionCallBack will be triggered from a
+     background thread. Any UI update should be made using:
+
+     dispatch_async(dispatch_get_main_queue()) {
+     // UI updates...
+     }
+     */
+
+    public func reverse_Async( baseDir: BaseDirectory = .Temp,
+                               name: String = "",
+                               completionCallBack: AKCallback) -> ReverseProcess {
+
+        let process = ReverseProcess(sourceFile: self, baseDir: baseDir, name: name,completionCallBack: completionCallBack)
+        return process
+    }
+
+    /**
+     Process the current AKAudioFile in background to return an
+     AKAudioFile normalized with a peak of newMaxLevel dB if succeeded
+
+     - Parameters:
+     - name: the name of the resulting file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp (Default is .Temp)
+     - newMaxLevel: max level targeted as a Float value (default if 0 dB)
+     - completionCallBack : AKCallback that will be triggered as soon as
+     process has been completed or failed.
+
+     - Returns: A NormalizeProcess Object.
+
+     Notice that completionCallBack will be triggered from a
+     background thread. Any UI update should be made using:
+
+     dispatch_async(dispatch_get_main_queue()) {
+     // UI updates...
+     }
+     */
+    public func normalize_Async( baseDir: BaseDirectory = .Temp,
+                                 name: String = "",
+                                 newMaxLevel: Float = 0.0,
+                                 completionCallBack: AKCallback) -> NormalizeProcess {
+
+        let process = NormalizeProcess(sourceFile: self, baseDir: baseDir, name: name, newMaxLevel: newMaxLevel, completionCallBack: completionCallBack)
+        return process
+    }
+    
+    /**
+     Process the current AKAudioFile in background to return an
+     AKAudioFile with another file audio appended, if succeeded
+
+     - Parameters:
+     - file: AKAudioFile to be appended to the current file.
+     - name: the name of the resulting file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp (Default is .Temp)
+     - completionCallBack : AKCallback that will be triggered as soon as
+     process has been completed or failed.
+
+     - Returns: an AppendProcess Object.
+
+     Notice that completionCallBack will be triggered from a
+     background thread. Any UI update should be made using:
+
+     dispatch_async(dispatch_get_main_queue()) {
+     // UI updates...
+     }
+     */
+    public func append_Async( file: AKAudioFile,
+                              baseDir: BaseDirectory = .Temp,
+                              name: String = "",
+                              newMaxLevel: Float = 0.0,
+                              completionCallBack: AKCallback) -> AppendProcess {
+
+        let process = AppendProcess(sourceFile: self,
+                                    file: file,
+                                    baseDir: baseDir,
+                                    name: name,
+                                    completionCallBack: completionCallBack)
+        return process
+    }
+    
+    
+    /**
+     Process the current AKAudioFile in background to return an
+     AKAudioFile extracted from the current AKAudioFile, if succeeded
+
+     - Parameters:
+     - from: the starting sampleFrame for extraction.
+     - to: the ending sampleFrame for extraction
+     - name: the name of the resulting file without its extension (String).
+     - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp (Default is .Temp)
+     - completionCallBack : AKCallback that will be triggered as soon as
+     process has been completed or failed.
+
+     - Returns: an ExtractProcess Object.
+
+     Notice that completionCallBack will be triggered from a
+     background thread. Any UI update should be made using:
+
+     dispatch_async(dispatch_get_main_queue()) {
+     // UI updates...
+     }
+     */
+    public func extract_Async( file: AKAudioFile,
+                               from: Int64 = 0,
+                               to: Int64 = 0,
+                               baseDir: BaseDirectory = .Temp,
+                               name: String = "",
+                               completionCallBack: AKCallback) -> ExtractProcess {
+
+
+        let fixedFrom = abs(from)
+        let fixedTo:Int64 = to == 0 ? Int64(self.samplesCount) : min(to,Int64(self.samplesCount))
+
+        let process = ExtractProcess(sourceFile: self,
+                                     from: fixedFrom,
+                                     to: fixedTo,
+                                     baseDir: baseDir,
+                                     name: name,
+                                     completionCallBack: completionCallBack)
+        return process
+    }
+    
+    
+
+}

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
@@ -2,7 +2,7 @@
 //  AKAudioFile+ConvenienceInitializers.swift
 //  AudioKit For iOS
 //
-//  Created by Aurelius Prochazka on 7/4/16.
+//  Created by Aurelius Prochazka and Laurent Veliscek on 7/4/16.
 //  Copyright © 2016 AudioKit. All rights reserved.
 //
 

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+Exporting.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+Exporting.swift
@@ -2,7 +2,7 @@
 //  AKAudioFile+Exporting.swift
 //  AudioKit For iOS
 //
-//  Created by Aurelius Prochazka on 7/4/16.
+//  Created by Aurelius Prochazka and Laurent Veliscek on 7/4/16.
 //  Copyright © 2016 AudioKit. All rights reserved.
 //
 

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+Processing.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+Processing.swift
@@ -2,21 +2,17 @@
 //  AKAudioFile+Processing.swift
 //  AudioKit For iOS
 //
-//  Created by Aurelius Prochazka on 7/4/16.
+//  Created by Aurelius Prochazka and Laurent Veliscek on 7/4/16.
 //  Copyright © 2016 AudioKit. All rights reserved.
+//
+//
+//  IMPORTANT: Any AKAudioFile process will output a .caf AKAudioFile
+//  set with a PCM Linear Encoding (no compression)
+//  But it can be applied to any readable file (.wav, .m4a, .mp3...)
 //
 
 import Foundation
 import AVFoundation
-
-@objc public protocol AKAudioFileDelegate {
-    /**
-     Presents the processed AKAudioFile
-     - Parameters:
-        - audioFile: the processed AKAudioFile*/
-    optional func didFinishProcessing(audioFile: AKAudioFile?)
-    
-}
 
 extension AKAudioFile {
     /**
@@ -61,54 +57,7 @@ extension AKAudioFile {
         outputFile = try AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
         return try AKAudioFile(forReading: outputFile.url)
     }
-    
-    /**
-     AKAudioFileDelegate recieves an AKAudioFile with audio data of the current AKAudioFile normalized to have a peak of newMaxLevel dB.
-     
-     - Parameters:
-        - name: the name of the file without its extension (String).
-        - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp
-        - newMaxLevel: max level targeted as a Float value (default if 0 dB)*/
-    public func asyncNormalize( baseDir: BaseDirectory = .Temp,
-                                name: String = "", newMaxLevel: Float = 0.0 ) {
-        
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            
-            OSAtomicIncrement32(&AKAudioFile.queueCount)
-            
-            let level = self.maxLevel
-            var outputFile = try? AKAudioFile (writeIn: baseDir, name: name)
-            
-            if self.samplesCount == 0 {
-                print( "WARNING AKAudioFile: cannot normalize an empty file")
-                OSAtomicDecrement32(&AKAudioFile.queueCount)
-                self.delegate!.didFinishProcessing?(try? AKAudioFile(forReading: outputFile!.url))
-            }
-            
-            if level == FLT_MIN {
-                print( "WARNING AKAudioFile: cannot normalize a silent file")
-                OSAtomicDecrement32(&AKAudioFile.queueCount)
-                self.delegate!.didFinishProcessing?(try? AKAudioFile(forReading: outputFile!.url))
-            }
-            
-            
-            let gainFactor = Float( pow(10.0, newMaxLevel/10.0) / pow(10.0, level / 10.0))
-            
-            let arrays = self.arraysOfFloats
-            
-            var newArrays: [[Float]] = []
-            for array in arrays {
-                let newArray = array.map {$0 * gainFactor}
-                newArrays.append(newArray)
-            }
-            
-            outputFile = try? AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
-            
-            OSAtomicDecrement32(&AKAudioFile.queueCount)
-            self.delegate!.didFinishProcessing?(try? AKAudioFile(forReading: outputFile!.url))
-        }
-    }
-    
+
     /**
      Returns an AKAudioFile with audio reversed (will playback in reverse from end to beginning).
      
@@ -138,40 +87,7 @@ extension AKAudioFile {
         outputFile = try AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
         return try AKAudioFile(forReading: outputFile.url)
     }
-    
-    /**
-     AKAudioFileDelegate recieves an AKAudioFile with audio reversed (will playback in reverse from end to beginning).
-     
-     - Parameters:
-        - name: the name of the file without its extension (String).
-        - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp*/
-    public func asyncReverse( baseDir: BaseDirectory = .Temp,
-                              name: String = "" ) {
-        
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            
-            OSAtomicIncrement32(&AKAudioFile.queueCount)
-            var outputFile = try? AKAudioFile (writeIn: baseDir, name: name)
-            
-            if self.samplesCount == 0 {
-                OSAtomicDecrement32(&AKAudioFile.queueCount)
-                self.delegate!.didFinishProcessing?(try? AKAudioFile(forReading: outputFile!.url))
-            }
-            
-            let arrays = self.arraysOfFloats
-            
-            var newArrays: [[Float]] = []
-            for array in arrays {
-                newArrays.append(Array(array.reverse()))
-            }
-            
-            outputFile = try? AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
-            
-            OSAtomicDecrement32(&AKAudioFile.queueCount)
-            self.delegate!.didFinishProcessing?(try? AKAudioFile(forReading: outputFile!.url))
-        }
-    }
-    
+
     /**
      Returns an AKAudioFile with appended audio data from another AKAudioFile.
      
@@ -230,10 +146,13 @@ extension AKAudioFile {
      - Throws: NSError if failed .
      
      - Returns: An AKAudioFile, or nil if init failed.*/
-    public func extract(from: Int64, to: Int64, baseDir: BaseDirectory = .Temp,
+    public func extract(from: Int64 = 0, to: Int64 = 0, baseDir: BaseDirectory = .Temp,
                         name: String = "") throws -> AKAudioFile {
-        if from < 0 || to > Int64(self.samplesCount) || to <= from {
-            print( "ERROR AKAudioFile: cannot extract, not a valid range !")
+
+        let fixedFrom = abs(from)
+        let fixedTo:Int64 = to == 0 ? Int64(self.samplesCount) : min(to,Int64(self.samplesCount))
+        if fixedTo <= fixedFrom {
+            print( "ERROR AKAudioFile: cannot extract, from must be less than to !")
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo:nil)
         }
         
@@ -243,52 +162,14 @@ extension AKAudioFile {
         var newArrays: [[Float]] = []
         
         for array in arrays {
-            let extract = Array(array[Int(from)..<Int(to)])
+            let extract = Array(array[Int(fixedFrom)..<Int(fixedTo)])
             newArrays.append(extract)
         }
         
         let newFile = try AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
         return try AKAudioFile(forReading: newFile.url)
     }
-    
-    /**
-     AKAudioFileDelegate recieves an AKAudioFile that will contain a range of samples from the current AKAudioFile
-     
-     - Parameters:
-        - from: the starting sampleFrame for extraction.
-        - to: the ending sampleFrame for extraction
-        - name: the name of the file without its extension (String).
-        - baseDir: where the file will be located, can be set to .Resources,  .Documents or .Temp*/
-    public func asyncExtract(from: Int64, to: Int64, baseDir: BaseDirectory = .Temp,
-                             name: String = "") {
-        
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            
-            OSAtomicIncrement32(&AKAudioFile.queueCount)
-            
-            if from < 0 || to > Int64(self.samplesCount) || to <= from {
-                print( "ERROR AKAudioFile: cannot extract, not a valid range !")
-                OSAtomicDecrement32(&AKAudioFile.queueCount)
-                return
-            }
-            
-            
-            let arrays = self.arraysOfFloats
-            
-            var newArrays: [[Float]] = []
-            
-            for array in arrays {
-                let extract = Array(array[Int(from)..<Int(to)])
-                newArrays.append(extract)
-            }
-            
-            let newFile = try? AKAudioFile(createFileFromFloats: newArrays, baseDir: baseDir, name: name)
-            
-            OSAtomicDecrement32(&AKAudioFile.queueCount)
-            self.delegate!.didFinishProcessing?(try? AKAudioFile(forReading: newFile!.url))
-        }
-    }
-    
+   
     /**
      Returns a silent AKAudioFile with a length set in samples.
      For a silent file of one second, set samples value to 44100...

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
@@ -46,7 +46,6 @@ public class AKAudioFile: AVAudioFile {
     }()
 
 
-
     // MARK: - Public AKAudioFileFormat Properties
 
     /// The number of samples can be accessed by .length property,
@@ -227,16 +226,6 @@ public class AKAudioFile: AVAudioFile {
             return (10 * log10(maxLev))
         }
     }()
-    
-    // MARK: - Public Other Properties
-    
-    /// How many processes in queue - see AKAudioFile+Processing.swift
-    static public var queueCount: Int32 = 0
-    
-    /// AKAudioFile Delegate
-    public var delegate: AKAudioFileDelegate? = nil
-    
-    // MARK: - Initialization
     
     /**
      Super.init inherited from AVAudioFile superclass

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -11,8 +11,13 @@ import AVFoundation
 
 public typealias AKCallback = Void -> Void
 
+
 /// Top level AudioKit managing class
 @objc public class AudioKit: NSObject {
+
+
+    // Queue used for AKAudioFile Async Processings
+    static let AKAudioFileProcessQueue = dispatch_queue_create("AKAudioFileProcessQueue", DISPATCH_QUEUE_SERIAL)
 
     // MARK: Global audio format (44.1K, Stereo)
 

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -380,7 +380,9 @@ public class AKAudioPlayer: AKNode, AKToggleable {
                 scheduleBuffer()
             } else {
                 stop()
-                completionHandler?()
+
+                    self.completionHandler?()
+
             }
         }
     }


### PR DESCRIPTION
- AKNodeRecorder throws : So I could move session category setting and permission checking from init to record() (big progress)
- AKAudioFile: replaced async « delegating » methods with « process » objects (easier, safer)
- AudioKit:  added a global static var « AKAudioFileProcessQueue »

Haven’t fixed playgrounds yet…