### PR TITLE
EZAudioFile updates

### DIFF
--- a/AudioKit/Common/Internals/EZAudio/EZAudioFile.h
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioFile.h
@@ -307,7 +307,7 @@ typedef void (^EZAudioWaveformDataCompletionBlock)(float **waveformData, int len
 
 /**
  A list of markers associated with the audio file. These are typically embedded within WAVE or AIFF files only.
- @return A NSArray containing the markers in the file
+ @return A NSArray containing the markers in the file. Will be NULL if no markers.
  */
 @property (readonly) NSArray *markers;
 

--- a/AudioKit/Common/Internals/EZAudio/EZAudioFile.h
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioFile.h
@@ -306,6 +306,14 @@ typedef void (^EZAudioWaveformDataCompletionBlock)(float **waveformData, int len
 //------------------------------------------------------------------------------
 
 /**
+ A list of markers associated with the audio file. These are typically embedded within WAVE or AIFF files only.
+ @return A NSArray containing the markers in the file
+ */
+@property (readonly) NSArray *markers;
+
+//------------------------------------------------------------------------------
+
+/**
  Provides the total duration of the audio file in seconds.
  @deprecated This property is deprecated starting in version 0.3.0.
  @note Please use `duration` property instead.

--- a/AudioKit/Common/Internals/EZAudio/EZAudioFile.m
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioFile.m
@@ -634,11 +634,7 @@ typedef struct
                             operation:"Failed to get the markers list"];
         
     } else {
-        // zero these out because they might have garbage in it when uninitialized
-        markers->mNumberMarkers = 0;
-        markers->mMarkers[0].mFramePosition = 0;
-        markers->mMarkers[0].mName = NULL;
-        markers->mSMPTE_TimeType = 0;
+        return NULL;
     }
     
     NSLog(@"# of markers: %d\n", markers->mNumberMarkers );

--- a/AudioKit/Common/Internals/EZAudio/EZAudioFileMarker.h
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioFileMarker.h
@@ -1,0 +1,19 @@
+//
+//  EZAudioFileMarker.h
+//
+//  Created by Ryan Francesconi on 10/29/16.
+//
+//  A simple Swift friendly wrapper around the following C struct:
+//  see: https://developer.apple.com/reference/audiotoolbox/audiofilemarker
+//  Used in EZAudioFile.markers
+
+#import <Foundation/Foundation.h>
+
+@interface EZAudioFileMarker : NSObject
+
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic) NSNumber *framePosition;
+@property (nonatomic, strong) NSNumber *markerID;
+@property (nonatomic, strong) NSNumber *type;
+
+@end

--- a/AudioKit/Common/Internals/EZAudio/EZAudioFileMarker.m
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioFileMarker.m
@@ -1,0 +1,13 @@
+//
+//  AKAudioFileMarker.m
+//  EDL
+//
+//  Created by Ryan Francesconi on 10/29/16.
+//  Copyright © 2016 Spongefork. All rights reserved.
+//
+
+#import "EZAudioFileMarker.h"
+
+@implementation EZAudioFileMarker
+
+@end

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		8D0E46581D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0E46561D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift */; };
 		8D0E46591D3827970000CCF8 /* AKAudioFile+Peripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0E46571D3827970000CCF8 /* AKAudioFile+Peripherals.swift */; };
 		8D6C6C531D421EBB008BFA4A /* AKAudioFile+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6C6C521D421EBB008BFA4A /* AKAudioFile+Utilities.swift */; };
+		B1F47ABB1DC54DCA00706A2F /* EZAudioFileMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = B1F47AB91DC54DCA00706A2F /* EZAudioFileMarker.h */; };
+		B1F47ABC1DC54DCA00706A2F /* EZAudioFileMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F47ABA1DC54DCA00706A2F /* EZAudioFileMarker.m */; };
 		C40716381D21160C00665C02 /* ADSR.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C40716371D21160C00665C02 /* ADSR.cpp */; };
 		C407163A1D21162900665C02 /* Twang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C40716391D21162900665C02 /* Twang.cpp */; };
 		C407163C1D21164E00665C02 /* Fir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C407163B1D21164E00665C02 /* Fir.cpp */; };
