### PR TITLE
memory free error in EZAudioUtilities

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -19,7 +19,7 @@ public typealias AKCallback = Void -> Void
     // MARK: Global audio format (44.1K, Stereo)
 
     /// Format of AudioKit Nodes
-    public static let format = AKSettings.audioFormat
+    public static var format = AKSettings.audioFormat
 
     // MARK: - Internal audio engine mechanics
 

--- a/AudioKit/Common/Internals/EZAudio/EZAudioUtilities.m
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioUtilities.m
@@ -709,9 +709,16 @@ BOOL __shouldExitOnCheckResultFail = YES;
 
 + (void)freeHistoryInfo:(EZPlotHistoryInfo *)historyInfo
 {
+    // This seems to be in the wrong order. It is causing memory errors in sporadic ways.
+    //    free(historyInfo->buffer);
+    //    free(historyInfo);
+    //    TPCircularBufferCleanup(&historyInfo->circularBuffer);
+    
+    // I believe the order should be:
+    
     free(historyInfo->buffer);
-    free(historyInfo);
     TPCircularBufferCleanup(&historyInfo->circularBuffer);
+    free(historyInfo);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I was getting sporadic crashes using the plots on OS X until I changed this code. As I understand EZAudio isn't supported any longer, I'm letting you know here.

// I believe the order should be:
    free(historyInfo->buffer);
    TPCircularBufferCleanup(&historyInfo->circularBuffer);
    free(historyInfo);