### PR TITLE
Fix iOS 11 crash when AKAudioPlayer stops internal

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -316,7 +316,9 @@ open class AKAudioPlayer: AKNode, AKToggleable {
         lastCurrentTime = Double(startTime / internalAudioFile.sampleRate)
         playing = false
         paused = false
-        internalPlayer.stop()
+        DispatchQueue.main.async { [weak self] () -> () in
+            self?.internalPlayer.stop()
+        }
 
     }
 


### PR DESCRIPTION
player from its own completion handler.

