### PR TITLE
Add option to lazilly buffer AKAudioPlayer's AKAudioFile.

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -242,6 +242,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     ///
     public init(file: AKAudioFile,
                 looping: Bool = false,
+                deferBuffering: Bool = false,
                 completionHandler: AKCallback? = nil) throws {
 
         let readFile: AKAudioFile
@@ -269,7 +270,9 @@ open class AKAudioPlayer: AKNode, AKToggleable {
         avAudioNode = internalMixer
         internalPlayer.volume = 1.0
 
-        initialize()
+        if !deferBuffering {
+            initialize()
+        }
     }
 
     fileprivate var defaultBufferOptions: AVAudioPlayerNodeBufferOptions {
@@ -284,6 +287,10 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
 
     open func play(at when: AVAudioTime?) {
+
+        if audioFileBuffer == nil {
+            initialize()
+        }
 
         if ❗️playing {
             if audioFileBuffer != nil {
@@ -339,10 +346,8 @@ open class AKAudioPlayer: AKNode, AKToggleable {
 
     /// Restart playback from current position
     open func resume() {
-        if ❗️playing && paused {
-            playing = true
-            paused = false
-            internalPlayer.play()
+        if paused {
+            self.play()
         }
     }
 


### PR DESCRIPTION
`AKAudioPlayer` can take a significant amount of time creating buffers for it's internal player when initialized. If immediate playback isn't necessary for your application optionally deferring buffering may save significant time when creating large graphs.

Looking for feedback on naming and any problems you all might see with this! Considering adding an public function for optionally ensuring the player is buffered before `start` but after `init` if more convenient. 