### PR TITLE
Fix memory leak when init() is called more than once

### DIFF
--- a/AudioKit/Common/Internals/Soundpipe/modules/ptrack.c
+++ b/AudioKit/Common/Internals/Soundpipe/modules/ptrack.c
@@ -92,7 +92,7 @@ typedef struct peak
 
 int sp_ptrack_create(sp_ptrack **p)
 {
-    *p = malloc(sizeof(sp_ptrack));
+    *p = calloc(1, sizeof(sp_ptrack));
     return SP_OK;
 }
 

--- a/AudioKit/Common/Nodes/Analysis/Frequency Tracker/AKFrequencyTrackerDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Analysis/Frequency Tracker/AKFrequencyTrackerDSPKernel.hpp
@@ -26,9 +26,11 @@ public:
 
     void init(int _channels, double _sampleRate) override {
         AKSoundpipeKernel::init(_channels, _sampleRate);
+        if (ptrack != nullptr) {
+          sp_ptrack_destroy(&ptrack);
+        }
         sp_ptrack_create(&ptrack);
         sp_ptrack_init(sp, ptrack, hopSize, peakCount);
-
     }
     
     void start() {
@@ -93,7 +95,7 @@ private:
     int hopSize = 4096;
     int peakCount = 20;
 
-    sp_ptrack *ptrack;
+    sp_ptrack *ptrack = nullptr;
 
 public:
     float trackedAmplitude = 0.0;


### PR DESCRIPTION
Noticed this while debugging. The question is, should all init() methods be safe to call more than once?