### PR TITLE
Solving some objc problems

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
@@ -27,7 +27,7 @@ extension AVAudioCommonFormat: CustomStringConvertible {
 }
 
 /// Helpful additions for using AVAudioFiles within AudioKit
-extension AVAudioFile {
+@objc extension AVAudioFile {
 
     // MARK: - Public Properties
 

--- a/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Mixer/AKMixer.swift
@@ -66,6 +66,11 @@ open class AKMixer: AKNode, AKToggleable, AKInput {
             volume = 0
         }
     }
+  
+    /// Detach
+    @objc open override func detach() {
+      super.detach()
+    }
 
     /// Connnect another input after initialization // Deprecated
     ///
@@ -81,4 +86,16 @@ open class AKMixer: AKNode, AKToggleable, AKInput {
     }
     //swiftlint:enable line_length
 
+    // It is not possible to use @objc on AKOutput extension, so [connectWithInput:bus:]
+    /// Connect for Objectivec access, with bus definition
+    @objc open func connect(input: AKNode?, bus: Int) {
+      input?.connect(to: self, bus: bus)
+    }
+  
+    // It is not possible to use @objc on AKOutput extension, so [connectWithInput:]
+    /// Connect for Objectivec access
+    @objc open func connect(input: AKNode?) {
+      input?.connect(to: self, bus: nextInput.bus)
+    }
+  
 }

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -383,7 +383,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
 
     /// Replace player's file with a new AKAudioFile file
-    open func replace(file: AKAudioFile) throws {
+    @objc open func replace(file: AKAudioFile) throws {
         internalAudioFile = file
         do {
             try reloadFile()
@@ -400,7 +400,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
 
     /// Play from startTime to endTime
-    open func play(from startTime: Double, to endTime: Double) {
+    @objc open func play(from startTime: Double, to endTime: Double) {
         play(from: startTime, to: endTime, avTime: nil)
     }
 


### PR DESCRIPTION
I'm sending three commits to your way.

Commit f644871 solves the problem for AKAudioFile's most variables not being accessible from ObjectiveC calls.

Commit 9e4b340 adds two connect methods on Swift side for AKMixer which makes them methods accessible from ObjectiveC. As it is not a class, extension does not accept @objc addition. Another method is for detach, which is not overriden before. It simply calls super's detach method.

Commit aa470ac adds @objc to AKAudioPlayer's replace:file and play:from:to methods. It looks like, some other methods too are missing @objc, but I did not want to mess with them.

I've run the travis tests, seems no errors were found. Framework is also building without any errors.

These additions solved [my problems](https://github.com/AudioKit/AudioKit/issues/1065).