### PR TITLE
Pulled render notify out of AKLazyTap and into a base class.

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.h
+++ b/AudioKit/Common/Internals/AudioKit.h
@@ -134,3 +134,7 @@ FOUNDATION_EXPORT const unsigned char AudioKitVersionString[];
 
 //Offline
 #import "AKOfflineRenderAudioUnit.h"
+
+//Taps
+#import "AKRenderTap.h"
+#import "AKLazyTap.h"

--- a/AudioKit/Common/Taps/AKLazyTap.h
+++ b/AudioKit/Common/Taps/AKLazyTap.h
@@ -9,24 +9,9 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioToolbox.h>
+#import "AKRenderTap.h"
 
-@interface AVAudioPCMBuffer (max)
--(double)max;
-@end
-
-@interface AKLazyTap : NSObject
-
-
-/*!
- * Initializes a tap by adding a render notify callback to the node's
- * underlying audioUnit.
- *
- * The render notify will be removed on dealloc.
- *
- * @param node The AVAudioNode that will the tap will pull buffers from.
- * @return An AKLazyTap if sucessful in adding the renderNotify.
- */
--(instancetype _Nullable )initWithNode:(AVAudioNode * _Nonnull)node;
+@interface AKLazyTap : AKRenderTap
 
 /*!
  * Initializes a tap by adding a render notify callback to the node's
@@ -50,7 +35,6 @@
  * @return An AKLazyTap if sucessful in adding the renderNotify.
  */
 -(instancetype _Nullable)initWithAudioUnit:(AudioUnit _Nonnull)audioUnit queueTime:(double)seconds NS_DESIGNATED_INITIALIZER;
-
 -(instancetype _Nonnull )init NS_UNAVAILABLE;
 
 /*!
@@ -63,11 +47,12 @@
  * it to bufferlistOut.
  *
  * @param bufferlistOut An audioBufferList that the audio will be copied
- * to,  Should be allocated to store at least one render cylce of audio.  
+ * to,  Should be allocated to store at least one render cylce of audio.
  * @param timeStamp On output, the timeStamp for the audioBufferlist.
  * @return True if audio was copied, false if no audio to copy.
  */
 -(BOOL)copyNextBufferList:(AudioBufferList * _Nonnull)bufferlistOut timeStamp:(inout AudioTimeStamp * _Nullable)timeStamp;
+
 /*!
  * Will fill the suplied buffer with as much audio as it can hold or
  * as much audio as the internal buffer contains, whichever is less.
@@ -78,19 +63,5 @@
  * @return True if audio was copied, false if no audio to copy.
  */
 -(BOOL)fillNextBuffer:(AVAudioPCMBuffer * _Nonnull)buffer timeStamp:(inout AudioTimeStamp * _Nullable)timeStamp;
+
 @end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/AudioKit/Common/Taps/AKRenderTap.h
+++ b/AudioKit/Common/Taps/AKRenderTap.h
@@ -1,0 +1,68 @@
+//
+//  AKRenderTap.h
+//  AudioKit
+//
+//  Created by David O'Neill on 8/16/17.
+//  Copyright © AudioKit. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <AudioToolbox/AudioToolbox.h>
+/**
+ * A block that will be called every pre and post render for an audio unit.
+ */
+typedef void(^AKRenderNotifyBlock)(AudioUnitRenderActionFlags * _Nonnull ioActionFlags,const AudioTimeStamp * _Nonnull inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames, AudioBufferList * _Nullable ioData);
+
+@interface AKRenderTap : NSObject
+
+/**
+ * A block that will be called every pre and post render for an audio unit.
+ * Meant to be implemented by subclasses.  Will be called from the render
+ * thread, so no locks, Swift functions or Objective-C messages from within
+ * this block.  Make sure not to capture self.
+ */
+@property (readonly) AKRenderNotifyBlock _Nullable renderNotifyBlock NS_SWIFT_UNAVAILABLE("No render code in Swift");
+
+/**
+ * return Is renderNotify added.
+ */
+@property (readonly) BOOL started;
+
+/*!
+ * Initializes a renderTap, holds reference to underlying audioUnit.
+ * underlying audioUnit.
+ *
+ * This is a base class implemtation.
+ *
+ * @param node The AVAudioNode that will the tap will notify on.
+ * @return A renderTap ready to start.
+ */
+-(instancetype _Nullable )initWithNode:(AVAudioNode * _Nonnull)node;
+
+/*!
+ * Initializes a renderTap, holds reference to audioUnit.
+ *
+ * This is a base class implemtation.
+ *
+ * @param audioUnit The audioUnit that will the tap notify on.
+ * @return A renderTap ready to start.
+ */
+-(instancetype _Nullable )initWithAudioUnit:(AudioUnit _Nonnull)audioUnit NS_DESIGNATED_INITIALIZER;
+
+/*!
+ * Starts a renderTap by adding a renderNotify to the internal audioUnit.
+ *
+ * @param outError On ouput, an error or NULL if successful.
+ * @return true if success.
+ */
+-(BOOL)start:(NSError * _Nullable  *_Nullable)outError;
+
+/*!
+ * Stops a renderTap by removing a renderNotify from the internal audioUnit.
+ */
+-(void)stop;
+
+-(instancetype _Nonnull )init NS_UNAVAILABLE;
+
+@end

