### PR TITLE
Added deinit methods to cleanup framework references

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDISampler.swift
+++ b/AudioKit/Common/MIDI/AKMIDISampler.swift
@@ -114,5 +114,13 @@ open class AKMIDISampler: AKSampler {
     open override func stop(noteNumber: MIDINoteNumber, channel: MIDIChannel) {
         samplerUnit.stopNote(UInt8(noteNumber), onChannel: UInt8(channel))
     }
+    
+    // Discard all virtual ports
+    open func destroyEndpoint() {
+        if midiIn != 0 {
+            MIDIEndpointDispose(midiIn)
+            midiIn = 0
+        }
+    }
 
 }

--- a/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
@@ -63,6 +63,22 @@ open class AKSequencer {
         NewMusicPlayer(&musicPlayer)
         MusicPlayerSetSequence(musicPlayer!, sequence)
     }
+    
+    deinit {
+        if let player = musicPlayer {
+            DisposeMusicPlayer(player)
+        }
+        
+        if let seq = sequence {
+            for track in self.tracks {
+                if let intTrack = track.internalMusicTrack {
+                    MusicSequenceDisposeTrack(seq, intTrack)
+                }
+            }
+            
+            DisposeMusicSequence(seq)
+        }
+    }
 
     /// Initialize the sequence with a MIDI file
     ///

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -44,6 +44,10 @@ extension AVAudioConnectionPoint {
                                 fromBus: bus,
                                 format: AudioKit.format)
     }
+    
+    deinit {
+        AudioKit.engine.detach(self.avAudioNode)
+    }
 }
 
 /// Protocol for responding to play and stop of MIDI notes

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -244,6 +244,10 @@ open class AKAudioPlayer: AKNode, AKToggleable {
         initialize()
     }
     
+    deinit {
+        AudioKit.engine.detach(internalPlayer)
+    }
+    
     // MARK: - Methods
     
     /// Start playback


### PR DESCRIPTION
I create and recreate AudioKit setups for a few different situations in my app and realised some underlying audiokit references weren't being cleared up. This seems to remove the ones I've experienced without any issues.