### PR TITLE
Move notification handling code to main thread/queue

### DIFF
--- a/AudioKit/Common/Internals/AKNotifications.swift
+++ b/AudioKit/Common/Internals/AKNotifications.swift
@@ -7,12 +7,14 @@
 //
 
 /// Object to handle notifications for events that can affect the audio
-@objc open class AKNotifications: NSObject {
+
+extension NSNotification.Name {
     /// After the audio route is changed, (headphones plugged in, for example) AudioKit restarts,
     ///  and engineRestartAfterRouteChange is sent.
     /// 
     /// The userInfo dictionary of this notification contains the AVAudioSessionRouteChangeReasonKey
     ///  and AVAudioSessionSilenceSecondaryAudioHintTypeKey keys, which provide information about the route change.
     ///
-    open static let engineRestartedAfterRouteChange: String = "io.audiokit.enginerestartedafterroutechange"
+    public static let AKEngineRestartedAfterRouteChange =
+      NSNotification.Name(rawValue: "io.audiokit.enginerestartedafterroutechange")
 }

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -332,12 +332,13 @@ extension AVAudioEngine {
             if shouldBeRunning {
                 do {
                     try self.engine.start()
-                    // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
+                    // Sends notification after restarting the engine, so it is safe to resume
+                    // AudioKit functions.
                     if AKSettings.notificationsEnabled {
                         NotificationCenter.default.post(
-                            name: Notification.Name(rawValue: AKNotifications.engineRestartedAfterRouteChange),
+                            name: .AKEngineRestartedAfterRouteChange,
                             object: nil,
-                            userInfo: (notification as NSNotification).userInfo)
+                            userInfo: notification.userInfo)
 
                     }
                 } catch {
@@ -353,7 +354,7 @@ extension AVAudioEngine {
         #if os(iOS)
             NotificationCenter.default.removeObserver(
                 self,
-                name: NSNotification.Name(rawValue: AKNotifications.engineRestartedAfterRouteChange),
+                name: .AKEngineRestartedAfterRouteChange,
                 object: nil)
         #endif
     }


### PR DESCRIPTION
While debugging I noticed these notifications weren't arriving on the main thread. This probably prevented the audio engine from being restarted correctly.