### PR TITLE
TPCircularBufferUnit

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.h
+++ b/AudioKit/Common/Internals/AudioKit.h
@@ -138,3 +138,9 @@ FOUNDATION_EXPORT const unsigned char AudioKitVersionString[];
 //Taps
 #import "AKRenderTap.h"
 #import "AKLazyTap.h"
+
+//Utilities
+#import "TPCircularBuffer.h"
+#import "TPCircularBuffer+Unit.h"
+#import "TPCircularBuffer+AudioBufferList.h"
+

--- a/AudioKit/Common/Internals/Utilities/TPCircularBuffer+Unit.c
+++ b/AudioKit/Common/Internals/Utilities/TPCircularBuffer+Unit.c
@@ -1,0 +1,48 @@
+//
+//  TPCircularBuffer+Unit.c
+//
+//  Created by David O'Neill on 8/21/17.
+//  Copyright © 2017 O'Neill. All rights reserved.
+//
+
+#include "TPCircularBuffer+Unit.h"
+
+typedef struct {
+    int length;
+    uint32_t type;
+    char payload[1];
+}GenericStruct;
+
+void *TPCircularBufferUnitHead(TPCircularBuffer *buffer, uint32_t *type, int length) {
+    int32_t availableBytes = 0;
+    GenericStruct *head = TPCircularBufferHead(buffer, &availableBytes);
+    if (offsetof(GenericStruct, payload) + length > availableBytes) {
+        return NULL;
+    }
+    head->type = type ? *type : 0;
+    head->length = length;
+    return head->payload;
+}
+
+void TPCircularBufferUnitProduce(TPCircularBuffer *buffer) {
+    int32_t availableBytes = 0;
+    GenericStruct *head = TPCircularBufferHead(buffer, &availableBytes);
+    if (head) {
+        TPCircularBufferProduce(buffer, offsetof(GenericStruct, payload) + head->length);
+    }
+}
+void *TPCircularBufferUnitTail(TPCircularBuffer *buffer, uint32_t *type, int *length) {
+    int32_t availableBytes = 0;
+    GenericStruct *tail = TPCircularBufferTail(buffer, &availableBytes);
+    if (!tail) return NULL;
+    if (type) *type = tail->type;
+    if (length) *length = tail->length;
+    return tail->payload;
+}
+void TPCircularBufferUnitConsume(TPCircularBuffer *buffer) {
+    int32_t availableBytes;
+    GenericStruct *tail = TPCircularBufferTail(buffer, &availableBytes);
+    if (tail) {
+        TPCircularBufferConsume(buffer, offsetof(GenericStruct, payload) + tail->length);
+    }
+}

