### PR TITLE
Built in a workaround for empty mixer on running engine bug.

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -526,7 +526,7 @@ extension AudioKit {
     // node to the mixer prior to making a connection, then removing the dummy node after the connection has been made.
     //
     private static func addDummyOnEmptyMixer(_ node: AVAudioNode) -> AVAudioNode? {
-        
+
         func mixerHasInputs(_ mixer: AVAudioMixerNode) -> Bool {
             for i in 0..<mixer.numberOfInputs {
                 if engine.inputConnectionPoint(for: mixer, inputBus: i) != nil {

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -521,14 +521,46 @@ extension AudioKit {
         }
     }
 
+    // If an AVAudioMixerNode's output connection is made while engine is running, and there are no input connections
+    // on the mixer, subsequent connections made to the mixer will silently fail.  A workaround is to connect a dummy
+    // node to the mixer prior to making a connection, then removing the dummy node after the connection has been made.
+    //
+    private static func addDummyOnEmptyMixer(_ node: AVAudioNode) -> AVAudioNode? {
+        
+        func mixerHasInputs(_ mixer: AVAudioMixerNode) -> Bool {
+            for i in 0..<mixer.numberOfInputs {
+                if engine.inputConnectionPoint(for: mixer, inputBus: i) != nil {
+                    return true
+                }
+            }
+            return false
+        }
+
+        // Only an issue if engine is running, node is a mixer, and mixer has no inputs
+        guard let mixer = node as? AVAudioMixerNode,
+            engine.isRunning,
+            !mixerHasInputs(mixer) else {
+            return nil
+        }
+
+        let dummy = AVAudioUnitSampler()
+        engine.attach(dummy)
+        engine.connect(dummy, to: mixer, format: AudioKit.format)
+        return dummy
+    }
+
     @objc open static func connect(_ sourceNode: AVAudioNode,
                                    to destNodes: [AVAudioConnectionPoint],
                                    fromBus sourceBus: AVAudioNodeBus,
                                    format: AVAudioFormat?) {
+
         let connectionsWithNodes = destNodes.filter { $0.node != nil }
         safeAttach([sourceNode] + connectionsWithNodes.map { $0.node! })
+        // See addDummyOnEmptyMixer for dummyNode explanation.
+        let dummyNode = addDummyOnEmptyMixer(sourceNode)
         checkMixerInputs(connectionsWithNodes)
         engine.connect(sourceNode, to: connectionsWithNodes, fromBus: sourceBus, format: format)
+        dummyNode?.disconnectOutput()
     }
 
     @objc open static func connect(_ node1: AVAudioNode,
@@ -536,8 +568,12 @@ extension AudioKit {
                                    fromBus bus1: AVAudioNodeBus,
                                    toBus bus2: AVAudioNodeBus,
                                    format: AVAudioFormat?) {
+
         safeAttach([node1, node2])
+        // See addDummyOnEmptyMixer for dummyNode explanation.
+        let dummyNode = addDummyOnEmptyMixer(node1)
         engine.connect(node1, to: node2, fromBus: bus1, toBus: bus2, format: format)
+        dummyNode?.disconnectOutput()
     }
 
     @objc open static func connect(_ node1: AVAudioNode, to node2: AVAudioNode, format: AVAudioFormat?) {


### PR DESCRIPTION
If an AVAudioMixerNode's output connection is made while engine is running, and
there are no input connections on the mixer, subsequent connections made to
the mixer will silently fail.  A workaround is to connect a dummy node to the mixer
prior to making a connection, then removing the dummy node after the connection
has been made.