### PR TITLE
Fix #817 

### DIFF
--- a/AudioKit/Common/Nodes/Input/AKMicrophone.swift
+++ b/AudioKit/Common/Nodes/Input/AKMicrophone.swift
@@ -47,6 +47,10 @@ open class AKMicrophone: AKNode, AKToggleable {
             }
         #endif
     }
+    
+    deinit {
+        AKSettings.audioInputEnabled = false
+    }
 
     /// Function to start, play, or activate the node, all do the same thing
     open func start() {

--- a/AudioKit/Common/Nodes/Input/AKMicrophone.swift
+++ b/AudioKit/Common/Nodes/Input/AKMicrophone.swift
@@ -47,7 +47,7 @@ open class AKMicrophone: AKNode, AKToggleable {
             }
         #endif
     }
-    
+
     deinit {
         AKSettings.audioInputEnabled = false
     }

--- a/AudioKit/Common/Nodes/Input/AKStereoInput.swift
+++ b/AudioKit/Common/Nodes/Input/AKStereoInput.swift
@@ -40,6 +40,10 @@ open class AKStereoInput: AKNode, AKToggleable {
             }
         #endif
     }
+    
+    deinit {
+        AKSettings.audioInputEnabled = false
+    }
 
     /// Function to start, play, or activate the node, all do the same thing
     open func start() {

--- a/AudioKit/Common/Nodes/Input/AKStereoInput.swift
+++ b/AudioKit/Common/Nodes/Input/AKStereoInput.swift
@@ -40,7 +40,7 @@ open class AKStereoInput: AKNode, AKToggleable {
             }
         #endif
     }
-    
+
     deinit {
         AKSettings.audioInputEnabled = false
     }


### PR DESCRIPTION
audioInputEnabled is always true if AKMicrophone or AKStereoInput is initialized.

Now setting it back to false in deinit