### PR TITLE
Fix potential AKAudioPlayer crash when using deferred/lazy buffering.

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -253,7 +253,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
                       looping: Bool = false,
                       lazyBuffering: Bool = false,
                       completionHandler: AKCallback? = nil) throws {
-        
+
         let readFile: AKAudioFile
 
         // Open the file for reading to avoid a crash when setting frame position

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -26,8 +26,17 @@ open class AKAudioPlayer: AKNode, AKToggleable {
 
     // MARK: - Properties
 
-    /// Buffer to be palyed
-    @objc open dynamic var audioFileBuffer: AVAudioPCMBuffer?
+    /// Buffer to be played
+    @objc fileprivate var _audioFileBuffer: AVAudioPCMBuffer?
+    @objc open dynamic var audioFileBuffer: AVAudioPCMBuffer? {
+        get {
+            if _audioFileBuffer == nil { updatePCMBuffer() }
+            return _audioFileBuffer
+        }
+        set {
+            _audioFileBuffer = newValue
+        }
+    }
 
     /// Will be triggered when AKAudioPlayer has finished to play.
     /// (will not as long as loop is on)
@@ -242,7 +251,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     ///
     @objc public init(file: AKAudioFile,
                 looping: Bool = false,
-                deferBuffering: Bool = false,
+                lazyBuffering: Bool = false,
                 completionHandler: AKCallback? = nil) throws {
 
         let readFile: AKAudioFile
@@ -270,9 +279,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
         avAudioNode = internalMixer
         internalPlayer.volume = 1.0
 
-        if !deferBuffering {
-            initialize()
-        }
+        initialize(lazyBuffering: lazyBuffering)
     }
 
     fileprivate var defaultBufferOptions: AVAudioPlayerNodeBufferOptions {
@@ -287,10 +294,6 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
 
     open func play(at when: AVAudioTime?) {
-
-        if audioFileBuffer == nil {
-            initialize()
-        }
 
         if ❗️playing {
             if audioFileBuffer != nil {
@@ -465,16 +468,14 @@ open class AKAudioPlayer: AKNode, AKToggleable {
 
     // MARK: - Private Methods
 
-    fileprivate func initialize() {
+    fileprivate func initialize(lazyBuffering: Bool = false) {
         audioFileBuffer = nil
         totalFrameCount = UInt32(internalAudioFile.length)
         startingFrame = 0
         endingFrame = totalFrameCount
 
-        if internalAudioFile.length > 0 {
+        if !lazyBuffering {
             updatePCMBuffer()
-        } else {
-            AKLog("AKAudioPlayer Warning:  \"\(internalAudioFile.fileNamePlusExtension)\" is an empty file")
         }
     }
 
@@ -487,6 +488,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
                                           at: atTime,
                                           options: options,
                                           completionHandler: looping ? nil : internalCompletionHandler)
+
             if atTime != nil {
                 internalPlayer.prepare(withFrameCount: framesToPlayCount)
             }
@@ -520,7 +522,11 @@ open class AKAudioPlayer: AKNode, AKToggleable {
 
     /// Fills the buffer with data read from internalAudioFile
     fileprivate func updatePCMBuffer() {
-        //AKLog("updatePCMBuffer() reversed \(self.reversed)")
+
+        guard internalAudioFile.length > 0 else {
+            AKLog("AKAudioPlayer Warning:  \"\(internalAudioFile.fileNamePlusExtension)\" is an empty file")
+            return
+        }
 
         var theStartFrame = startingFrame
         var theEndFrame = endingFrame

--- a/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKAudioPlayer.swift
@@ -250,10 +250,10 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     /// - Returns: an AKAudioPlayer if init succeeds, or nil if init fails. If fails, errors may be caught.
     ///
     @objc public init(file: AKAudioFile,
-                looping: Bool = false,
-                lazyBuffering: Bool = false,
-                completionHandler: AKCallback? = nil) throws {
-
+                      looping: Bool = false,
+                      lazyBuffering: Bool = false,
+                      completionHandler: AKCallback? = nil) throws {
+        
         let readFile: AKAudioFile
 
         // Open the file for reading to avoid a crash when setting frame position


### PR DESCRIPTION
I attempted to add lazy buffering to `AKAudioPlayer` in #1034 but did so naively where depending on the `play(…)` method used the PCM buffer might not be buffered before it needed to be accessed. This PR should fix it for all cases by integrating the lazy load into the getter of the buffer itself. 

This PR does change the optional parameter name from `deferBuffering` to `lazyBuffering`; if this is too much of a breaking change it can be changed to match the old parameter name but I thought this might be clearer.

Would love to hear feedback on if this is the right way to create a lazy getter like this.