### PR TITLE
Implement AKInput for AVAudioNode

### DIFF
--- a/AudioKit/Common/Nodes/AKConnection.swift
+++ b/AudioKit/Common/Nodes/AKConnection.swift
@@ -35,6 +35,9 @@ extension AKOutput{
     public func disconnectOutput() {
         AudioKit.engine.disconnectNodeOutput(outputNode)
     }
+    public func disconnectOutput(from: AKInput) {
+        connectionPoints = connectionPoints.filter({ $0.node != from.inputNode })
+    }
     public func disconnectOutput(bus: Int) {
         AudioKit.engine.disconnectNodeOutput(outputNode, bus: bus)
     }
@@ -67,6 +70,9 @@ extension AKOutput{
 
 
     //Set connection, this will remove existing connections from the output.
+    @discardableResult public func setOutput(to node: AKInput) -> AKInput {
+        return setOutput(to: node, bus: node.nextInput.bus, format: AudioKit.format)
+    }
     @discardableResult public func setOutput(to node: AKInput, bus: Int, format: AVAudioFormat) -> AKInput {
         AudioKit.connect(outputNode, to: node.inputNode, fromBus: 0, toBus: bus, format: format)
         return node

--- a/AudioKit/Common/Nodes/AKConnection.swift
+++ b/AudioKit/Common/Nodes/AKConnection.swift
@@ -134,7 +134,16 @@ extension AKInput {
 
 }
 
-
+extension AVAudioNode: AKInput {
+    public var outputNode: AVAudioNode {
+        return self
+    }
+}
+extension AVAudioMixerNode {
+    public var nextInput: AKInputConnection {
+        return AKInputConnection(node: self, bus: nextAvailableInputBus)
+    }
+}
 
 // Set output connection(s)
 infix operator >>>: AdditionPrecedence


### PR DESCRIPTION
AVAudioNodes can now be connected, and held in an array along with AKNodes.  

I did a blanket implementation of the base class, so units like AVAudioUnitSampler can be connected to.  There may be some work to be done around implementing AKInput for the subclasses only.  Or, maybe it's OK to let users erroneously try to connect to an output only node.

Added disconnect(from: AKInput) to disconnect from a node rather than finding the bus yourself.
Added another setOutput convenience function.