### PR TITLE
AVAudioPCMBuffer extensions refactoring.

### DIFF
--- a/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
+++ b/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
@@ -39,18 +39,18 @@ extension AVAudioPCMBuffer {
             )
         )
         let frameSize = Int(format.streamDescription.pointee.mBytesPerFrame)
-        if let src = floatChannelData,
-            let dst = buffer.floatChannelData {
+        if let src = buffer.floatChannelData,
+            let dst = floatChannelData {
             for channel in 0..<Int(format.channelCount) {
                 memcpy(dst[channel] + Int(frameLength), src[channel] + Int(readOffset), count * frameSize)
             }
-        } else if let src = int16ChannelData,
-            let dst = buffer.int16ChannelData {
+        } else if let src = buffer.int16ChannelData,
+            let dst = int16ChannelData {
             for channel in 0..<Int(format.channelCount) {
                 memcpy(dst[channel] + Int(frameLength), src[channel] + Int(readOffset), count * frameSize)
             }
-        } else if let src = int32ChannelData,
-            let dst = buffer.int32ChannelData {
+        } else if let src = buffer.int32ChannelData,
+            let dst = int32ChannelData {
             for channel in 0..<Int(format.channelCount) {
                 memcpy(dst[channel] + Int(frameLength), src[channel] + Int(readOffset), count * frameSize)
             }

--- a/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
+++ b/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
@@ -8,65 +8,67 @@
 
 extension AVAudioPCMBuffer {
 
-    /// Returns an AVAudioPCMBuffer copied from a sample offset to the end of the buffer.
-    open func copyFrom(startSample: AVAudioFrameCount) -> AVAudioPCMBuffer? {
-        guard startSample < frameLength,
-            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameLength - startSample)
-        else {
-            return nil
-        }
+    /**
+     Copies data from another PCM buffer.  Will copy to the end of the buffer (frameLength), and
+     increment frameLength. Will not exceed frameCapacity.
 
-        let count = Int(frameLength - startSample)
+     - Parameter buffer: The source buffer that data will be copied from.
+     - Parameter readOffset: The offset into the source buffer to read from.
+     - Parameter frames: The number of frames to copy from the source buffer.
+     - Returns: The number of frames copied.
+     */
+    @discardableResult open func copy(from buffer: AVAudioPCMBuffer,
+                                      readOffset: AVAudioFrameCount = 0,
+                                      frames: AVAudioFrameCount = 0) -> AVAudioFrameCount {
+
+        let remainingCapacity = frameCapacity - frameLength
+        if (remainingCapacity == 0) { return 0 }
+        let count = Int(
+            min(
+                min(frames == 0 ? buffer.frameLength : frames, remainingCapacity),
+                buffer.frameLength - readOffset
+            )
+        )
         let frameSize = Int(format.streamDescription.pointee.mBytesPerFrame)
         if let src = floatChannelData,
             let dst = buffer.floatChannelData {
             for channel in 0..<Int(format.channelCount) {
-                memcpy(dst[channel], src[channel] + Int(startSample), count * frameSize)
+                memcpy(dst[channel] + Int(frameLength), src[channel] + Int(readOffset), count * frameSize)
             }
         } else if let src = int16ChannelData,
             let dst = buffer.int16ChannelData {
             for channel in 0..<Int(format.channelCount) {
-                memcpy(dst[channel], src[channel] + Int(startSample), count * frameSize)
+                memcpy(dst[channel] + Int(frameLength), src[channel] + Int(readOffset), count * frameSize)
             }
         } else if let src = int32ChannelData,
             let dst = buffer.int32ChannelData {
             for channel in 0..<Int(format.channelCount) {
-                memcpy(dst[channel], src[channel] + Int(startSample), count * frameSize)
+                memcpy(dst[channel] + Int(frameLength), src[channel] + Int(readOffset), count * frameSize)
             }
         } else {
+            return 0
+        }
+        frameLength += AVAudioFrameCount(count)
+        return AVAudioFrameCount(count)
+    }
+
+    /// Returns an AVAudioPCMBuffer copied from a sample offset to the end of the buffer.
+    open func copyFrom(startSample: AVAudioFrameCount) -> AVAudioPCMBuffer? {
+        guard startSample < frameLength,
+            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameLength - startSample) else {
             return nil
         }
-        buffer.frameLength = AVAudioFrameCount(count)
-        return buffer
+        let framesCopied = buffer.copy(from: self, readOffset: startSample)
+        return framesCopied > 0 ? buffer : nil
     }
 
     /// Returns an AVAudioPCMBuffer copied from the start of the buffer to the specified endSample.
     open func copyTo(endSample: AVAudioFrameCount) -> AVAudioPCMBuffer? {
         guard endSample < frameLength,
-            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: endSample)
-        else {
+            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: endSample) else {
             return nil
         }
-        let frameSize = Int(format.streamDescription.pointee.mBytesPerFrame)
-
-        if let src = buffer.floatChannelData,
-            let dst = buffer.floatChannelData {
-            for channel in 0..<Int(buffer.format.channelCount) {
-                memcpy(dst[channel], src[channel], Int(endSample) * frameSize)
-            }
-        } else if let src = buffer.int16ChannelData,
-            let dst = buffer.int16ChannelData {
-            for channel in 0..<Int(buffer.format.channelCount) {
-                memcpy(dst[channel], src[channel], Int(endSample) * frameSize)
-            }
-        } else if let src = buffer.int32ChannelData,
-            let dst = buffer.int32ChannelData {
-            for channel in 0..<Int(buffer.format.channelCount) {
-                memcpy(dst[channel], src[channel], Int(endSample) * frameSize)
-            }
-        } else {
-            return nil
-        }
-        return buffer
+        let framesCopied = buffer.copy(from: self, readOffset: 0, frames: endSample)
+        return framesCopied > 0 ? buffer : nil
     }
 }

