### PR TITLE
Fix AKAudioPlayer Looping Drift

### DIFF
--- a/AudioKit/Common/Internals/AKScheduledAction.swift
+++ b/AudioKit/Common/Internals/AKScheduledAction.swift
@@ -8,32 +8,34 @@
 
 import Foundation
 
-class AKScheduledAction
-{
+class AKScheduledAction {
+
     private var interval: TimeInterval
     private var block: (() -> Void)
     private var timer: Timer?
-    
+
     init(interval: TimeInterval, block: @escaping () -> Void) {
         self.interval = interval
         self.block = block
         start()
     }
-    
+
     dynamic func start() {
         timer?.invalidate()
         timer = nil
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] (timer) in
-            guard timer.isValid else { return }
-            self?.block()
-        }
+        timer = Timer.scheduledTimer(withTimeInterval: interval,
+                                     repeats: false,
+                                     block: { [weak self] (timer) in
+                                        guard timer.isValid else { return }
+                                        self?.block()
+        })
     }
-    
+
     dynamic func stop() {
         timer?.invalidate()
         timer = nil
     }
-    
+
     deinit {
         stop()
     }

--- a/AudioKit/Common/Internals/AKScheduledAction.swift
+++ b/AudioKit/Common/Internals/AKScheduledAction.swift
@@ -1,0 +1,40 @@
+//
+//  AKScheduledAction.swift
+//  AudioKit For iOS
+//
+//  Created by David Sweetman on 4/1/17.
+//  Copyright © 2017 AudioKit. All rights reserved.
+//
+
+import Foundation
+
+class AKScheduledAction
+{
+    private var interval: TimeInterval
+    private var block: (() -> Void)
+    private var timer: Timer?
+    
+    init(interval: TimeInterval, block: @escaping () -> Void) {
+        self.interval = interval
+        self.block = block
+        start()
+    }
+    
+    dynamic func start() {
+        timer?.invalidate()
+        timer = nil
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] (timer) in
+            guard timer.isValid else { return }
+            self?.block()
+        }
+    }
+    
+    dynamic func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    deinit {
+        stop()
+    }
+}

--- a/AudioKit/Common/Internals/AKScheduledAction.swift
+++ b/AudioKit/Common/Internals/AKScheduledAction.swift
@@ -20,20 +20,23 @@ class AKScheduledAction {
         start()
     }
 
