### PR TITLE
Make AKMicrophoneTrackerEngine SoundPipe parameters on par with AKFrequencyTracker

### DIFF
--- a/AudioKit/Common/Internals/Microphone Tracker/AKMicrophoneTrackerEngine.m
+++ b/AudioKit/Common/Internals/Microphone Tracker/AKMicrophoneTrackerEngine.m
@@ -25,9 +25,12 @@
         sp_create(&sp);
         sp->sr = 44100;
         sp->nchan = 1;
+        
+        int hopSize = 4096;
+        int peakCount = 20;
 
         sp_ptrack_create(&ptrack);
-        sp_ptrack_init(sp, ptrack, 512, 20);
+        sp_ptrack_init(sp, ptrack, hopSize, peakCount);
         
         ezmic = [EZMicrophone microphoneWithDelegate:self];
     }


### PR DESCRIPTION
`AKMicrophoneTrackerEngine` was having difficulty tracking low notes (E2 on a guitar is what lead to finding this bug). This change brings `AKMicrophoneTrackerEngine`'s values on par with `AKFrequencyTracker` to give it a larger window to detect lower frequencies ("Smaller windows will give better time precision, but worse frequency accuracy (esp. in low fundamentals)." [according to psound documentation](https://groups.google.com/d/msg/audiokit/3ZPNv1vY9ZY/TTHL1MRLBwAJ)).