### PR TITLE
Fix AK3DPanner and make AKOutput.setOutput format optional

### DIFF
--- a/AudioKit/Common/Nodes/AKConnection.swift
+++ b/AudioKit/Common/Nodes/AKConnection.swift
@@ -94,7 +94,7 @@ extension AKOutput {
     ///   - Parameter node: Input that output will be connected to.
     ///   - Parameter bus: The bus on the input that the output will connect to.
     ///   - Parameter format: The format of the connection.
-    @discardableResult public func setOutput(to node: AKInput, bus: Int, format: AVAudioFormat) -> AKInput {
+    @discardableResult public func setOutput(to node: AKInput, bus: Int, format: AVAudioFormat?) -> AKInput {
         AudioKit.connect(outputNode, to: node.inputNode, fromBus: 0, toBus: bus, format: format)
         return node
     }
@@ -102,7 +102,7 @@ extension AKOutput {
     /// Sets output connections to an array of inputs, removes previously existing output connections.
     ///   - Parameter nodes: Inputs that output will be connected to.
     ///   - Parameter format: The format of the connections.
-    @discardableResult public func setOutput(to nodes: [AKInput], format: AVAudioFormat) -> [AKInput] {
+    @discardableResult public func setOutput(to nodes: [AKInput], format: AVAudioFormat?) -> [AKInput] {
         setOutput(to: nodes.map { $0.nextInput.avConnection }, format: format)
         return nodes
     }
@@ -116,7 +116,7 @@ extension AKOutput {
     /// Sets output connections to an array of inputConnectios, removes previously existing output connections.
     ///   - Parameter toInputs: Inputs that output will be connected to.
     ///   - Parameter format: The format of the connections.
-    @discardableResult public func setOutput(toInputs: [AKInputConnection], format: AVAudioFormat) -> [AKInput] {
+    @discardableResult public func setOutput(toInputs: [AKInputConnection], format: AVAudioFormat?) -> [AKInput] {
         setOutput(to: toInputs.map { $0.avConnection }, format: format)
         return toInputs.map { $0.node }
     }
@@ -130,14 +130,14 @@ extension AKOutput {
     /// Sets output connections to a single connectionPoint, removes previously existing output connections.
     ///   - Parameter connectionPoint: Input that output will be connected to.
     ///   - Parameter format: The format of the connections.
-    public func setOutput(to connectionPoint: AVAudioConnectionPoint, format: AVAudioFormat) {
+    public func setOutput(to connectionPoint: AVAudioConnectionPoint, format: AVAudioFormat?) {
         setOutput(to: [connectionPoint], format: format)
     }
 
     /// Sets output connections to an array of connectionPoints, removes previously existing output connections.
     ///   - Parameter connectionPoints: Inputs that output will be connected to.
     ///   - Parameter format: The format of the connections.
-    public func setOutput(to connectionPoints: [AVAudioConnectionPoint], format: AVAudioFormat) {
+    public func setOutput(to connectionPoints: [AVAudioConnectionPoint], format: AVAudioFormat?) {
         AudioKit.connect(outputNode, to: connectionPoints, fromBus: 0, format: format)
     }
 

--- a/AudioKit/Common/Nodes/Mixing/Environment/AK3DPanner.swift
+++ b/AudioKit/Common/Nodes/Mixing/Environment/AK3DPanner.swift
@@ -47,10 +47,10 @@ open class AK3DPanner: AKNode, AKInput {
         super.init(avAudioNode: environmentNode, attach: true)
 
         input?.connect(to: inputMixer)
-        
+
         let monoFormat = AVAudioFormat(standardFormatWithSampleRate: AKSettings.sampleRate, channels: 1)
         inputMixer.setOutput(to: environmentNode, bus: 0, format: monoFormat)
-       
+
     }
     public var inputNode: AVAudioNode {
         return inputMixer.avAudioNode

--- a/AudioKit/Common/Nodes/Mixing/Environment/AK3DPanner.swift
+++ b/AudioKit/Common/Nodes/Mixing/Environment/AK3DPanner.swift
@@ -46,18 +46,11 @@ open class AK3DPanner: AKNode, AKInput {
         self.z = z
         super.init(avAudioNode: environmentNode, attach: true)
 
-        guard let inputNode = input else {
-            AKLog("Unable to create inputNode")
-            return
-        }
         input?.connect(to: inputMixer)
-        var inputsConnectionPoints = inputNode.connectionPoints
-        inputsConnectionPoints.append(AVAudioConnectionPoint(node: inputMixer.avAudioNode,
-                                                             bus: inputMixer.nextInput.bus))
-
-        let format = AVAudioFormat(standardFormatWithSampleRate: AKSettings.sampleRate, channels: 1)
-
-        AudioKit.engine.connect(inputNode.avAudioNode, to: inputsConnectionPoints, fromBus: 0, format: format)
+        
+        let monoFormat = AVAudioFormat(standardFormatWithSampleRate: AKSettings.sampleRate, channels: 1)
+        inputMixer.setOutput(to: environmentNode, bus: 0, format: monoFormat)
+       
     }
     public var inputNode: AVAudioNode {
         return inputMixer.avAudioNode


### PR DESCRIPTION
Fixed AK3DPanner to address https://github.com/AudioKit/AudioKit/issues/1083.
Made AKOutput.setOutput's format argument optional to match AVFoundation's existing API.