### PR TITLE
A small correction of openOutput() function

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDI+SendingMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+SendingMIDI.swift
@@ -57,19 +57,28 @@ extension AKMIDI {
     ///
     /// - parameter namedOutput: String containing the name of the MIDI Input
     ///
-    public func openOutput(_ namedOutput: String = "") {
+    // Destination name (string) can be empty for some hardware device;
+    // So optional string is better for checking and targeting the device.
+    public func openOutput(_ namedOutput: String? = nil) {
         guard let tempPort = MIDIOutputPort(client: client, name: outputPortName) else {
             return
         }
         outputPort = tempPort
-
-        _ = zip(destinationNames, MIDIDestinations()).first { name, _ in
-            namedOutput.isEmpty || namedOutput == name
-        }.map {
-          endpoints[$0] = $1
+        
+        // To get all endpoints; and set in endpoints array (mapping without condition)
+        if namedOutput == nil {
+            _ = zip(destinationNames, MIDIDestinations()).map {
+                endpoints[$0] = $1
+            }
+        }else{
+            // To get only  endpoint with name provided in namedOutput (conditional mapping)
+            _ = zip(destinationNames, MIDIDestinations()).first { name, _ in
+                namedOutput! == name
+                }.map {
+                    endpoints[$0] = $1
+            }
         }
     }
-
     /// Send Message with data
     public func sendMessage(_ data: [MIDIByte]) {
         let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)


### PR DESCRIPTION
I've just corrected endpoint array creation according to requested name.
Now; 

`openOutput() `
creates endpoint array with all available endpoints

`openOutput("")`
 creates endpoint array with endpoint nameless device (cause some device has no name in the system so this way can help to point)

`openOutput("Bluetooth")`
creates endpoint array with Bluetooth device (or any given name)

By the way I'm not sure if the `endpoints` array should hold only requested endpoints for output OR should it keep all endpoints available on device? So my correction doesn't change the logic but just the functionality expected from the func.