### PR TITLE
Add AKFMOscillatorBankMonophonic and AKOscillatorBankMonophonic

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.h
+++ b/AudioKit/Common/Internals/AudioKit.h
@@ -79,6 +79,7 @@ FOUNDATION_EXPORT const unsigned char AudioKitVersionString[];
 
 // Generators
 #import "AKOperationGeneratorAudioUnit.h"
+#import "AKInputDeviceAudioUnit.h"
 
 // Generators / Noise
 #import "AKBrownianNoiseAudioUnit.h"

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBank.swift
@@ -296,20 +296,23 @@ open class AKFMOscillatorBank: AKPolyphonicNode, AKComponent {
     open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
-    
+
     /// Function to start, play, or activate the node with time at which it will be automatically stopped
-    open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, stopAfter: Double)
-    {
+    open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, stopAfter: Double) {
         self.play(noteNumber: noteNumber, velocity: velocity)
         noteStoppers[noteNumber]?.invalidate()
-        noteStoppers[noteNumber] = Timer.scheduledTimer(timeInterval: stopAfter, target: self, selector: #selector(stopFromTimer(_:)), userInfo: noteNumber, repeats: false)
+        noteStoppers[noteNumber] = Timer.scheduledTimer(timeInterval: stopAfter,
+                                                        target: self,
+                                                        selector: #selector(stopFromTimer(_:)),
+                                                        userInfo: noteNumber,
+                                                        repeats: false)
     }
 
     /// Function to stop or bypass the node, both are equivalent
     open override func stop(noteNumber: MIDINoteNumber) {
         internalAU?.stopNote(noteNumber)
     }
-    
+
     /// Callback to stop notes from noteStopper timers
     func stopFromTimer(_ timer: Timer) {
         internalAU?.stopNote(timer.userInfo as! MIDINoteNumber)

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBank.swift
@@ -38,6 +38,8 @@ open class AKFMOscillatorBank: AKPolyphonicNode, AKComponent {
     fileprivate var detuningOffsetParameter: AUParameter?
     fileprivate var detuningMultiplierParameter: AUParameter?
 
+    fileprivate var noteStoppers: [MIDINoteNumber:Timer] = [:]
+
     /// Ramp Time represents the speed at which parameters are allowed to change
     open dynamic var rampTime: Double = AKSettings.rampTime {
         willSet {
@@ -294,9 +296,22 @@ open class AKFMOscillatorBank: AKPolyphonicNode, AKComponent {
     open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
+    
+    /// Function to start, play, or activate the node with time at which it will be automatically stopped
+    open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, stopAfter: Double)
+    {
+        self.play(noteNumber: noteNumber, velocity: velocity)
+        noteStoppers[noteNumber]?.invalidate()
+        noteStoppers[noteNumber] = Timer.scheduledTimer(timeInterval: stopAfter, target: self, selector: #selector(stopFromTimer(_:)), userInfo: noteNumber, repeats: false)
+    }
 
     /// Function to stop or bypass the node, both are equivalent
     open override func stop(noteNumber: MIDINoteNumber) {
         internalAU?.stopNote(noteNumber)
+    }
+    
+    /// Callback to stop notes from noteStopper timers
+    func stopFromTimer(_ timer: Timer) {
+        internalAU?.stopNote(timer.userInfo as! MIDINoteNumber)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBankMonophonic.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBankMonophonic.swift
@@ -1,0 +1,38 @@
+//
+//  AKFMOscillatorBankMonophonic.swift
+//  Blackbox
+//
+//  Created by Ryan McLeod on 4/28/17.
+//  Copyright © 2017 Ryan McLeod. All rights reserved.
+//
+
+import AudioKit
+
+// NOTE: This does the exact same thing as AKOscillatorBankMonophonic
+//       Should this monophonic behavior instead be a category or protocol?
+class AKFMOscillatorBankMonophonic : AKFMOscillatorBank
+{
+    var playingNote = false
+    var currentNote: MIDINoteNumber = 0
+    
+    override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity)
+    {
+        if (!playingNote || (currentNote != noteNumber))
+        {
+            super.stop(noteNumber: currentNote)
+            super.play(noteNumber: noteNumber, velocity: velocity)
+        }
+        currentNote = noteNumber
+    }
+    
+    override func stop(noteNumber: MIDINoteNumber)
+    {
+        super.stop(noteNumber: currentNote)
+        playingNote = false
+    }
+    
+    public func stopCurrentNote()
+    {
+        self.stop(noteNumber: currentNote)
+    }
+}

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBankMonophonic.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator Bank/AKFMOscillatorBankMonophonic.swift
@@ -6,33 +6,24 @@
 //  Copyright © 2017 Ryan McLeod. All rights reserved.
 //
 
-import AudioKit
-
-// NOTE: This does the exact same thing as AKOscillatorBankMonophonic
-//       Should this monophonic behavior instead be a category or protocol?
-class AKFMOscillatorBankMonophonic : AKFMOscillatorBank
-{
+class AKFMOscillatorBankMonophonic: AKFMOscillatorBank {
     var playingNote = false
     var currentNote: MIDINoteNumber = 0
-    
-    override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity)
-    {
-        if (!playingNote || (currentNote != noteNumber))
-        {
+
+    override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity) {
+        if !playingNote || (currentNote != noteNumber) {
             super.stop(noteNumber: currentNote)
             super.play(noteNumber: noteNumber, velocity: velocity)
         }
         currentNote = noteNumber
     }
-    
-    override func stop(noteNumber: MIDINoteNumber)
-    {
+
+    override func stop(noteNumber: MIDINoteNumber) {
         super.stop(noteNumber: currentNote)
         playingNote = false
     }
-    
-    public func stopCurrentNote()
-    {
+
+    public func stopCurrentNote() {
         self.stop(noteNumber: currentNote)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBank.swift
@@ -35,9 +35,8 @@ open class AKOscillatorBank: AKPolyphonicNode, AKComponent {
     fileprivate var releaseDurationParameter: AUParameter?
     fileprivate var detuningOffsetParameter: AUParameter?
     fileprivate var detuningMultiplierParameter: AUParameter?
-    
-    fileprivate var noteStoppers: [MIDINoteNumber:Timer] = [:]
 
+    fileprivate var noteStoppers: [MIDINoteNumber:Timer] = [:]
 
     /// Ramp Time represents the speed at which parameters are allowed to change
     open dynamic var rampTime: Double = AKSettings.rampTime {
@@ -225,13 +224,16 @@ open class AKOscillatorBank: AKPolyphonicNode, AKComponent {
     open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
-    
+
     // Function to start, play, or activate the node with time at which it will be automatically stopped
-    open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, stopAfter: Double)
-    {
+    open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, stopAfter: Double) {
         self.play(noteNumber: noteNumber, velocity: velocity)
         noteStoppers[noteNumber]?.invalidate()
-        noteStoppers[noteNumber] = Timer.scheduledTimer(timeInterval: stopAfter, target: self, selector: #selector(stop(noteNumber:)), userInfo: noteNumber, repeats: false)
+        noteStoppers[noteNumber] = Timer.scheduledTimer(timeInterval: stopAfter,
+                                                        target: self,
+                                                        selector: #selector(stop(noteNumber:)),
+                                                        userInfo: noteNumber,
+                                                        repeats: false)
     }
 
     /// Function to stop or bypass the node, both are equivalent

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBank.swift
@@ -35,6 +35,9 @@ open class AKOscillatorBank: AKPolyphonicNode, AKComponent {
     fileprivate var releaseDurationParameter: AUParameter?
     fileprivate var detuningOffsetParameter: AUParameter?
     fileprivate var detuningMultiplierParameter: AUParameter?
+    
+    fileprivate var noteStoppers: [MIDINoteNumber:Timer] = [:]
+
 
     /// Ramp Time represents the speed at which parameters are allowed to change
     open dynamic var rampTime: Double = AKSettings.rampTime {
@@ -221,6 +224,14 @@ open class AKOscillatorBank: AKPolyphonicNode, AKComponent {
     // Function to start, play, or activate the node at frequency
     open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
+    }
+    
+    // Function to start, play, or activate the node with time at which it will be automatically stopped
+    open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, stopAfter: Double)
+    {
+        self.play(noteNumber: noteNumber, velocity: velocity)
+        noteStoppers[noteNumber]?.invalidate()
+        noteStoppers[noteNumber] = Timer.scheduledTimer(timeInterval: stopAfter, target: self, selector: #selector(stop(noteNumber:)), userInfo: noteNumber, repeats: false)
     }
 
     /// Function to stop or bypass the node, both are equivalent

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBankMonophonic.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBankMonophonic.swift
@@ -1,0 +1,37 @@
+//
+//  AKOscillatorBankMonophonic.swift
+//  BlackboxAudioTestbed
+//
+//  Created by Ryan McLeod on 4/19/17.
+//  Copyright © 2017 Ryan McLeod. All rights reserved.
+//
+
+import AudioKit
+
+class AKOscillatorBankMonophonic : AKOscillatorBank
+{
+    var playingNote = false
+    var currentNote: MIDINoteNumber = 0
+    var noteStoppers: [MIDINoteNumber:Timer] = [:]
+        
+    override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity)
+    {
+        if (!playingNote || (currentNote != noteNumber))
+        {
+            super.stop(noteNumber: currentNote)
+            super.play(noteNumber: noteNumber, velocity: velocity)
+        }
+        currentNote = noteNumber
+    }
+    
+    override func stop(noteNumber: MIDINoteNumber)
+    {
+        super.stop(noteNumber: currentNote)
+        playingNote = false
+    }
+    
+    public func stopCurrentNote()
+    {
+        self.stop(noteNumber: currentNote)
+    }
+}

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBankMonophonic.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator Bank/AKOscillatorBankMonophonic.swift
@@ -6,32 +6,25 @@
 //  Copyright © 2017 Ryan McLeod. All rights reserved.
 //
 
-import AudioKit
-
-class AKOscillatorBankMonophonic : AKOscillatorBank
-{
+class AKOscillatorBankMonophonic: AKOscillatorBank {
     var playingNote = false
     var currentNote: MIDINoteNumber = 0
     var noteStoppers: [MIDINoteNumber:Timer] = [:]
-        
-    override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity)
-    {
-        if (!playingNote || (currentNote != noteNumber))
-        {
+
+    override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity) {
+        if !playingNote || (currentNote != noteNumber) {
             super.stop(noteNumber: currentNote)
             super.play(noteNumber: noteNumber, velocity: velocity)
         }
         currentNote = noteNumber
     }
-    
-    override func stop(noteNumber: MIDINoteNumber)
-    {
+
+    override func stop(noteNumber: MIDINoteNumber) {
         super.stop(noteNumber: currentNote)
         playingNote = false
     }
-    
-    public func stopCurrentNote()
-    {
+
+    public func stopCurrentNote() {
         self.stop(noteNumber: currentNote)
     }
 }

--- a/AudioKit/Common/Nodes/Input/Input Device/AKInputDevice.swift
+++ b/AudioKit/Common/Nodes/Input/Input Device/AKInputDevice.swift
@@ -1,0 +1,52 @@
+//
+//  AKInputDevice.swift
+//  AudioKit
+//
+//  Created by Aurelius Prochazka, revision history on Github.
+//  Copyright © 2017 Aurelius Prochazka. All rights reserved.
+//
+
+/// Reads from the table sequentially and repeatedly at given frequency. Linear
+/// interpolation is applied for table look up from internal phase values.
+///
+open class AKInputDevice: AKNode, AKToggleable, AKComponent {
+    public typealias AKAudioUnitType = AKInputDeviceAudioUnit
+    public static let ComponentDescription = AudioComponentDescription(generator: "ezin")
+
+    // MARK: - Properties
+
+    private var internalAU: AKAudioUnitType?
+
+    /// Tells whether the node is processing (ie. started, playing, or active)
+    open dynamic var isStarted: Bool {
+        return internalAU?.isPlaying() ?? false
+    }
+
+    // MARK: - Initialization
+
+    /// Initialize this input device node
+    ///
+    public override init() {
+
+        _Self.register()
+
+        super.init()
+        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { [weak self] avAudioUnit in
+
+            self?.avAudioNode = avAudioUnit
+            self?.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+
+        }
+
+    }
+
+    /// Function to start, play, or activate the node, all do the same thing
+    open func start() {
+        internalAU?.start()
+    }
+
+    /// Function to stop or bypass the node, both are equivalent
+    open func stop() {
+        internalAU?.stop()
+    }
+}

--- a/AudioKit/Common/Nodes/Input/Input Device/AKInputDeviceAudioUnit.h
+++ b/AudioKit/Common/Nodes/Input/Input Device/AKInputDeviceAudioUnit.h
@@ -1,0 +1,17 @@
+//
+//  AKInputDeviceAudioUnit.h
+//  AudioKit
+//
+//  Created by Aurelius Prochazka, revision history on Github.
+//  Copyright © 2017 Aurelius Prochazka. All rights reserved.
+//
+
+#pragma once
+
+#import "AKAudioUnit.h"
+#import "EZMicrophone.h"
+
+@interface AKInputDeviceAudioUnit : AKAudioUnit<EZMicrophoneDelegate>
+
+@end
+

--- a/AudioKit/Common/Nodes/Input/Input Device/AKInputDeviceAudioUnit.mm
+++ b/AudioKit/Common/Nodes/Input/Input Device/AKInputDeviceAudioUnit.mm
@@ -1,0 +1,82 @@
+//
+//  AKInputDeviceAudioUnit.mm
+//  AudioKit
+//
+//  Created by Aurelius Prochazka, revision history on Github.
+//  Copyright © 2017 Aurelius Prochazka. All rights reserved.
+//
+
+#import "AKInputDeviceAudioUnit.h"
+#import "BufferedAudioBus.hpp"
+
+@implementation AKInputDeviceAudioUnit {
+    // C++ members need to be ivars; they would be copied on access if they were properties.
+    BufferedInputBus _inputBus;
+    EZMicrophone *_mic;
+    AudioBufferList *_micBufferList;
+}
+@synthesize parameterTree = _parameterTree;
+
+- (void)createParameters {
+
+//    standardSetup(InputDevice)  Might need input bus stuff
+
+}
+
+//AUAudioUnitGeneratorOverrides(InputDevice)
+
+- (BOOL)allocateRenderResourcesAndReturnError:(NSError **)outError {
+    if (![super allocateRenderResourcesAndReturnError:outError]) {
+        return NO;
+    }
+    _inputBus.allocateRenderResources(self.maximumFramesToRender);
+    *_micBufferList = AudioBufferList(); //Highly suspect
+    _mic = [[EZMicrophone alloc] initWithMicrophoneDelegate:self];
+    [_mic startFetchingAudio];
+//    _kernel.init(self.outputBus.format.channelCount, self.outputBus.format.sampleRate);
+//    _kernel.reset()
+    return YES;
+}
+
+- (void)deallocateRenderResources {
+    [super deallocateRenderResources];
+//    _kernel.destroy();
+    _inputBus.deallocateRenderResources();
+}
+
+- (AUInternalRenderBlock)internalRenderBlock {
+//    __block AK##str##DSPKernel *state = &_kernel;
+    __block BufferedInputBus *input = &_inputBus;
+    return ^AUAudioUnitStatus(
+                              AudioUnitRenderActionFlags *actionFlags,
+                              const AudioTimeStamp       *timestamp,
+                              AVAudioFrameCount           frameCount,
+                              NSInteger                   outputBusNumber,
+                              AudioBufferList            *outputData,
+                              const AURenderEvent        *realtimeEventListHead,
+                              AURenderPullInputBlock      pullInputBlock) {
+//        AudioBufferList *inAudioBufferList = input->mutableAudioBufferList;
+//        AudioBufferList *outAudioBufferList = outputData;
+//        if (outAudioBufferList->mBuffers[0].mData == nullptr) {
+//            for (UInt32 i = 0; i < outAudioBufferList->mNumberBuffers; ++i) {
+//                outAudioBufferList->mBuffers[i].mData = inAudioBufferList->mBuffers[i].mData;
+//            }
+//        }
+// This needs to get replaced with calls into EZMicrophone
+//        state->setBuffer(outAudioBufferList);
+//        state->processWithEvents(timestamp, frameCount, realtimeEventListHead);
+        outputData = _micBufferList;
+        return noErr;
+    };
+}
+
+- (void) microphone:(EZMicrophone *)microphone
+      hasBufferList:(AudioBufferList *)bufferList
+     withBufferSize:(UInt32)bufferSize
+withNumberOfChannels:(UInt32)numberOfChannels {
+    _micBufferList = bufferList;
+}
+
+@end
+
+

--- a/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
@@ -82,6 +82,16 @@ open class AKMixer: AKNode, AKToggleable {
             AudioKit.start()
         }
     }
+    
+    /// Connnect multiple inputs after initialization
+    ///
+    /// - parameter inputs: A varaiadic list of AKNodes to connect
+    ///
+    open func connect(_ inputs: AKNode?...) {
+        for input in inputs {
+            connect(input)
+        }
+    }
 
     /// Function to start, play, or activate the node, all do the same thing
     open func start() {

--- a/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
@@ -82,7 +82,7 @@ open class AKMixer: AKNode, AKToggleable {
             AudioKit.start()
         }
     }
-    
+
     /// Connnect multiple inputs after initialization
     ///
     /// - parameter inputs: A varaiadic list of AKNodes to connect

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -808,6 +808,8 @@
 		C4F8D0941D5951C100D85987 /* AKPlaygroundResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F8D0931D5951C100D85987 /* AKPlaygroundResources.swift */; };
 		C4FE01631CED2DB40062B3A3 /* AKNodeRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FE01611CED2DB40062B3A3 /* AKNodeRecorder.swift */; };
 		C4FF7CB01D9F7F0B001BB82C /* AudioUnit+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FF7CAF1D9F7F0B001BB82C /* AudioUnit+Helpers.swift */; };
+		DC328A1B1EC04A39002E7290 /* AKOscillatorBankMonophonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC328A1A1EC04A39002E7290 /* AKOscillatorBankMonophonic.swift */; };
+		DC328A1F1EC04A76002E7290 /* AKFMOscillatorBankMonophonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC328A1E1EC04A76002E7290 /* AKFMOscillatorBankMonophonic.swift */; };
 		E4630B461D2BC73300437E75 /* AKMandolinPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4630B451D2BC73300437E75 /* AKMandolinPresets.swift */; };
 		E4630B4A1D2BC78600437E75 /* AKCostelloReverbPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4630B491D2BC78600437E75 /* AKCostelloReverbPresets.swift */; };
 		E4630B4C1D2BC79A00437E75 /* AKDistortionPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4630B4B1D2BC79A00437E75 /* AKDistortionPresets.swift */; };
@@ -1404,7 +1406,7 @@
 		C49D69531D1F1C6500BF018A /* AKPWMOscillatorBankAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPWMOscillatorBankAudioUnit.h; sourceTree = "<group>"; };
 		C49D69541D1F1C6500BF018A /* AKPWMOscillatorBankAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKPWMOscillatorBankAudioUnit.mm; sourceTree = "<group>"; };
 		C49D69551D1F1C6500BF018A /* AKPWMOscillatorBankDSPKernel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKPWMOscillatorBankDSPKernel.hpp; sourceTree = "<group>"; };
-		C49D695F1D1F1DE300BF018A /* AKFMOscillatorBank.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKFMOscillatorBank.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		C49D695F1D1F1DE300BF018A /* AKFMOscillatorBank.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKFMOscillatorBank.swift; sourceTree = "<group>"; };
 		C49D69601D1F1DE300BF018A /* AKFMOscillatorBankAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKFMOscillatorBankAudioUnit.h; sourceTree = "<group>"; };
 		C49D69611D1F1DE300BF018A /* AKFMOscillatorBankAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKFMOscillatorBankAudioUnit.mm; sourceTree = "<group>"; };
 		C49D69621D1F1DE300BF018A /* AKFMOscillatorBankDSPKernel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKFMOscillatorBankDSPKernel.hpp; sourceTree = "<group>"; };
@@ -1642,6 +1644,8 @@
 		C4F8D0931D5951C100D85987 /* AKPlaygroundResources.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKPlaygroundResources.swift; sourceTree = "<group>"; };
 		C4FE01611CED2DB40062B3A3 /* AKNodeRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKNodeRecorder.swift; sourceTree = "<group>"; };
 		C4FF7CAF1D9F7F0B001BB82C /* AudioUnit+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AudioUnit+Helpers.swift"; sourceTree = "<group>"; };
+		DC328A1A1EC04A39002E7290 /* AKOscillatorBankMonophonic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKOscillatorBankMonophonic.swift; sourceTree = "<group>"; };
+		DC328A1E1EC04A76002E7290 /* AKFMOscillatorBankMonophonic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKFMOscillatorBankMonophonic.swift; sourceTree = "<group>"; };
 		E4630B451D2BC73300437E75 /* AKMandolinPresets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMandolinPresets.swift; sourceTree = "<group>"; };
 		E4630B491D2BC78600437E75 /* AKCostelloReverbPresets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKCostelloReverbPresets.swift; sourceTree = "<group>"; };
 		E4630B4B1D2BC79A00437E75 /* AKDistortionPresets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKDistortionPresets.swift; sourceTree = "<group>"; };
@@ -3436,6 +3440,7 @@
 			isa = PBXGroup;
 			children = (
 				C49D695F1D1F1DE300BF018A /* AKFMOscillatorBank.swift */,
+				DC328A1E1EC04A76002E7290 /* AKFMOscillatorBankMonophonic.swift */,
 				C49D69601D1F1DE300BF018A /* AKFMOscillatorBankAudioUnit.h */,
 				C49D69611D1F1DE300BF018A /* AKFMOscillatorBankAudioUnit.mm */,
 				C49D69621D1F1DE300BF018A /* AKFMOscillatorBankDSPKernel.hpp */,
@@ -3458,6 +3463,7 @@
 			isa = PBXGroup;
 			children = (
 				C49D69691D1F1DE300BF018A /* AKOscillatorBank.swift */,
+				DC328A1A1EC04A39002E7290 /* AKOscillatorBankMonophonic.swift */,
 				C49D696A1D1F1DE300BF018A /* AKOscillatorBankAudioUnit.h */,
 				C49D696B1D1F1DE300BF018A /* AKOscillatorBankAudioUnit.mm */,
 				C49D696C1D1F1DE300BF018A /* AKOscillatorBankDSPKernel.hpp */,
@@ -4049,7 +4055,9 @@
 				C40C41551C40E3A5009D870B /* EZAudioFFT.m in Sources */,
 				C40C416B1C40E3A5009D870B /* EZRecorder.m in Sources */,
 				C4F8C91F1DCA8CE4001F38F2 /* tabread.c in Sources */,
+				DC328A1B1EC04A39002E7290 /* AKOscillatorBankMonophonic.swift in Sources */,
 				C40C415B1C40E3A5009D870B /* EZAudioFloatData.m in Sources */,
+				DC328A1F1EC04A76002E7290 /* AKFMOscillatorBankMonophonic.swift in Sources */,
 				C4F8C9371DCA8CE4001F38F2 /* zeros.c in Sources */,
 				C4F8C9071DCA8CE4001F38F2 /* pshift.c in Sources */,
 				C47047921E76997200D9906F /* TwoZero.cpp in Sources */,

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -4425,11 +4425,8 @@
 				B1F47ABC1DC54DCA00706A2F /* EZAudioFileMarker.m in Sources */,
 				C4FF7CB01D9F7F0B001BB82C /* AudioUnit+Helpers.swift in Sources */,
 				C4F8C9031DCA8CE4001F38F2 /* port.c in Sources */,
-<<<<<<< HEAD
 				F4CA85851EB666260066BE5C /* AKTuningTable.swift in Sources */,
-=======
 				C425DB9F1EAECF01002675D2 /* AKInputDeviceAudioUnit.mm in Sources */,
->>>>>>> Initial version of EZMicrophone powered AKInputDevice
 				C48C6CA41D3C15F1008EA51B /* samphold.c in Sources */,
 				C48C6C951D3C15F1008EA51B /* port.c in Sources */,
 				C4F8C8EF1DCA8CE4001F38F2 /* metro.c in Sources */,

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -119,6 +119,9 @@
 		C421DCE01D39650000E15879 /* AKPhaseDistortionOscillatorAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C421DCDC1D39650000E15879 /* AKPhaseDistortionOscillatorAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C421DCE11D39650000E15879 /* AKPhaseDistortionOscillatorAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = C421DCDD1D39650000E15879 /* AKPhaseDistortionOscillatorAudioUnit.mm */; };
 		C421DCE21D39650000E15879 /* AKPhaseDistortionOscillatorDSPKernel.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C421DCDE1D39650000E15879 /* AKPhaseDistortionOscillatorDSPKernel.hpp */; };
+		C425DB9D1EAECF01002675D2 /* AKInputDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C425DB9A1EAECF01002675D2 /* AKInputDevice.swift */; };
+		C425DB9E1EAECF01002675D2 /* AKInputDeviceAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C425DB9B1EAECF01002675D2 /* AKInputDeviceAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C425DB9F1EAECF01002675D2 /* AKInputDeviceAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = C425DB9C1EAECF01002675D2 /* AKInputDeviceAudioUnit.mm */; };
 		C426BF361E3443AA008EFCB5 /* AKBluetoothMIDIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C426BF351E3443AA008EFCB5 /* AKBluetoothMIDIButton.swift */; };
 		C42858F21E90B647009B737D /* AKDynamicRangeCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42858EE1E90B647009B737D /* AKDynamicRangeCompressor.swift */; };
 		C42858F31E90B647009B737D /* AKDynamicRangeCompressorAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C42858EF1E90B647009B737D /* AKDynamicRangeCompressorAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -944,6 +947,9 @@
 		C421DCDC1D39650000E15879 /* AKPhaseDistortionOscillatorAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKPhaseDistortionOscillatorAudioUnit.h; sourceTree = "<group>"; };
 		C421DCDD1D39650000E15879 /* AKPhaseDistortionOscillatorAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKPhaseDistortionOscillatorAudioUnit.mm; sourceTree = "<group>"; };
 		C421DCDE1D39650000E15879 /* AKPhaseDistortionOscillatorDSPKernel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKPhaseDistortionOscillatorDSPKernel.hpp; sourceTree = "<group>"; };
+		C425DB9A1EAECF01002675D2 /* AKInputDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKInputDevice.swift; sourceTree = "<group>"; };
+		C425DB9B1EAECF01002675D2 /* AKInputDeviceAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKInputDeviceAudioUnit.h; sourceTree = "<group>"; };
+		C425DB9C1EAECF01002675D2 /* AKInputDeviceAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKInputDeviceAudioUnit.mm; sourceTree = "<group>"; };
 		C426BF351E3443AA008EFCB5 /* AKBluetoothMIDIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKBluetoothMIDIButton.swift; sourceTree = "<group>"; };
 		C42858EE1E90B647009B737D /* AKDynamicRangeCompressor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKDynamicRangeCompressor.swift; sourceTree = "<group>"; };
 		C42858EF1E90B647009B737D /* AKDynamicRangeCompressorAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKDynamicRangeCompressorAudioUnit.h; sourceTree = "<group>"; };
@@ -1918,6 +1924,16 @@
 			path = "Phase Distortion Oscillator";
 			sourceTree = "<group>";
 		};
+		C425DB991EAECF01002675D2 /* Input Device */ = {
+			isa = PBXGroup;
+			children = (
+				C425DB9A1EAECF01002675D2 /* AKInputDevice.swift */,
+				C425DB9B1EAECF01002675D2 /* AKInputDeviceAudioUnit.h */,
+				C425DB9C1EAECF01002675D2 /* AKInputDeviceAudioUnit.mm */,
+			);
+			path = "Input Device";
+			sourceTree = "<group>";
+		};
 		C42858ED1E90B647009B737D /* Dynamic Range Compressor */ = {
 			isa = PBXGroup;
 			children = (
@@ -2816,6 +2832,7 @@
 			children = (
 				C46303C71C212682009B44D9 /* AKMicrophone.swift */,
 				C4F3ADD41DD3CDFD009AF0BE /* AKStereoInput.swift */,
+				C425DB991EAECF01002675D2 /* Input Device */,
 			);
 			path = Input;
 			sourceTree = "<group>";
@@ -3763,6 +3780,7 @@
 				C47AE4B91D39C5B10091118F /* AKPhaseDistortionOscillatorBankAudioUnit.h in Headers */,
 				C42858FE1E90B689009B737D /* AKPhaserDSPKernel.hpp in Headers */,
 				C4537FBA1C3A438D00A51738 /* AKDCBlockAudioUnit.h in Headers */,
+				C425DB9E1EAECF01002675D2 /* AKInputDeviceAudioUnit.h in Headers */,
 				C407180C1D2119F600665C02 /* FileRead.h in Headers */,
 				C4537FD61C3A438D00A51738 /* AKLowShelfParametricEqualizerFilterAudioUnit.h in Headers */,
 				C42859051E90B6BC009B737D /* AKZitaReverbAudioUnit.h in Headers */,
@@ -4228,6 +4246,7 @@
 				C49A0A1D1D540009007D8ADB /* reverberateWithCombFilter.swift in Sources */,
 				C463028B1C20E7A7009B44D9 /* fmOscillator.swift in Sources */,
 				C4F8C8D91DCA8CE4001F38F2 /* gen_file.c in Sources */,
+				C425DB9D1EAECF01002675D2 /* AKInputDevice.swift in Sources */,
 				C4537FB91C3A438D00A51738 /* AKDCBlock.swift in Sources */,
 				C4537FF21C3A438D00A51738 /* AKToneComplementFilter.swift in Sources */,
 				C43622CD1CCDC70B00DB41DE /* AKMIDISampler.swift in Sources */,
@@ -4406,7 +4425,11 @@
 				B1F47ABC1DC54DCA00706A2F /* EZAudioFileMarker.m in Sources */,
 				C4FF7CB01D9F7F0B001BB82C /* AudioUnit+Helpers.swift in Sources */,
 				C4F8C9031DCA8CE4001F38F2 /* port.c in Sources */,
+<<<<<<< HEAD
 				F4CA85851EB666260066BE5C /* AKTuningTable.swift in Sources */,
+=======
+				C425DB9F1EAECF01002675D2 /* AKInputDeviceAudioUnit.mm in Sources */,
+>>>>>>> Initial version of EZMicrophone powered AKInputDevice
 				C48C6CA41D3C15F1008EA51B /* samphold.c in Sources */,
 				C48C6C951D3C15F1008EA51B /* port.c in Sources */,
 				C4F8C8EF1DCA8CE4001F38F2 /* metro.c in Sources */,

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		B1F47AB81DC5385500706A2F /* EZAudioFileMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F47AB61DC5385500706A2F /* EZAudioFileMarker.m */; };
 		C40101D41DED705B000C5765 /* AKAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C40101D21DED705B000C5765 /* AKAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40101D51DED705B000C5765 /* AKAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = C40101D31DED705B000C5765 /* AKAudioUnit.mm */; };
+		C425DBA41EAEE533002675D2 /* AKInputDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C425DBA11EAEE533002675D2 /* AKInputDevice.swift */; };
+		C425DBA51EAEE533002675D2 /* AKInputDeviceAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C425DBA21EAEE533002675D2 /* AKInputDeviceAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C425DBA61EAEE533002675D2 /* AKInputDeviceAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = C425DBA31EAEE533002675D2 /* AKInputDeviceAudioUnit.mm */; };
 		C42858EC1E90B5BE009B737D /* AKScheduledAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42858EB1E90B5BE009B737D /* AKScheduledAction.swift */; };
 		C42899921D552E2C00B941B5 /* smoothDelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899911D552E2C00B941B5 /* smoothDelay.swift */; };
 		C42899941D552F9F00B941B5 /* lowPassButterworthFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899931D552F9F00B941B5 /* lowPassButterworthFilter.swift */; };