@@ -722,6 +724,8 @@
 		8D0E46561D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKAudioFile+ProcessingAsynchronously.swift"; sourceTree = "<group>"; };
 		8D0E46571D3827970000CCF8 /* AKAudioFile+Peripherals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKAudioFile+Peripherals.swift"; sourceTree = "<group>"; };
 		8D6C6C521D421EBB008BFA4A /* AKAudioFile+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKAudioFile+Utilities.swift"; sourceTree = "<group>"; };
+		B1F47AB91DC54DCA00706A2F /* EZAudioFileMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFileMarker.h; sourceTree = "<group>"; };
+		B1F47ABA1DC54DCA00706A2F /* EZAudioFileMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioFileMarker.m; sourceTree = "<group>"; };
 		C40716371D21160C00665C02 /* ADSR.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ADSR.cpp; sourceTree = "<group>"; };
 		C40716391D21162900665C02 /* Twang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Twang.cpp; sourceTree = "<group>"; };
 		C407163B1D21164E00665C02 /* Fir.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Fir.cpp; sourceTree = "<group>"; };
@@ -1535,6 +1539,8 @@
 				C40C41351C40E3A5009D870B /* EZAudioFFT.m */,
 				C40C41361C40E3A5009D870B /* EZAudioFile.h */,
 				C40C41371C40E3A5009D870B /* EZAudioFile.m */,
+				B1F47AB91DC54DCA00706A2F /* EZAudioFileMarker.h */,
+				B1F47ABA1DC54DCA00706A2F /* EZAudioFileMarker.m */,
 				C40C41381C40E3A5009D870B /* EZAudioFloatConverter.h */,
 				C40C41391C40E3A5009D870B /* EZAudioFloatConverter.m */,
 				C40C413A1C40E3A5009D870B /* EZAudioFloatData.h */,
@@ -3332,6 +3338,7 @@
 				C48C6C4F1D3C15F1008EA51B /* kiss_fft.h in Headers */,
 				C49D69721D1F1DE300BF018A /* AKMorphingOscillatorBankAudioUnit.h in Headers */,
 				C40718061D2119BF00665C02 /* SineWave.h in Headers */,
+				B1F47ABB1DC54DCA00706A2F /* EZAudioFileMarker.h in Headers */,
 				C42F35041C057E03000E937C /* AudioKit.h in Headers */,
 				C40C415C1C40E3A5009D870B /* EZAudioPlayer.h in Headers */,
 				C4537FDE1C3A438D00A51738 /* AKMoogLadderAudioUnit.h in Headers */,
@@ -3918,6 +3925,7 @@
 				C40C416C1C40E3A5009D870B /* TPCircularBuffer.c in Sources */,
 				C48C6D161D3C15F2008EA51B /* pshift.c in Sources */,
 				C48C6D3A1D3C15F2008EA51B /* zeros.c in Sources */,
+				B1F47ABC1DC54DCA00706A2F /* EZAudioFileMarker.m in Sources */,
 				C48C6CF11D3C15F2008EA51B /* gbuzz.c in Sources */,
 				C48C6D351D3C15F2008EA51B /* tseq.c in Sources */,
 				C4FF7CB01D9F7F0B001BB82C /* AudioUnit+Helpers.swift in Sources */,

--- a/AudioKit/macOS/AudioKit for macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit for macOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B1F47AB71DC5385500706A2F /* EZAudioFileMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = B1F47AB51DC5385500706A2F /* EZAudioFileMarker.h */; };
+		B1F47AB81DC5385500706A2F /* EZAudioFileMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F47AB61DC5385500706A2F /* EZAudioFileMarker.m */; };
 		C42899921D552E2C00B941B5 /* smoothDelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899911D552E2C00B941B5 /* smoothDelay.swift */; };
 		C42899941D552F9F00B941B5 /* lowPassButterworthFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899931D552F9F00B941B5 /* lowPassButterworthFilter.swift */; };
 		C42899961D5543E400B941B5 /* korgLowPassFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899951D5543E400B941B5 /* korgLowPassFilter.swift */; };