-    dynamic func start() {
+    func start() {
         timer?.invalidate()
-        timer = nil
-        timer = Timer.scheduledTimer(withTimeInterval: interval,
-                                     repeats: false,
-                                     block: { [weak self] (timer) in
-                                        guard timer.isValid else { return }
-                                        self?.block()
-        })
+        timer = Timer.scheduledTimer(timeInterval: interval,
+                                     target: self,
+                                     selector: #selector(fire(timer:)),
+                                     userInfo: nil,
+                                     repeats: false)
     }
 
-    dynamic func stop() {
+    func stop() {
         timer?.invalidate()
         timer = nil
+    }
+
+    private dynamic func fire(timer: Timer) {
+        guard timer.isValid else { return }
+        self.block()
     }
 
     deinit {

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -466,6 +466,9 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
     
     open func stopAtNextLoopEnd() {
+        guard playing else {
+            return
+        }
         scheduledStopAction = AKScheduledAction(interval: endTime - currentTime) {
             self.stop()
             self.completionHandler?()

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -431,15 +431,11 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
 
     fileprivate func scheduleBuffer(atTime: AVAudioTime?, options: AVAudioPlayerNodeBufferOptions) {
-        if audioFileBuffer != nil {
-
-            if let buffer = audioFileBuffer {
-                internalPlayer.scheduleBuffer(buffer,
-                                              at: atTime,
-                                              options: options,
-                                              completionHandler: looping ? nil : internalCompletionHandler)
-            }
-
+        if let buffer = audioFileBuffer {
+            internalPlayer.scheduleBuffer(buffer,
+                                          at: atTime,
+                                          options: options,
+                                          completionHandler: looping ? nil : internalCompletionHandler)
             if atTime != nil {
                 internalPlayer.prepare(withFrameCount: framesToPlayCount)
             }

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -29,14 +29,22 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     /// (will not as long as loop is on)
     open dynamic var completionHandler: AKCallback?
 
-    /// Boolean indicating whether or not to loop the playback
-    open dynamic var looping: Bool = false {
+    private var _looping: Bool = false {
         didSet {
             if playing {
                 let options: AVAudioPlayerNodeBufferOptions = looping ? [.loops, .interruptsAtLoop] : [.interruptsAtLoop]
                 scheduleBuffer(atTime: nil, options: options)
             }
         }
+    }
+
+    /// Boolean indicating whether or not to loop the playback (Default false)
+    open dynamic var looping: Bool {
+        set {
+            guard  newValue != _looping else { return }
+            _looping = newValue
+        }
+        get { return _looping }
     }
 
     /// Boolean indicating to play the buffer in reverse
@@ -236,9 +244,9 @@ open class AKAudioPlayer: AKNode, AKToggleable {
         }
         internalAudioFile = readFile
         self.completionHandler = completionHandler
-        self.looping = looping
 
         super.init()
+        self.looping = looping
         AudioKit.engine.attach(internalPlayer)
         let mixer = AVAudioMixerNode()
         AudioKit.engine.attach(mixer)

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -294,7 +294,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     /// Stop playback
     open func stop() {
         scheduledStopAction = nil
-        
+
         if !playing {
             return
         }
@@ -460,11 +460,11 @@ open class AKAudioPlayer: AKNode, AKToggleable {
             let options: AVAudioPlayerNodeBufferOptions = [.loops, .interruptsAtLoop]
             scheduleBuffer(atTime: nil, options: options)
         } else {
-            // Looping is toggled of: schedule to stop at the end of the current loop.
+            // Looping is toggled off: schedule to stop at the end of the current loop.
             stopAtNextLoopEnd()
         }
     }
-    
+
     open func stopAtNextLoopEnd() {
         guard playing else {
             return

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -439,6 +439,8 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
 
     fileprivate func scheduleBuffer(atTime: AVAudioTime?, options: AVAudioPlayerNodeBufferOptions) {
+        scheduledStopAction = nil
+
         if let buffer = audioFileBuffer {
             scheduledStopAction = nil
             internalPlayer.scheduleBuffer(buffer,

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -468,6 +468,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     open func stopAtNextLoopEnd() {
         scheduledStopAction = AKScheduledAction(interval: endTime - currentTime) {
             self.stop()
+            self.completionHandler?()
         }
     }
 

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5251477B1CC4AD7E00421C52 /* AKNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5251477A1CC4AD7E00421C52 /* AKNotifications.swift */; };
+		55F29C091E90654C00A2151F /* AKScheduledAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F29C081E90654C00A2151F /* AKScheduledAction.swift */; };
 		6520FFC21D361B030052410C /* resonantFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6520FFC11D361B030052410C /* resonantFilter.swift */; };
 		898DED261C6944430026FCC3 /* AKVariSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898DED251C6944430026FCC3 /* AKVariSpeed.swift */; };
 		8D0E46581D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0E46561D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift */; };
@@ -811,6 +812,7 @@
 
 /* Begin PBXFileReference section */
 		5251477A1CC4AD7E00421C52 /* AKNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKNotifications.swift; sourceTree = "<group>"; };
+		55F29C081E90654C00A2151F /* AKScheduledAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKScheduledAction.swift; sourceTree = "<group>"; };
 		6520FFC11D361B030052410C /* resonantFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = resonantFilter.swift; sourceTree = "<group>"; };
 		898DED251C6944430026FCC3 /* AKVariSpeed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKVariSpeed.swift; sourceTree = "<group>"; };
 		8D0E46561D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKAudioFile+ProcessingAsynchronously.swift"; sourceTree = "<group>"; };
@@ -1933,6 +1935,7 @@
 				EA6949E11C59A9FC0035B5DF /* AKSettings.swift */,
 				C40C411D1C40E2E1009D870B /* AKTable.swift */,
 				C40C411E1C40E2E1009D870B /* AudioKitHelpers.swift */,
+				55F29C081E90654C00A2151F /* AKScheduledAction.swift */,
 				C49E9E001D2B491500E5E8BF /* Audio File */,
 				C40C41221C40E344009D870B /* CoreAudio */,
 				C40C412D1C40E3A5009D870B /* EZAudio */,
@@ -4290,6 +4293,7 @@
 				C48C6C8D1D3C15F1008EA51B /* pareq.c in Sources */,
 				C48C6CA91D3C15F1008EA51B /* tabread.c in Sources */,
 				C4F8C8B31DCA8CE4001F38F2 /* bal.c in Sources */,
+				55F29C091E90654C00A2151F /* AKScheduledAction.swift in Sources */,
 				C48C6CB51D3C15F1008EA51B /* tone.c in Sources */,
 				C48C6C581D3C15F1008EA51B /* bar.c in Sources */,
 				C48C6C8B1D3C15F1008EA51B /* pan2.c in Sources */,


### PR DESCRIPTION
## Why?
With the previous looping logic in `AKAudioPlayer`, the playback time would drift because of overhead incurred by the interface between AKAudioPlayer and AVAudioPlayerNode. This can be resolved by deferring to `AVAudioPlayerNode`'s internal looping mechanism.

This is in response to https://github.com/audiokit/AudioKit/issues/807 and incorporates @aure's suggested fix while maintaining the completion handler behavior.

## What Changed?
* Use AVAudioPlayerNode's internal looping mechanism instead of applying the buffer looping in AKAudioPlayer.
* `internalCompletionHandler` is only used for when the audio track actually completes playback.
* When the user toggles the `looping` boolean and the track is playing, the player schedules its next buffer with the updated looping logic at the next loop time.
* When `looping` is set to `false`, the loop will stop and the callback will fire when the current loop completes.

## Caveats
* I'm not quite sure what will happen if the user rapidly/frequently changes the value of `looping`, since each time they do it will trigger a call to `scheduleBuffer`. Though presumably the _previous_ call would have its buffer 'interrupted' and so only the last would win.
* This seems like it adds too much code (looking at the `AKScheduledAction` class). I think it may be better to disallow the user to toggle looping on/off after the player is created. The problem of course is that would be an API-breaking change.


## Tests
I didn't write any :P if the general idea represented here is OK'd I'll try to fill in some tests for this behavior.

## Playground
This playground can be used to demonstrate the fix, and demonstrate the `looping` toggle.
[fix-akaudioplayer-loop.playground.zip](https://github.com/audiokit/AudioKit/files/887737/fix-akaudioplayer-loop.playground.zip)