--- a/AudioKit/Common/Internals/Utilities/TPCircularBuffer+Unit.h
+++ b/AudioKit/Common/Internals/Utilities/TPCircularBuffer+Unit.h
@@ -1,0 +1,154 @@
+//
+//  TPCircularBuffer+Unit.h
+//
+//  Created by David O'Neill on 8/21/17.
+//  Copyright © 2017 O'Neill. All rights reserved.
+//
+
+#ifndef TPCircularBuffer_Unit_h
+#define TPCircularBuffer_Unit_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#import "TPCircularBuffer.h"
+
+/**
+ * @brief Utilitiy functions for writing arbitrary sized values to a TPCircularBuffer.
+ *
+ * @discussion
+ * TPCircularBufferUnitHead prepares the internal buffer using a header struct that store the
+ * length and type, then returns a pointer to write to. TPCircularBufferUnitProduce
+ * will advance the head by the length provided in the call to TPCircularBufferUnitHead plus
+ * the length of the internal header struct.  TPCircularBufferUnitTail will return the first
+ * pointer that was produced, and TPCircularBufferUnitConsume will consume it.  The type
+ * arguments can be used to determine what kind of value is being written so that it can be
+ * cast to the correct type when retrieved.  It is important to use TPCircularBufferUnitProduce
+ * only after a call to TPCircularBufferUnitHead, and to use TPCircularBufferUnitTail to retrieve
+ * values that were written using TPCircularBufferUnitHead/TPCircularBufferUnitProduce.
+ * TPCircularBufferUnitConsume can be called without calling TPCircularBufferUnitTail.
+*/
+
+/**
+ * @brief Returns a pointer for writing.
+ *
+ * @discussion Should be followed by a call to TPCircularBufferUnitProduce.
+ *
+ * @param buffer The circular buffer.
+ * @param type A pointer to a flag that can be retrieved using TPCircularBufferUnitTail.  Can be NULL.
+ * @param length the byteSize of the value that will be written to head.
+ */
+void *TPCircularBufferUnitHead(TPCircularBuffer *buffer, uint32_t *type, int length);
+
+/**
+ * @brief Moves buffer head forward by length specified in TPCircularBufferUnitHead.
+ *
+ * @discussion Must be proceeded by a call to TPCircularBufferUnitHead.
+ *
+ * @param buffer The circular buffer.
+ */
+void TPCircularBufferUnitProduce(TPCircularBuffer *buffer);
+
+/**
+ * @brief Returns a pointer for reading.
+ *
+ * @discussion Follow with TPCircularBufferUnitConsume to consume value read.
+ *
+ * @param buffer The circular buffer.
+ * @param type On output, a flag that was set with TPCircularBufferUnitHead.  Can be NULL.
+ * @param length On output, the byteSize of the value that was read. Can be NULL.
+ */
+void *TPCircularBufferUnitTail(TPCircularBuffer *buffer, uint32_t *type, int *length);
+
+/**
+ * @brief Consumes the next value in buffer.
+ *
+ * @discussion Does not have to be proceeded by TPCircularBufferUnitTail.
+ *
+ * @param buffer The circular buffer.
+ */
+void TPCircularBufferUnitConsume(TPCircularBuffer *buffer);
+
+/**
+ @code
+
+    typedef struct {
+        float x;
+        float y;
+    }PointStruct;
+
+    typedef struct {
+        char name[20];
+        int age;
+    }Person;
+
+    TPCircularBuffer tpCircularBuffer;
+
+    UInt32 pointType = 0;
+    UInt32 personType = 1;
+    UInt32 intsType = 2;
+
+    TPCircularBufferInit(&tpCircularBuffer, 4096);
+
+
+    Person jim = {
+        .name = "Jimmy",
+        .age = 123
+    };
+
+    void *head = TPCircularBufferUnitHead(&tpCircularBuffer, &personType, sizeof(jim));
+    memcpy(head, &jim, sizeof(jim));
+    TPCircularBufferUnitProduce(&tpCircularBuffer);
+
+    PointStruct *pointHead = TPCircularBufferUnitHead(&tpCircularBuffer, &pointType, sizeof(PointStruct));
+    pointHead->x = 12.34;
+    pointHead->y = 56.789;
+    TPCircularBufferUnitProduce(&tpCircularBuffer);
+
+    int ints[7] = {8,6,7,5,3,0,9};
+    head = TPCircularBufferUnitHead(&tpCircularBuffer, &intsType, sizeof(ints));
+    memcpy(head, ints, sizeof(ints));
+    TPCircularBufferUnitProduce(&tpCircularBuffer);
+
+    PointStruct point = {.x = 543, .y = 0.321 };
+    pointHead = TPCircularBufferUnitHead(&tpCircularBuffer, &pointType, sizeof(point));
+    *pointHead = point;
+    TPCircularBufferUnitProduce(&tpCircularBuffer);
+
+    UInt32 type;
+    int length;
+    void *tail = TPCircularBufferUnitTail(&tpCircularBuffer, &type, &length);
+
+    while (tail != NULL) {
+        if (type == pointType) {
+            PointStruct *point = tail;
+            printf("point - { x: %.3f, y: %.3f }\n", point->x, point->y);
+        }
+        else if (type == personType ) {
+            Person *person = tail;
+            printf("person - { name: %s, age: %i }\n", person->name, person->age);
+        }
+        else if (type == intsType) {
+            int *ints = tail;
+            int count = length / sizeof(int);
+            printf("ints - [");
+            for (int i = 0; i < count; i++) {
+                printf("%i",ints[i]);
+                if (i != count - 1) printf(",");
+                    }
+            printf("]\n");
+        }
+        TPCircularBufferUnitConsume(&tpCircularBuffer);
+        tail = TPCircularBufferUnitTail(&tpCircularBuffer, &type, &length);
+    }
+    TPCircularBufferCleanup(&tpCircularBuffer);
+
+ @endCode
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TPCircularBuffer_Unit_h */

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		558D80931F4D2DC8001E7BC1 /* AKLazyTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 558D80911F4D2DC8001E7BC1 /* AKLazyTap.m */; };
 		55E25CCC1F4E6C2F00F5AF08 /* AKRenderTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25CCA1F4E6C2F00F5AF08 /* AKRenderTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E25CCD1F4E6C2F00F5AF08 /* AKRenderTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E25CCB1F4E6C2F00F5AF08 /* AKRenderTap.m */; };
