### PR TITLE
Proposed fix to EZAudioPlot continuous redraw of non-rolling waveform

### DIFF
--- a/AudioKit/Common/Internals/EZAudio/EZAudioPlot.m
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioPlot.m
@@ -353,6 +353,7 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
         case EZPlotTypeBuffer:
             [self setSampleData:buffer
                          length:bufferSize];
+            [self redraw];
             break;
         case EZPlotTypeRolling:
             
@@ -444,7 +445,9 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
 
 - (void)displayLinkNeedsDisplay:(EZAudioDisplayLink *)displayLink
 {
-    [self redraw];
+    if (self.plotType == EZPlotTypeRolling) {
+        [self redraw];
+    }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Hey Aure,

I'm back from the dead.

Hey, in EZAudioKit's EZAudioPlot.m file, I've discovered that the **displayLinkNeedsDisplay** method is getting continuously fired from EZAudioDisplayLink's CADisplayLink target callback, of which EZAudioPlot is a delegate. It appears this was intended for rolling audio waveform buffers, so that buffers would be continuously rendered by EZAudioPlot. The delegate method triggers a redraw every time the display link fires, which is basically all the time.

However, with static non-rolling buffers, there's no need for the expensive redraw to keep getting fired. I have three separate instances of EZAudioPlot on my app, and on an old iPad 3, this resulted in a continuous chewing up of 30% more CPU, about 10% per audio plot.

I think I've figured out a good solution which seems to work well so far. Check out the diff below. The delegate method only performs a redraw if it's a rolling waveform, and the updateBuffer method does a manual redraw if it's non-rolling. EZAudioPlot is ultimately a UIView, and if the user changes the plotType to or from rolling, this code should handle the change on the fly.