### PR TITLE
Add support for a clip playback completion handler.

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClip.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClip.swift
@@ -44,7 +44,7 @@ extension AKClip {
 /// A file based AKClip, with a completion handler.
 @objc public protocol FileClip: AKClip {
     var audioFile: AKAudioFile { get }
-    var completionCallback: AKCallback?
+    var completionCallback: AKCallback? { get }
 }
 
 /// A FileClip implementation, used by AKClipPlayer.

--- a/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClip.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClip.swift
@@ -41,7 +41,7 @@ extension AKClip {
     }
 }
 
-/// A file based AKClip
+/// A file based AKClip, with a completion handler.
 @objc public protocol FileClip: AKClip {
     var audioFile: AKAudioFile { get }
     var completionCallback: AKCallback?

--- a/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClip.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClip.swift
@@ -44,6 +44,7 @@ extension AKClip {
 /// A file based AKClip
 @objc public protocol FileClip: AKClip {
     var audioFile: AKAudioFile { get }
+    var completionCallback: AKCallback?
 }
 
 /// A FileClip implementation, used by AKClipPlayer.
@@ -61,6 +62,9 @@ open class AKFileClip: NSObject, FileClip {
     /// The duration of playback.
     open var duration: Double
 
+    // The callback executed when the end of the clip is reached.
+    open var completionCallback: AKCallback?
+
     /// Create a new file clip.
     ///
     /// - Parameters:
@@ -68,16 +72,19 @@ open class AKFileClip: NSObject, FileClip {
     ///   - time: The time in the timeline that the clip should begin playing.
     ///   - offset: The offset into the clip's audio (where to start playing from within the clip).
     ///   - duration: The duration of playback.
+    ///   - completion: Callback executed when the end of the clip is reached.
     ///
     public init(audioFile: AKAudioFile,
                 time: Double = 0,
                 offset: Double = 0,
-                duration: Double = 0) {
+                duration: Double = 0,
+                completionCallback: AKCallback? = nil) {
 
         self.audioFile = audioFile
         self.time = time
         self.offset = offset
         self.duration = duration == 0 ? audioFile.duration : duration
+        self.completionCallback = completionCallback
     }
 
     /// Init a file clip from a url with time and offset at zero, and duration set to file duration.

--- a/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipPlayer.swift
@@ -105,7 +105,7 @@ open class AKClipPlayer: AKNode, AKTiming {
                                  time: 0,
                                  offset: clip.offset + diff,
                                  duration: clip.duration - diff,
-                                 completion: nil)
+                                 completion: clip.completionCallback)
                 }
 
             } else {
@@ -113,7 +113,7 @@ open class AKClipPlayer: AKNode, AKTiming {
                              time: clip.time - offset,
                              offset: clip.offset,
                              duration: clip.duration,
-                             completion: nil)
+                             completion: clip.completionCallback)
             }
         }
         scheduled = true


### PR DESCRIPTION
Add an optional `AKCallback` onto the `FileClip` protocol, which allows users to perform an action when a clip finishes playing.

This was almost already supported, since the private `scheduleFile` takes an optional completion handler, but there was no way for the client to pass a completion block in.