+		55E25CD91F4E8D5700F5AF08 /* TPCircularBuffer+Unit.c in Sources */ = {isa = PBXBuildFile; fileRef = 55E25CD71F4E8D5700F5AF08 /* TPCircularBuffer+Unit.c */; };
+		55E25CDA1F4E8D5700F5AF08 /* TPCircularBuffer+Unit.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25CD81F4E8D5700F5AF08 /* TPCircularBuffer+Unit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55F29C091E90654C00A2151F /* AKScheduledAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F29C081E90654C00A2151F /* AKScheduledAction.swift */; };
 		6520FFC21D361B030052410C /* resonantFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6520FFC11D361B030052410C /* resonantFilter.swift */; };
 		701E04861F1B7CB500A7A2D8 /* AKRotaryKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701E04851F1B7CB500A7A2D8 /* AKRotaryKnob.swift */; };
@@ -974,6 +976,8 @@
 		558D80911F4D2DC8001E7BC1 /* AKLazyTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKLazyTap.m; sourceTree = "<group>"; };
 		55E25CCA1F4E6C2F00F5AF08 /* AKRenderTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKRenderTap.h; sourceTree = "<group>"; };
 		55E25CCB1F4E6C2F00F5AF08 /* AKRenderTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRenderTap.m; sourceTree = "<group>"; };
+		55E25CD71F4E8D5700F5AF08 /* TPCircularBuffer+Unit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "TPCircularBuffer+Unit.c"; sourceTree = "<group>"; };
+		55E25CD81F4E8D5700F5AF08 /* TPCircularBuffer+Unit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TPCircularBuffer+Unit.h"; sourceTree = "<group>"; };
 		55F29C081E90654C00A2151F /* AKScheduledAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKScheduledAction.swift; sourceTree = "<group>"; };
 		6520FFC11D361B030052410C /* resonantFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = resonantFilter.swift; sourceTree = "<group>"; };
 		701E04851F1B7CB500A7A2D8 /* AKRotaryKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKRotaryKnob.swift; sourceTree = "<group>"; };
@@ -1922,6 +1926,8 @@
 			children = (
 				558D80881F4D2D9D001E7BC1 /* TPCircularBuffer+AudioBufferList.c */,
 				558D80891F4D2D9D001E7BC1 /* TPCircularBuffer+AudioBufferList.h */,
+				55E25CD71F4E8D5700F5AF08 /* TPCircularBuffer+Unit.c */,
+				55E25CD81F4E8D5700F5AF08 /* TPCircularBuffer+Unit.h */,
 				558D808A1F4D2D9D001E7BC1 /* TPCircularBuffer.c */,
 				558D808B1F4D2D9D001E7BC1 /* TPCircularBuffer.h */,
 			);
