### PR TITLE
AKCallbackInstrument more usable

### DIFF
--- a/AudioKit/Common/MIDI/AKCallbackInstrument.swift
+++ b/AudioKit/Common/MIDI/AKCallbackInstrument.swift
@@ -15,7 +15,7 @@ public class AKCallbackInstrument: AKMIDIInstrument {
     // MARK: Properties
 
     /// All callbacks that will get triggered by MIDI events
-    public var callbacks = [AKMIDICallback]()
+    public var callback: AKMIDICallback?
 
     /// Initialize the callback instrument
     ///
@@ -25,7 +25,7 @@ public class AKCallbackInstrument: AKMIDIInstrument {
         super.init()
         let midi = AKMIDI()
         self.enableMIDI(midi.client, name: "callback midi in")
-        callbacks.append(callback)
+        self.callback = callback
         avAudioNode = AVAudioMixerNode()
         AudioKit.engine.attachNode(self.avAudioNode)
     }
@@ -33,8 +33,8 @@ public class AKCallbackInstrument: AKMIDIInstrument {
     private func triggerCallbacks(status: AKMIDIStatus,
                                   noteNumber: MIDINoteNumber,
                                   velocity: MIDIVelocity) {
-        for callback in callbacks {
-            callback(status, noteNumber, velocity)
+        if callback != nil {
+            callback!(status, noteNumber, velocity)
         }
     }
 

--- a/AudioKit/Common/MIDI/AKCallbackInstrument.swift
+++ b/AudioKit/Common/MIDI/AKCallbackInstrument.swift
@@ -21,7 +21,7 @@ public class AKCallbackInstrument: AKMIDIInstrument {
     ///
     /// - parameter callback: Initial callback
     ///
-    public init(callback: AKMIDICallback) {
+    public init(callback: AKMIDICallback? = nil) {
         super.init()
         let midi = AKMIDI()
         self.enableMIDI(midi.client, name: "callback midi in")


### PR DESCRIPTION
Changed callbacks into callback? :
- an array is unnecessary and less efficient.
- make it optional avoid some tricky things (egg-and-chicken dilemma
with callback definition and instrument init)