### PR TITLE
Added constructor to AKMixer.swift to accept a swift array of AKNode …

### DIFF
--- a/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
@@ -47,6 +47,19 @@ open class AKMixer: AKNode, AKToggleable {
             connect(input)
         }
     }
+    
+    /// Initialize the mixer node with multiple inputs
+    ///
+    /// - parameter inputs: An array of AKNodes
+    ///
+    public init(_ inputs: [AKNode]) {
+        super.init()
+        self.avAudioNode = mixerAU
+        AudioKit.engine.attach(self.avAudioNode)
+        for input in inputs {
+            connect(input)
+        }
+    }
 
     /// Connnect another input after initialization
     ///


### PR DESCRIPTION
Added constructor to AKMixer.swift to accept a swift array of AKNode objects, which gives more options for working with Swift syntax.

In the HelloWorld example, you can now pass an array instead of having to produce vaargs

    override func viewDidLoad() {
        super.viewDidLoad()

        let oscillators = [oscillator, oscillator2]
        AudioKit.output = AKMixer(oscillators)
        AudioKit.start()
    }