--- a/AudioKit/Common/Taps/AKRenderTap.m
+++ b/AudioKit/Common/Taps/AKRenderTap.m
@@ -1,0 +1,102 @@
+//
+//  AKRenderTap.m
+//  AudioKit
+//
+//  Created by David O'Neill on 8/16/17.
+//  Copyright © AudioKit. All rights reserved.
+//
+
+#import "AKRenderTap.h"
+#import "TPCircularBuffer+AudioBufferList.h"
+#import <pthread/pthread.h>
+
+
+@implementation AKRenderTap{
+    AudioUnit _audioUnit;
+    AKRenderNotifyBlock _renderNotifyBlock;
+    BOOL _started;
+}
+
+-(instancetype _Nullable )initWithAudioUnit:(AudioUnit _Nonnull)audioUnit {
+    self = [super init];
+    if (self) {
+        _audioUnit = audioUnit;
+    }
+    return self;
+}
+-(BOOL)start:(NSError **)outError {
+    if (_started) {
+        return true;
+    }
+    _renderNotifyBlock = _renderNotifyBlock ?: self.renderNotifyBlock;
+    if (!_renderNotifyBlock) {
+        if (outError) {
+            NSString *description = [NSString stringWithFormat:@"%@ start renderNotifyBlock nil!",NSStringFromClass(self.class)];
+            *outError =  [NSError errorWithDomain:@"AKRenderTap"
+                                             code:1
+                                         userInfo:@{NSLocalizedDescriptionKey:description}];
+        }
+        return false;
+    }
+    OSStatus status = AudioUnitAddRenderNotify(_audioUnit, renderNotify, (__bridge void *)_renderNotifyBlock);
+    if (status) {
+        if (outError) {
+            NSString *description = [NSString stringWithFormat:@"%@ start error",NSStringFromClass(self.class)];
+            *outError =  [NSError errorWithDomain:NSOSStatusErrorDomain
+                                             code:status
+                                         userInfo:@{NSLocalizedDescriptionKey:description}];
+        }
+        return false;
+    }
+    _started = true;
+    return true;
+}
+-(void)stop{
+    if (!_started) {
+        return;
+    }
+    OSStatus status = AudioUnitRemoveRenderNotify(_audioUnit, renderNotify, (__bridge void *)_renderNotifyBlock);
+    if (status) {
+        printf("%s OSStatus %d %d\n",NSStringFromClass(self.class).UTF8String,status,__LINE__);
+    }
+    _started = false;
+}
+-(BOOL)started {
+    return _started;
+}
+-(instancetype)initWithNode:(AVAudioNode *)node {
+    AVAudioUnit *avAudioUnit = (AVAudioUnit *)node;
+    if (![avAudioUnit respondsToSelector:@selector(audioUnit)]) {
+        NSLog(@"%@ doesn't have an accessible audioUnit",NSStringFromClass(node.class));
+        return nil;
+    }
+    return [self initWithAudioUnit:avAudioUnit.audioUnit];
+}
+
+- (void)dealloc {
+    [self stop];
+
+    //Cleanup should happen after at least two render cycles so that nothing is deallocated mid-render
+    double timeFromNow = 0.2;
+    AKRenderNotifyBlock dBlock = _renderNotifyBlock;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeFromNow * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        AKRenderNotifyBlock block = dBlock;
+        block = nil;
+    });
+}
+
+static OSStatus renderNotify(void                        * inRefCon,
+                            AudioUnitRenderActionFlags   * ioActionFlags,
+                            const AudioTimeStamp         * inTimeStamp,
+                            UInt32                       inBusNumber,
+                            UInt32                       inNumberFrames,
+                            AudioBufferList              * ioData) {
+
+    __unsafe_unretained AKRenderNotifyBlock notifyBlock = (__bridge AKRenderNotifyBlock)(inRefCon);
+    if (notifyBlock) {
+        notifyBlock(ioActionFlags, inTimeStamp, inBusNumber, inNumberFrames, ioData);
+    }
+    return noErr;
+}
+
+@end

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		558D808F1F4D2D9D001E7BC1 /* TPCircularBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D808B1F4D2D9D001E7BC1 /* TPCircularBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D80921F4D2DC8001E7BC1 /* AKLazyTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80901F4D2DC8001E7BC1 /* AKLazyTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D80931F4D2DC8001E7BC1 /* AKLazyTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 558D80911F4D2DC8001E7BC1 /* AKLazyTap.m */; };
+		55E25CCC1F4E6C2F00F5AF08 /* AKRenderTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25CCA1F4E6C2F00F5AF08 /* AKRenderTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55E25CCD1F4E6C2F00F5AF08 /* AKRenderTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E25CCB1F4E6C2F00F5AF08 /* AKRenderTap.m */; };
 		55F29C091E90654C00A2151F /* AKScheduledAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F29C081E90654C00A2151F /* AKScheduledAction.swift */; };
 		6520FFC21D361B030052410C /* resonantFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6520FFC11D361B030052410C /* resonantFilter.swift */; };
 		701E04861F1B7CB500A7A2D8 /* AKRotaryKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701E04851F1B7CB500A7A2D8 /* AKRotaryKnob.swift */; };
