### PR TITLE
Making cc messages always 3 bytes

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -248,13 +248,16 @@ public struct AKMIDIEvent {
         
         switch status {
         case .controllerChange:
+            length = 3
+            /*
+            //this code was causing problems with our midi parser. Even though the last byte of a cc might be undefined, it is probably worth leaving in, as they still come in as 3-byte values, and someone might actually be using this 3rd byte for a custom application.
             if byte1 < AKMIDIControl.dataEntryPlus.rawValue ||
                 byte1 == AKMIDIControl.localControlOnOff.rawValue {
                 
-                length = 3
             } else {
                 length = 2
             }
+             */
         case .channelAftertouch: break
         case .programChange:
             length = 2

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -249,15 +249,6 @@ public struct AKMIDIEvent {
         switch status {
         case .controllerChange:
             length = 3
-            /*
-            //this code was causing problems with our midi parser. Even though the last byte of a cc might be undefined, it is probably worth leaving in, as they still come in as 3-byte values, and someone might actually be using this 3rd byte for a custom application.
-            if byte1 < AKMIDIControl.dataEntryPlus.rawValue ||
-                byte1 == AKMIDIControl.localControlOnOff.rawValue {
-                
-            } else {
-                length = 2
-            }
-             */
         case .channelAftertouch: break
         case .programChange:
             length = 2


### PR DESCRIPTION
There are a few messages that have the 3rd byte undefined by the MIDI standard (CC 96-121 [60-79 in hex]).
AK was dropping that byte from the midi event, creating a non-standard 2-byte cc message. Even if that 3rd byte is undefined, it should be included so all cc messages are 3 bytes, in case a midi developer decides to use those cc's for their own purposes (which is how I found this bug...a hardware manufacturer was using midi cc 119 for a custom message).