### PR TITLE
Sporth Custom Ugen: Renamed fp to funcPtr to remove ambiguity.

### DIFF
--- a/AudioKit/Common/Internals/Sporth Custom Ugens/AKCustomUgenInfo.h
+++ b/AudioKit/Common/Internals/Sporth Custom Ugens/AKCustomUgenInfo.h
@@ -10,6 +10,6 @@
 
 typedef struct {
     const char *name;
-    plumber_dyn_func fp;
+    plumber_dyn_func func;
     void *userData;
 } AKCustomUgenInfo;

--- a/AudioKit/Common/Nodes/Effects/AudioKit Operation-Based Effect/AKOperationEffectDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Effects/AudioKit Operation-Based Effect/AKOperationEffectDSPKernel.hpp
@@ -34,7 +34,7 @@ public:
         plumber_init(&pd);
 
         for (auto info : customUgens) {
-          plumber_ftmap_add_function(&pd, info.name, info.fp, info.userData);
+          plumber_ftmap_add_function(&pd, info.name, info.func, info.userData);
         }
 
         pd.sp = sp;

--- a/AudioKit/Common/Nodes/Generators/AudioKit Operation-Based Generator/AKOperationGeneratorDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/AudioKit Operation-Based Generator/AKOperationGeneratorDSPKernel.hpp
@@ -50,7 +50,7 @@ public:
 
     void addUgensToFTable(plumber_data *pd) {
       for (auto info : customUgens) {
-        plumber_ftmap_add_function(pd, info.name, info.fp, info.userData);
+        plumber_ftmap_add_function(pd, info.name, info.func, info.userData);
       }
     }
     


### PR DESCRIPTION
This is a minor nitpick. "fp", presumably standing for "function pointer", is a variable name traditionally used for file i/o operations as the "file pointer". To avoid the confusion, and since it's not obvious that plumber_dyn_func is a function pointer, I have renamed fp to funcPtr. It is clearer, and adheres to
the coding style that surrounds it.