@@ -4045,6 +4051,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				558D80921F4D2DC8001E7BC1 /* AKLazyTap.h in Headers */,
+				55E25CDA1F4E8D5700F5AF08 /* TPCircularBuffer+Unit.h in Headers */,
 				55E25CCC1F4E6C2F00F5AF08 /* AKRenderTap.h in Headers */,
 				558D808D1F4D2D9D001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */,
 				558D808F1F4D2D9D001E7BC1 /* TPCircularBuffer.h in Headers */,
@@ -4394,6 +4401,7 @@
 				C40716411D21168100665C02 /* OnePole.cpp in Sources */,
 				C40716541D2116DA00665C02 /* Stk.cpp in Sources */,
 				C407165A1D21172800665C02 /* FileRead.cpp in Sources */,
+				55E25CD91F4E8D5700F5AF08 /* TPCircularBuffer+Unit.c in Sources */,
 				52145B611F3C5B1A0069C88B /* LPFCombFilter.cpp in Sources */,
 				C4F8C8B51DCA8CE4001F38F2 /* biscale.c in Sources */,
 				C407163C1D21164E00665C02 /* Fir.cpp in Sources */,

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		558D80A41F4D440F001E7BC1 /* AKLazyTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 558D80A21F4D440F001E7BC1 /* AKLazyTap.m */; };
 		55E25CD11F4E76B100F5AF08 /* AKRenderTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25CCF1F4E76B100F5AF08 /* AKRenderTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E25CD21F4E76B100F5AF08 /* AKRenderTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E25CD01F4E76B100F5AF08 /* AKRenderTap.m */; };
+		55E25D611F4F3B6800F5AF08 /* TPCircularBuffer+Unit.c in Sources */ = {isa = PBXBuildFile; fileRef = 55E25D5F1F4F3B6800F5AF08 /* TPCircularBuffer+Unit.c */; };
+		55E25D621F4F3B6800F5AF08 /* TPCircularBuffer+Unit.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25D601F4F3B6800F5AF08 /* TPCircularBuffer+Unit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7078DE4D1F260A3600F1DC67 /* AKRotaryKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7078DE4C1F260A3600F1DC67 /* AKRotaryKnob.swift */; };
 		A8E996F41EB9212600116ADA /* AKTuningTable+Brun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E996F31EB9212600116ADA /* AKTuningTable+Brun.swift */; };
 		B19AE76D1F30F58500F9DC25 /* AKAudioUnitInstrument.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19AE76B1F30F58500F9DC25 /* AKAudioUnitInstrument.swift */; };
@@ -941,6 +943,8 @@
 		558D80A21F4D440F001E7BC1 /* AKLazyTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKLazyTap.m; sourceTree = "<group>"; };
 		55E25CCF1F4E76B100F5AF08 /* AKRenderTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKRenderTap.h; sourceTree = "<group>"; };
 		55E25CD01F4E76B100F5AF08 /* AKRenderTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRenderTap.m; sourceTree = "<group>"; };
+		55E25D5F1F4F3B6800F5AF08 /* TPCircularBuffer+Unit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "TPCircularBuffer+Unit.c"; sourceTree = "<group>"; };
+		55E25D601F4F3B6800F5AF08 /* TPCircularBuffer+Unit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TPCircularBuffer+Unit.h"; sourceTree = "<group>"; };
 		7078DE4C1F260A3600F1DC67 /* AKRotaryKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKRotaryKnob.swift; sourceTree = "<group>"; };
 		A8E996F31EB9212600116ADA /* AKTuningTable+Brun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Brun.swift"; sourceTree = "<group>"; };
 		B19AE76B1F30F58500F9DC25 /* AKAudioUnitInstrument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AKAudioUnitInstrument.swift; path = "AudioUnit Host/AKAudioUnitInstrument.swift"; sourceTree = "<group>"; };
@@ -1871,6 +1875,8 @@
 			children = (
 				558D807B1F4D2A3D001E7BC1 /* TPCircularBuffer+AudioBufferList.c */,
 				558D807C1F4D2A3D001E7BC1 /* TPCircularBuffer+AudioBufferList.h */,
