### PR TITLE
Ignore DerivedData folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # xcode noise
 build/
+DerivedData/
 *.pyc
 *~.nib/
 *.pbxuser


### PR DESCRIPTION
Ignores local DerivedData folder created by Xcode, where Preferences > Locations > DerivedData may be set to "Relative".