@@ -728,6 +730,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B1F47AB51DC5385500706A2F /* EZAudioFileMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFileMarker.h; sourceTree = "<group>"; };
+		B1F47AB61DC5385500706A2F /* EZAudioFileMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioFileMarker.m; sourceTree = "<group>"; };
 		C42899911D552E2C00B941B5 /* smoothDelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = smoothDelay.swift; sourceTree = "<group>"; };
 		C42899931D552F9F00B941B5 /* lowPassButterworthFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = lowPassButterworthFilter.swift; sourceTree = "<group>"; };
 		C42899951D5543E400B941B5 /* korgLowPassFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = korgLowPassFilter.swift; sourceTree = "<group>"; };
@@ -1605,6 +1609,8 @@
 				C45662D51D448D7D00D26565 /* EZAudioFFT.m */,
 				C45662D61D448D7D00D26565 /* EZAudioFile.h */,
 				C45662D71D448D7D00D26565 /* EZAudioFile.m */,
+				B1F47AB51DC5385500706A2F /* EZAudioFileMarker.h */,
+				B1F47AB61DC5385500706A2F /* EZAudioFileMarker.m */,
 				C45662D81D448D7D00D26565 /* EZAudioFloatConverter.h */,
 				C45662D91D448D7D00D26565 /* EZAudioFloatConverter.m */,
 				C45662DA1D448D7D00D26565 /* EZAudioFloatData.h */,
@@ -3464,6 +3470,7 @@
 				C45668221D448D7E00D26565 /* Noise.h in Headers */,
 				C45669681D448D7E00D26565 /* AKFMOscillatorDSPKernel.hpp in Headers */,
 				C45669351D448D7E00D26565 /* AKToneComplementFilterDSPKernel.hpp in Headers */,
+				B1F47AB71DC5385500706A2F /* EZAudioFileMarker.h in Headers */,
 				C456695A1D448D7E00D26565 /* AKOperationGeneratorAudioUnit.h in Headers */,
 				C45666AF1D448D7E00D26565 /* EZAudio.h in Headers */,
 				C45669071D448D7E00D26565 /* AKHighShelfParametricEqualizerFilterAudioUnit.h in Headers */,
@@ -4000,6 +4007,7 @@
 				C45668C11D448D7E00D26565 /* AKOperationEffect.swift in Sources */,
 				C456697C1D448D7E00D26565 /* AKOscillatorBankAudioUnit.mm in Sources */,
 				C45667141D448D7E00D26565 /* panst.c in Sources */,
+				B1F47AB81DC5385500706A2F /* EZAudioFileMarker.m in Sources */,
 				C45668B01D448D7E00D26565 /* AKMIDIStatus.swift in Sources */,
 				C45667881D448D7E00D26565 /* loadspa.c in Sources */,
 				C45667851D448D7E00D26565 /* jitter.c in Sources */,

--- a/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
+++ b/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		524B77BA1CC4B060001D82D1 /* AKNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524B77B91CC4B060001D82D1 /* AKNotifications.swift */; };
+		B1F47ABF1DC54E0F00706A2F /* EZAudioFileMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = B1F47ABD1DC54E0F00706A2F /* EZAudioFileMarker.h */; };
+		B1F47AC01DC54E0F00706A2F /* EZAudioFileMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F47ABE1DC54E0F00706A2F /* EZAudioFileMarker.m */; };
 		C40718281D211AB400665C02 /* ADSR.h in Headers */ = {isa = PBXBuildFile; fileRef = C407181B1D211AB400665C02 /* ADSR.h */; };
 		C40718291D211AB400665C02 /* DelayA.h in Headers */ = {isa = PBXBuildFile; fileRef = C407181C1D211AB400665C02 /* DelayA.h */; };
 		C407182A1D211AB400665C02 /* DelayL.h in Headers */ = {isa = PBXBuildFile; fileRef = C407181D1D211AB400665C02 /* DelayL.h */; };