+				55E25D5F1F4F3B6800F5AF08 /* TPCircularBuffer+Unit.c */,
+				55E25D601F4F3B6800F5AF08 /* TPCircularBuffer+Unit.h */,
 				558D807D1F4D2A3D001E7BC1 /* TPCircularBuffer.c */,
 				558D807E1F4D2A3D001E7BC1 /* TPCircularBuffer.h */,
 			);
@@ -4036,6 +4042,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				558D80A31F4D440F001E7BC1 /* AKLazyTap.h in Headers */,
+				55E25D621F4F3B6800F5AF08 /* TPCircularBuffer+Unit.h in Headers */,
 				55E25CD11F4E76B100F5AF08 /* AKRenderTap.h in Headers */,
 				558D80801F4D2A3D001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */,
 				558D80821F4D2A3D001E7BC1 /* TPCircularBuffer.h in Headers */,
@@ -4912,6 +4919,7 @@
 				C45666B21D448D7E00D26565 /* EZAudioDevice.m in Sources */,
 				C45669CB1D448D7E00D26565 /* resonantFilter.swift in Sources */,
 				C42899921D552E2C00B941B5 /* smoothDelay.swift in Sources */,
+				55E25D611F4F3B6800F5AF08 /* TPCircularBuffer+Unit.c in Sources */,
 				C49A0A311D542999007D8ADB /* threePoleLowPassFilter.swift in Sources */,
 				C4146DA91F3E47F9001AAE11 /* pluginobjects.cpp in Sources */,
 				C45669531D448D7E00D26565 /* AKFlatFrequencyResponseReverbAudioUnit.mm in Sources */,

--- a/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
+++ b/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
@@ -9,13 +9,15 @@
 /* Begin PBXBuildFile section */
 		524B77BA1CC4B060001D82D1 /* AKNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524B77B91CC4B060001D82D1 /* AKNotifications.swift */; };
 		558D80991F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.c in Sources */ = {isa = PBXBuildFile; fileRef = 558D80951F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.c */; };
-		558D809A1F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80961F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.h */; };
+		558D809A1F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80961F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D809B1F4D3D5C001E7BC1 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 558D80971F4D3D5C001E7BC1 /* TPCircularBuffer.c */; };
-		558D809C1F4D3D5C001E7BC1 /* TPCircularBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80981F4D3D5C001E7BC1 /* TPCircularBuffer.h */; };
+		558D809C1F4D3D5C001E7BC1 /* TPCircularBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80981F4D3D5C001E7BC1 /* TPCircularBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D80A71F4D443A001E7BC1 /* AKLazyTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 558D80A51F4D443A001E7BC1 /* AKLazyTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558D80A81F4D443A001E7BC1 /* AKLazyTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 558D80A61F4D443A001E7BC1 /* AKLazyTap.m */; };
 		55E25CD51F4E76F000F5AF08 /* AKRenderTap.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25CD31F4E76F000F5AF08 /* AKRenderTap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E25CD61F4E76F000F5AF08 /* AKRenderTap.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E25CD41F4E76F000F5AF08 /* AKRenderTap.m */; };
+		55E25D651F4F3BA200F5AF08 /* TPCircularBuffer+Unit.c in Sources */ = {isa = PBXBuildFile; fileRef = 55E25D631F4F3BA200F5AF08 /* TPCircularBuffer+Unit.c */; };
+		55E25D661F4F3BA200F5AF08 /* TPCircularBuffer+Unit.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E25D641F4F3BA200F5AF08 /* TPCircularBuffer+Unit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A8E996F61EB921D100116ADA /* AKTuningTable+Brun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E996F51EB921D100116ADA /* AKTuningTable+Brun.swift */; };
 		B1F47ABF1DC54E0F00706A2F /* EZAudioFileMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = B1F47ABD1DC54E0F00706A2F /* EZAudioFileMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1F47AC01DC54E0F00706A2F /* EZAudioFileMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F47ABE1DC54E0F00706A2F /* EZAudioFileMarker.m */; };
