### PR TITLE
Fix crash with AKMIDISampler and AKSequencer

### DIFF
--- a/AudioKit/Common/MIDI/Packets/MIDIPacketList+SequenceType.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacketList+SequenceType.swift
@@ -5,27 +5,31 @@
 //  Created by Aurelius Prochazka, revision history on Github.
 //  Copyright © 2016 AudioKit. All rights reserved.
 //
+import CoreMIDI
 
 extension MIDIPacketList: Sequence {
     /// Type alis for MIDI Packet List Generator
-    public typealias Element = MIDIPacket
+//    public typealias Element = MIDIPacket
+    public typealias Iterator = MIDIPacketListGenerator
     /// Create a generator from the packet list
-    public func makeIterator() -> AnyIterator<Element> {
-      var i = 0
-      var ptr = UnsafeMutablePointer<Element>.allocate(capacity: 1)
-      ptr.initialize(to: packet)
-
-      return AnyIterator {
-          guard i < Int(self.numPackets) else {
-            ptr.deallocate(capacity: 1)
-            return nil
-          }
-
-          defer {
-            ptr = MIDIPacketNext(ptr)
-            i += 1
-          }
-          return ptr.pointee
-      }
+    public func makeIterator() -> Iterator {
+        return Iterator(packetList: self)
     }
+//      var i = 0
+//      var ptr = UnsafeMutablePointer<Element>.allocate(capacity: 1)
+//      ptr.initialize(to: packet)
+//
+//      return AnyIterator {
+//          guard i < Int(self.numPackets) else {
+//            ptr.deallocate(capacity: 1)
+//            return nil
+//          }
+//
+//          defer {
+//            ptr = MIDIPacketNext(ptr)
+//            i += 1
+//          }
+//          return ptr.pointee
+//      }
+//    }
 }

--- a/AudioKit/Common/MIDI/Packets/MIDIPacketList+SequenceType.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacketList+SequenceType.swift
@@ -5,7 +5,6 @@
 //  Created by Aurelius Prochazka, revision history on Github.
 //  Copyright © 2016 AudioKit. All rights reserved.
 //
-import CoreMIDI
 
 extension MIDIPacketList: Sequence {
     /// Type alis for MIDI Packet List Generator

--- a/AudioKit/Common/MIDI/Packets/MIDIPacketListGenerator.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacketListGenerator.swift
@@ -1,0 +1,40 @@
+//
+//  MIDIPacketListGenerator.swift
+//  AudioKit
+//
+//  Created by Aurelius Prochazka, revision history on Github.
+//  Copyright © 2016 AudioKit. All rights reserved.
+//
+
+/// Generator for MIDIPacketList allowing iteration over its list of MIDIPacket objects.
+public struct MIDIPacketListGenerator: IteratorProtocol {
+    public typealias Element = MIDIPacket
+    
+    /// Initialize the packet list generator with a packet list
+    ///
+    /// - parameter packetList: MIDI Packet List
+    ///
+    init(packetList: MIDIPacketList) {
+        let ptr = UnsafeMutablePointer<MIDIPacket>.allocate(capacity: 1)
+        ptr.initialize(to: packetList.packet)
+        self.packet = ptr
+        self.count = packetList.numPackets
+    }
+    
+    /// Provide the next element (packet)
+    public mutating func next() -> Element? {
+        guard self.packet != nil && self.index < self.count else { return nil }
+        
+        let lastPacket = self.packet!
+        self.packet = MIDIPacketNext(self.packet!)
+        self.index += 1
+        return lastPacket.pointee
+    }
+    
+    // Extracted packet list info
+    var count: UInt32
+    var index: UInt32 = 0
+    
+    // Iteration state
+    var packet: UnsafeMutablePointer<MIDIPacket>?
+}

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -300,6 +300,14 @@ open class AKAudioPlayer: AKNode, AKToggleable {
         }
     }
     
+    open func resume() {
+        if !playing && paused {
+            playing = true
+            paused = false
+            internalPlayer.play()
+        }
+    }
+    
     /// resets in and out times for playing
     open func reloadFile() throws {
         let wasPlaying  = playing


### PR DESCRIPTION
It looks a rewrite of how the MIDIPacketList iterator worked between version 3.5 and 3.5.1 led to crashes in an app which used MP3's or WAV's via AKMIDISampler.

The guard statement in MIDIPacketList+SequenceType which deallocated packets was triggering a object freed before being allocated error. I assume there was a reason it was rewritten so if there's a way to reincorporate those changes whilst making it safe for use in the situations I've found let me know and hopefully we can solve it.


There's also a small addition to AKAudioPlayer which adds a resume() method which doesn't jump to the start of a track after starting again after a pause.