### PR TITLE
Fix issue with loop running x60 slower on iOS10

### DIFF
--- a/AudioKit/iOS/AudioKit/User Interface/AKPlaygroundLoop.swift
+++ b/AudioKit/iOS/AudioKit/User Interface/AKPlaygroundLoop.swift
@@ -26,7 +26,7 @@ open class AKPlaygroundLoop {
         internalHandler = handler
         let displayLink = CADisplayLink(target: self, selector: #selector(update))
         if #available(iOS 10.0, *) {
-            displayLink.preferredFramesPerSecond = 1
+            displayLink.preferredFramesPerSecond = 60
         }
         displayLink.add(to: RunLoop.current, forMode: RunLoopMode.commonModes)
     }
@@ -41,7 +41,7 @@ open class AKPlaygroundLoop {
         internalHandler = handler
         let displayLink = CADisplayLink(target: self, selector: #selector(update))
         if #available(iOS 10.0, *) {
-            displayLink.preferredFramesPerSecond = 1
+            displayLink.preferredFramesPerSecond = 60
         }
         displayLink.add(to: RunLoop.current, forMode: RunLoopMode.commonModes)
     }


### PR DESCRIPTION
The playground loop code uses a counter that counts up to a trigger. This logic depends on the loop function being called 60 times a second.

Currently this loop runs vvvvveeeerrrryyyyyy ssssslllloooooowwwwllllyyy