### PR TITLE
Added start(at) to AKClipPlayer.

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipPlayer.swift
@@ -216,3 +216,8 @@ open class AKClipPlayer: AKNode, AKTiming {
         set { playerNode.pan = newValue }
     }
 }
+extension AKClipPlayer {
+    open func start(at audioTime: AVAudioTime? = nil) {
+        play(at: audioTime)
+    }
+}


### PR DESCRIPTION
start() and start(at:) map directly to play() and play(at:) for https://github.com/AudioKit/AudioKit/issues/1128