### PR TITLE
Fix for issue: Pause / Play broken on AKAudioPlayer #686

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -252,7 +252,10 @@ open class AKAudioPlayer: AKNode, AKToggleable {
         if !playing {
             if audioFileBuffer != nil {
                 // schedule it at some point in the future / or immediately if 0
-                scheduleBuffer( secondsToAVAudioTime(scheduledTime) )
+                // don't schedule the buffer if it is paused as it will overwrite what is in it
+                if !paused {
+                    scheduleBuffer( secondsToAVAudioTime(scheduledTime) )
+                }
                 
                 playing = true
                 paused = false


### PR DESCRIPTION
Buffer was being overwritten in the start() method despite pause being true.