@@ -679,6 +681,8 @@
 
 /* Begin PBXFileReference section */
 		524B77B91CC4B060001D82D1 /* AKNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKNotifications.swift; sourceTree = "<group>"; };
+		B1F47ABD1DC54E0F00706A2F /* EZAudioFileMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFileMarker.h; sourceTree = "<group>"; };
+		B1F47ABE1DC54E0F00706A2F /* EZAudioFileMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioFileMarker.m; sourceTree = "<group>"; };
 		C407181B1D211AB400665C02 /* ADSR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADSR.h; sourceTree = "<group>"; };
 		C407181C1D211AB400665C02 /* DelayA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DelayA.h; sourceTree = "<group>"; };
 		C407181D1D211AB400665C02 /* DelayL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DelayL.h; sourceTree = "<group>"; };
@@ -1411,6 +1415,8 @@
 				C40C41F21C40E5C2009D870B /* EZAudioFFT.m */,
 				C40C41F31C40E5C2009D870B /* EZAudioFile.h */,
 				C40C41F41C40E5C2009D870B /* EZAudioFile.m */,
+				B1F47ABD1DC54E0F00706A2F /* EZAudioFileMarker.h */,
+				B1F47ABE1DC54E0F00706A2F /* EZAudioFileMarker.m */,
 				C40C41F51C40E5C2009D870B /* EZAudioFloatConverter.h */,
 				C40C41F61C40E5C2009D870B /* EZAudioFloatConverter.m */,
 				C40C41F71C40E5C2009D870B /* EZAudioFloatData.h */,
@@ -3115,6 +3121,7 @@
 				C48C6ACE1D3C1574008EA51B /* test.h in Headers */,
 				C40C42861C41BF00009D870B /* AKPluckedStringDSPKernel.hpp in Headers */,
 				C48C6AD21D3C1574008EA51B /* ugens.h in Headers */,
+				B1F47ABF1DC54E0F00706A2F /* EZAudioFileMarker.h in Headers */,
 				C45381C01C3A5CBD00A51738 /* AKFormantFilterAudioUnit.h in Headers */,
 				C453821A1C3A5CBD00A51738 /* AKOscillatorDSPKernel.hpp in Headers */,
 				C45381F11C3A5CBD00A51738 /* AKToneComplementFilterAudioUnit.h in Headers */,
@@ -3436,6 +3443,7 @@
 				C48C6B291D3C1574008EA51B /* rpt.c in Sources */,
 				C4ABF5371C82AEC00078EE8E /* AKMetalBar.swift in Sources */,
 				C4E3769F1D1357D900FDB70D /* Fir.cpp in Sources */,
+				B1F47AC01DC54E0F00706A2F /* EZAudioFileMarker.m in Sources */,
 				C48C6B151D3C1574008EA51B /* oscmorph.c in Sources */,
 				C4E376861D1357D900FDB70D /* ADSR.cpp in Sources */,
 				C48C6A921D3C1574008EA51B /* noise.c in Sources */,


### PR DESCRIPTION
I've added support for embedded markers for WAVE/AIFF files into EZAudioFile. Since you have to deal with the AudioToolbox C stuff to dig these out, I thought this'd be the best place to put this. I've added a new class EZAudioFileMarker to facilitate simpler Swift access over the native C structs that are returned.

I'm not positive this is the best way to import to Swift, but it is working fine like so:

```
            if let markerList = _file.markers {

                Swift.print("Marker List: \(markerList)")
                
                for afm in markerList {
                    let m = afm as! EZAudioFileMarker
                    Swift.print( "name:\(m.name) markerID: \(m.markerID) framePosition: \(m.framePosition) type: \(m.type) ")
                }
```
