### PR TITLE
Fix: cannot create an AKAudioFile with space in name via init(writeIn…

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
@@ -71,7 +71,6 @@ extension AKAudioFile {
             let filePath: String = try baseDir.create(file: extPath, write: true)
             let fileURL = URL(fileURLWithPath: filePath)
 
-            
             // Directory exists ?
             let absDirPath = fileURL.deletingLastPathComponent().path
 

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ConvenienceInitializers.swift
@@ -69,10 +69,11 @@ extension AKAudioFile {
         throws {
             let extPath: String = "\(name ?? UUID().uuidString).caf"
             let filePath: String = try baseDir.create(file: extPath, write: true)
-            let nsurl = try URL(string: filePath) ?? .fileCreateError
+            let fileURL = URL(fileURLWithPath: filePath)
 
+            
             // Directory exists ?
-            let absDirPath = nsurl.deletingLastPathComponent().absoluteString
+            let absDirPath = fileURL.deletingLastPathComponent().path
 
             _ = try FileManager.default.fileExists(atPath: absDirPath) || .fileCreateError
 
@@ -82,7 +83,7 @@ extension AKAudioFile {
             fixedSettings[AVLinearPCMIsNonInterleaved] = NSNumber(value: false)
 
             do {
-                try self.init(forWriting: nsurl, settings: fixedSettings)
+                try self.init(forWriting: fileURL, settings: fixedSettings)
             } catch let error as NSError {
                 AKLog("ERROR AKAudioFile: Couldn't create an AKAudioFile...")
                 AKLog("Error: \(error)")


### PR DESCRIPTION
Creating an AKAudioFile with `AKAudioFile(writeIn: , name: , settings: )` fail if the name contains characters which are not allowed in URLs (like spaces).

Use the URL initializer `URL(fileURLWithPath: )` instead of `URL(string: )` to fix the issue.