### PR TITLE
Create URL for export session with fileURLWithPath

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
@@ -328,7 +328,7 @@ extension AKAudioFile {
             }
         }
 
-        let asset = AVURLAsset(url: url)
+        let asset = AVURLAsset(url: URL(fileURLWithPath: url.absoluteString))
         if let internalExportSession = AVAssetExportSession(asset: asset, presetName: avExportPreset) {
             AKLog("internalExportSession session created")
 


### PR DESCRIPTION
This is a proposed fix for #709. It re-creates the URL for the `AVAssetExportSession` using `fileURLWithPath`. There might be a nicer way of doing this elsewhere, but I think this is the safest fix for me to make without more knowledge of the framework.