### PR TITLE
Let AKSampler propagate exceptions

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Sampler/AKSampler.swift
@@ -53,14 +53,15 @@ open class AKSampler: AKNode {
     ///
     /// - parameter file: Name of the file without an extension (assumed to be accessible from the bundle)
     ///
-    open func loadWav(_ file: String) {
+    open func loadWav(_ file: String) throws {
         guard let url = Bundle.main.url(forResource: file, withExtension: "wav") else {
                 fatalError("file not found.")
         }
         do {
             try samplerUnit.loadAudioFiles(at: [url])
-        } catch {
-            AKLog("Error loading wav file at the given file location.")
+        } catch let error as NSError {
+            AKLog("Error loading wav file at \(url)")
+            throw error
         }
     }
 
@@ -68,8 +69,8 @@ open class AKSampler: AKNode {
     ///
     /// - parameter file: Name of the EXS24 file without the .exs extension
     ///
-    open func loadEXS24(_ file: String) {
-        loadInstrument(file, type: "exs")
+    open func loadEXS24(_ file: String) throws {
+        try loadInstrument(file, type: "exs")
     }
 
     /// Load an AKAudioFile
@@ -80,7 +81,7 @@ open class AKSampler: AKNode {
         do {
             try samplerUnit.loadAudioFiles(at: [file.url])
         } catch let error as NSError {
-            AKLog("AKSampler Error loading \"\(file.fileNamePlusExtension)\" !...")
+            AKLog("Error loading audio file \"\(file.fileNamePlusExtension)\"")
             throw error
         }
     }
@@ -97,12 +98,12 @@ open class AKSampler: AKNode {
         do {
             try samplerUnit.loadAudioFiles(at: urls)
         } catch let error as NSError {
-            AKLog("AKSampler Error loading audioFiles !...")
+            AKLog("Error loading audio files \(urls)")
             throw error
         }
     }
 
-    fileprivate func loadSoundFont(_ file: String, preset: Int, type: Int) {
+    fileprivate func loadSoundFont(_ file: String, preset: Int, type: Int) throws {
         guard let url = Bundle.main.url(forResource: file, withExtension: "sf2") else {
             fatalError("file not found.")
         }
@@ -112,8 +113,9 @@ open class AKSampler: AKNode {
                 program: MIDIByte(preset),
                 bankMSB: MIDIByte(type),
                 bankLSB: MIDIByte(kAUSampler_DefaultBankLSB))
-        } catch {
-            AKLog("Error loading SoundFont.")
+        } catch let error as NSError {
+            AKLog("Error loading SoundFont \(file)")
+            throw error
         }
     }
 
@@ -123,8 +125,8 @@ open class AKSampler: AKNode {
     ///   - file: Name of the SoundFont SF2 file without the .sf2 extension
     ///   - preset: Number of the program to use
     ///
-    open func loadMelodicSoundFont(_ file: String, preset: Int) {
-        loadSoundFont(file, preset: preset, type: kAUSampler_DefaultMelodicBankMSB)
+    open func loadMelodicSoundFont(_ file: String, preset: Int) throws {
+        try loadSoundFont(file, preset: preset, type: kAUSampler_DefaultMelodicBankMSB)
     }
 
     /// Load a Percussive SoundFont SF2 sample data file
@@ -133,8 +135,8 @@ open class AKSampler: AKNode {
     ///   - file: Name of the SoundFont SF2 file without the .sf2 extension
     ///   - preset: Number of the program to use
     ///
-    open func loadPercussiveSoundFont(_ file: String, preset: Int) {
-        loadSoundFont(file, preset: preset, type: kAUSampler_DefaultPercussionBankMSB)
+    open func loadPercussiveSoundFont(_ file: String, preset: Int) throws {
+        try loadSoundFont(file, preset: preset, type: kAUSampler_DefaultPercussionBankMSB)
     }
 
 
@@ -146,19 +148,20 @@ open class AKSampler: AKNode {
         do {
             try samplerUnit.loadInstrument(at: URL(fileURLWithPath: filePath))
         } catch {
-            AKLog("Error loading file at given file path.")
+            AKLog("Error loading audio file at \(filePath)")
         }
     }
 
-    internal func loadInstrument(_ file: String, type: String) {
+    internal func loadInstrument(_ file: String, type: String) throws {
         //AKLog("filename is \(file)")
         guard let url = Bundle.main.url(forResource: file, withExtension: type) else {
-                fatalError("file not found.")
+            fatalError("file not found.")
         }
         do {
             try samplerUnit.loadInstrument(at: url)
-        } catch {
-            AKLog("Error loading instrument.")
+        } catch let error as NSError {
+            AKLog("Error loading instrument resource \(file)")
+            throw error
         }
     }
 

--- a/Examples/iOS/SamplerDemo/SamplerDemo/Conductor.swift
+++ b/Examples/iOS/SamplerDemo/SamplerDemo/Conductor.swift
@@ -39,10 +39,10 @@ class Conductor {
         filter?.cutoffFrequency = 20000
         AudioKit.output = filter
 
-        arpeggioSynthesizer.loadEXS24("Sounds/Sampler Instruments/sqrTone1")
-        padSynthesizer.loadEXS24("Sounds/Sampler Instruments/sawPad1")
-        bassSynthesizer.loadEXS24("Sounds/Sampler Instruments/sawPiano1")
-        drumKit.loadEXS24("Sounds/Sampler Instruments/drumSimp")
+        try! arpeggioSynthesizer.loadEXS24("Sounds/Sampler Instruments/sqrTone1")
+        try! padSynthesizer.loadEXS24("Sounds/Sampler Instruments/sawPad1")
+        try! bassSynthesizer.loadEXS24("Sounds/Sampler Instruments/sawPiano1")
+        try! drumKit.loadEXS24("Sounds/Sampler Instruments/drumSimp")
         AudioKit.start()
         sequence = AKSequencer(filename: "seqDemo", engine: AudioKit.engine)
         sequence?.enableLooping()
@@ -108,11 +108,11 @@ class Conductor {
         
         switch synthesizer {
         case Synthesizer.Arpeggio:
-            arpeggioSynthesizer.loadEXS24(path)
+            try! arpeggioSynthesizer.loadEXS24(path)
         case Synthesizer.Pad:
-            padSynthesizer.loadEXS24(path)
+            try! padSynthesizer.loadEXS24(path)
         case Synthesizer.Bass:
-            bassSynthesizer.loadEXS24(path)
+            try! bassSynthesizer.loadEXS24(path)
         }
     }
     


### PR DESCRIPTION
I think it would be a good idea to be able to get more information when the various loading functions for `AKSampler` fail. This changes the APIs to let the methods throw any raised exceptions.

Also cleaned up a little bit what was being sent to `AKLog()` for consistency.