### PR TITLE
Adjust AKMusicTrack.clearRange() method to calculate range duration correctly

### DIFF
--- a/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
@@ -351,11 +351,11 @@ open class AKMusicTrack {
         return outBool
     }
 
-    /// Clear some events from the track
+    /// Clear all events from this track within the specified range
     ///
     /// - Parameters:
     ///   - start: Start of the range to clear, in beats (inclusive)
-    ///   - duration: Duration of the range to clear, in beats (exclusive)
+    ///   - duration: Length of time after the start position to clear, in beats (exclusive)
     ///
     open func clearRange(start: AKDuration, duration: AKDuration) {
         guard let track = internalMusicTrack else {

--- a/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
@@ -40,6 +40,7 @@ open class AKMusicTrack {
         }
         return lengthFromMusicTimeStamp
     }
+
     /// Total duration of the music track
     open var initLength: MusicTimeStamp {
         var size: UInt32 = 0
@@ -151,7 +152,6 @@ open class AKMusicTrack {
         if let musicTrack = internalMusicTrack {
             MusicTrackSetProperty(musicTrack, kSequenceTrackProperty_LoopInfo, &loopInfo, size)
         }
-
     }
 
     /// Set length
@@ -354,16 +354,17 @@ open class AKMusicTrack {
     /// Clear some events from the track
     ///
     /// - Parameters:
-    ///   - start:    Start of the range to clear, in beats
-    ///   - duration: Duration of the range to clear, in beats
+    ///   - start: Start of the range to clear, in beats (inclusive)
+    ///   - duration: Duration of the range to clear, in beats (exclusive)
     ///
     open func clearRange(start: AKDuration, duration: AKDuration) {
         guard let track = internalMusicTrack else {
             AKLog("internalMusicTrack does not exist")
             return
         }
+
         if isNotEmpty {
-            MusicTrackClear(track, start.beats, duration.beats)
+            MusicTrackClear(track, start.beats, start.beats + duration.beats)
         }
     }
 
@@ -395,6 +396,7 @@ open class AKMusicTrack {
 
         MusicTrackNewMIDINoteEvent(track, position.musicTimeStamp, &noteMessage)
     }
+
     /// Add Controller change to sequence
     ///
     /// - Parameters:
@@ -451,7 +453,6 @@ open class AKMusicTrack {
     ///   - channel: MIDI channel to insert pitch bend on
     ///
     open func addPitchBend(_ value: Int = 8_192, position: AKDuration, channel: MIDIChannel = 0) {
-
         guard let track = internalMusicTrack else {
             AKLog("internalMusicTrack does not exist")
             return
@@ -523,6 +524,7 @@ open class AKMusicTrack {
     open func debug() {
         CAShow(trackPointer)
     }
+
     open func debugInitTrack() {
         CAShow(initTrackPointer)
     }

--- a/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
@@ -164,7 +164,6 @@ open class AKSequencer {
 
     /// Set the tempo of the sequencer
     open func setTempo(_ bpm: Double) {
-
         let constrainedTempo = (10...280).clamp(bpm)
 
         var tempoTrack: MusicTrack?
@@ -196,7 +195,6 @@ open class AKSequencer {
     ///   - position: Point in time in beats
     ///
     open func addTempoEventAt(tempo bpm: Double, position: AKDuration) {
-
         let constrainedTempo = (10...280).clamp(bpm)
 
         var tempoTrack: MusicTrack?
@@ -207,7 +205,6 @@ open class AKSequencer {
         if let existingTempoTrack = tempoTrack {
             MusicTrackNewExtendedTempoEvent(existingTempoTrack, position.beats, constrainedTempo)
         }
-
     }
 
     /// Tempo retrieved from the sequencer
@@ -353,6 +350,7 @@ open class AKSequencer {
         let duration = AKDuration(beats: currentTime)
         return duration
     }
+
     /// Current Time relative to sequencer length
     open var currentRelativePosition: AKDuration {
         return currentPosition % length //can switch to modTime func when/if % is removed
@@ -437,11 +435,11 @@ open class AKSequencer {
         return tracks.last
     }
 
-    /// Clear some events from the track
+    /// Clear all events from all tracks within the specified range
     //
     /// - Parameters:
-    ///   - start:    Starting position of clearing
-    ///   - duration: Length of time after the start position to clear
+    ///   - start: Start of the range to clear, in beats (inclusive)
+    ///   - duration: Length of time after the start position to clear, in beats (exclusive)
     ///
     open func clearRange(start: AKDuration, duration: AKDuration) {
         for track in tracks {

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -134,7 +134,7 @@ extension AKMusicTrack {
         )
     }
 
-    private func iterateThroughEvents(_ processMIDIEvent: (_ eventTime: MusicTimeStamp, _ eventType: MusicEventType, _ eventData: UnsafeRawPointer?) -> ()) {
+    private func iterateThroughEvents(_ processMIDIEvent: (_ eventTime: MusicTimeStamp, _ eventType: MusicEventType, _ eventData: UnsafeRawPointer?) -> Void) {
         guard let track = internalMusicTrack else {
             XCTFail("internalMusicTrack does not exist")
             return

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -91,17 +91,15 @@ class AKMusicTrackTests: AKTestCase {
 // MARK: - For AKMusicTrack Testing
 extension AKMusicTrack {
     var noteCount: Int {
-        get {
-            var count = 0
+        var count = 0
 
-            iterateThroughEvents { _, eventType, _ in
-                if eventType == kMusicEventType_MIDINoteMessage {
-                    count += 1
-                }
+        iterateThroughEvents { _, eventType, _ in
+            if eventType == kMusicEventType_MIDINoteMessage {
+                count += 1
             }
-
-            return count
         }
+
+        return count
     }
 
     func hasNote(atPosition position: MusicTimeStamp,

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -1,0 +1,182 @@
+//
+//  AKMusicTrackTests.swift
+//  iOSTestSuiteTests
+//
+//  Created by Derek Lee, revision history on GitHub.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+import AudioKit
+import XCTest
+
+class AKMusicTrackTests: AKTestCase {
+    var musicTrack: AKMusicTrack!
+
+    override func setUp() {
+        super.setUp()
+
+        musicTrack = AKMusicTrack()
+        musicTrack.setLength(AKDuration(beats: 4.0))
+    }
+
+    // MARK: - add()
+    func testAdd_addsANewNote() {
+        musicTrack.addNote(withNumber: 60, atPosition: 0.75)
+
+
+        XCTAssertEqual(musicTrack.noteCount, 1)
+        XCTAssertTrue(musicTrack.hasNote(atPosition: 0.75, withNoteNumber: 60))
+    }
+
+    // MARK: - clear()
+    func testClear_clearsAllNotes() {
+        musicTrack.addNote(withNumber: 60, atPosition: 1.0)
+        musicTrack.addNote(withNumber: 61, atPosition: 2.0)
+        XCTAssertEqual(musicTrack.noteCount, 2)
+
+
+        musicTrack.clear()
+
+
+        XCTAssertEqual(musicTrack.noteCount, 0)
+    }
+
+    // MARK: - clearRange()
+    func testClearRange_doesNotRemoveNotesPriorToTheStartTime() {
+        musicTrack.addNote(withNumber: 60, atPosition: 1.99)
+        musicTrack.addNote(withNumber: 61, atPosition: 2.0)
+
+
+        musicTrack.clearRange(
+            start: AKDuration(beats: 2.0),
+            duration: AKDuration(beats: 1.0)
+        )
+
+
+        XCTAssertTrue(musicTrack.hasNote(atPosition: 1.99, withNoteNumber: 60))
+        XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.0, withNoteNumber: 61))
+    }
+
+    func testClearRange_removesNoteInclusiveOfTheStartTime() {
+        musicTrack.addNote(withNumber: 60, atPosition: 2.0)
+
+
+        musicTrack.clearRange(
+            start: AKDuration(beats: 2.0),
+            duration: AKDuration(beats: 0.1)
+        )
+
+
+        XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.0, withNoteNumber: 60))
+    }
+
+    func testClearRange_removesNoteAtTheEndOfTheDuration() {
+        musicTrack.addNote(withNumber: 60, atPosition: 2.99)
+
+
+        musicTrack.clearRange(
+            start: AKDuration(beats: 2.0),
+            duration: AKDuration(beats: 1.0)
+        )
+
+
+        XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.99, withNoteNumber: 60))
+    }
+
+    func testClearRange_doesNotRemoveNotesInclusiveOfTheDesiredDuration() {
+        musicTrack.addNote(withNumber: 60, atPosition: 2.0)
+        musicTrack.addNote(withNumber: 61, atPosition: 3.0)
+
+
+        musicTrack.clearRange(
+            start: AKDuration(beats: 2.0),
+            duration: AKDuration(beats: 1.0)
+        )
+
+
+        XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.0, withNoteNumber: 60))
+        XCTAssertTrue(musicTrack.hasNote(atPosition: 3.0, withNoteNumber: 61))
+    }
+}
+
+// MARK: - For AKMusicTrack Testing
+extension AKMusicTrack {
+    var noteCount: Int {
+        get {
+            var count = 0
+
+            iterateThroughEvents { _, eventType, _ in
+                if eventType == kMusicEventType_MIDINoteMessage {
+                    count += 1
+                }
+            }
+
+            return count
+        }
+    }
+
+    func hasNote(atPosition position: MusicTimeStamp,
+                 withNoteNumber noteNumber: MIDINoteNumber) -> Bool {
+        var noteFound = false
+
+        iterateThroughEvents { eventTime, eventType, eventData in
+            if eventType == kMusicEventType_MIDINoteMessage {
+                if let midiNoteMessage = eventData?.load(as: MIDINoteMessage.self) {
+                    if (eventTime == position && midiNoteMessage.note == noteNumber) {
+                        noteFound = true
+                    }
+                }
+            }
+        }
+
+        return noteFound
+    }
+
+    func doesNotHaveNote(atPosition position: MusicTimeStamp,
+                         withNoteNumber noteNumber: MIDINoteNumber) -> Bool {
+        return !hasNote(atPosition: position, withNoteNumber: noteNumber)
+    }
+
+    func addNote(withNumber noteNumber: MIDINoteNumber,
+                 atPosition position: MusicTimeStamp) {
+        self.add(
+            noteNumber: noteNumber,
+            velocity: 127,
+            position: AKDuration(beats: position),
+            duration: AKDuration(beats: 1.0)
+        )
+    }
+
+    private func iterateThroughEvents(_ processMIDIEvent: (_ eventTime: MusicTimeStamp, _ eventType: MusicEventType, _ eventData: UnsafeRawPointer?) -> ()) {
+        guard let track = internalMusicTrack else {
+            XCTFail("internalMusicTrack does not exist")
+            return
+        }
+
+        var tempIterator: MusicEventIterator?
+        NewMusicEventIterator(track, &tempIterator)
+        guard let iterator = tempIterator else {
+            XCTFail("Unable to create iterator")
+            return
+        }
+
+        var hasNextEvent: DarwinBoolean = false
+        MusicEventIteratorHasCurrentEvent(iterator, &hasNextEvent)
+
+        while hasNextEvent.boolValue {
+            var eventTime = MusicTimeStamp(0)
+            var eventType = MusicEventType()
+            var eventData: UnsafeRawPointer?
+            var eventDataSize: UInt32 = 0
+
+            MusicEventIteratorGetEventInfo(iterator, &eventTime, &eventType, &eventData, &eventDataSize)
+
+            processMIDIEvent(eventTime, eventType, eventData)
+
+            MusicEventIteratorNextEvent(iterator)
+            MusicEventIteratorHasCurrentEvent(iterator, &hasNextEvent)
+        }
+
+        DisposeMusicEventIterator(iterator)
+    }
+}

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -23,7 +23,6 @@ class AKMusicTrackTests: AKTestCase {
     func testAdd_addsANewNote() {
         musicTrack.addNote(withNumber: 60, atPosition: 0.75)
 
-
         XCTAssertEqual(musicTrack.noteCount, 1)
         XCTAssertTrue(musicTrack.hasNote(atPosition: 0.75, withNoteNumber: 60))
     }
@@ -34,9 +33,7 @@ class AKMusicTrackTests: AKTestCase {
         musicTrack.addNote(withNumber: 61, atPosition: 2.0)
         XCTAssertEqual(musicTrack.noteCount, 2)
 
-
         musicTrack.clear()
-
 
         XCTAssertEqual(musicTrack.noteCount, 0)
     }
@@ -46,12 +43,10 @@ class AKMusicTrackTests: AKTestCase {
         musicTrack.addNote(withNumber: 60, atPosition: 1.99)
         musicTrack.addNote(withNumber: 61, atPosition: 2.0)
 
-
         musicTrack.clearRange(
             start: AKDuration(beats: 2.0),
             duration: AKDuration(beats: 1.0)
         )
-
 
         XCTAssertTrue(musicTrack.hasNote(atPosition: 1.99, withNoteNumber: 60))
         XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.0, withNoteNumber: 61))
@@ -60,12 +55,10 @@ class AKMusicTrackTests: AKTestCase {
     func testClearRange_removesNoteInclusiveOfTheStartTime() {
         musicTrack.addNote(withNumber: 60, atPosition: 2.0)
 
-
         musicTrack.clearRange(
             start: AKDuration(beats: 2.0),
             duration: AKDuration(beats: 0.1)
         )
-
 
         XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.0, withNoteNumber: 60))
     }
@@ -73,12 +66,10 @@ class AKMusicTrackTests: AKTestCase {
     func testClearRange_removesNoteAtTheEndOfTheDuration() {
         musicTrack.addNote(withNumber: 60, atPosition: 2.99)
 
-
         musicTrack.clearRange(
             start: AKDuration(beats: 2.0),
             duration: AKDuration(beats: 1.0)
         )
-
 
         XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.99, withNoteNumber: 60))
     }
@@ -87,12 +78,10 @@ class AKMusicTrackTests: AKTestCase {
         musicTrack.addNote(withNumber: 60, atPosition: 2.0)
         musicTrack.addNote(withNumber: 61, atPosition: 3.0)
 
-
         musicTrack.clearRange(
             start: AKDuration(beats: 2.0),
             duration: AKDuration(beats: 1.0)
         )
-
 
         XCTAssertTrue(musicTrack.doesNotHaveNote(atPosition: 2.0, withNoteNumber: 60))
         XCTAssertTrue(musicTrack.hasNote(atPosition: 3.0, withNoteNumber: 61))

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -109,7 +109,7 @@ extension AKMusicTrack {
         iterateThroughEvents { eventTime, eventType, eventData in
             if eventType == kMusicEventType_MIDINoteMessage {
                 if let midiNoteMessage = eventData?.load(as: MIDINoteMessage.self) {
-                    if (eventTime == position && midiNoteMessage.note == noteNumber) {
+                    if eventTime == position && midiNoteMessage.note == noteNumber {
                         noteFound = true
                     }
                 }

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -1,6 +1,6 @@
 //
 //  AKMusicTrackTests.swift
-//  iOSTestSuiteTests
+//  AudioKitTestSuite
 //
 //  Created by Derek Lee, revision history on GitHub.
 //  Copyright © 2018 AudioKit. All rights reserved.

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -139,7 +139,6 @@ extension AKMusicTrack {
         _ eventType: MusicEventType,
         _ eventData: UnsafeRawPointer?
     ) -> Void
-    
     private func iterateThroughEvents(_ processMIDIEvent: MIDIEventProcessor) {
         guard let track = internalMusicTrack else {
             XCTFail("internalMusicTrack does not exist")

--- a/Tests/TestCases/AKMusicTrackTests.swift
+++ b/Tests/TestCases/AKMusicTrackTests.swift
@@ -134,7 +134,13 @@ extension AKMusicTrack {
         )
     }
 
-    private func iterateThroughEvents(_ processMIDIEvent: (_ eventTime: MusicTimeStamp, _ eventType: MusicEventType, _ eventData: UnsafeRawPointer?) -> Void) {
+    typealias MIDIEventProcessor = (
+        _ eventTime: MusicTimeStamp,
+        _ eventType: MusicEventType,
+        _ eventData: UnsafeRawPointer?
+    ) -> Void
+    
+    private func iterateThroughEvents(_ processMIDIEvent: MIDIEventProcessor) {
         guard let track = internalMusicTrack else {
             XCTFail("internalMusicTrack does not exist")
             return

--- a/Tests/iOSTestSuite/iOSTestSuite.xcodeproj/project.pbxproj
+++ b/Tests/iOSTestSuite/iOSTestSuite.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 				C44FF8921FD0994F00B2217D /* AKMoogLadderTests.swift */,
 				C44FF8CF1FD0994F00B2217D /* AKMorphingOscillatorBankTests.swift */,
 				C44FF8B41FD0994F00B2217D /* AKMorphingOscillatorTests.swift */,
+				52D4534A1FFB3B0000555360 /* AKMusicTrackTests.swift */,
 				C44FF8AF1FD0994F00B2217D /* AKOscillatorBankTests.swift */,
 				C44FF8BA1FD0994F00B2217D /* AKOscillatorTests.swift */,
 				C44FF8CA1FD0994F00B2217D /* AKPeakingParametricEqualizerFilterTests.swift */,
@@ -397,7 +398,6 @@
 				C44FF8841FD0994F00B2217D /* triangleWaveTests.swift */,
 				C44FF8831FD0994F00B2217D /* variableDelayTests.swift */,
 				C44FF8C01FD0994F00B2217D /* whiteNoiseTests.swift */,
-				52D4534A1FFB3B0000555360 /* AKMusicTrackTests.swift */,
 			);
 			name = TestCases;
 			path = ../../TestCases;

--- a/Tests/iOSTestSuite/iOSTestSuite.xcodeproj/project.pbxproj
+++ b/Tests/iOSTestSuite/iOSTestSuite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		52D4534B1FFB3B0000555360 /* AKMusicTrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D4534A1FFB3B0000555360 /* AKMusicTrackTests.swift */; };
 		C4289A151D56D20300B941B5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4289A141D56D20300B941B5 /* AppDelegate.swift */; };
 		C42D30A61D5A9C5C00F92555 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C42D30A51D5A9C5C00F92555 /* Default-568h@2x.png */; };
 		C44FF7BB1FD098DE00B2217D /* AudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C44FF7B91FD098D000B2217D /* AudioKit.framework */; };
@@ -134,6 +135,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		52D4534A1FFB3B0000555360 /* AKMusicTrackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKMusicTrackTests.swift; sourceTree = "<group>"; };
 		C4289A111D56D20300B941B5 /* iOSTestSuite.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSTestSuite.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4289A141D56D20300B941B5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C4289A201D56D20300B941B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 				C44FF8841FD0994F00B2217D /* triangleWaveTests.swift */,
 				C44FF8831FD0994F00B2217D /* variableDelayTests.swift */,
 				C44FF8C01FD0994F00B2217D /* whiteNoiseTests.swift */,
+				52D4534A1FFB3B0000555360 /* AKMusicTrackTests.swift */,
 			);
 			name = TestCases;
 			path = ../../TestCases;
@@ -548,6 +551,7 @@
 				C44FF8F11FD0994F00B2217D /* AKCompressorTests.swift in Sources */,
 				C44FF8DE1FD0994F00B2217D /* AKDCBlockTests.swift in Sources */,
 				C44FF9301FD0994F00B2217D /* AKPWMOscillatorTests.swift in Sources */,
+				52D4534B1FFB3B0000555360 /* AKMusicTrackTests.swift in Sources */,
 				C44FF9331FD0994F00B2217D /* AKLowShelfParametricEqualizerFilterTests.swift in Sources */,
 				C44FF92A1FD0994F00B2217D /* AKPeakingParametricEqualizerFilterTests.swift in Sources */,
 				C44FF90F1FD0994F00B2217D /* AKOscillatorBankTests.swift in Sources */,


### PR DESCRIPTION
Simple fix to the AKMusicTrack.clearRange() method to correctly calculate the range of notes to remove:
* Decided to stick with the existing API definition since this was also being utilized by the AKSequencer.clearRange() method. 
* The actual change itself was quite simple, but to have a bit more confidence I added some tests around this and the related methods for AKMusicTrack.
* Cleaned up some formatting to match the current style in the existing files since I was already in there.
* Updated the API documentation to standardize the descriptions for both AKSequencer as well as AKMusicTrack. 
* Note that clearRange() is inclusive of the start time, but *exclusive* of the end time.  This was surprising to me but is also noted in Apple's documentation:

```
	@function	MusicTrackClear
	@abstract	Removes all events within the specified range
	@discussion	All time ranges are [starttime < endtime]
```