### PR TITLE
add setting allowing developer to handle AVAudioSessionRouteChange no…

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -101,7 +101,13 @@
 
     /// Enable AudioKit AVAudioSession Category Management
     open static var disableAVAudioSessionCategoryManagement: Bool = false
-
+    
+    // If set to true, AudioKit will not handle the AVAudioSession route change 
+    // notification (AVAudioSessionRouteChange) and will not restart the AVAudioEngine
+    // instance when such notifications are posted. The developer can instead subscribe
+    // to these notifications and restart AudioKit after rebuiling their audio chain.
+    open static var disableRouteChangeHandling: Bool = false
+    
     /// Turn off AudioKit logging
     open static var enableLogging: Bool = true
 }

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -219,12 +219,13 @@ extension AVAudioEngine {
             self.engine.prepare()
 
             #if os(iOS)
-
-                NotificationCenter.default.addObserver(
-                    self,
-                    selector: #selector(AudioKit.restartEngineAfterRouteChange),
-                    name: .AVAudioSessionRouteChange,
-                    object: nil)
+                if !AKSettings.disableRouteChangeHandling {
+                    NotificationCenter.default.addObserver(
+                        self,
+                        selector: #selector(AudioKit.restartEngineAfterRouteChange),
+                        name: .AVAudioSessionRouteChange,
+                        object: nil)
+                }
             #endif
             #if !os(macOS)
                 if AKSettings.audioInputEnabled {


### PR DESCRIPTION
Adds a setting allowing developers to handle the AVAudioSessionRouteChange notification independently, instead of having AudioKit handle this and restart the audio engine any time a route change occurs.

This is critical for apps that re-build the audio chain during runtime, because they will need to re-build the audio chain in case of a route change as well.