### PR TITLE
Minor Correction MidiMonitor Example to handle Pitch Wheel (issue #886)

### DIFF
--- a/Examples/iOS/MidiMonitor/MidiMonitor/ViewController.swift
+++ b/Examples/iOS/MidiMonitor/MidiMonitor/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController, AKMIDIListener {
         updateText("Channel: \(channel + 1) midiAfterTouch pressure: \(pressure) ")
     }
 
-    func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIByte, channel: MIDIChannel) {
+    func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord, channel: MIDIChannel) {
         updateText("Channel: \(channel + 1)  midiPitchWheel: \(pitchWheelValue)")
     }
 


### PR DESCRIPTION
(issue #886) In the example handler `func pitchWheelValue` wasn't calling by handler because of type mismatch. 
I've just updated the code according to  Aurelius'  solution.
