### PR TITLE
Song processor update

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -39,12 +39,12 @@
         case longest = 12
 
         /// The buffer Length expressed as number of samples
-        var samplesCount: AVAudioFrameCount {
+        public var samplesCount: AVAudioFrameCount {
             return AVAudioFrameCount(pow(2.0, Double(rawValue)))
         }
 
         /// The buffer Length expressed as a duration in seconds
-        var duration: Double {
+        public var duration: Double {
             return Double(samplesCount) / AKSettings.sampleRate
         }
     }

--- a/Examples/iOS/SongProcessor/SongProcessor/SongExporter.swift
+++ b/Examples/iOS/SongProcessor/SongProcessor/SongExporter.swift
@@ -20,11 +20,12 @@ class SongExporter {
         self.exportPath = exportPath
     }
 
-    func exportSong(_ song: MPMediaItem) {
+    func exportSong(_ song: MPMediaItem, completion: ((Bool) -> Void)? = nil) {
 
         isReadyToPlay = false
 
         guard let url = song.value(forProperty: MPMediaItemPropertyAssetURL) as? URL else {
+            completion?(false)
             return
         }
         let songAsset = AVURLAsset(url: url, options: nil)
@@ -39,6 +40,7 @@ class SongExporter {
 
             if !assetReader.canAdd(assetReaderOutput) {
                 print("Can't add reader output...die!")
+                completion?(false)
             } else {
                 assetReader.add(assetReaderOutput)
             }
@@ -48,7 +50,9 @@ class SongExporter {
                 print("Deleting said file.")
                 do {
                     try FileManager.default.removeItem(atPath: exportPath)
-                } catch _ {
+                } catch {
+                    print(error)
+                    completion?(false)
                 }
             }
 
@@ -60,10 +64,12 @@ class SongExporter {
             } catch let error as NSError {
                 assetError = error
                 assetWriter = nil
+                completion?(false)
             }
 
             if let error = assetError {
                 print("Error: \(error)")
+                completion?(false)
                 return
             }
 
@@ -88,6 +94,7 @@ class SongExporter {
                 assetWriter.add(assetWriterInput)
             } else {
                 print("cant add asset writer input...die!")
+                completion?(false)
                 return
             }
 
@@ -129,6 +136,7 @@ class SongExporter {
                         assetWriterInput.markAsFinished()
                         assetWriter.finishWriting {
                             self.isReadyToPlay = true
+                            completion?(true)
                         }
                         assetReader.cancelReading()
                         break
@@ -140,6 +148,7 @@ class SongExporter {
 
         } catch let error as NSError {
             assetError = error
+            completion?(false)
             print("Initializing assetReader Failed")
         }
 

--- a/Examples/iOS/SongProcessor/SongProcessor/SongProcessor.swift
+++ b/Examples/iOS/SongProcessor/SongProcessor/SongProcessor.swift
@@ -14,8 +14,7 @@ class SongProcessor {
 
     static let sharedInstance = SongProcessor()
 
-    var audioFile: AKAudioFile!
-    var audioFilePlayer: AKAudioPlayer!
+    var iTunesFilePlayer: AKAudioPlayer?
     var variableDelay: AKVariableDelay!
     var delayMixer: AKDryWetMixer!
     var moogLadder: AKMoogLadder!
@@ -28,8 +27,19 @@ class SongProcessor {
     var bitCrushMixer: AKDryWetMixer!
     var playerBooster: AKBooster!
 
-    var currentSong: MPMediaItem?
-    var isPlaying: Bool?
+    var iTunesPlaying: Bool {
+        set{
+            if newValue {
+                guard let iTunesFilePlayer = iTunesFilePlayer else { return }
+                if !iTunesFilePlayer.isPlaying { iTunesFilePlayer.play() }
+            } else {
+                iTunesFilePlayer?.stop()
+            }
+        }
+        get{
+            return iTunesFilePlayer?.isPlaying ?? false
+        }
+    }
     var loopsPlaying: Bool {
         set{
             if newValue {
@@ -48,11 +58,6 @@ class SongProcessor {
     var playerMixer = AKMixer()
     
     init() {
-        audioFile = try? AKAudioFile(readFileName: "mixloop.wav",
-                                     baseDir: .resources)
-        audioFilePlayer = try? AKAudioPlayer(file: audioFile)
-        audioFilePlayer?.looping = true
-        playerMixer.connect(audioFilePlayer)
         
         for name in ["bass","drum","guitar","lead"]{
             do{

--- a/Examples/iOS/SongProcessor/SongProcessor/View Controllers/LoopsViewController.swift
+++ b/Examples/iOS/SongProcessor/SongProcessor/View Controllers/LoopsViewController.swift
@@ -18,9 +18,18 @@ class LoopsViewController: UIViewController {
     }
 
     fileprivate func playNew(loop: String) {
-        songProcessor.audioFile = try? AKAudioFile(readFileName: "\(loop)loop.wav", baseDir: .resources)
-        let _ = try? songProcessor.audioFilePlayer?.replace(file: songProcessor.audioFile!)
-        songProcessor.audioFilePlayer?.play()
+//        songProcessor.audioFile = try? AKAudioFile(readFileName: "\(loop)loop.wav", baseDir: .resources)
+//        let _ = try? songProcessor.audioFilePlayer?.replace(file: songProcessor.audioFile!)
+//        songProcessor.audioFilePlayer?.play()
+        
+        if loop == "mix" {
+            songProcessor.playersDo{ $0.volume = 1 }
+        } else {
+            guard let player = songProcessor.players[loop] else { return }
+            songProcessor.playersDo{ $0.volume = $0 == player ? 1 : 0 }
+        }
+     
+        songProcessor.loopsPlaying = true
     }
 
     @IBAction func playMix(_ sender: UIButton) {
@@ -45,6 +54,7 @@ class LoopsViewController: UIViewController {
 
     @IBAction func stop(_ sender: UIButton) {
         songProcessor.audioFilePlayer?.stop()
+        songProcessor.loopsPlaying = false
     }
 
 }

--- a/Examples/iOS/SongProcessor/SongProcessor/View Controllers/LoopsViewController.swift
+++ b/Examples/iOS/SongProcessor/SongProcessor/View Controllers/LoopsViewController.swift
@@ -18,17 +18,15 @@ class LoopsViewController: UIViewController {
     }
 
     fileprivate func playNew(loop: String) {
-//        songProcessor.audioFile = try? AKAudioFile(readFileName: "\(loop)loop.wav", baseDir: .resources)
-//        let _ = try? songProcessor.audioFilePlayer?.replace(file: songProcessor.audioFile!)
-//        songProcessor.audioFilePlayer?.play()
-        
         if loop == "mix" {
             songProcessor.playersDo{ $0.volume = 1 }
         } else {
             guard let player = songProcessor.players[loop] else { return }
             songProcessor.playersDo{ $0.volume = $0 == player ? 1 : 0 }
         }
-     
+        if !songProcessor.loopsPlaying {
+            songProcessor.rewindLoops()
+        }
         songProcessor.loopsPlaying = true
     }
 
@@ -53,7 +51,7 @@ class LoopsViewController: UIViewController {
     }
 
     @IBAction func stop(_ sender: UIButton) {
-        songProcessor.audioFilePlayer?.stop()
+        songProcessor.iTunesFilePlayer?.stop()
         songProcessor.loopsPlaying = false
     }
 

--- a/Examples/iOS/SongProcessor/SongProcessor/View Controllers/iTunes Library Access/SongViewController.swift
+++ b/Examples/iOS/SongProcessor/SongProcessor/View Controllers/iTunes Library Access/SongViewController.swift
@@ -23,15 +23,43 @@ class SongViewController: UIViewController {
 
     var song: MPMediaItem? {
         didSet {
-            if song?.persistentID != songProcessor.currentSong?.persistentID {
-
-                songProcessor.audioFilePlayer?.stop()
-                songProcessor.isPlaying = false
-                songProcessor.currentSong = song!
-                startTime = 0
-
-            } else { // the same song again.
-                exporter?.isReadyToPlay = true
+            songProcessor.iTunesFilePlayer?.stop()
+            
+            let fail = {
+                let alert = UIAlertController(title: "Couldn't load song", message: nil, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { (action) in
+                    self.navigationController?.popViewController(animated: true)
+                }))
+                self.present(alert, animated: true, completion: nil)
+            }
+            
+            guard let newSong = song else {
+                return fail()
+            }
+            
+            DispatchQueue.global(qos: .default).async {
+                let docDirs: [NSString] = NSSearchPathForDirectoriesInDomains(.documentDirectory,
+                                                                              .userDomainMask,
+                                                                              true) as [NSString]
+                let docDir = docDirs[0]
+                let tmp = docDir.appendingPathComponent("exported") as NSString
+                self.exportPath = tmp.appendingPathExtension("caf")!
+                
+                self.exporter = SongExporter(exportPath: self.exportPath)
+                self.exporter?.exportSong(newSong, completion:{ success in
+                    DispatchQueue.main.async {
+                        if success {
+                            
+                            self.loadSong()
+                            self.playButton.isUserInteractionEnabled = true;
+                            self.playButton.setTitle("Play", for: UIControlState())
+                            
+                        } else {
+                            fail()
+                        }
+                        
+                    }
+                })
             }
         }
     }
@@ -39,71 +67,50 @@ class SongViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if let art = songProcessor.currentSong!.value(forProperty: MPMediaItemPropertyArtwork) as? MPMediaItemArtwork {
-            albumImageView.image = art.image(at: self.view.bounds.size)
-        }
+        
 
-        if songProcessor.isPlaying! {
-            playButton.setTitle("Pause", for: UIControlState())
-        } else {
-            if exporter?.isReadyToPlay == false {
-                playButton.setTitle("Loading", for: UIControlState())
-            }
-            playButton.setTitle("Play", for: UIControlState())
-
-        }
+        playButton.setTitle("Loading", for: UIControlState())
+        playButton.isUserInteractionEnabled = false;
 
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        let docDirs: [NSString] = NSSearchPathForDirectoriesInDomains(.documentDirectory,
-                                                                      .userDomainMask,
-                                                                      true) as [NSString]
-        let docDir = docDirs[0]
-        let tmp = docDir.appendingPathComponent("exported") as NSString
-        exportPath = tmp.appendingPathExtension("wav")!
-
-        exporter = SongExporter(exportPath: exportPath)
-        print("Exporting song")
-        exporter?.exportSong(song!)
+    override func viewDidAppear(_ animated: Bool) {
+        if let art = song?.value(forProperty: MPMediaItemPropertyArtwork) as? MPMediaItemArtwork {
+            self.albumImageView.image = art.image(at: self.view.bounds.size)
+        }
     }
 
     @IBAction func play(_ sender: UIButton) {
-        /*
-        if exporter?.isReadyToPlay == false {
-            print("Not Ready")
-            playButton.setTitle("Loading", for: UIControlState())
-        } else {
-            playButton.setTitle("Play", for: UIControlState())
-        }
-        */
-        if sender.titleLabel!.text == "Play" {
-            loadSong()
-            playButton.setTitle("Stop", for: UIControlState())
-            songProcessor.audioFilePlayer!.play()
-            songProcessor.isPlaying = true
-
-        } else {
-            playButton.setTitle("Play", for: UIControlState())
-            songProcessor.audioFilePlayer!.stop()
-            songProcessor.isPlaying = false
-        }
+        songProcessor.iTunesPlaying = !songProcessor.iTunesPlaying
+        playButton.setTitle(songProcessor.iTunesPlaying ? "Stop" : "Play", for: UIControlState())
     }
 
     func loadSong() {
-
-        if FileManager.default.fileExists(atPath: exportPath) == false {
+        
+        let url = URL.init(fileURLWithPath: exportPath)
+        
+        
+        if FileManager.default.fileExists(atPath: url.path) == false {
             print("exportPath: \(exportPath)")
             print("File does not exist.")
             return
         }
 
-        playButton.isHidden = false
-
-        songProcessor.audioFile = try? AKAudioFile(readFileName: "exported.wav", baseDir: .documents)
-
-        try? songProcessor.audioFilePlayer?.replace(file: songProcessor.audioFile!)
+        
+        do{
+            let exportedFile = try AKAudioFile.init(forReading:url)
+            if songProcessor.iTunesFilePlayer == nil {
+                songProcessor.iTunesFilePlayer = try AKAudioPlayer(file:exportedFile)
+                songProcessor.playerMixer.connect(songProcessor.iTunesFilePlayer!)
+            }
+            guard let iTunesFilePlayer = songProcessor.iTunesFilePlayer else { return }
+            
+            try iTunesFilePlayer.replace(file: exportedFile)
+        } catch {
+            print(error)
+        }
+        
+        
 
     }
 


### PR DESCRIPTION
Playing all files in separate players to demonstrate AKAudioFile sync with play(at:)
Gave iTunes exporter a completion callback to make loading asynchronous and handle failures easier.
Moved song loading logic into song {didSet{}}
Various UI fixes to handle asynchronous loading.