### PR TITLE
Fixing crash from route/category changes when app is not active 

### DIFF
--- a/AudioKit/Common/Internals/AKNotifications.swift
+++ b/AudioKit/Common/Internals/AKNotifications.swift
@@ -17,4 +17,14 @@ extension NSNotification.Name {
     ///
     public static let AKEngineRestartedAfterRouteChange =
       NSNotification.Name(rawValue: "io.audiokit.enginerestartedafterroutechange")
+
+    /// After the audio engine configuration is changed, (change in input or output hardware's channel count or
+    /// sample rate, for example) AudioKit restarts, and engineRestartAfterCategoryChange is sent.
+    ///
+    /// The userInfo dictionary of this notification is the same as the originating
+    /// AVAudioEngineConfigurationChange notification's userInfo.
+    ///
+    public static let AKEngineRestartedAfterConfigurationChange =
+        NSNotification.Name(rawValue: "io.audiokit.enginerestartedafterconfigurationchange")
+
 }

--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -119,6 +119,13 @@
 
     /// Turn off AudioKit logging
     open static var enableLogging: Bool = true
+
+    /// Checks the application's info.plist to see if UIBackgroundModes includes "audio".
+    /// If background audio is supported then the system will allow the AVAudioEngine to start even if the app is in,
+    /// or entering, a background state. This can help prevent a potential crash
+    /// (AVAudioSessionErrorCodeCannotStartPlaying aka error code 561015905) when a route/category change causes
+    /// AudioEngine to attempt to start while the app is not active and background audio is not supported.
+    open static let appSupportsBackgroundAudio = (Bundle.main.infoDictionary?["UIBackgroundModes"] as? [String])?.contains("audio") ?? false
 }
 
 #if !os(macOS)
@@ -146,7 +153,6 @@ extension AKSettings {
         }
 
         // Preferred IO Buffer Duration
-
         do {
             try session.setPreferredIOBufferDuration(bufferLength.duration)
         } catch let error as NSError {
@@ -213,6 +219,6 @@ extension AKSettings {
             fatalError("unrecognized AVAudioSessionCategory \(self)")
 
       }
-  }
+   }
 }
 #endif

--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -120,12 +120,14 @@
     /// Turn off AudioKit logging
     open static var enableLogging: Bool = true
 
+    #if !os(macOS)
     /// Checks the application's info.plist to see if UIBackgroundModes includes "audio".
     /// If background audio is supported then the system will allow the AVAudioEngine to start even if the app is in,
     /// or entering, a background state. This can help prevent a potential crash
     /// (AVAudioSessionErrorCodeCannotStartPlaying aka error code 561015905) when a route/category change causes
     /// AudioEngine to attempt to start while the app is not active and background audio is not supported.
     open static let appSupportsBackgroundAudio = (Bundle.main.infoDictionary?["UIBackgroundModes"] as? [String])?.contains("audio") ?? false
+    #endif
 }
 
 #if !os(macOS)

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -216,7 +216,7 @@ extension AVAudioEngine {
         }
         // Start the engine.
         do {
-            self.engine.prepare()
+            engine.prepare()
 
             #if os(iOS)
 
@@ -299,7 +299,7 @@ extension AVAudioEngine {
 
             #endif
 
-            try self.engine.start()
+            try engine.start()
             shouldBeRunning = true
 
         } catch {
@@ -310,7 +310,7 @@ extension AVAudioEngine {
     /// Stop the audio engine
     open static func stop() {
         // Stop the engine.
-        self.engine.stop()
+        engine.stop()
         shouldBeRunning = false
         #if os(iOS)
         do {
@@ -338,9 +338,9 @@ extension AVAudioEngine {
         tester = AKTester(node, samples: samples)
         output = tester
         start()
-        self.engine.pause()
+        engine.pause()
         tester?.play()
-        let renderer = AKOfflineRenderer(engine: self.engine)
+        let renderer = AKOfflineRenderer(engine: engine)
         renderer?.render(Int32(samples))
     }
 


### PR DESCRIPTION
Apps that do not support [background audio](https://developer.apple.com/library/content/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html) (UIBackgroundModes array in info.plist) and attempt to start AVAudioEngine while the app is in, or entering, the background crash (error code `561015905`, more humanly readable as `AVAudioSessionErrorCodeCannotStartPlaying`).

These changes add a convenience constant to `AKSettings` indicating if the app supports background audio; if it does then route/category changes that happen while the app is not active will allow AudioKit to attempt to (re)start the AVAudioEngine. Apps that do not will do nothing. This does not prevent explicit calls to `AudioKit.start()` when the app is not active.

This may not be a perfect or all inclusive solution. Open to suggestions, ideas, and concerns! 
It'd be worth having a larger discussion around whether these same protections should be added to `start` and other places.