### PR TITLE
Andres.fix#1079

### DIFF
--- a/AudioKit/Common/User Interface/AKNodeOutputPlot.swift
+++ b/AudioKit/Common/User Interface/AKNodeOutputPlot.swift
@@ -34,7 +34,7 @@ open class AKNodeOutputPlot: EZAudioPlot {
     internal var bufferSize: UInt32 = 1_024
 
     /// The node whose output to graph
-    open var node: AKNode? {
+    @objc open var node: AKNode? {
         willSet {
             node?.avAudioNode.removeTap(onBus: 0)
         }
@@ -53,7 +53,7 @@ open class AKNodeOutputPlot: EZAudioPlot {
     ///
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        setupNode(AudioKit.output)
+        setupNode(nil)
     }
 
     /// Initialize the plot with the output from a given node and optional plot size

--- a/Examples/iOS/HelloObjectiveC/HelloObjectiveC/Base.lproj/Main.storyboard
+++ b/Examples/iOS/HelloObjectiveC/HelloObjectiveC/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13189.4" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13165.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -65,6 +65,9 @@
                             <constraint firstItem="g7X-bw-gc2" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="ws3-qt-8bg"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="nodeOutputPlot" destination="int-Kr-iJa" id="3XG-WM-QhP"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Examples/iOS/HelloObjectiveC/HelloObjectiveC/ViewController.m
+++ b/Examples/iOS/HelloObjectiveC/HelloObjectiveC/ViewController.m
@@ -9,12 +9,16 @@
 #import "ViewController.h"
 
 @import AudioKit;
+@import AudioKitUI;
 
 @interface ViewController () {
     AKOscillator *oscillator1;
     AKOscillator *oscillator2;
     AKMixer *mixer;
 }
+
+@property (weak, nonatomic) IBOutlet AKNodeOutputPlot *nodeOutputPlot;
+
 @end
 
 @implementation ViewController
@@ -26,10 +30,16 @@
     oscillator2 = [[AKOscillator alloc] init];
     mixer = [[AKMixer alloc] init: @[oscillator1, oscillator2]];
     mixer.volume = 0.5;
+
     AudioKit.output = mixer;
     [AudioKit start];
-    
+
     return self;
+}
+
+- (void) viewDidLoad {
+    [super viewDidLoad];
+    self.nodeOutputPlot.node = mixer;
 }
 
 - (IBAction)toggleSound:(UIButton *)sender {


### PR DESCRIPTION
- Removed default setupNode(AudioKit.output) when initializing AKNodeOutputPlot from Interface Builder.
- Fixed HelloObjectiveC example to work with the previous modification.