### PR TITLE
Refactored AKAudioPlayer for offline render compatibility, and for safer synchronization of start.

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -442,10 +442,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
             self.endTime = endTime
         }
         self.startTime = time
-
-        if endingFrame > startingFrame {
-            scheduledAVTime = avTime
-        }
+        scheduledAVTime = avTime
     }
 
     // MARK: - Static Methods

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -280,6 +280,10 @@ open class AKAudioPlayer: AKNode, AKToggleable {
 
     /// Start playback
     open func start() {
+        play(at:nil)
+    }
+
+    open func play(at when: AVAudioTime?) {
 
         if ❗️playing {
             if audioFileBuffer != nil {
@@ -289,7 +293,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
                     scheduleBuffer(atTime: scheduledAVTime, options: defaultBufferOptions)
                 }
 
-                internalPlayer.play()
+                internalPlayer.play(at: when)
 
                 playing = true
                 paused = false
@@ -422,6 +426,16 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     ///              important that this value be the same for all of them as a reference point.
     ///
     open func play(from time: Double, to endTime: Double, avTime: AVAudioTime? ) {
+        schedule(from: time, to: endTime, avTime: avTime)
+        if endingFrame > startingFrame {
+            start()
+        } else {
+            AKLog("ERROR AKaudioPlayer: cannot play, \(internalAudioFile.fileNamePlusExtension) " +
+                "is empty or segment is too short")
+        }
+    }
+
+    open func schedule(from time: Double, to endTime: Double, avTime: AVAudioTime? ) {
         stop()
 
         if endTime > 0 {
@@ -431,10 +445,6 @@ open class AKAudioPlayer: AKNode, AKToggleable {
 
         if endingFrame > startingFrame {
             scheduledAVTime = avTime
-            start()
-        } else {
-            AKLog("ERROR AKaudioPlayer: cannot play, \(internalAudioFile.fileNamePlusExtension) " +
-                "is empty or segment is too short")
         }
     }
 


### PR DESCRIPTION
Separated a new function schedule(from time: Double, to endTime: Double, avTime: AVAudioTime? ) from existing play(from time: Double, to endTime: Double, avTime: AVAudioTime? ) .
Added play(at when: AVAudioTime?).
start() now calls play(at: nil) internally.

AVAudioPlayer.play() will block until the next render cycle completes.  When performing an offline render, the rendering is paused and you must provide an AVAudioTime with a valid sampleTime or the player will block indefinitely.  AKAudioPlayer.play(at:) facilitates this need.
The combination of schedule(from:...) and play(at:) also allows for files to be prepared before setting the avTime that they'll be synchronized with.  Once files are prepared, you can start them one (or two to be safe) render cycles in the future and they'll definitely be ready.