### PR TITLE
Ak node io connections

### DIFF
--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -18,9 +18,6 @@ extension AVAudioConnectionPoint {
     /// The internal AVAudioEngine AVAudioNode
     open var avAudioNode: AVAudioNode
 
-    /// An array of all connections
-    internal var connectionPoints = [AVAudioConnectionPoint]()
-
     /// Create the node
     override public init() {
         self.avAudioNode = AVAudioNode()
@@ -33,28 +30,49 @@ extension AVAudioConnectionPoint {
         AudioKit.engine.attach(avAudioNode)
       }
     }
+}
 
+//Connections
+extension AKNode {
+
+    /// An array of all connections
+    open var connectionPoints: [AVAudioConnectionPoint]{
+        get{ return AudioKit.engine.outputConnectionPoints(for: avAudioNode, outputBus: 0) }
+        set{ AudioKit.connect(avAudioNode, to: newValue, fromBus: 0, format: AudioKit.format) }
+    }
     /// Connect this node to another
     open func addConnectionPoint(_ node: AKNode, bus: Int = 0) {
         connectionPoints.append(AVAudioConnectionPoint(node, to: bus))
-        AudioKit.engine.connect(avAudioNode,
-                                to: connectionPoints,
-                                fromBus: 0,
-                                format: AudioKit.format)
     }
 
-    /// Disconnect the node
+    open func disconnectInput() {
+        AudioKit.engine.disconnectNodeInput(avAudioNode)
+    }
+    open func disconnectOutput() {
+        AudioKit.engine.disconnectNodeOutput(avAudioNode)
+    }
+    open func disconnectInput(bus: Int) {
+        AudioKit.engine.disconnectNodeInput(avAudioNode, bus: bus)
+    }
+    open func disconnectOutput(bus: Int) {
+        AudioKit.engine.disconnectNodeOutput(avAudioNode, bus: bus)
+    }
+    open func detach() {
+        AudioKit.detach(nodes: [avAudioNode])
+    }
+}
+
+//Deprecated
+extension AKNode {
+    
+    @available(*, deprecated, renamed: "detach")
     open func disconnect() {
-        disconnect(nodes: [self.avAudioNode])
+        detach()
     }
-
-    /// Disconnect an array of nodes
+    
+    @available(*, deprecated, message: "Use AudioKit.dettach(nodes:) instead")
     open func disconnect(nodes: [AVAudioNode]) {
-        for node in nodes {
-            AudioKit.engine.disconnectNodeInput(node)
-            AudioKit.engine.disconnectNodeOutput(node)
-            AudioKit.engine.detach(node)
-        }
+        AudioKit.detach(nodes: nodes)
     }
 }
 

--- a/AudioKit/Common/Nodes/Mixing/Balancer/AKBalancer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Balancer/AKBalancer.swift
@@ -45,7 +45,6 @@ open class AKBalancer: AKNode, AKToggleable, AKComponent {
             input?.addConnectionPoint(self!)
 
             comparator.connectionPoints.append(AVAudioConnectionPoint(node: self!.avAudioNode, bus: 1))
-            AudioKit.engine.connect(comparator.avAudioNode, to: comparator.connectionPoints, fromBus: 0, format: nil)
         }
     }
 

--- a/AudioKit/Common/Nodes/Mixing/Environment/AK3DPanner.swift
+++ b/AudioKit/Common/Nodes/Mixing/Environment/AK3DPanner.swift
@@ -49,12 +49,13 @@ open class AK3DPanner: AKNode {
             return
         }
 
-        inputNode.connectionPoints.append(AVAudioConnectionPoint(node: environmentNode,
-                                                                 bus: environmentNode.numberOfInputs))
+        var inputsConnectionPoints = inputNode.connectionPoints
+        inputsConnectionPoints.append(AVAudioConnectionPoint(node: environmentNode,
+                                                             bus: environmentNode.numberOfInputs))
 
         let format = AVAudioFormat(standardFormatWithSampleRate: AKSettings.sampleRate, channels: 1)
 
-        AudioKit.engine.connect(inputNode.avAudioNode, to: inputNode.connectionPoints, fromBus: 0, format: format)
+        AudioKit.engine.connect(inputNode.avAudioNode, to: inputsConnectionPoints, fromBus: 0, format: format)
     }
 
 }

--- a/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
@@ -84,11 +84,6 @@ open class AKMixer: AKNode, AKToggleable {
 
         if let existingInput = input {
             existingInput.connectionPoints.append(AVAudioConnectionPoint(node: mixerAU!, bus: chan))
-            AudioKit.engine.connect(existingInput.avAudioNode,
-                                    to: existingInput.connectionPoints,
-                                    fromBus: 0,
-                                    format: AudioKit.format)
-
             connectionCounter += 1
 
             AKLog("AKMixer.connect() input: \(existingInput) on bus \(chan), Mixer now has \(mixerAU!.numberOfInputs) total inputs and \(connectionCounter) recent connections.")


### PR DESCRIPTION
README - Significant change  :)

This is the riskiest bit in preparation for clean disconnect and making connections post initialization. 

Added an extension to AudioKit with static connect functions mirroring AVAudioEngine's with the intent of convenience and safety. 
 An AVAudioNode will be automatically attached if connecting using these.

In AKNode, connectionPoints are now public and calculated from AVAudioEngine rather than storing an instance variable that could get out of sync with AVAudioEngine.
The biggest difference implementation-wise is that when appending to connectionPoints, an output connection is made automatically with AudioKit.format
Now that AKMixer is using nextAvailableInput instead of connectionPoints.count for input bus this hopefully won't be an issue for anyone.
Refactored AKBalancer, AK3DPanner, and AKMixer around use of connectionPoints.

Added disconnect convenience wrappers to AKNode.
    
Deprecated AKNode.disconnect() as the naming is misleading, renamed it to detach.
Deprecated AKNode.disconnect(nodes:) as the naming is misleading and function is unrelated to self, warning suggests using new AudioKit.detach(nodes: [AVAudioNode]) convenience function instead.

I ran the Examples using AKBalancer and AK3DPanner without issue.