@@ -852,6 +855,9 @@
 		B1F47AB61DC5385500706A2F /* EZAudioFileMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioFileMarker.m; sourceTree = "<group>"; };
 		C40101D21DED705B000C5765 /* AKAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKAudioUnit.h; sourceTree = "<group>"; };
 		C40101D31DED705B000C5765 /* AKAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKAudioUnit.mm; sourceTree = "<group>"; };
+		C425DBA11EAEE533002675D2 /* AKInputDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKInputDevice.swift; sourceTree = "<group>"; };
+		C425DBA21EAEE533002675D2 /* AKInputDeviceAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKInputDeviceAudioUnit.h; sourceTree = "<group>"; };
+		C425DBA31EAEE533002675D2 /* AKInputDeviceAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKInputDeviceAudioUnit.mm; sourceTree = "<group>"; };
 		C42858EB1E90B5BE009B737D /* AKScheduledAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKScheduledAction.swift; sourceTree = "<group>"; };
 		C42899911D552E2C00B941B5 /* smoothDelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = smoothDelay.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C42899931D552F9F00B941B5 /* lowPassButterworthFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = lowPassButterworthFilter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -1692,6 +1698,16 @@
 				4871D4641DD913800046A768 /* AKClarinetDSPKernel.hpp */,
 			);
 			name = Clarinet;
