### PR TITLE
Remove unnecessary code from AKNodeRecorder.record

### DIFF
--- a/AudioKit/Common/Internals/AKNodeRecorder.swift
+++ b/AudioKit/Common/Internals/AKNodeRecorder.swift
@@ -94,33 +94,6 @@
             return
         }
 
-        #if os(iOS)
-            // requestRecordPermission...
-            var permissionGranted: Bool = false
-
-            AKSettings.session.requestRecordPermission {
-                permissionGranted = $0
-            }
-
-            if !permissionGranted {
-                AKLog("AKNodeRecorder Error: Permission to record not granted")
-                throw NSError(domain: NSURLErrorDomain,
-                              code: NSURLErrorUnknown,
-                              userInfo: nil)
-            }
-
-            // Sets AVAudioSession Category to be Play and Record
-
-            if AKSettings.session.category != "\(AKSettings.SessionCategory.playAndRecord)" {
-                do {
-                    try AKSettings.setSession(category: .playAndRecord)
-                } catch let error as NSError {
-                    AKLog("AKNodeRecorder Error: Cannot set AVAudioSession Category to be .PlaybackAndRecord")
-                    throw error
-                }
-            }
-        #endif
-
         guard let node = node else {
             AKLog("AKNodeRecorder Error: input node is not available")
             return


### PR DESCRIPTION
Do not request record permission and keep current audio session category when recording with AKNodeRecorder.

Record permission is needed only when recording from a microphone, not when tapping an AVAudioNode

------

 [Related issue: #917](https://github.com/audiokit/AudioKit/issues/917)

------

My testing code snippet:


```
class ViewController: UIViewController {

    private var recorder: AKNodeRecorder!
    private var player: AKAudioPlayer!
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        let tape = try! AKAudioFile()
        player = try! AKAudioPlayer(file: tape)
        
        let clarinet = AKClarinet()
        
        let mixer = AKMixer(clarinet, player)
        AudioKit.output = mixer
        AudioKit.start()
        
        recorder = try! AKNodeRecorder(file: tape)

        Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
            clarinet.trigger(frequency: clarinet.frequency == 440 ? 220 : 440)
        }
        
        print("Audio session category: \(AVAudioSession.sharedInstance().category)")
    }

    @IBAction func recordButtonTouchUpInside(_ sender: Any) {
        if !recorder.isRecording {
            try! recorder.reset()
            try! recorder.record()
        }
        else {
            recorder.stop()
            try! player.reloadFile()
            player.play()
        }
    }
}
```