@@ -970,6 +972,8 @@
 		558D808B1F4D2D9D001E7BC1 /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 		558D80901F4D2DC8001E7BC1 /* AKLazyTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKLazyTap.h; sourceTree = "<group>"; };
 		558D80911F4D2DC8001E7BC1 /* AKLazyTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKLazyTap.m; sourceTree = "<group>"; };
+		55E25CCA1F4E6C2F00F5AF08 /* AKRenderTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKRenderTap.h; sourceTree = "<group>"; };
+		55E25CCB1F4E6C2F00F5AF08 /* AKRenderTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRenderTap.m; sourceTree = "<group>"; };
 		55F29C081E90654C00A2151F /* AKScheduledAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKScheduledAction.swift; sourceTree = "<group>"; };
 		6520FFC11D361B030052410C /* resonantFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = resonantFilter.swift; sourceTree = "<group>"; };
 		701E04851F1B7CB500A7A2D8 /* AKRotaryKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKRotaryKnob.swift; sourceTree = "<group>"; };
@@ -2215,6 +2219,8 @@
 			children = (
 				C474B1631CE43A9D00EB8D8E /* AKAmplitudeTap.swift */,
 				C474B1641CE43A9D00EB8D8E /* AKFFTTap.swift */,
+				55E25CCA1F4E6C2F00F5AF08 /* AKRenderTap.h */,
+				55E25CCB1F4E6C2F00F5AF08 /* AKRenderTap.m */,
 				558D80901F4D2DC8001E7BC1 /* AKLazyTap.h */,
 				558D80911F4D2DC8001E7BC1 /* AKLazyTap.m */,
 			);
@@ -4039,6 +4045,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				558D80921F4D2DC8001E7BC1 /* AKLazyTap.h in Headers */,
+				55E25CCC1F4E6C2F00F5AF08 /* AKRenderTap.h in Headers */,
 				558D808D1F4D2D9D001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */,
 				558D808F1F4D2D9D001E7BC1 /* TPCircularBuffer.h in Headers */,
 				52145B621F3C5B1A0069C88B /* LPFCombFilter.h in Headers */,
@@ -4427,6 +4434,7 @@
 				C4F8C9371DCA8CE4001F38F2 /* zeros.c in Sources */,
 				C4F8C9071DCA8CE4001F38F2 /* pshift.c in Sources */,
 				C47047921E76997200D9906F /* TwoZero.cpp in Sources */,