@@ -68,7 +70,7 @@
 		C40C422D1C40E5C2009D870B /* EZAudioUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C40C42001C40E5C2009D870B /* EZAudioUtilities.m */; };
 		C40C422E1C40E5C2009D870B /* EZMicrophone.h in Headers */ = {isa = PBXBuildFile; fileRef = C40C42011C40E5C2009D870B /* EZMicrophone.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40C422F1C40E5C2009D870B /* EZMicrophone.m in Sources */ = {isa = PBXBuildFile; fileRef = C40C42021C40E5C2009D870B /* EZMicrophone.m */; };
-		C40C42301C40E5C2009D870B /* EZOutput.h in Headers */ = {isa = PBXBuildFile; fileRef = C40C42031C40E5C2009D870B /* EZOutput.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C40C42301C40E5C2009D870B /* EZOutput.h in Headers */ = {isa = PBXBuildFile; fileRef = C40C42031C40E5C2009D870B /* EZOutput.h */; };
 		C40C42311C40E5C2009D870B /* EZOutput.m in Sources */ = {isa = PBXBuildFile; fileRef = C40C42041C40E5C2009D870B /* EZOutput.m */; };
 		C40C42321C40E5C2009D870B /* EZPlot.h in Headers */ = {isa = PBXBuildFile; fileRef = C40C42051C40E5C2009D870B /* EZPlot.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40C42331C40E5C2009D870B /* EZPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C40C42061C40E5C2009D870B /* EZPlot.m */; };
@@ -869,6 +871,8 @@
 		558D80A61F4D443A001E7BC1 /* AKLazyTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKLazyTap.m; sourceTree = "<group>"; };
 		55E25CD31F4E76F000F5AF08 /* AKRenderTap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKRenderTap.h; sourceTree = "<group>"; };
 		55E25CD41F4E76F000F5AF08 /* AKRenderTap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKRenderTap.m; sourceTree = "<group>"; };
+		55E25D631F4F3BA200F5AF08 /* TPCircularBuffer+Unit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "TPCircularBuffer+Unit.c"; sourceTree = "<group>"; };
+		55E25D641F4F3BA200F5AF08 /* TPCircularBuffer+Unit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TPCircularBuffer+Unit.h"; sourceTree = "<group>"; };
 		A8E996F51EB921D100116ADA /* AKTuningTable+Brun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Brun.swift"; sourceTree = "<group>"; };
 		B1F47ABD1DC54E0F00706A2F /* EZAudioFileMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EZAudioFileMarker.h; sourceTree = "<group>"; };
 		B1F47ABE1DC54E0F00706A2F /* EZAudioFileMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EZAudioFileMarker.m; sourceTree = "<group>"; };
@@ -1731,6 +1735,8 @@
 			children = (
 				558D80951F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.c */,
 				558D80961F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.h */,
+				55E25D631F4F3BA200F5AF08 /* TPCircularBuffer+Unit.c */,
+				55E25D641F4F3BA200F5AF08 /* TPCircularBuffer+Unit.h */,
 				558D80971F4D3D5C001E7BC1 /* TPCircularBuffer.c */,
 				558D80981F4D3D5C001E7BC1 /* TPCircularBuffer.h */,
 			);
@@ -3758,13 +3764,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				558D80A71F4D443A001E7BC1 /* AKLazyTap.h in Headers */,
+				558D809A1F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */,
+				55E25D661F4F3BA200F5AF08 /* TPCircularBuffer+Unit.h in Headers */,
+				558D809C1F4D3D5C001E7BC1 /* TPCircularBuffer.h in Headers */,
 				55E25CD51F4E76F000F5AF08 /* AKRenderTap.h in Headers */,
 				C45210711E7D0884007C38FE /* AKSporthStack+Internal.h in Headers */,
 				B1F47ABF1DC54E0F00706A2F /* EZAudioFileMarker.h in Headers */,
 				C45382101C3A5CBD00A51738 /* AKWhiteNoiseAudioUnit.h in Headers */,
 				C4E13D3E1C42703C008F0A3C /* AKPhaseLockedVocoderAudioUnit.h in Headers */,
 				C45382011C3A5CBD00A51738 /* AKCostelloReverbDSPKernel.hpp in Headers */,
-				558D809A1F4D3D5C001E7BC1 /* TPCircularBuffer+AudioBufferList.h in Headers */,
 				C45381E31C3A5CBD00A51738 /* AKPeakingParametricEqualizerFilterDSPKernel.hpp in Headers */,
 				C48C6A5C1D3C1574008EA51B /* kiss_fftr.h in Headers */,
 				C470480E1E78FDFA00D9906F /* AKTubularBellsAudioUnit.h in Headers */,
@@ -3802,7 +3810,6 @@
 				C49DCD661D2100BF00BF018A /* AKPWMOscillatorBankAudioUnit.h in Headers */,
 				C453820C1C3A5CBD00A51738 /* AKPinkNoiseAudioUnit.h in Headers */,
 				C45381FB1C3A5CBD00A51738 /* AKChowningReverbAudioUnit.h in Headers */,
-				558D809C1F4D3D5C001E7BC1 /* TPCircularBuffer.h in Headers */,
 				C45382081C3A5CBD00A51738 /* AKOperationGeneratorAudioUnit.h in Headers */,
 				C45381D01C3A5CBD00A51738 /* AKLowPassButterworthFilterDSPKernel.hpp in Headers */,
 				C45210721E7D0884007C38FE /* AKSporthStack.h in Headers */,
@@ -3851,6 +3858,7 @@
 				C4146DDA1F3E4829001AAE11 /* Compressor.h in Headers */,
 				C45382051C3A5CBD00A51738 /* AKFlatFrequencyResponseReverbDSPKernel.hpp in Headers */,
 				C45382141C3A5CBD00A51738 /* AKFMOscillatorAudioUnit.h in Headers */,
+				C40C42301C40E5C2009D870B /* EZOutput.h in Headers */,
 				C45381981C3A5CBD00A51738 /* AKBitCrusherDSPKernel.hpp in Headers */,
 				C48C6AD11D3C1574008EA51B /* sporth.h in Headers */,
 				C45381861C3A5CBD00A51738 /* AKAmplitudeTrackerDSPKernel.hpp in Headers */,
@@ -3971,7 +3979,6 @@
 				C45381FD1C3A5CBD00A51738 /* AKChowningReverbDSPKernel.hpp in Headers */,
 				C4146DF01F3E4829001AAE11 /* FFTRealUseTrigo.hpp in Headers */,
 				C45381D41C3A5CBD00A51738 /* AKLowShelfParametricEqualizerFilterAudioUnit.h in Headers */,
-				C40C42301C40E5C2009D870B /* EZOutput.h in Headers */,
 				C47AE4E31D39CCC60091118F /* AKPhaseDistortionOscillatorBankDSPKernel.hpp in Headers */,
 				C46615501EEA654C0044A5FC /* vocwrapper.h in Headers */,
 				C407182D1D211AB400665C02 /* Fir.h in Headers */,
@@ -4378,6 +4385,7 @@
 				C49A09E81D5099D9007D8ADB /* smoothdelay.c in Sources */,
 				C453820F1C3A5CBD00A51738 /* AKWhiteNoise.swift in Sources */,
 				C4E752461C23888700688A1B /* pinkNoise.swift in Sources */,
+				55E25D651F4F3BA200F5AF08 /* TPCircularBuffer+Unit.c in Sources */,
 				C4E375A31D13575C00FDB70D /* AKMandolinAudioUnit.mm in Sources */,
 				C48C6A631D3C1574008EA51B /* bar.c in Sources */,
 				C48C6A611D3C1574008EA51B /* autowah.c in Sources */,


### PR DESCRIPTION
These are utility functions for managing the passing of arbitrary data structures through a TPCircularBuffer.
They will be used for message passing to and from the render thread.