### PR TITLE
Add missing check for engine isRunning after restartEngineAfterRouteChange

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -329,7 +329,7 @@ extension AVAudioEngine {
     // Restarts the engine after audio output has been changed, like headphones plugged in.
     @objc fileprivate static func restartEngineAfterRouteChange(_ notification: Notification) {
         DispatchQueue.main.async {
-            if shouldBeRunning {
+            if shouldBeRunning && !engine.isRunning {
                 do {
                     try self.engine.start()
                     // Sends notification after restarting the engine, so it is safe to resume


### PR DESCRIPTION
We should only call start if the engine wasn't started to begin with.
![axqr1hnemgjiw](https://cloud.githubusercontent.com/assets/220240/25792353/fab8c5b8-337a-11e7-8d9b-1636c9b966e5.gif)