+				55E25CCD1F4E6C2F00F5AF08 /* AKRenderTap.m in Sources */,
 				C4F8C9231DCA8CE4001F38F2 /* tenv.c in Sources */,
 				F4CA85801EB666260066BE5C /* AKTuningTable+EqualTemperament.swift in Sources */,
 				C40C41591C40E3A5009D870B /* EZAudioFloatConverter.m in Sources */,

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		558D80821F4D2A3D001E7BC1 /* TPCircularBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D807E1F4D2A3D001E7BC1 /* TPCircularBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D80A31F4D440F001E7BC1 /* AKLazyTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80A11F4D440F001E7BC1 /* AKLazyTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D80A41F4D440F001E7BC1 /* AKLazyTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 558D80A21F4D440F001E7BC1 /* AKLazyTap.m */; };
+		55E25CD11F4E76B100F5AF08 /* AKRenderTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25CCF1F4E76B100F5AF08 /* AKRenderTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55E25CD21F4E76B100F5AF08 /* AKRenderTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E25CD01F4E76B100F5AF08 /* AKRenderTap.m */; };
 		7078DE4D1F260A3600F1DC67 /* AKRotaryKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7078DE4C1F260A3600F1DC67 /* AKRotaryKnob.swift */; };
 		A8E996F41EB9212600116ADA /* AKTuningTable+Brun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E996F31EB9212600116ADA /* AKTuningTable+Brun.swift */; };
 		B19AE76D1F30F58500F9DC25 /* AKAudioUnitInstrument.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19AE76B1F30F58500F9DC25 /* AKAudioUnitInstrument.swift */; };
@@ -937,6 +939,8 @@
 		558D807E1F4D2A3D001E7BC1 /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 		558D80A11F4D440F001E7BC1 /* AKLazyTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKLazyTap.h; sourceTree = "<group>"; };
 		558D80A21F4D440F001E7BC1 /* AKLazyTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKLazyTap.m; sourceTree = "<group>"; };
+		55E25CCF1F4E76B100F5AF08 /* AKRenderTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKRenderTap.h; sourceTree = "<group>"; };
+		55E25CD01F4E76B100F5AF08 /* AKRenderTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRenderTap.m; sourceTree = "<group>"; };
 		7078DE4C1F260A3600F1DC67 /* AKRotaryKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKRotaryKnob.swift; sourceTree = "<group>"; };
 		A8E996F31EB9212600116ADA /* AKTuningTable+Brun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Brun.swift"; sourceTree = "<group>"; };
 		B19AE76B1F30F58500F9DC25 /* AKAudioUnitInstrument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AKAudioUnitInstrument.swift; path = "AudioUnit Host/AKAudioUnitInstrument.swift"; sourceTree = "<group>"; };
@@ -3817,6 +3821,8 @@
 			children = (
 				C45666921D448D7E00D26565 /* AKAmplitudeTap.swift */,
 				C45666931D448D7E00D26565 /* AKFFTTap.swift */,
+				55E25CCF1F4E76B100F5AF08 /* AKRenderTap.h */,
+				55E25CD01F4E76B100F5AF08 /* AKRenderTap.m */,
 				558D80A11F4D440F001E7BC1 /* AKLazyTap.h */,
 				558D80A21F4D440F001E7BC1 /* AKLazyTap.m */,
 			);
@@ -4030,6 +4036,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				558D80A31F4D440F001E7BC1 /* AKLazyTap.h in Headers */,
+				55E25CD11F4E76B100F5AF08 /* AKRenderTap.h in Headers */,
 				558D80801F4D2A3D001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */,
 				558D80821F4D2A3D001E7BC1 /* TPCircularBuffer.h in Headers */,
 				552CD4901F3BBA34005762E9 /* AKOfflineRenderAudioUnit.h in Headers */,
@@ -4708,6 +4715,7 @@
 				C4F8CA051DCA9256001F38F2 /* pan.c in Sources */,
 				C47047CE1E78FB4500D9906F /* Shakers.cpp in Sources */,
 				7078DE4D1F260A3600F1DC67 /* AKRotaryKnob.swift in Sources */,
+				55E25CD21F4E76B100F5AF08 /* AKRenderTap.m in Sources */,
 				C45669EC1D448D7E00D26565 /* periodicTrigger.swift in Sources */,
 				C4F8CA011DCA9256001F38F2 /* nsmp.c in Sources */,
 				C49390991E088F4C009FEAA1 /* AKStereoFieldLimiterAudioUnit.mm in Sources */,

