### PR TITLE
Fixes for AKNodeOutputPlot and HelloWorld examples

### DIFF
--- a/AudioKit/Common/User Interface/AKNodeOutputPlot.swift
+++ b/AudioKit/Common/User Interface/AKNodeOutputPlot.swift
@@ -53,7 +53,7 @@ open class AKNodeOutputPlot: EZAudioPlot {
     ///
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        setupNode(nil)
+        setupNode(AudioKit.output)
     }
 
     /// Initialize the plot with the output from a given node and optional plot size

--- a/Examples/iOS/HelloObjectiveC/HelloObjectiveC/Base.lproj/Main.storyboard
+++ b/Examples/iOS/HelloObjectiveC/HelloObjectiveC/Base.lproj/Main.storyboard
@@ -43,7 +43,7 @@
                                     <action selector="toggleSound:" destination="BYZ-38-t0r" eventType="touchUpInside" id="FPo-Ob-AQb"/>
                                 </connections>
                             </button>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="int-Kr-iJa" customClass="AKOutputWaveformPlot" customModule="AudioKitUI">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="int-Kr-iJa" customClass="AKNodeOutputPlot" customModule="AudioKitUI">
                                 <rect key="frame" x="20" y="20" width="374" height="128"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>

--- a/Examples/iOS/HelloObjectiveC/HelloObjectiveC/ViewController.m
+++ b/Examples/iOS/HelloObjectiveC/HelloObjectiveC/ViewController.m
@@ -19,15 +19,17 @@
 
 @implementation ViewController
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    
     oscillator1 = [[AKOscillator alloc] init];
     oscillator2 = [[AKOscillator alloc] init];
     mixer = [[AKMixer alloc] init: @[oscillator1, oscillator2]];
     mixer.volume = 0.5;
     AudioKit.output = mixer;
     [AudioKit start];
+    
+    return self;
 }
 
 - (IBAction)toggleSound:(UIButton *)sender {

--- a/Examples/iOS/HelloWorld/HelloWorld/ViewController.swift
+++ b/Examples/iOS/HelloWorld/HelloWorld/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
         AudioKit.output = mixer
         AudioKit.start()
     }
-    
+
     @IBAction func toggleSound(_ sender: UIButton) {
         if oscillator1.isPlaying {
             oscillator1.stop()

--- a/Examples/iOS/HelloWorld/HelloWorld/ViewController.swift
+++ b/Examples/iOS/HelloWorld/HelloWorld/ViewController.swift
@@ -17,15 +17,14 @@ class ViewController: UIViewController {
     var oscillator2 = AKOscillator()
     var mixer = AKMixer()
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
         mixer = AKMixer(oscillator1, oscillator2)
         mixer.volume = 0.5
         AudioKit.output = mixer
         AudioKit.start()
     }
-
+    
     @IBAction func toggleSound(_ sender: UIButton) {
         if oscillator1.isPlaying {
             oscillator1.stop()

--- a/Examples/macOS/HelloWorld/HelloWorld/Base.lproj/Main.storyboard
+++ b/Examples/macOS/HelloWorld/HelloWorld/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13189.4" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13189.4"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -658,6 +658,9 @@
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="8Qi-PK-XeW"/>
+                        </connections>
                     </window>
                     <connections>
                         <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
@@ -712,9 +715,6 @@
                             <constraint firstItem="skp-Z1-XqT" firstAttribute="centerY" secondItem="m2S-Jp-Qdl" secondAttribute="centerY" multiplier="1.5" id="lWm-ai-qCd"/>
                         </constraints>
                     </view>
-                    <connections>
-                        <outlet property="plot" destination="KyK-oq-Xcd" id="C7V-S5-jRN"/>
-                    </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/macOS/HelloWorld/HelloWorld/ViewController.swift
+++ b/Examples/macOS/HelloWorld/HelloWorld/ViewController.swift
@@ -15,10 +15,8 @@ class ViewController: NSViewController {
     var oscillator = AKOscillator()
     var oscillator2 = AKOscillator()
 
-    @IBOutlet private var plot: AKOutputWaveformPlot!
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
 
         AudioKit.output = AKMixer(oscillator, oscillator2)
         AudioKit.start()

--- a/Examples/tvOS/HelloWorld/HelloWorld/Base.lproj/Main.storyboard
+++ b/Examples/tvOS/HelloWorld/HelloWorld/Base.lproj/Main.storyboard
@@ -22,12 +22,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a9R-38-Wi4" customClass="AKOutputWaveformPlot" customModule="AudioKitUI">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a9R-38-Wi4" customClass="AKNodeOutputPlot" customModule="AudioKitUI">
                                 <rect key="frame" x="110" y="80" width="1700" height="920"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="gain">
-                                        <real key="value" value="0.0"/>
+                                        <real key="value" value="0.80000000000000004"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
@@ -61,9 +61,6 @@
                             <constraint firstAttribute="trailingMargin" secondItem="a9R-38-Wi4" secondAttribute="trailing" id="uDs-Zk-Qwr"/>
                         </constraints>
                     </view>
-                    <connections>
-                        <outlet property="plot" destination="a9R-38-Wi4" id="ehJ-zM-UBd"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/tvOS/HelloWorld/HelloWorld/ViewController.swift
+++ b/Examples/tvOS/HelloWorld/HelloWorld/ViewController.swift
@@ -14,10 +14,8 @@ class ViewController: UIViewController {
 
     var oscillator = AKOscillator()
 
-    @IBOutlet private var plot: AKOutputWaveformPlot!
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
 
         AudioKit.output = oscillator
         AudioKit.start()


### PR DESCRIPTION
I took a closer look at why the plots were no longer working in the HelloWorld examples, and basically this was because the `AKNodeOutputPlot` class didn't really connect itself to a tap if a node wasn't given to it explicitly, which never happened when loading the plot from a storyboard.

Instead a reasonable default is to set it up with the default global output since that's what this plot seems to be here for.

The other step to make this work was to move the AK init stuff in the examples out of the `viewDidLoad` methods to the basic init, so they get called earlier in the lifecycle before the plot got instantiated - allowing the default to work as expected. It just makes more sense to move non-UI code to this kind of init anyway.

I'm not sure at what point this plot class started deviating from the others as they seem to have different types of setup, but in any case that fixes it for now. I haven't checked macOS either yet.
