### PR TITLE
Removed last forward splash from filePath in AKAudioFile init for Temp Directory

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
@@ -94,7 +94,7 @@ extension AKAudioFile {
             var filePath: String
             switch baseDir {
             case .Temp:
-                filePath =  (NSTemporaryDirectory() as String) + "/" + fileNameWithExtension
+                filePath =  (NSTemporaryDirectory() as String) + fileNameWithExtension
             case .Documents:
                 filePath =  (NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]) + "/" + fileNameWithExtension
             case .Resources:


### PR DESCRIPTION
`NSTemporaryDirectory()` returns tmp directory path with forward splash **/** already added at the end.

This was causing problem issue while using `AKAudioFile`'s processing functions when target file was in tmp directory.