### PR TITLE
EndpointInfo structure created for having more information about the EndPoint

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
@@ -1,0 +1,56 @@
+//
+//  AKMIDIEndpointInfo.swift
+//  AudioKit For iOS
+//
+//  Created by dejaWorks on 06/05/2017.
+//  Copyright © 2017 AudioKit. All rights reserved.
+//
+
+import UIKit
+
+public struct EndpointInfo {
+    public var name = ""
+    public var displayName = ""
+    public var model = ""
+    public var manufacturer = ""
+    public var image = ""
+    public var driverOwner = ""
+
+}
+extension Collection where Iterator.Element == MIDIEndpointRef {
+    var endpointInfos: [EndpointInfo] {
+        
+        let name            = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyName) }
+        let displayName     = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDisplayName) }
+        let manufacturer    = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyModel) }
+        let model           = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyManufacturer) }
+        let image           = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyImage) }
+        let driverOwner     = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDriverOwner) }
+        
+        
+        
+        var ei = [EndpointInfo]()
+        for i in 0 ..< displayName.count{
+            ei.append(EndpointInfo(name: name[i],
+                                   displayName: displayName[i],
+                                   model: model[i],
+                                   manufacturer: manufacturer[i],
+                                   image: image[i],
+                                   driverOwner: driverOwner[i]
+                                   ))
+        }
+        return ei
+    }
+}
+
+extension AKMIDI {
+    
+    public var destinationInfos: [EndpointInfo] {
+        return MIDIDestinations().endpointInfos
+    }
+    // Array
+    public var inputInfos: [EndpointInfo] {
+        return MIDISources().endpointInfos
+    }
+}
+

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -804,6 +804,7 @@
 		C4F8D0941D5951C100D85987 /* AKPlaygroundResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F8D0931D5951C100D85987 /* AKPlaygroundResources.swift */; };
 		C4FE01631CED2DB40062B3A3 /* AKNodeRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FE01611CED2DB40062B3A3 /* AKNodeRecorder.swift */; };
 		C4FF7CB01D9F7F0B001BB82C /* AudioUnit+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FF7CAF1D9F7F0B001BB82C /* AudioUnit+Helpers.swift */; };
+		DC7DDDC21EBE86A1004B73E7 /* AKMIDIEndpointInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7DDDC11EBE86A1004B73E7 /* AKMIDIEndpointInfo.swift */; };
 		E4630B461D2BC73300437E75 /* AKMandolinPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4630B451D2BC73300437E75 /* AKMandolinPresets.swift */; };
 		E4630B4A1D2BC78600437E75 /* AKCostelloReverbPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4630B491D2BC78600437E75 /* AKCostelloReverbPresets.swift */; };
 		E4630B4C1D2BC79A00437E75 /* AKDistortionPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4630B4B1D2BC79A00437E75 /* AKDistortionPresets.swift */; };
@@ -1625,6 +1626,7 @@
 		C4F8D0931D5951C100D85987 /* AKPlaygroundResources.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKPlaygroundResources.swift; sourceTree = "<group>"; };
 		C4FE01611CED2DB40062B3A3 /* AKNodeRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKNodeRecorder.swift; sourceTree = "<group>"; };
 		C4FF7CAF1D9F7F0B001BB82C /* AudioUnit+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AudioUnit+Helpers.swift"; sourceTree = "<group>"; };
+		DC7DDDC11EBE86A1004B73E7 /* AKMIDIEndpointInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMIDIEndpointInfo.swift; sourceTree = "<group>"; };
 		E4630B451D2BC73300437E75 /* AKMandolinPresets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMandolinPresets.swift; sourceTree = "<group>"; };
 		E4630B491D2BC78600437E75 /* AKCostelloReverbPresets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKCostelloReverbPresets.swift; sourceTree = "<group>"; };
 		E4630B4B1D2BC79A00437E75 /* AKDistortionPresets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKDistortionPresets.swift; sourceTree = "<group>"; };
@@ -2007,6 +2009,7 @@
 				C40B0FFA1C463A32000BE96E /* AKMIDI.swift */,
 				C48DB7A91CD554A000D1EC13 /* AKMIDI+ReceivingMIDI.swift */,
 				C48DB7AA1CD554A000D1EC13 /* AKMIDI+SendingMIDI.swift */,
+				DC7DDDC11EBE86A1004B73E7 /* AKMIDIEndpointInfo.swift */,
 				C40AD6951C463B2600B638AF /* AKMIDIEvent.swift */,
 				FEBD4F6E1C5D47550007B60D /* AKMIDIListener.swift */,
 				C40AD6961C463B2600B638AF /* AKMIDIInstrument.swift */,
@@ -3991,6 +3994,7 @@
 				C40C41651C40E3A5009D870B /* EZMicrophone.m in Sources */,
 				C4F8C9151DCA8CE4001F38F2 /* scale.c in Sources */,
 				C4F8C8EE1DCA8CE4001F38F2 /* maytrig.c in Sources */,
+				DC7DDDC21EBE86A1004B73E7 /* AKMIDIEndpointInfo.swift in Sources */,
 				C40C41551C40E3A5009D870B /* EZAudioFFT.m in Sources */,
 				C40C416B1C40E3A5009D870B /* EZRecorder.m in Sources */,
 				C4F8C91F1DCA8CE4001F38F2 /* tabread.c in Sources */,
@@ -4593,7 +4597,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -4641,7 +4645,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "AudioKit-Swift.h";
@@ -4673,7 +4677,7 @@
 				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4701,7 +4705,7 @@
 				);
 				INFOPLIST_FILE = AudioKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Hi,

The new file I've added is for having more information about Endpoint.
Existing base structure was giving only `names` of the endpoints. 
Like;

    for n in midi.inputNames{
        print("Name: \(n)")
    }

I've added a similar structure and keep the exist (for backward compatibility)
Now we have;

    for info in midi.inputInfos{
            print("Display name: \(info.displayName)")
            print("Manufacturer: \(info.manufacturer)")
            // name, driverOwner, model, image
        }

More info properties can be added. I've added 6 most important ones.

