### PR TITLE
Disconnect AKNode subclasses safely

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -380,6 +380,12 @@ extension AVAudioEngine {
             }
         }
     }
+    
+    // MARK: - Disconnect node inputs
+    
+    @objc open static func disconnectAllInputs() {
+        engine.disconnectNodeInput(finalMixer.avAudioNode)
+    }
 
     // MARK: - Deinitialization
 

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -41,10 +41,13 @@ extension AVAudioConnectionPoint {
                                 fromBus: bus,
                                 format: AudioKit.format)
     }
+    
+    open func disconnect() {
+        // Override this method in subclasses
+        print("Error: Should not call disconnect on AKNode. Override this method in subclasses.")
+    }
 
     deinit {
-        //AKLog("* AKNode")
-        AudioKit.engine.detach(self.avAudioNode)
     }
 }
 

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Compressor/AKCompressor.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Compressor/AKCompressor.swift
@@ -82,6 +82,8 @@ open class AKCompressor: AKNode, AKToggleable, AUEffect {
     fileprivate var lastKnownMix: Double = 100
     fileprivate var inputGain: AKMixer?
     fileprivate var effectGain: AKMixer?
+    
+    fileprivate var compressorEffect:AVAudioUnitEffect
 
     /// Tells whether the node is processing (ie. started, playing, or active)
     open dynamic var isStarted = true
@@ -124,6 +126,8 @@ open class AKCompressor: AKNode, AKToggleable, AUEffect {
                 AudioKit.engine.connect(node, to: effect)
             }
             AudioKit.engine.connect(effect, to: mixer.avAudioNode)
+        
+            self.compressorEffect = effect
 
             super.init(avAudioNode: mixer.avAudioNode)
 
@@ -149,5 +153,20 @@ open class AKCompressor: AKNode, AKToggleable, AUEffect {
             dryWetMix = 0
             isStarted = false
         }
+    }
+    
+    // Disconnect the node
+    override open func disconnect() {
+        stop()
+        
+        let nodes = [inputGain!.avAudioNode, effectGain!.avAudioNode, mixer.avAudioNode]
+        
+        for node in nodes {
+            AudioKit.engine.disconnectNodeInput(node)
+            AudioKit.engine.disconnectNodeOutput(node)
+            AudioKit.engine.detach(node)
+        }
+        
+        AudioKit.engine.detach(self.compressorEffect)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifter.swift
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifter.swift
@@ -144,4 +144,15 @@ open class AKPitchShifter: AKNode, AKToggleable, AKComponent {
     open func stop() {
         internalAU?.stop()
     }
+    
+    // Disconnect the node
+    override open func disconnect() {
+        let nodes = [self.avAudioNode]
+        
+        for node in nodes {
+            AudioKit.engine.disconnectNodeInput(node)
+            AudioKit.engine.disconnectNodeOutput(node)
+            AudioKit.engine.detach(node)
+        }
+    }
 }

--- a/AudioKit/Common/Nodes/Mixing/Dry Wet Mixer/AKDryWetMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Dry Wet Mixer/AKDryWetMixer.swift
@@ -48,4 +48,15 @@ open class AKDryWetMixer: AKNode {
         wetGain?.volume = balance
         mixer.connect(wetGain)
     }
+    
+    // Disconnect the node
+    override open func disconnect() {
+        let nodes = [mixer.avAudioNode, dryGain!.avAudioNode, wetGain!.avAudioNode]
+        
+        for node in nodes {
+            AudioKit.engine.disconnectNodeInput(node)
+            AudioKit.engine.disconnectNodeOutput(node)
+            AudioKit.engine.detach(node)
+        }
+    }
 }

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -258,12 +258,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
 
         initialize()
     }
-
-    deinit {
-        AKLog("* AKAudioPlayer")
-        AudioKit.engine.detach(internalPlayer)
-    }
-
+    
     fileprivate var defaultBufferOptions: AVAudioPlayerNodeBufferOptions {
         return looping ? [.loops, .interrupts] : [.interrupts]
     }
@@ -564,5 +559,18 @@ open class AKAudioPlayer: AKNode, AKToggleable {
             stop()
             completionHandler?()
         }
+    }
+    
+    // Disconnect the node
+    override open func disconnect() {
+        let nodes = [self.avAudioNode]
+        
+        for node in nodes {
+            AudioKit.engine.disconnectNodeInput(node)
+            AudioKit.engine.disconnectNodeOutput(node)
+            AudioKit.engine.detach(node)
+        }
+        
+        AudioKit.engine.detach(self.internalPlayer)
     }
 }


### PR DESCRIPTION
- Examples of how to implement a disconnect method for AKNode subclasses.
- Remove existing generic disconnect logic in AKNode's deinit method. This would only work for a select few classes.