--- a/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
+++ b/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
@@ -22,12 +22,12 @@ extension AVAudioPCMBuffer {
                                       frames: AVAudioFrameCount = 0) -> AVAudioFrameCount {
 
         let remainingCapacity = frameCapacity - frameLength
-        if (remainingCapacity == 0) {
+        if remainingCapacity == 0 {
             print("AVAudioBuffer copy(from) - no capacity!")
             return 0
         }
 
-        if (format != buffer.format) {
+        if format != buffer.format {
             print("AVAudioBuffer copy(from) - formats must match!")
             return 0
         }
@@ -82,7 +82,7 @@ extension AVAudioPCMBuffer {
         guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: count) else {
             return nil
         }
-        let framesCopied = buffer.copy(from: self, readOffset: 0, frames: min(count,frameLength))
+        let framesCopied = buffer.copy(from: self, readOffset: 0, frames: min(count, frameLength))
         return framesCopied > 0 ? buffer : nil
     }
 }

--- a/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
+++ b/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
@@ -38,6 +38,12 @@ extension AVAudioPCMBuffer {
                 buffer.frameLength - readOffset
             )
         )
+
+        if count <= 0 {
+            print("AVAudioBuffer copy(from) - No frames to copy!")
+            return 0
+        }
+
         let frameSize = Int(format.streamDescription.pointee.mBytesPerFrame)
         if let src = buffer.floatChannelData,
             let dst = floatChannelData {
@@ -72,12 +78,11 @@ extension AVAudioPCMBuffer {
     }
 
     /// Returns an AVAudioPCMBuffer copied from the start of the buffer to the specified endSample.
-    open func copyTo(endSample: AVAudioFrameCount) -> AVAudioPCMBuffer? {
-        guard endSample < frameLength,
-            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: endSample) else {
+    open func copyTo(count: AVAudioFrameCount) -> AVAudioPCMBuffer? {
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: count) else {
             return nil
         }
-        let framesCopied = buffer.copy(from: self, readOffset: 0, frames: endSample)
+        let framesCopied = buffer.copy(from: self, readOffset: 0, frames: min(count,frameLength))
         return framesCopied > 0 ? buffer : nil
     }
 }

--- a/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
+++ b/AudioKit/Common/Internals/Utilities/AVAudioBufferConvenience.swift
@@ -22,7 +22,16 @@ extension AVAudioPCMBuffer {
                                       frames: AVAudioFrameCount = 0) -> AVAudioFrameCount {
 
         let remainingCapacity = frameCapacity - frameLength
-        if (remainingCapacity == 0) { return 0 }
+        if (remainingCapacity == 0) {
+            print("AVAudioBuffer copy(from) - no capacity!")
+            return 0
+        }
+
+        if (format != buffer.format) {
+            print("AVAudioBuffer copy(from) - formats must match!")
+            return 0
+        }
+
         let count = Int(
             min(
                 min(frames == 0 ? buffer.frameLength : frames, remainingCapacity),

--- a/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipRecorder.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/ClipPlayer/AKClipRecorder.swift
@@ -213,7 +213,7 @@ open class AKClipRecorder {
                 if lastBuffer {
                     let timeLeft = clip.endTime - timeIn
                     let samplesLeft = AVAudioFrameCount(timeLeft * buffer.format.sampleRate)
-                    if let partial = buffer.copyTo(endSample: samplesLeft) {
+                    if let partial = buffer.copyTo(count: samplesLeft) {
                         adjustedBuffer = partial
                     }
                 }


### PR DESCRIPTION
Refactor copyFrom(startSample) and copyTo(endSample) to use common AVAudioPCMBuffer.copy(from )