### PR TITLE
Added support for multi-stream interfaces

### DIFF
--- a/AudioKit/Common/Internals/EZAudio/EZAudioDevice.m
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioDevice.m
@@ -396,21 +396,33 @@
     address.mElement = kAudioObjectPropertyElementMaster;
     address.mSelector = kAudioDevicePropertyStreamConfiguration;
     
-    AudioBufferList streamConfiguration = { 0 };
-    UInt32 propSize = sizeof(streamConfiguration);
+    UInt32 dataSize = 0;
+    [EZAudioUtilities checkResult:AudioObjectGetPropertyDataSize(deviceID,
+                                                                 &address,
+                                                                 0,
+                                                                 NULL,
+                                                                 &dataSize)
+                        operation:"Failed to get buffer size"];
+    
+    AudioBufferList *bufferList = (AudioBufferList *)(malloc(dataSize));
+
     [EZAudioUtilities checkResult:AudioObjectGetPropertyData(deviceID,
                                                  &address,
                                                  0,
                                                  NULL,
-                                                 &propSize,
-                                                 &streamConfiguration)
-                        operation:"Failed to get frame size"];
+                                                 &dataSize,
+                                                 bufferList)
+                        operation:"Failed to get buffer list"];
+    
+    UInt32 numBuffers = bufferList->mNumberBuffers;
     
     NSInteger channelCount = 0;
-    for (NSInteger i = 0; i < streamConfiguration.mNumberBuffers; i++)
+    for (NSInteger i = 0; i < numBuffers; i++)
     {
-        channelCount += streamConfiguration.mBuffers[i].mNumberChannels;
+        channelCount += bufferList->mBuffers[i].mNumberChannels;
     }
+    
+    free(bufferList), bufferList = NULL;
     
     return channelCount;
 }


### PR DESCRIPTION
On interfaces that contain more then 1 stream, this method would fail. Reason being because you needed to get the size of the buffer, but originally it was defaulted to 0 and thus failed.

Also renamed a couple variables to make it more readable.