### PR TITLE
Fix delay issue with AKFFTTap

### DIFF
--- a/AudioKit/Common/Taps/AKFFTTap.swift
+++ b/AudioKit/Common/Taps/AKFFTTap.swift
@@ -11,11 +11,11 @@ import Foundation
 /// FFT Calculation for any node
 @objc open class AKFFTTap: NSObject, EZAudioFFTDelegate {
     
-    internal let bufferSize: UInt32 = 512
+    internal let bufferSize: UInt32 = 1024
     internal var fft: EZAudioFFT?
     
     /// Array of FFT data
-    open var fftData = [Double](zeroes: 512)
+    open var fftData = [Double](zeroes: 1024)
     
     /// Initialze the FFT calculation on a given node
     ///
@@ -37,7 +37,7 @@ import Foundation
     /// Callback function for FFT computation
     @objc open func fft(_ fft: EZAudioFFT!, updatedWithFFTData fftData: UnsafeMutablePointer<Float>, bufferSize: vDSP_Length) {
         DispatchQueue.main.async { () -> Void in
-            for i in 0...511 {
+            for i in 0..<1024 {
                 self.fftData[i] = Double(fftData[i])
             }
         }

--- a/AudioKit/Common/Taps/AKFFTTap.swift
+++ b/AudioKit/Common/Taps/AKFFTTap.swift
@@ -15,7 +15,7 @@ import Foundation
     internal var fft: EZAudioFFT?
     
     /// Array of FFT data
-    open var fftData = [Double](zeroes: 1024)
+    open var fftData = [Double](zeroes: 512)
     
     /// Initialze the FFT calculation on a given node
     ///
@@ -37,7 +37,7 @@ import Foundation
     /// Callback function for FFT computation
     @objc open func fft(_ fft: EZAudioFFT!, updatedWithFFTData fftData: UnsafeMutablePointer<Float>, bufferSize: vDSP_Length) {
         DispatchQueue.main.async { () -> Void in
-            for i in 0..<1024 {
+            for i in 0..<512 {
                 self.fftData[i] = Double(fftData[i])
             }
         }


### PR DESCRIPTION
AKFFTTap had long delays of more than 1000ms.
Since AKNodeFFTPlot worked well and has a larger buffer (1024 instead of 512), I tried that value in AKFFTTap and it resolved the issue.

A clue also came from AVAudionode.installTap where the documentation says "Supported range is [100, 400] ms." That doesn't seem to be true since 1024 works fine but 1024 / 44100/s = 0.02322..s < 100ms, i.e. outside the documented range, but it served as clue that the buffer might be too small.

The other thing I noticed is that `fftData` should be half the size. Since the input for the FFT is real the first half of `fftData` was always zero anyways.

So it's two changes in one (which might be confusing), so I've split it in two commits.

Lastly, I wonder if `fftData` shouldn't just be Float. (?)