+			sourceTree = "<group>";
+		};
+		C425DBA01EAEE533002675D2 /* Input Device */ = {
+			isa = PBXGroup;
+			children = (
+				C425DBA11EAEE533002675D2 /* AKInputDevice.swift */,
+				C425DBA21EAEE533002675D2 /* AKInputDeviceAudioUnit.h */,
+				C425DBA31EAEE533002675D2 /* AKInputDeviceAudioUnit.mm */,
+			);
+			path = "Input Device";
 			sourceTree = "<group>";
 		};
 		C42F36C21C0582E6000E937C = {
@@ -3247,6 +3263,7 @@
 			isa = PBXGroup;
 			children = (
 				C456662A1D448D7E00D26565 /* AKMicrophone.swift */,
+				C425DBA01EAEE533002675D2 /* Input Device */,
 			);
 			path = Input;
 			sourceTree = "<group>";
@@ -3875,6 +3892,7 @@
 				C45669351D448D7E00D26565 /* AKToneComplementFilterDSPKernel.hpp in Headers */,
 				C456695A1D448D7E00D26565 /* AKOperationGeneratorAudioUnit.h in Headers */,
 				C45666AF1D448D7E00D26565 /* EZAudio.h in Headers */,
+				C425DBA51EAEE533002675D2 /* AKInputDeviceAudioUnit.h in Headers */,
 				C45669071D448D7E00D26565 /* AKHighShelfParametricEqualizerFilterAudioUnit.h in Headers */,
 				C45666C31D448D7E00D26565 /* EZAudioUtilities.h in Headers */,
 				C45666B31D448D7E00D26565 /* EZAudioDisplayLink.h in Headers */,
@@ -4180,6 +4198,7 @@
 				C4F8C9EE1DCA9256001F38F2 /* gen_vals.c in Sources */,
 				C45231051DCDC21900A4F0DC /* save.swift in Sources */,
 				C45669CF1D448D7E00D26565 /* reverberateWithFlatFrequencyResponse.swift in Sources */,
+				C425DBA61EAEE533002675D2 /* AKInputDeviceAudioUnit.mm in Sources */,
 				C4F8CA2E1DCA9256001F38F2 /* tenv.c in Sources */,
 				A8E996F41EB9212600116ADA /* AKTuningTable+Brun.swift in Sources */,
 				C4F8CA001DCA9256001F38F2 /* noise.c in Sources */,
@@ -4432,6 +4451,7 @@
 				C45666F91D448D7E00D26565 /* eqfil.c in Sources */,
 				C456691C1D448D7E00D26565 /* AKMoogLadderPresets.swift in Sources */,
 				C45669721D448D7E00D26565 /* AKMorphingOscillatorBank.swift in Sources */,
+				C425DBA41EAEE533002675D2 /* AKInputDevice.swift in Sources */,
 				C45667521D448D7E00D26565 /* plumber.c in Sources */,
 				C456698A1D448D7E00D26565 /* AKPWMOscillatorBank.swift in Sources */,
 				C4F8C9C71DCA9255001F38F2 /* bitwise.c in Sources */,


### PR DESCRIPTION
* Add `AKOscillatorBankMonophonic`/`AKFMOscillatorBankMonophonic` classes: All the great note-playing benefits of AKOscillatorBanks without the polyphony; plus methods to play a note with a velocity and duration.
* Add ability to connect multiple inputs at a time to `AKMixer` after initialization

There's definitely a bit of code reuse here I'd like to DRY if anyone has suggestions! I'm new to Swift but a protocol or extension didn't seem quite right? Probably best to add this in such a way that the other kinds of oscillator banks can easily inherit the behavior…

![giphy-1](https://cloud.githubusercontent.com/assets/220240/25792875/2d75c98a-337e-11e7-95fe-58f87648fff9.gif)