--- a/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
+++ b/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		558D809C1F4D3D5C001E7BC1 /* TPCircularBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80981F4D3D5C001E7BC1 /* TPCircularBuffer.h */; };
 		558D80A71F4D443A001E7BC1 /* AKLazyTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80A51F4D443A001E7BC1 /* AKLazyTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D80A81F4D443A001E7BC1 /* AKLazyTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 558D80A61F4D443A001E7BC1 /* AKLazyTap.m */; };
+		55E25CD51F4E76F000F5AF08 /* AKRenderTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25CD31F4E76F000F5AF08 /* AKRenderTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55E25CD61F4E76F000F5AF08 /* AKRenderTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E25CD41F4E76F000F5AF08 /* AKRenderTap.m */; };
 		A8E996F61EB921D100116ADA /* AKTuningTable+Brun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E996F51EB921D100116ADA /* AKTuningTable+Brun.swift */; };
 		B1F47ABF1DC54E0F00706A2F /* EZAudioFileMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = B1F47ABD1DC54E0F00706A2F /* EZAudioFileMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1F47AC01DC54E0F00706A2F /* EZAudioFileMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F47ABE1DC54E0F00706A2F /* EZAudioFileMarker.m */; };
@@ -865,6 +867,8 @@
 		558D80981F4D3D5C001E7BC1 /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
 		558D80A51F4D443A001E7BC1 /* AKLazyTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKLazyTap.h; sourceTree = "<group>"; };
 		558D80A61F4D443A001E7BC1 /* AKLazyTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKLazyTap.m; sourceTree = "<group>"; };
+		55E25CD31F4E76F000F5AF08 /* AKRenderTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKRenderTap.h; sourceTree = "<group>"; };
+		55E25CD41F4E76F000F5AF08 /* AKRenderTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRenderTap.m; sourceTree = "<group>"; };
 		A8E996F51EB921D100116ADA /* AKTuningTable+Brun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Brun.swift"; sourceTree = "<group>"; };
 		B1F47ABD1DC54E0F00706A2F /* EZAudioFileMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFileMarker.h; sourceTree = "<group>"; };
 		B1F47ABE1DC54E0F00706A2F /* EZAudioFileMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioFileMarker.m; sourceTree = "<group>"; };
@@ -2748,6 +2752,8 @@
 			children = (
 				C474B16D1CE43BF300EB8D8E /* AKAmplitudeTap.swift */,
 				C474B16E1CE43BF300EB8D8E /* AKFFTTap.swift */,
+				55E25CD31F4E76F000F5AF08 /* AKRenderTap.h */,
+				55E25CD41F4E76F000F5AF08 /* AKRenderTap.m */,
 				558D80A51F4D443A001E7BC1 /* AKLazyTap.h */,
 				558D80A61F4D443A001E7BC1 /* AKLazyTap.m */,
 			);
@@ -3752,6 +3758,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				558D80A71F4D443A001E7BC1 /* AKLazyTap.h in Headers */,
+				55E25CD51F4E76F000F5AF08 /* AKRenderTap.h in Headers */,
 				C45210711E7D0884007C38FE /* AKSporthStack+Internal.h in Headers */,
 				B1F47ABF1DC54E0F00706A2F /* EZAudioFileMarker.h in Headers */,
 				C45382101C3A5CBD00A51738 /* AKWhiteNoiseAudioUnit.h in Headers */,
@@ -4160,6 +4167,7 @@
 				C48C6A9C1D3C1574008EA51B /* phasor.c in Sources */,
 				C4F8CB101DCA928B001F38F2 /* pareq.c in Sources */,
 				C4D1FD081CE5BDC60043209E /* AKTremolo.swift in Sources */,
+				55E25CD61F4E76F000F5AF08 /* AKRenderTap.m in Sources */,
 				C4F8CAF71DCA928B001F38F2 /* gen_sporth.c in Sources */,
 				C4A916961C25083A006C1A15 /* metronome.swift in Sources */,
 				C4F8CAEF1DCA928B001F38F2 /* gbuzz.c in Sources */,


### PR DESCRIPTION

AKRenderTap is a base class that will set a render notify on an audio unit.
Instead of other classes having to set a render notify using the C interface, they can just subclass AKRenderTap and implement  renderNotifyBlock.
Implementing renderNotifyBlock is similar to how AUAudioUnit subclasses implement internalRenderBlock.

AKLazyTap inherits from AKRenderTap.
Added AKRenderTap and AKLazyTap to AudioKit.h.
