### PR TITLE
Deprecated AKOfflineRenderNode in favor of AudioKit.renderToFile.

### DIFF
--- a/AudioKit/Common/Nodes/Offline/OfflineRender/AKOfflineRenderAudioUnit.h
+++ b/AudioKit/Common/Nodes/Offline/OfflineRender/AKOfflineRenderAudioUnit.h
@@ -9,6 +9,7 @@
 #pragma once
 #import "AKAudioUnit.h"
 
+NS_DEPRECATED(10_10, 10_13, 8_0, 11_0)
 @interface AKOfflineRenderAudioUnit : AKAudioUnit
 @property BOOL internalRenderEnabled; // default = true;
 

--- a/AudioKit/Common/Nodes/Offline/OfflineRender/AKOfflineRenderNode.swift
+++ b/AudioKit/Common/Nodes/Offline/OfflineRender/AKOfflineRenderNode.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+@available(iOS, obsoleted: 11)
+@available(tvOS, obsoleted: 11)
+@available(macOS, obsoleted: 10.13)
 open class AKOfflineRenderNode: AKNode, AKComponent, AKInput {
 
     public typealias AKAudioUnitType = AKOfflineRenderAudioUnit


### PR DESCRIPTION
AKOfflineRenderNode was not working post iOS 11, so it's been deprecated.  

Extended AVAudioEngine and AudioKit with renderToFile method to support offline rendering moving forward.