### PR TITLE
Mixer connection saftey

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -493,9 +493,35 @@ extension AVAudioEngine {
 //This extension makes connect calls shorter, and safer by attaching nodes if not already attached.
 extension AudioKit {
 
+    // Attaches nodes if node.engine == nil
     private static func safeAttach(_ nodes: [AVAudioNode]) {
         _ = nodes.filter { $0.engine == nil }.map { engine.attach($0) }
     }
+    
+    // AVAudioMixer will crash if engine is started and connection is made to a bus exceeding mixer's
+    // numberOfInputs. The crash only happens when using the AVAudioEngine function that connects a node to an array
+    // of AVAudioConnectionPoints and the mixer is one of those points. When AVAudioEngine uses a different function
+    // that connects a node's output to a single AVAudioMixerNode, the mixer's inputs are incremented to accommodate
+    // the new connection. So the workaround is to create a dummy node, make a connection to the mixer using the
+    // function that makes the mixer create new inputs, then remove the dummy node so that there is an available
+    // bus to connect to.
+    //
+    private static func checkMixerInputs(_ connectionPoints: [AVAudioConnectionPoint]) {
+        
+        if !engine.isRunning { return }
+        
+        for connection in connectionPoints {
+            if let mixer = connection.node as? AVAudioMixerNode,
+                connection.bus >= mixer.numberOfInputs {
+                
+                let dummyNode = AVAudioUnitSampler()
+                dummyNode.setOutput(to: mixer)
+                dummyNode.disconnectOutput()
+
+            }
+        }
+    }
+    
 
     @objc open static func connect(_ sourceNode: AVAudioNode,
                                    to destNodes: [AVAudioConnectionPoint],
@@ -503,6 +529,7 @@ extension AudioKit {
                                    format: AVAudioFormat?) {
         let connectionsWithNodes = destNodes.filter { $0.node != nil }
         safeAttach([sourceNode] + connectionsWithNodes.map { $0.node! })
+        checkMixerInputs(connectionsWithNodes)
         engine.connect(sourceNode, to: connectionsWithNodes, fromBus: sourceBus, format: format)
     }
 

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -497,7 +497,7 @@ extension AudioKit {
     private static func safeAttach(_ nodes: [AVAudioNode]) {
         _ = nodes.filter { $0.engine == nil }.map { engine.attach($0) }
     }
-    
+
     // AVAudioMixer will crash if engine is started and connection is made to a bus exceeding mixer's
     // numberOfInputs. The crash only happens when using the AVAudioEngine function that connects a node to an array
     // of AVAudioConnectionPoints and the mixer is one of those points. When AVAudioEngine uses a different function
@@ -507,21 +507,19 @@ extension AudioKit {
     // bus to connect to.
     //
     private static func checkMixerInputs(_ connectionPoints: [AVAudioConnectionPoint]) {
-        
+
         if !engine.isRunning { return }
-        
+
         for connection in connectionPoints {
             if let mixer = connection.node as? AVAudioMixerNode,
                 connection.bus >= mixer.numberOfInputs {
-                
-                let dummyNode = AVAudioUnitSampler()
-                dummyNode.setOutput(to: mixer)
-                dummyNode.disconnectOutput()
 
+                let dummyNode = AVAudioUnitSampler()
+                dummyNode.setOutput(to: mixer)  // Using setOutput will increment the mixer's numberOfInputs.
+                dummyNode.disconnectOutput()
             }
         }
     }
-    
 
     @objc open static func connect(_ sourceNode: AVAudioNode,
                                    to destNodes: [AVAudioConnectionPoint],

--- a/AudioKit/Common/Nodes/AKConnection.swift
+++ b/AudioKit/Common/Nodes/AKConnection.swift
@@ -177,6 +177,10 @@ extension AKInput {
         AudioKit.engine.disconnectNodeInput(inputNode, bus: bus )
     }
     public var nextInput: AKInputConnection {
+
+        if let mixer = inputNode as? AVAudioMixerNode {
+            return input(mixer.nextAvailableInputBus)
+        }
         return input(0)
     }
     public func input(_ bus: Int) -> AKInputConnection {
@@ -188,14 +192,6 @@ extension AKInput {
 @objc extension AVAudioNode: AKInput {
     public var outputNode: AVAudioNode {
         return self
-    }
-}
-
-extension AVAudioMixerNode {
-
-    /// Mixer and the mixer's nextAvailableInputBus wrapped in an inputConnection object.
-    public var nextInput: AKInputConnection {
-        return AKInputConnection(node: self, bus: nextAvailableInputBus)
     }
 }
 

--- a/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
@@ -52,10 +52,6 @@ open class AKMixer: AKNode, AKToggleable, AKInput {
         }
     }
 
-    @objc public var nextInput: AKInputConnection {
-        return AKInputConnection(node: self, bus: mixerAU.nextAvailableInputBus)
-    }
-
     /// Function to start, play, or activate the node, all do the same thing
     @objc open func start() {
         if isStopped {


### PR DESCRIPTION
Safeguard for making connections to AVAudioMixer. 

AVAudioMixer will crash if engine is started and connection is made to a
bus exceeding mixer's numberOfInputs. The crash only happens when
using the AVAudioEngine function that connects a node to an array of
AVAudioConnectionPoints and the mixer is one of those points. When
AVAudioEngine uses a different function that connects a node's output
to a single AVAudioMixerNode, the mixer's inputs are incremented to
accommodate the new connection. So the workaround is to create a
dummy node, make a connection to the mixer using the function that
makes the mixer create new inputs, then remove the dummy node so
that there is an available bus to connect to.