### PR TITLE
added touch logic polyphonic and mono keyboard modes

### DIFF
--- a/AudioKit/iOS/AudioKit/User Interface/AKKeyboardView.swift
+++ b/AudioKit/iOS/AudioKit/User Interface/AKKeyboardView.swift
@@ -71,6 +71,7 @@ public protocol AKKeyboardDelegate: class {
     
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        isMultipleTouchEnabled = true
     }
     
     // MARK: - Storyboard Rendering


### PR DESCRIPTION
(first pull request, so apologies if I'm a little off on github practices)

This implementation seems to behave touch-wise as I would expect a touch keyboard to behave.  In mono mode, if there are multiple keys being pressed down and the key which is actually being sounded is removed, it will replace it with the key from the highest remaining touch.

One limitation of this implementation is that if a touch originates outside of the AKKeyboardView frame and is dragged onto a key, that touch won't register.  I'm sure that there are ways around that in a project, but the workaround would involve code in the superview.  I don't think that limitation is a big deal anyway.
I will keep playing around with other improvements here.
