### PR TITLE
Fix an error when creating a mono AKAudioFile from floats

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
@@ -112,7 +112,7 @@ extension AKAudioFile {
 
         fixedSettings[AVNumberOfChannelsKey] = channels
 
-        try self.init(writeIn: baseDir, name: name)
+        try self.init(writeIn: baseDir, name: name, settings: fixedSettings)
 
         // create buffer for floats
         let format = AVAudioFormat(standardFormatWithSampleRate: 44_100,


### PR DESCRIPTION
Related issue: https://github.com/audiokit/AudioKit/issues/902