### PR TITLE
Memory error in DSPKernel

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/DSPKernel.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/DSPKernel.hpp
@@ -120,10 +120,13 @@ public:
     }
 
     ~AKSporthKernel() {
+        //printf("~AKSporthKernel(), &sp is %p\n", (void *)sp);
+        // releasing the memory in the destructor only
         sp_destroy(&sp);
     }
+    
     void destroy() {
-        sp_destroy(&sp);
+        //printf("AKSporthKernel.destroy(), &sp is %p\n", (void *)sp);
     }
 };
 

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -46,6 +46,7 @@ extension AVAudioConnectionPoint {
     }
     
     deinit {
+        //AKLog("* AKNode")
         AudioKit.engine.detach(self.avAudioNode)
     }
 }

--- a/AudioKit/Common/Nodes/Analysis/Amplitude Tracker/AKAmplitudeTracker.swift
+++ b/AudioKit/Common/Nodes/Analysis/Amplitude Tracker/AKAmplitudeTracker.swift
@@ -82,6 +82,10 @@ open class AKAmplitudeTracker: AKNode, AKToggleable, AKComponent {
         halfPowerPointParameter?.setValue(Float(halfPowerPoint), originator: token!)
     }
 
+    deinit {
+        AKLog("* AKAmplitudeTracker")
+    }
+    
     // MARK: - Control
 
     /// Function to start, play, or activate the node, all do the same thing
@@ -94,7 +98,4 @@ open class AKAmplitudeTracker: AKNode, AKToggleable, AKComponent {
         internalAU!.stop()
     }
     
-    deinit {
-        AKLog("* AKAmplitudeTracker")
-    }
 }

--- a/AudioKit/Common/Nodes/Analysis/Amplitude Tracker/AKAmplitudeTrackerDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Analysis/Amplitude Tracker/AKAmplitudeTrackerDSPKernel.hpp
@@ -43,8 +43,9 @@ public:
     }
 
     void destroy() {
-        sp_rms_destroy(&rms);
+        //printf("AKAmplitudeTrackerDSPKernel.destroy() \n");
         AKSporthKernel::destroy();
+        sp_rms_destroy(&rms);
     }
 
     void reset() {

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -236,6 +236,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
     
     deinit {
+        AKLog("* AKAudioPlayer")
         AudioKit.engine.detach(internalPlayer)
     }
     

--- a/AudioKit/Common/Playgrounds/Playback.playground/Pages/Phase-Locked Vocoder.xcplaygroundpage/Contents.swift
+++ b/AudioKit/Common/Playgrounds/Playback.playground/Pages/Phase-Locked Vocoder.xcplaygroundpage/Contents.swift
@@ -22,7 +22,7 @@ class PlaygroundView: AKPlaygroundView {
     
     override func setup() {
         
-        addTitle("Phsae Locked Vocoder")
+        addTitle("Phase Locked Vocoder")
         
         
         playingPositionSlider = AKPropertySlider(


### PR DESCRIPTION
There was a double freed error happening in DSPKernel.hpp 
(*** error for object 0xbaddc0dedeadbead: pointer being freed was not allocated) 

This was because the destroy() method of AKAmplitudeTrackerDSPKernel was being explicitly called but the destructor was also being triggered, the same pointer was being freed twice in both the destructor and in the destroy(). Please check this as I'm seeing some weird behavior about when the destroy() methods are being called. I'm seeing destroy() being called on objects that I never instantiated personally! 

This fix solves the crash I was seeing, but perhaps there are other situations? 

This crash is related to adding deinit { engine.detach() } to AKNode as well as the previous memory fix I did for the self in closures for AUv3. Reason being, I believe beforehand because the memory was being leaked and the objects held onto - these destroy methods were never called. This is my theory anyway! Once things are properly released, this bug was revealed. BOOM!
