### PR TITLE
Adjusting minimum qualityFactor values

### DIFF
--- a/AudioKit/OSX/AudioKit/AudioKit for OSX.playground/Pages/Modal Resonance Filter.xcplaygroundpage/Contents.swift
+++ b/AudioKit/OSX/AudioKit/AudioKit for OSX.playground/Pages/Modal Resonance Filter.xcplaygroundpage/Contents.swift
@@ -44,7 +44,7 @@ class PlaygroundView: AKPlaygroundView {
         addSlider(#selector(setFrequency), value: filter.frequency, minimum: 0, maximum: 5000)
 
         qualityFactorLabel = addLabel("Quality Factor: \(filter.qualityFactor)")
-        addSlider(#selector(setQualityFactor), value: filter.qualityFactor, minimum: 0, maximum: 20)
+        addSlider(#selector(setQualityFactor), value: filter.qualityFactor, minimum: 0.1, maximum: 20)
     }
 
     func startLoop(part: String) {

--- a/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Modal Resonance Filter.xcplaygroundpage/Contents.swift
+++ b/AudioKit/iOS/AudioKit/AudioKit.playground/Pages/Modal Resonance Filter.xcplaygroundpage/Contents.swift
@@ -44,7 +44,7 @@ class PlaygroundView: AKPlaygroundView {
         addSlider(#selector(setFrequency), value: filter.frequency, minimum: 0, maximum: 5000)
 
         qualityFactorLabel = addLabel("Quality Factor: \(filter.qualityFactor)")
-        addSlider(#selector(setQualityFactor), value: filter.qualityFactor, minimum: 0, maximum: 20)
+        addSlider(#selector(setQualityFactor), value: filter.qualityFactor, minimum: 0.1, maximum: 20)
     }
 
     func startLoop(part: String) {


### PR DESCRIPTION
Setting the minimum value of `qualityFactor` in Modal Resonance playgrounds to 0.1 instead of 0.0. For some reason, if the quality factor is set to 0.0, audio output stops, and is not able to start again unless the playground is restarted.