### PR TITLE
Include Bluetooth AD2P and HFP as recognized headphone types

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -286,11 +286,13 @@ extension AKSettings {
         return options
     }
 
-    /// Checks if headphones are plugged
-    /// Returns true if headPhones are plugged, otherwise return false
+    /// Checks if headphones are connected
+    /// Returns true if headPhones are connected, otherwise return false
     @objc static open var headPhonesPlugged: Bool {
         return session.currentRoute.outputs.contains {
-            $0.portType == AVAudioSessionPortHeadphones
+            [AVAudioSessionPortHeadphones,
+             AVAudioSessionPortBluetoothHFP,
+             AVAudioSessionPortBluetoothA2DP].contains($0.portType)
         }
     }
 


### PR DESCRIPTION
Currently connected headphones like AirPods and other bluetooth headphones don't result in a true value from AudioKit's `headPhonesPlugged` variable. This fixes that.

## Notes
* The variable name is kind of questionable now considering wireless headphones aren't plugged in but I'm not sure how big of a deal it is to change and let people update. 
* I'm not sure HFP should be included considering it could be a one piece bluetooth headset (or one Airpod). For most of my use-cases I'm checking the variable to know if I should expect sound to be routed via the device speaker or not so including HFP makes sense.

### Fun fact
When one AirPod is in your ear its `AVAudioSessionPortDescription`’s `portType` is `AVAudioSessionPortBluetoothA2DP`.

When *both* AirPods are in both ears its `AVAudioSessionPortDescription`’s `portType` is `AVAudioSessionPortBluetoothHFP`.