### PR TITLE
Added completion handler to AKClipPlayer

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipPlayer.swift
@@ -6,14 +6,14 @@
 //  Copyright © 2017 Audive Inc. All rights reserved.
 //
 
-public typealias AKClipCallback = (FileClip) -> ()
+public typealias AKClipCallback = (FileClip) -> Void
 
 /// Schedules multiple audio files to be played in a sequence.
 open class AKClipPlayer: AKNode, AKTiming {
 
     /// Will be triggered when the player reaches the end of each clip
     open var completionHandler: AKClipCallback?
-    
+
     private var timeAtStart: Double = 0
 
     /// The underlying player node
@@ -176,7 +176,7 @@ open class AKClipPlayer: AKNode, AKTiming {
                                    at: startTime,
                                    completionHandler: completion)
     }
-    
+
     // Triggered each time the player reaches the end of a clip
     private func internalCompletionHandler(clip: FileClip) {
         DispatchQueue.main.async {


### PR DESCRIPTION
The motivation behind this change is that you may want to update the UI in response to clip playing status. This change adds a completion hander (AKClipCallback) to AKClipPlayer that is called back as each clip is finished playing. I have tried to design and implement it in a similar way to the completion handler on AKAudioPlayer.

(My first contribution to AudioKit - apologies if there are any mistakes in my code or conduct!)

