### PR TITLE
Updates to Audio Unit Manager

### DIFF
--- a/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitManager.swift
+++ b/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitManager.swift
@@ -10,52 +10,49 @@ import AVFoundation
 
 /// Audio Unit Manager
 open class AKAudioUnitManager: NSObject {
-
+    
     /// All possible types of notifications this class may generate
     public enum Notification {
         case effectsAvailable, instrumentsAvailable, changed, crashed, added
     }
-
-    //TODO: make this variable on init()
-    public static let maxInserts: Int = 6
-
+    
     /// Delegate that will be sent notifications
     open weak var delegate: AKAudioUnitManagerDelegate?
-
+    
     /// first node in chain, generally a player or instrument
     open var input: AKNode?
-
+    
     /// last node in chain, generally a mixer or some kind of output
     open var output: AKNode?
-
+    
     // Serializes all access to `availableEffects`.
     private let availableEffectsAccessQueue = DispatchQueue(label: "AKAudioUnitManager.availableEffectsAccessQueue")
-
+    
     // List of available audio unit components.
     private var _availableEffects = [AVAudioUnitComponent]()
-
+    
     // Serializes all access to `_availableInstruments`.
     private let availableInstrumentsAccessQueue = DispatchQueue(label: "AKAudioUnitManager.availableInstrumentsAccessQueue")
-
+    
     // List of available audio unit components.
     private var _availableInstruments = [AVAudioUnitComponent]()
-
-    private var _effectsChain = [AVAudioUnitEffect?](repeating: nil, count: AKAudioUnitManager.maxInserts)
-
+    
+    private var _effectsChain = [AVAudioUnit?](repeating: nil, count: 6)
+    
     /// Effects Chain
-    public var effectsChain: [AVAudioUnitEffect?] {
+    public var effectsChain: [AVAudioUnit?] {
         get {
             return _effectsChain
         }
-
+        
         set {
-            guard newValue.count == AKAudioUnitManager.maxInserts else {
+            guard newValue.count == _effectsChain.count else {
                 AKLog("number of newValues doesnt match number of inserts")
                 return
             }
-
+            
             var unitsCreated: Int = 0
-
+            
             for i in 0 ..< newValue.count {
                 if _effectsChain[i] != newValue[i] {
                     if newValue[i] == nil {
@@ -65,29 +62,29 @@ open class AKAudioUnitManager: NSObject {
                         self._effectsChain[i] = nil
                         continue
                     }
-
-                    let acd = newValue[i]!.audioComponentDescription
-
-                    createEffectAudioUnit(acd, completionHandler: { au in
-                        unitsCreated += 1
-
-                        self._effectsChain[i] = au
-                    })
+                    
+                    if let acd = newValue[i]?.audioComponentDescription {
+                        createEffectAudioUnit(acd, completionHandler: { au in
+                            unitsCreated += 1
+                            
+                            self._effectsChain[i] = au //as? AVAudioUnitEffect
+                        })
+                    }
                 } else {
                     unitsCreated += 1
                 }
-
-                if unitsCreated == AKAudioUnitManager.maxInserts {
+                
+                if unitsCreated == _effectsChain.count {
                     self.connectEffects()
                 }
             }
         }
     }
-
+    
     // just get a non nil list of Audio Units
-    private var linkedEffects: [AVAudioUnitEffect] {
-        var out = [AVAudioUnitEffect]()
-
+    private var linkedEffects: [AVAudioUnit] {
+        var out = [AVAudioUnit]()
+        
         for fx in _effectsChain {
             if fx != nil {
                 out.append(fx!)
@@ -95,41 +92,41 @@ open class AKAudioUnitManager: NSObject {
         }
         return out
     }
-
+    
     /// How many effects are active
     public var effectsCount: Int {
         return linkedEffects.count
     }
-
+    
     /// `availableEffects` is accessed from multiple thread contexts. Use a dispatch queue for synchronization.
     public var availableEffects: [AVAudioUnitComponent] {
         get {
             var result: [AVAudioUnitComponent]!
-
+            
             availableEffectsAccessQueue.sync {
                 result = self._availableEffects
             }
             return result
         }
-
+        
         set {
             availableEffectsAccessQueue.sync {
                 self._availableEffects = newValue
             }
         }
     }
-
+    
     /// `availableEffects` is accessed from multiple thread contexts. Use a dispatch queue for synchronization.
     public var availableInstruments: [AVAudioUnitComponent] {
         get {
             var result: [AVAudioUnitComponent]!
-
+            
             availableInstrumentsAccessQueue.sync {
                 result = self._availableInstruments
             }
             return result
         }
-
+        
         set {
             availableInstrumentsAccessQueue.sync {
                 self._availableInstruments = newValue
@@ -137,7 +134,11 @@ open class AKAudioUnitManager: NSObject {
         }
     }
 
-    // MARK: - Initialization
+    /// Initialize the manager with arbritary amount of inserts
+    public convenience init(inserts: Int) {
+        self.init()
+        _effectsChain = [AVAudioUnit?](repeating: nil, count: inserts)
+    }
 
     /// Initialize the manager
     override public init() {
@@ -146,19 +147,20 @@ open class AKAudioUnitManager: NSObject {
         // Sign up for a notification when the list of available components changes.
         var name = NSNotification.Name(rawValue: kAudioComponentRegistrationsChangedNotification as String)
         NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) { [weak self] _ in
-
+            
             guard let strongSelf = self else {
                 AKLog("Unable to create strong ref to self")
                 return
             }
-
+            
             AKLog("* Audio Units available changed *")
-
+            
             if strongSelf.delegate != nil {
-                strongSelf.delegate!.handleAudioUnitNotification(type: Notification.changed, object: nil)
+                strongSelf.delegate!.handleAudioUnitNotification(type: AKAudioUnitManager.Notification.changed, object: nil)
             }
         }
-
+        
+        //TODO: This might not be working?
         // Sign up for a notification when an audio unit crashes. Note that we handle this on the main queue for thread-safety.
         name = NSNotification.Name(String(kAudioComponentInstanceInvalidationNotification))
         NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) { [weak self] notification in
@@ -166,20 +168,18 @@ open class AKAudioUnitManager: NSObject {
                 AKLog("Unable to create strong ref to self")
                 return
             }
-            /*
-             If the crashed audio unit was that of our type, remove it from
-             the signal chain. Note: we should notify the UI at this point.
-             */
+            
+            //TODO: remove from signal chain
             let crashedAU = notification.object as? AUAudioUnit
-
+            
             AKLog("Audio Unit Crashed: \(crashedAU.debugDescription)")
-
+            
             if strongSelf.delegate != nil {
-                strongSelf.delegate!.handleAudioUnitNotification(type: Notification.crashed, object: crashedAU)
+                strongSelf.delegate!.handleAudioUnitNotification(type: AKAudioUnitManager.Notification.crashed, object: crashedAU)
             }
         }
     }
-
+    
     /// request a list of Effects, will be returned async
     public func requestEffects(completionHandler: (([AVAudioUnitComponent]) -> Void)? = nil) {
         updateEffectsList(completionHandler: {
@@ -188,48 +188,35 @@ open class AKAudioUnitManager: NSObject {
             }
         })
     }
-
+    
     private func updateEffectsList( completionHandler: (() -> Void)? = nil) {
+        //Locating components can be a little slow, especially the first time.
+        //Do this work on a separate dispatch thread.
         DispatchQueue.global(qos: .default).async {
-            /*
-             Locating components can be a little slow, especially the first time.
-             Do this work on a separate dispatch thread.
-             
-             Make a component description matching any AU of the type.
-             */
-//            var componentDescription = AudioComponentDescription()
-//            componentDescription.componentType = kAudioUnitType_Effect
-//            componentDescription.componentSubType = 0
-//            componentDescription.componentManufacturer = 0
-//            componentDescription.componentFlags = 0
-//            componentDescription.componentFlagsMask = 0
-//
-//            self.availableEffects = AVAudioUnitComponentManager.shared().components(matching: componentDescription)
-
+            /// Predicate will return all types of effects including kAudioUnitType_Effect and kAudioUnitType_MusicEffect
+            /// which are the ones that we care about here
             let predicate = NSPredicate(format: "typeName CONTAINS 'Effect'", argumentArray: [])
             self.availableEffects = AVAudioUnitComponentManager.shared().components(matching: predicate)
-//            for au in predicateEffects {
-//                Swift.print("predicateEffects: \(au.name)")
-//            }
+            
+            self.availableEffects = self.availableEffects.sorted {
+                return $0.name < $1.name
+            }
+            
+            //            for au in self.availableEffects {
+            //                AKLog("Registering Effect: \(au.name)")
+            //            }
             
             // Let the UI know that we have an updated list of units.
             DispatchQueue.main.async {
-                for au in self.availableEffects {
-                    AKLog("Registering Effect: \(au.name)")
-                }
                 // notify delegate
-                if self.delegate != nil {
-                    self.delegate!.handleAudioUnitNotification(type: AKAudioUnitManager.Notification.effectsAvailable,
-                                                               object: self.availableEffects)
-                }
-
-                if completionHandler != nil {
-                    completionHandler!()
-                }
-            } // dispatch main
-        } //dispatch global
+                self.delegate?.handleAudioUnitNotification(type: AKAudioUnitManager.Notification.effectsAvailable,
+                                                           object: self.availableEffects)
+                completionHandler?()
+                
+            }
+        }
     }
-
+    
     /// request a list of Instruments, will be returned async
     public func requestInstruments(completionHandler: (([AVAudioUnitComponent]) -> Void)? = nil) {
         updateInstrumentsList(completionHandler: {
@@ -238,7 +225,7 @@ open class AKAudioUnitManager: NSObject {
             }
         })
     }
-
+    
     private func updateInstrumentsList( completionHandler: (() -> Void)? = nil) {
         DispatchQueue.global(qos: .default).async {
             /*
@@ -253,43 +240,43 @@ open class AKAudioUnitManager: NSObject {
             componentDescription.componentManufacturer = 0
             componentDescription.componentFlags = 0
             componentDescription.componentFlagsMask = 0
-
+            
             self.availableInstruments = AVAudioUnitComponentManager.shared().components(matching: componentDescription)
-
+            
             // Let the UI know that we have an updated list of units.
             DispatchQueue.main.async {
-                for au in self.availableInstruments {
-                    AKLog("Registering Instrument: \(au.name)")
-                }
+//                for au in self.availableInstruments {
+//                    AKLog("Registering Instrument: \(au.name)")
+//                }
                 // notify delegate
                 if self.delegate != nil {
                     self.delegate!.handleAudioUnitNotification(type: AKAudioUnitManager.Notification.instrumentsAvailable,
                                                                object: self.availableInstruments)
                 }
-
+                
                 if completionHandler != nil {
                     completionHandler!()
                 }
             } // dispatch main
         } //dispatch global
     }
-
+    
     /*
      Asynchronously create the AU, then call the
      supplied completion handler when the operation is complete.
      */
     public func createEffectAudioUnit(_ componentDescription: AudioComponentDescription,
-                                      completionHandler: @escaping ((AVAudioUnitEffect?) -> Void)) {
-
+                                      completionHandler: @escaping ((AVAudioUnit?) -> Void)) {
+        
         AVAudioUnitEffect.instantiate(with: componentDescription, options: .loadOutOfProcess) { avAudioUnit, _ in
             guard let avAudioUnit = avAudioUnit else {
                 completionHandler(nil)
                 return
             }
-            completionHandler(avAudioUnit as? AVAudioUnitEffect)
+            completionHandler(avAudioUnit) //as? AVAudioUnitEffect
         }
     }
-
+    
     /*
      Asynchronously create the AU, then call the
      supplied completion handler when the operation is complete.
@@ -304,42 +291,46 @@ open class AKAudioUnitManager: NSObject {
             completionHandler(avAudioUnit as? AVAudioUnitMIDIInstrument)
         }
     }
-
+    
     public func removeEffect(at index: Int) {
         _effectsChain[index] = nil
         connectEffects()
     }
-
+    
     // Create the Audio Unit at the specified index of the chain
     public func insertAudioUnit( name: String, at index: Int) {
-        if index < 0 || index > AKAudioUnitManager.maxInserts - 1 {
+        if index < 0 || index > _effectsChain.count - 1 {
             return
         }
-
+        
         for component in availableEffects {
             if component.name == name {
                 let acd = component.audioComponentDescription
-
+                
                 AKLog("#\(index) \(name) -- \(acd)")
-
+                
                 createEffectAudioUnit(acd, completionHandler: { au in
                     guard let audioUnit = au else {
                         AKLog("Unable to create audioUnit")
                         return
                     }
-
+                    
                     if audioUnit.inputFormat(forBus: 0).channelCount == 1 {
                         // Dialog.showInformation(title: "Mono Effects aren't supported",
                         //                        text: "\(audioUnit.name) is a Mono effect. Please select a stereo version of it.")
                         // return
                         AKLog("Warning: \(audioUnit.name) is a Mono effect.")
                     }
-
-                    AKLog("* \(audioUnit.name) : Audio Unit created")
-
+                    
+                    Swift.print("* \(audioUnit.name) : Audio Unit created, version: \(audioUnit)")
+                    
+                    if audioUnit.isKind(of: AVAudioUnitEffect.self) {
+                        Swift.print("IS AN EFFECT")
+                    }
+                    
                     self._effectsChain[index] = audioUnit
                     self.connectEffects()
-
+                    
                     if self.delegate != nil {
                         AKLog("effectsChanged: \(self._effectsChain)")
                         self.delegate!.handleEffectAdded(at: index)
@@ -348,21 +339,21 @@ open class AKAudioUnitManager: NSObject {
             }
         }
     }
-
+    
     /// Create an instrument with a name and a completion handler
     public func createInstrument(name: String, completionHandler: ((AVAudioUnitMIDIInstrument?) -> Void)? = nil) {
         for component in availableInstruments {
             if component.name == name {
                 let acd = component.audioComponentDescription
-
+                
                 AKLog("\(name) -- \(acd)")
-
+                
                 createInstrumentAudioUnit(acd, completionHandler: { au in
                     guard let audioUnit = au else {
                         AKLog("Unable to create audioUnit")
                         return
                     }
-
+                    
                     if completionHandler != nil {
                         completionHandler!( audioUnit )
                     }
@@ -370,94 +361,108 @@ open class AKAudioUnitManager: NSObject {
             }
         }
     }
-
+    
     /// Reset all effects
     open func resetEffects() {
         for i in 0 ..< _effectsChain.count {
             if let au = _effectsChain[i] {
                 AKLog("Detaching: \(au.name)")
-
+                
                 if au.engine != nil {
                     AudioKit.engine.disconnectNodeInput(au)
                     AudioKit.engine.detach(au)
                 }
-
+                
                 _effectsChain[i] = nil
             }
         }
-
+        
         for i in 0 ..< _effectsChain.count {
             _effectsChain[i] = nil
         }
     }
-
+    
     /// called from client to hook the chain together
     /// firstNode would be something like a player, and last something like a mixer that's headed
     /// to the output.
     open func connectEffects( firstNode: AKNode? = nil, lastNode: AKNode? = nil) {
-
         if firstNode != nil {
             self.input = firstNode
         }
-
+        
         if lastNode != nil {
             self.output = lastNode
         }
-
+        
         guard self.input != nil else {
-            AKLog("self.input is nil")
+            AKLog("input is nil")
             return
         }
         guard self.output != nil else {
             AKLog("output is nil")
             return
         }
-
+        
         // it's an effects sandwich
         let inputAV = self.input!.avAudioNode
         let effects = linkedEffects
         let outputAV = self.output!.avAudioNode
-
+        
         let processingFormat = inputAV.outputFormat(forBus: 0)
-
         AKLog("\(effects.count) to connect... chain source format: \(processingFormat)")
-
+        
         if effects.count == 0 {
-            AudioKit.engine.connect(inputAV, to: outputAV, format: processingFormat)
+            AudioKit.connect(inputAV, to: outputAV, format: processingFormat)
             return
         }
         var au = effects[0]
-
-        if au.engine == nil {
-            AudioKit.engine.attach(au)
-        }
-        let auInputFormat = au.inputFormat(forBus: 0)
-        let auOutputFormat = au.outputFormat(forBus: 0)
-
-        AKLog("Connecting input to \(au.name) with format \(processingFormat), AU input: \(auInputFormat), output: \(auOutputFormat)")
-        AudioKit.engine.connect(inputAV, to: au, format: processingFormat)
-
+        
+        AudioKit.connect(inputAV, to: au, format: processingFormat)
+        
         if effects.count > 1 {
             for i in 1 ..< effects.count {
                 au = effects[i]
                 let prevAU = effects[i - 1]
-
-                if au.engine == nil {
-                    AudioKit.engine.attach(au)
-                }
-                AudioKit.engine.connect(prevAU, to: au, format: processingFormat)
-
-                AKLog("Connecting \(prevAU.name) to \(au.name)")
+                
+                AudioKit.connect(prevAU, to: au, format: processingFormat)
+                
+                AKLog("Connecting \(prevAU.name) to \(au.name) with format \(processingFormat)")
             }
         }
-
-        AKLog("Connecting \(au.name) to \(outputAV)")
-        AudioKit.engine.connect(au, to: outputAV, format: processingFormat)
+        
+        //processingFormat = au.outputFormat(forBus: 0)
+        AKLog("Connecting \(au.name) to output: \(outputAV),  with format \(processingFormat)")
+        AudioKit.connect(au, to: outputAV, format: processingFormat)
+        
     }
-
+    
+    public func reset() {
+        for aunit in linkedEffects {
+            aunit.reset()
+        }
+    }
+    
+    private func initAudioUnitFactoryPreset(_ au: AVAudioUnit ) {
+        if let presets = au.auAudioUnit.factoryPresets {
+            for p in presets {
+                Swift.print("Factory Preset: \(p.name) \(p.number)")
+            }
+            
+            if presets.count > 0 {
+                Swift.print("Setting Preset: \(presets[0].name) \(presets[0].number)")
+                
+                au.auAudioUnit.currentPreset = presets[0]
+                
+                //try? au.auAudioUnit.allocateRenderResources()
+            }
+        }
+    }
+    
 }
 
 public protocol AKAudioUnitManagerDelegate: class {
     func handleAudioUnitNotification(type: AKAudioUnitManager.Notification, object: Any?)
     func handleEffectAdded(at auIndex: Int)
 }
+
+

--- a/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitManager.swift
+++ b/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitManager.swift
@@ -85,8 +85,8 @@ open class AKAudioUnitManager: NSObject {
     }
 
     // just get a non nil list of Audio Units
-    private var linkedEffects: [AVAudioUnit] {
-        var out = [AVAudioUnit]()
+    private var linkedEffects: [AVAudioUnitEffect] {
+        var out = [AVAudioUnitEffect]()
 
         for fx in _effectsChain {
             if fx != nil {
@@ -197,15 +197,21 @@ open class AKAudioUnitManager: NSObject {
              
              Make a component description matching any AU of the type.
              */
-            var componentDescription = AudioComponentDescription()
-            componentDescription.componentType = kAudioUnitType_Effect
-            componentDescription.componentSubType = 0
-            componentDescription.componentManufacturer = 0
-            componentDescription.componentFlags = 0
-            componentDescription.componentFlagsMask = 0
+//            var componentDescription = AudioComponentDescription()
+//            componentDescription.componentType = kAudioUnitType_Effect
+//            componentDescription.componentSubType = 0
+//            componentDescription.componentManufacturer = 0
+//            componentDescription.componentFlags = 0
+//            componentDescription.componentFlagsMask = 0
+//
+//            self.availableEffects = AVAudioUnitComponentManager.shared().components(matching: componentDescription)
 
-            self.availableEffects = AVAudioUnitComponentManager.shared().components(matching: componentDescription)
-
+            let predicate = NSPredicate(format: "typeName CONTAINS 'Effect'", argumentArray: [])
+            self.availableEffects = AVAudioUnitComponentManager.shared().components(matching: predicate)
+//            for au in predicateEffects {
+//                Swift.print("predicateEffects: \(au.name)")
+//            }
+            
             // Let the UI know that we have an updated list of units.
             DispatchQueue.main.async {
                 for au in self.availableEffects {
@@ -274,6 +280,7 @@ open class AKAudioUnitManager: NSObject {
      */
     public func createEffectAudioUnit(_ componentDescription: AudioComponentDescription,
                                       completionHandler: @escaping ((AVAudioUnitEffect?) -> Void)) {
+
         AVAudioUnitEffect.instantiate(with: componentDescription, options: .loadOutOfProcess) { avAudioUnit, _ in
             guard let avAudioUnit = avAudioUnit else {
                 completionHandler(nil)
@@ -444,7 +451,7 @@ open class AKAudioUnitManager: NSObject {
             }
         }
 
-        AKLog("Connecting \(au.name) to output")
+        AKLog("Connecting \(au.name) to \(outputAV)")
         AudioKit.engine.connect(au, to: outputAV, format: processingFormat)
     }
 

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager.xcodeproj/project.pbxproj
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B103E9091F800969006DEABB /* AKAudioUnitManagerDev.swift in Sources */ = {isa = PBXBuildFile; fileRef = B103E9081F800969006DEABB /* AKAudioUnitManagerDev.swift */; };
 		B12311FF1F193EA200888115 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12311FE1F193EA200888115 /* AppDelegate.swift */; };
 		B12312011F193EA200888115 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12312001F193EA200888115 /* ViewController.swift */; };
 		B12312031F193EA200888115 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B12312021F193EA200888115 /* Assets.xcassets */; };
@@ -34,6 +35,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B103E9081F800969006DEABB /* AKAudioUnitManagerDev.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKAudioUnitManagerDev.swift; sourceTree = "<group>"; };
 		B12311FB1F193EA100888115 /* AudioUnitManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AudioUnitManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B12311FE1F193EA200888115 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B12312001F193EA200888115 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 		B12312151F193F6900888115 /* AU */ = {
 			isa = PBXGroup;
 			children = (
+				B103E9081F800969006DEABB /* AKAudioUnitManagerDev.swift */,
 				B12312101F193F6100888115 /* AudioUnitGenericView.swift */,
 				B12312111F193F6100888115 /* AudioUnitParamSlider.swift */,
 				B1FB61BE1F2E958400FF6DE7 /* InstrumentPlayer.swift */,
@@ -133,6 +136,7 @@
 				TargetAttributes = {
 					B12311FA1F193EA100888115 = {
 						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = AL5THFEQGA;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -177,6 +181,7 @@
 				B12312011F193EA200888115 /* ViewController.swift in Sources */,
 				B12312141F193F6100888115 /* AudioUnitParamSlider.swift in Sources */,
 				B12311FF1F193EA200888115 /* AppDelegate.swift in Sources */,
+				B103E9091F800969006DEABB /* AKAudioUnitManagerDev.swift in Sources */,
 				B12312131F193F6100888115 /* AudioUnitGenericView.swift in Sources */,
 				B1FB61BF1F2E958400FF6DE7 /* InstrumentPlayer.swift in Sources */,
 			);
@@ -308,7 +313,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AL5THFEQGA;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AudioUnitManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -325,7 +330,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AL5THFEQGA;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AudioUnitManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager.xcodeproj/project.pbxproj
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B103E9091F800969006DEABB /* AKAudioUnitManagerDev.swift in Sources */ = {isa = PBXBuildFile; fileRef = B103E9081F800969006DEABB /* AKAudioUnitManagerDev.swift */; };
 		B12311FF1F193EA200888115 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12311FE1F193EA200888115 /* AppDelegate.swift */; };
 		B12312011F193EA200888115 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12312001F193EA200888115 /* ViewController.swift */; };
 		B12312031F193EA200888115 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B12312021F193EA200888115 /* Assets.xcassets */; };
@@ -35,7 +34,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		B103E9081F800969006DEABB /* AKAudioUnitManagerDev.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKAudioUnitManagerDev.swift; sourceTree = "<group>"; };
 		B12311FB1F193EA100888115 /* AudioUnitManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AudioUnitManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B12311FE1F193EA200888115 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B12312001F193EA200888115 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -95,7 +93,6 @@
 		B12312151F193F6900888115 /* AU */ = {
 			isa = PBXGroup;
 			children = (
-				B103E9081F800969006DEABB /* AKAudioUnitManagerDev.swift */,
 				B12312101F193F6100888115 /* AudioUnitGenericView.swift */,
 				B12312111F193F6100888115 /* AudioUnitParamSlider.swift */,
 				B1FB61BE1F2E958400FF6DE7 /* InstrumentPlayer.swift */,
@@ -136,7 +133,6 @@
 				TargetAttributes = {
 					B12311FA1F193EA100888115 = {
 						CreatedOnToolsVersion = 8.3.3;
-						DevelopmentTeam = AL5THFEQGA;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -181,7 +177,6 @@
 				B12312011F193EA200888115 /* ViewController.swift in Sources */,
 				B12312141F193F6100888115 /* AudioUnitParamSlider.swift in Sources */,
 				B12311FF1F193EA200888115 /* AppDelegate.swift in Sources */,
-				B103E9091F800969006DEABB /* AKAudioUnitManagerDev.swift in Sources */,
 				B12312131F193F6100888115 /* AudioUnitGenericView.swift in Sources */,
 				B1FB61BF1F2E958400FF6DE7 /* InstrumentPlayer.swift in Sources */,
 			);
@@ -313,7 +308,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = AL5THFEQGA;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AudioUnitManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -330,7 +325,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = AL5THFEQGA;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AudioUnitManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/AppDelegate.swift
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/AppDelegate.swift
@@ -13,6 +13,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
+        
+        NotificationCenter.default.post(name: Notification.Name("AudioUnitManager.handleApplicationInit"), object: nil)
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/Base.lproj/Main.storyboard
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13189.4" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13189.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13196"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="system font weights other than Regular or Bold" minToolsVersion="7.0"/>
@@ -58,25 +58,25 @@
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="File" id="dMs-cI-mzQ">
+                            <menuItem title="File" enabled="NO" id="dMs-cI-mzQ">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="File" id="bib-Uj-vzu">
                                     <items>
-                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                        <menuItem title="New" enabled="NO" keyEquivalent="n" id="Was-JA-tGl">
                                             <connections>
                                                 <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                        <menuItem title="Open…" enabled="NO" keyEquivalent="o" id="IAo-SY-fd9">
                                             <connections>
                                                 <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                        <menuItem title="Open Recent" enabled="NO" id="tXI-mr-wws">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
                                                 <items>
-                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                    <menuItem title="Clear Menu" enabled="NO" id="vNY-rz-j42">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
@@ -86,34 +86,34 @@
                                             </menu>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
-                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                        <menuItem title="Close" enabled="NO" keyEquivalent="w" id="DVo-aG-piG">
                                             <connections>
                                                 <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                        <menuItem title="Save…" enabled="NO" keyEquivalent="s" id="pxx-59-PXV">
                                             <connections>
                                                 <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                        <menuItem title="Save As…" enabled="NO" keyEquivalent="S" id="Bw7-FT-i3A">
                                             <connections>
                                                 <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                        <menuItem title="Revert to Saved" enabled="NO" keyEquivalent="r" id="KaW-ft-85H">
                                             <connections>
                                                 <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
-                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                        <menuItem title="Page Setup…" enabled="NO" keyEquivalent="P" id="qIS-W8-SiK">
                                             <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                             <connections>
                                                 <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                        <menuItem title="Print…" enabled="NO" keyEquivalent="p" id="aTl-1u-JFS">
                                             <connections>
                                                 <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
                                             </connections>
@@ -121,85 +121,85 @@
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                            <menuItem title="Edit" enabled="NO" id="5QF-Oa-p0T">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Edit" id="W48-6f-4Dl">
                                     <items>
-                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                        <menuItem title="Undo" enabled="NO" keyEquivalent="z" id="dRJ-4n-Yzg">
                                             <connections>
                                                 <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                        <menuItem title="Redo" enabled="NO" keyEquivalent="Z" id="6dh-zS-Vam">
                                             <connections>
                                                 <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
-                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                        <menuItem title="Cut" enabled="NO" keyEquivalent="x" id="uRl-iY-unG">
                                             <connections>
                                                 <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                        <menuItem title="Copy" enabled="NO" keyEquivalent="c" id="x3v-GG-iWU">
                                             <connections>
                                                 <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                        <menuItem title="Paste" enabled="NO" keyEquivalent="v" id="gVA-U4-sdL">
                                             <connections>
                                                 <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                        <menuItem title="Paste and Match Style" enabled="NO" keyEquivalent="V" id="WeT-3V-zwk">
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                             <connections>
                                                 <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                        <menuItem title="Delete" enabled="NO" id="pa3-QI-u2k">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                        <menuItem title="Select All" enabled="NO" keyEquivalent="a" id="Ruw-6m-B2m">
                                             <connections>
                                                 <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
-                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                        <menuItem title="Find" enabled="NO" id="4EN-yA-p0u">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Find" id="1b7-l0-nxx">
                                                 <items>
-                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                    <menuItem title="Find…" tag="1" enabled="NO" keyEquivalent="f" id="Xz5-n4-O0W">
                                                         <connections>
                                                             <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                    <menuItem title="Find and Replace…" tag="12" enabled="NO" keyEquivalent="f" id="YEy-JH-Tfz">
                                                         <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                                         <connections>
                                                             <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                    <menuItem title="Find Next" tag="2" enabled="NO" keyEquivalent="g" id="q09-fT-Sye">
                                                         <connections>
                                                             <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                    <menuItem title="Find Previous" tag="3" enabled="NO" keyEquivalent="G" id="OwM-mh-QMV">
                                                         <connections>
                                                             <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                    <menuItem title="Use Selection for Find" tag="7" enabled="NO" keyEquivalent="e" id="buJ-ug-pKt">
                                                         <connections>
                                                             <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                    <menuItem title="Jump to Selection" enabled="NO" keyEquivalent="j" id="S0p-oC-mLd">
                                                         <connections>
                                                             <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
                                                         </connections>
@@ -207,34 +207,34 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
-                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                        <menuItem title="Spelling and Grammar" enabled="NO" id="Dv1-io-Yv7">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
                                                 <items>
-                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                    <menuItem title="Show Spelling and Grammar" enabled="NO" keyEquivalent=":" id="HFo-cy-zxI">
                                                         <connections>
                                                             <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                    <menuItem title="Check Document Now" enabled="NO" keyEquivalent=";" id="hz2-CU-CR7">
                                                         <connections>
                                                             <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
-                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                    <menuItem title="Check Spelling While Typing" enabled="NO" id="rbD-Rh-wIN">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                    <menuItem title="Check Grammar With Spelling" enabled="NO" id="mK6-2p-4JG">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                    <menuItem title="Correct Spelling Automatically" enabled="NO" id="78Y-hA-62v">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
@@ -243,48 +243,48 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
-                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                        <menuItem title="Substitutions" enabled="NO" id="9ic-FL-obx">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
                                                 <items>
-                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                    <menuItem title="Show Substitutions" enabled="NO" id="z6F-FW-3nz">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
-                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                    <menuItem title="Smart Copy/Paste" enabled="NO" id="9yt-4B-nSM">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                    <menuItem title="Smart Quotes" enabled="NO" id="hQb-2v-fYv">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                    <menuItem title="Smart Dashes" enabled="NO" id="rgM-f4-ycn">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                    <menuItem title="Smart Links" enabled="NO" id="cwL-P1-jid">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                    <menuItem title="Data Detectors" enabled="NO" id="tRr-pd-1PS">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                    <menuItem title="Text Replacement" enabled="NO" id="HFQ-gK-NFA">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
@@ -293,23 +293,23 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
-                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                        <menuItem title="Transformations" enabled="NO" id="2oI-Rn-ZJC">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
                                                 <items>
-                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                    <menuItem title="Make Upper Case" enabled="NO" id="vmV-6d-7jI">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                    <menuItem title="Make Lower Case" enabled="NO" id="d9M-CD-aMd">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                    <menuItem title="Capitalize" enabled="NO" id="UEZ-Bs-lqG">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
@@ -318,17 +318,17 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
-                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                        <menuItem title="Speech" enabled="NO" id="xrE-MZ-jX0">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
                                                 <items>
-                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                    <menuItem title="Start Speaking" enabled="NO" id="Ynk-f8-cLZ">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                    <menuItem title="Stop Speaking" enabled="NO" id="Oyz-dy-DGm">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
@@ -340,49 +340,49 @@
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="Format" id="jxT-CU-nIS">
+                            <menuItem title="Format" enabled="NO" id="jxT-CU-nIS">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Format" id="GEO-Iw-cKr">
                                     <items>
-                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                        <menuItem title="Font" enabled="NO" id="Gi5-1S-RQB">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
                                                 <items>
-                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq"/>
-                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27"/>
-                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq"/>
-                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                    <menuItem title="Show Fonts" enabled="NO" keyEquivalent="t" id="Q5e-8K-NDq"/>
+                                                    <menuItem title="Bold" tag="2" enabled="NO" keyEquivalent="b" id="GB9-OM-e27"/>
+                                                    <menuItem title="Italic" tag="1" enabled="NO" keyEquivalent="i" id="Vjx-xi-njq"/>
+                                                    <menuItem title="Underline" enabled="NO" keyEquivalent="u" id="WRG-CD-K1S">
                                                         <connections>
                                                             <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
-                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL"/>
-                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST"/>
+                                                    <menuItem title="Bigger" tag="3" enabled="NO" keyEquivalent="+" id="Ptp-SP-VEL"/>
+                                                    <menuItem title="Smaller" tag="4" enabled="NO" keyEquivalent="-" id="i1d-Er-qST"/>
                                                     <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
-                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                    <menuItem title="Kern" enabled="NO" id="jBQ-r6-VK2">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
                                                             <items>
-                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                <menuItem title="Use Default" enabled="NO" id="GUa-eO-cwY">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                <menuItem title="Use None" enabled="NO" id="cDB-IK-hbR">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                <menuItem title="Tighten" enabled="NO" id="46P-cB-AYj">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                <menuItem title="Loosen" enabled="NO" id="ogc-rX-tC1">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
@@ -391,23 +391,23 @@
                                                             </items>
                                                         </menu>
                                                     </menuItem>
-                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                    <menuItem title="Ligatures" enabled="NO" id="o6e-r0-MWq">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
                                                             <items>
-                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                <menuItem title="Use Default" enabled="NO" id="agt-UL-0e3">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                <menuItem title="Use None" enabled="NO" id="J7y-lM-qPV">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                <menuItem title="Use All" enabled="NO" id="xQD-1f-W4t">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
@@ -416,35 +416,35 @@
                                                             </items>
                                                         </menu>
                                                     </menuItem>
-                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                    <menuItem title="Baseline" enabled="NO" id="OaQ-X3-Vso">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <menu key="submenu" title="Baseline" id="ijk-EB-dga">
                                                             <items>
-                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                <menuItem title="Use Default" enabled="NO" id="3Om-Ey-2VK">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                <menuItem title="Superscript" enabled="NO" id="Rqc-34-cIF">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                <menuItem title="Subscript" enabled="NO" id="I0S-gh-46l">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                <menuItem title="Raise" enabled="NO" id="2h7-ER-AoG">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                <menuItem title="Lower" enabled="NO" id="1tx-W0-xDw">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
@@ -454,19 +454,19 @@
                                                         </menu>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
-                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                    <menuItem title="Show Colors" enabled="NO" keyEquivalent="C" id="bgn-CT-cEk">
                                                         <connections>
                                                             <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
-                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                    <menuItem title="Copy Style" enabled="NO" keyEquivalent="c" id="5Vv-lz-BsD">
                                                         <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                                         <connections>
                                                             <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                    <menuItem title="Paste Style" enabled="NO" keyEquivalent="v" id="vKC-jM-MkH">
                                                         <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                                         <connections>
                                                             <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
@@ -475,54 +475,54 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
-                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                        <menuItem title="Text" enabled="NO" id="Fal-I4-PZk">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Text" id="d9c-me-L2H">
                                                 <items>
-                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                    <menuItem title="Align Left" enabled="NO" keyEquivalent="{" id="ZM1-6Q-yy1">
                                                         <connections>
                                                             <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                    <menuItem title="Center" enabled="NO" keyEquivalent="|" id="VIY-Ag-zcb">
                                                         <connections>
                                                             <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                    <menuItem title="Justify" enabled="NO" id="J5U-5w-g23">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                    <menuItem title="Align Right" enabled="NO" keyEquivalent="}" id="wb2-vD-lq4">
                                                         <connections>
                                                             <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
-                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                    <menuItem title="Writing Direction" enabled="NO" id="H1b-Si-o9J">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
                                                             <items>
                                                                 <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                 </menuItem>
-                                                                <menuItem id="YGs-j5-SAR">
+                                                                <menuItem enabled="NO" id="YGs-j5-SAR">
                                                                     <string key="title">	Default</string>
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem id="Lbh-J2-qVU">
+                                                                <menuItem enabled="NO" id="Lbh-J2-qVU">
                                                                     <string key="title">	Left to Right</string>
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem id="jFq-tB-4Kx">
+                                                                <menuItem enabled="NO" id="jFq-tB-4Kx">
                                                                     <string key="title">	Right to Left</string>
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
@@ -533,21 +533,21 @@
                                                                 <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                 </menuItem>
-                                                                <menuItem id="Nop-cj-93Q">
+                                                                <menuItem enabled="NO" id="Nop-cj-93Q">
                                                                     <string key="title">	Default</string>
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem id="BgM-ve-c93">
+                                                                <menuItem enabled="NO" id="BgM-ve-c93">
                                                                     <string key="title">	Left to Right</string>
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
                                                                         <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
                                                                     </connections>
                                                                 </menuItem>
-                                                                <menuItem id="RB4-Sm-HuC">
+                                                                <menuItem enabled="NO" id="RB4-Sm-HuC">
                                                                     <string key="title">	Right to Left</string>
                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                     <connections>
@@ -558,19 +558,19 @@
                                                         </menu>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
-                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                    <menuItem title="Show Ruler" enabled="NO" id="vLm-3I-IUL">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                    <menuItem title="Copy Ruler" enabled="NO" keyEquivalent="c" id="MkV-Pr-PK5">
                                                         <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                                         <connections>
                                                             <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                    <menuItem title="Paste Ruler" enabled="NO" keyEquivalent="v" id="LVM-kO-fVI">
                                                         <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                                         <connections>
                                                             <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
@@ -582,30 +582,30 @@
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="View" id="H8h-7b-M4v">
+                            <menuItem title="View" enabled="NO" id="H8h-7b-M4v">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="View" id="HyV-fh-RgO">
                                     <items>
-                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                        <menuItem title="Show Toolbar" enabled="NO" keyEquivalent="t" id="snW-S8-Cw5">
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                             <connections>
                                                 <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                        <menuItem title="Customize Toolbar…" enabled="NO" id="1UK-8n-QPP">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
-                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                        <menuItem title="Show Sidebar" enabled="NO" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
                                                 <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                        <menuItem title="Enter Full Screen" enabled="NO" keyEquivalent="f" id="4J7-dP-txa">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
                                                 <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
@@ -666,7 +666,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="⚡︎" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" identifier="main" title="⚡︎" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/InstrumentPlayer.swift
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/InstrumentPlayer.swift
@@ -1,7 +1,7 @@
 // MARK: - Instrument Player
 /*
 	This class implements a basic player for our instrument sample au,
- sending some fake MIDI events on a concurrent thread until stopped.
+ sending a whole tone scale on a concurrent thread until stopped.
  */
 import Cocoa
 import AVFoundation

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/InstrumentPlayer.swift
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/InstrumentPlayer.swift
@@ -1,4 +1,4 @@
-// MARK: - Instrument Player - from Apple
+// MARK: - Instrument Player
 /*
 	This class implements a basic player for our instrument sample au,
  sending some fake MIDI events on a concurrent thread until stopped.
@@ -7,9 +7,27 @@ import Cocoa
 import AVFoundation
 
 public class InstrumentPlayer: NSObject {
-    public var isPlaying = false
-    private var isDone = false
+    private let playingQueue = DispatchQueue(label: "InstrumentPlayer.playingQueue")
+
     private var noteBlock: AUScheduleMIDIEventBlock
+    
+    private var _isPlaying: Bool = false
+    
+    public var isPlaying: Bool {
+        get {
+            var result = false
+            playingQueue.sync {
+                result = self._isPlaying
+            }
+            return result
+        }
+        
+        set {
+            playingQueue.sync {
+                self._isPlaying = newValue
+            }
+        }
+    }
 
     internal init?(audioUnit: AUAudioUnit?) {
         guard audioUnit != nil else { return nil }
@@ -20,23 +38,13 @@ public class InstrumentPlayer: NSObject {
     }
 
     internal func play() {
-        if (false == isPlaying) {
-            isDone = false
+        if !isPlaying {
             scheduleInstrumentLoop()
         }
     }
 
-    @discardableResult
-    internal func stop() -> Bool {
+    func stop() {
         self.isPlaying = false
-        synced(self.isDone as AnyObject) {}
-        return isDone
-    }
-
-    private func synced(_ lock: AnyObject, closure: () -> Void) {
-        objc_sync_enter(lock)
-        closure()
-        objc_sync_exit(lock)
     }
 
     private func scheduleInstrumentLoop() {
@@ -51,44 +59,39 @@ public class InstrumentPlayer: NSObject {
             self.noteBlock(AUEventSampleTimeImmediate, 0, 3, cbytes)
 
             usleep(useconds_t(0.1 * 1e6))
-
             var releaseTime: Float = 0.05
-
             usleep(useconds_t(0.1 * 1e6))
 
             var i = 0
-            self.synced(self.isDone as AnyObject) {
-                while self.isPlaying {
-                    // lengthen the releaseTime by 5% each time up to 10 seconds.
-                    if releaseTime < 10.0 {
-                        releaseTime = min(releaseTime * 1.05, 10.0)
-                    }
+            while self.isPlaying {
+                // lengthen the releaseTime by 5% each time up to 10 seconds.
+                if releaseTime < 10.0 {
+                    releaseTime = min(releaseTime * 1.05, 10.0)
+                }
 
-                    cbytes[0] = 0x90
-                    cbytes[1] = UInt8(60 + i)
-                    cbytes[2] = 64
-                    self.noteBlock(AUEventSampleTimeImmediate, 0, 3, cbytes)
-
-                    usleep(useconds_t(0.2 * 1e6))
-
-                    cbytes[2] = 0    // note off
-                    self.noteBlock(AUEventSampleTimeImmediate, 0, 3, cbytes)
-
-                    i += 2
-                    if i >= 24 {
-                        i = -12
-                    }
-                } // while isPlaying
-
-                cbytes[0] = 0xB0
-                cbytes[1] = 123
-                cbytes[2] = 0
+                cbytes[0] = 0x90
+                cbytes[1] = UInt8(60 + i)
+                cbytes[2] = 64
                 self.noteBlock(AUEventSampleTimeImmediate, 0, 3, cbytes)
 
-                cbytes.deallocate(capacity: 3)
+                usleep(useconds_t(0.2 * 1e6))
 
-                self.isDone = true
-            } // synced
+                cbytes[2] = 0    // note off
+                self.noteBlock(AUEventSampleTimeImmediate, 0, 3, cbytes)
+
+                i += 2
+                if i >= 24 {
+                    i = -12
+                }
+            } // while isPlaying
+
+            cbytes[0] = 0xB0
+            cbytes[1] = 123
+            cbytes[2] = 0
+            self.noteBlock(AUEventSampleTimeImmediate, 0, 3, cbytes)
+
+            cbytes.deallocate(capacity: 3)
+
         } // dispached
     } // scheduleInstrumentLoop
 }

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/ViewController.swift
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: NSViewController {
     @IBOutlet weak var midiDeviceSelector: NSPopUpButton!
 
     var openPanel: NSOpenPanel?
-    var auManager: AKAudioUnitManagerDev?
+    var auManager: AKAudioUnitManager?
     var midiManager: AKMIDI?
     var player: AKAudioPlayer?
     var fm: AKFMOscillator?
@@ -56,7 +56,7 @@ class ViewController: NSViewController {
         
         AudioKit.output = mainOutput
 
-        auManager = AKAudioUnitManagerDev()
+        auManager = AKAudioUnitManager(inserts: 6)
         auManager?.delegate = self
 
         auManager?.requestEffects(completionHandler: { audioUnits in

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/ViewController.swift
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: NSViewController {
     @IBOutlet weak var midiDeviceSelector: NSPopUpButton!
 
     var openPanel: NSOpenPanel?
-    var auManager: AKAudioUnitManager?
+    var auManager: AKAudioUnitManagerDev?
     var midiManager: AKMIDI?
     var player: AKAudioPlayer?
     var fm: AKFMOscillator?
@@ -36,21 +36,27 @@ class ViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         initialize()
+        
     }
 
     override func viewDidAppear() {
-        if let w = view.window {
-            w.delegate = self
-        }
     }
 
+    @objc func handleApplicationInit() {
+        view.window?.delegate = self
+    }
+    
     func initialize() {
+        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.handleApplicationInit), name: Notification.Name("AudioUnitManager.handleApplicationInit"), object: nil)
+        
         fm = AKFMOscillator()
         mixer = AKMixer()
-        AudioKit.output = mixer
-        AudioKit.start()
+        let mainOutput = AKMixer()
+        mixer?.connect(to: mainOutput)
+        
+        AudioKit.output = mainOutput
 
-        auManager = AKAudioUnitManager()
+        auManager = AKAudioUnitManagerDev()
         auManager?.delegate = self
 
         auManager?.requestEffects(completionHandler: { audioUnits in
@@ -62,6 +68,8 @@ class ViewController: NSViewController {
         })
 
         initMIDI()
+        
+        AudioKit.start()
     }
 
     private func initMIDI() {
@@ -235,8 +243,9 @@ class ViewController: NSViewController {
             }
             self.auManager?.connectEffects(firstNode: self.auInstrument, lastNode: self.mixer )
             self.showAudioUnit(audioUnit, identifier: 6)
-            self.instrumentPlayButton.isEnabled = true
-
+            DispatchQueue.main.async {
+                self.instrumentPlayButton.isEnabled = true
+            }
             //self.midiManager!.addListener(self.auInstrument!)
         })
     }
@@ -272,6 +281,7 @@ class ViewController: NSViewController {
 
     @IBAction func handlePlayButton(_ sender: Any) {
         guard let player = player else { return }
+        
 
         if fm != nil && fm!.isStarted {
             fmButton!.state = .off
@@ -286,6 +296,10 @@ class ViewController: NSViewController {
             player.stop()
             playButton.title = "▶️"
         } else {
+            auManager?.reset()
+            if !AudioKit.engine.isRunning {
+                AudioKit.start()
+            }
             player.play()
             playButton.title = "⏹"
         }
@@ -294,6 +308,10 @@ class ViewController: NSViewController {
     @IBAction func handleInstrumentPlayButton(_ sender: NSButton) {
         guard auInstrument != nil else { return }
 
+        if !AudioKit.engine.isRunning {
+            AudioKit.start()
+        }
+        
         if fm != nil && fm!.isStarted {
             fmButton!.state = .off
             fm!.stop()
@@ -314,7 +332,17 @@ class ViewController: NSViewController {
 
     @IBAction func handleFMButton(_ sender: NSButton) {
         guard let fm = fm else { return }
+        
+//        if AudioKit.engine.isRunning {
+//           AudioKit.stop()
+//        }
 
+        //auManager?.reset()
+        
+//        if !AudioKit.engine.isRunning {
+//            AudioKit.start()
+//        }
+        
         if player != nil && player!.isStarted {
             handlePlayButton(playButton)
         }
@@ -324,7 +352,6 @@ class ViewController: NSViewController {
         }
 
         if sender.state == .on {
-
             initFM()
 
         } else if fm.isStarted {
@@ -363,7 +390,6 @@ class ViewController: NSViewController {
             player!.completionHandler = handleAudioComplete
 
             auManager!.connectEffects(firstNode: player, lastNode: mixer)
-
             player!.looping = loopButton.state == .on
 
             playButton.isEnabled = true
@@ -385,12 +411,17 @@ class ViewController: NSViewController {
         if fmTimer != nil && fmTimer!.isValid {
             fmTimer!.invalidate()
         }
+        
+        if !AudioKit.engine.isRunning {
+            AudioKit.start()
+        }
+        fm.start()
 
         //let randInterval = Double(randomNumber(range: 10...100)) / 100
         fmTimer = Timer.scheduledTimer(timeInterval: 0.2, target: self, selector: #selector(randomFM), userInfo: nil, repeats: true)
 
-        randomFM()
-        fm.start()
+//        randomFM()
+//        fm.start()
     }
 
     @objc func randomFM() {
@@ -399,7 +430,7 @@ class ViewController: NSViewController {
         fm!.baseFrequency = Double(frequency)
         fm!.carrierMultiplier = Double(randomNumber(range: 10...100)) / 100
         fm!.amplitude = Double(randomNumber(range: 10...100)) / 100
-        //AKLog("randomFM() \(fm!.baseFrequency)")
+        //AKLog("\(fm!.baseFrequency)")
     }
 
     func randomNumber(range: ClosedRange<Int> = 100...500) -> Int {
@@ -409,7 +440,7 @@ class ViewController: NSViewController {
     }
 
     open func testAUInstrument(state: Bool) {
-        AKLog("testAUInstrument()")
+        AKLog("\(state)")
 
         guard auInstrument != nil else { return }
 
@@ -435,17 +466,18 @@ class ViewController: NSViewController {
             var ui = viewController
             guard let strongSelf = self else { return }
 
-            if ui == nil {
-                AKLog("No ViewController for \(audioUnit.name )")
-                ui = NSViewController()
-                ui!.view = AudioUnitGenericView(au: audioUnit)
-            }
-
-            AKLog("Audio Unit incoming frame: \(ui!.view.frame)")
-
-            guard let selfWindow = strongSelf.view.window else { return }
-
             DispatchQueue.main.async {
+                if ui == nil {
+                    AKLog("No ViewController for \(audioUnit.name )")
+                    ui = NSViewController()
+                    ui!.view = AudioUnitGenericView(au: audioUnit)
+                }
+
+                AKLog("Audio Unit incoming frame: \(ui!.view.frame)")
+
+                guard let selfWindow = strongSelf.view.window else { return }
+
+            
                 let unitWindow = NSWindow(contentViewController: ui!)
                 unitWindow.title = "\(audioUnit.name)"
                 unitWindow.delegate = self
@@ -471,7 +503,8 @@ class ViewController: NSViewController {
                 if let button = strongSelf.getEffectsButtonFromIdentifier( identifier ) {
                     button.state = .on
                 }
-            }
+                                
+            } //dispatch
         }
     }
 }
@@ -552,21 +585,23 @@ extension ViewController:  AKAudioUnitManagerDelegate {
 /// Handle Window Events
 extension ViewController: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        if let obj = notification.object {
-            if let w = obj as? NSWindow {
-
-                if let id = w.identifier?.rawValue.toInt() {
-                    if let b = getEffectsButtonFromIdentifier(id) {
-                        b.state = .off
-                        return
-                    }
-                }
-
-                // QUIT
-                if w == self.view.window {
-                    exit(0)
+        
+        Swift.print("windowWillClose: \(notification)")
+        
+        if let w = notification.object as? NSWindow {
+            if w == view.window {
+                auManager?.reset()
+                AudioKit.stop()
+                exit(0)
+            }
+            
+            if let wid = w.identifier?.rawValue {
+                if let b = getEffectsButtonFromIdentifier(wid.toInt()) {
+                    b.state = .off
+                    return
                 }
             }
+
         }
     }
 }


### PR DESCRIPTION
I've updated the Audio Unit manager to correctly load AU's that are midi controlled. 
kAudioUnitType_MusicEffect
vs
kAudioUnitType_Effect

These were missing before. I've unfortunately had to make a code breaking change and change the format of the internal AU array to be of a more generic type "AVAudioUnit" from "AVAudioUnitEffect". The docs say the midi AU's are "AVAudioUnitEffect" but it doesn't work.

I've also made the init that allows for custom insert lengths.