### PR TITLE
Allow AudioKit to throw exceptions rather than consume or fail on them

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -316,24 +316,23 @@ extension AKSettings {
         case multiRoute
 
         public var description: String {
-
-            if self == .ambient {
+            switch self {
+            case .ambient:
                 return AVAudioSessionCategoryAmbient
-            } else if self == .soloAmbient {
+            case .soloAmbient:
                 return AVAudioSessionCategorySoloAmbient
-            } else if self == .playback {
+            case .playback:
                 return AVAudioSessionCategoryPlayback
-            } else if self == .record {
+            case .record:
                 return AVAudioSessionCategoryRecord
-            } else if self == .playAndRecord {
+            case .playAndRecord:
                 return AVAudioSessionCategoryPlayAndRecord
-            } else if self == .multiRoute {
+            case .multiRoute:
                 return AVAudioSessionCategoryMultiRoute
+            case .audioProcessing:
+                return AVAudioSessionCategoryAudioProcessing
             }
-
-            fatalError("unrecognized AVAudioSessionCategory \(self)")
-
-      }
+        }
    }
 }
 #endif

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -278,11 +278,11 @@ public typealias AKCallback = () -> Void
         engine.stop()
         shouldBeRunning = false
 
+        #if os(iOS)
         notificationObservers.forEach { (observer) in
             NotificationCenter.default.removeObserver(observer)
         }
 
-        #if os(iOS)
         do {
             try AVAudioSession.sharedInstance().setActive(false)
         } catch {

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -43,9 +43,13 @@ public typealias AKCallback = () -> Void
     /// An audio output operation that most applications will need to use last
     @objc open static var output: AKNode? {
         didSet {
-            updateSessionCategoryAndOptions()
-            output?.connect(to: finalMixer)
-            engine.connect(finalMixer.avAudioNode, to: engine.outputNode)
+            do {
+                try updateSessionCategoryAndOptions()
+                output?.connect(to: finalMixer)
+                engine.connect(finalMixer.avAudioNode, to: engine.outputNode)
+            } catch {
+                AKLog("Could not set output: \(error)")
+            }
         }
     }
 
@@ -205,71 +209,65 @@ public typealias AKCallback = () -> Void
     // MARK: - Start/Stop
 
     /// Start up the audio engine with periodic functions
-    open static func start(withPeriodicFunctions functions: AKPeriodicFunction...) {
+    open static func start(withPeriodicFunctions functions: AKPeriodicFunction...) throws {
         for function in functions {
             function.connect(to: finalMixer)
         }
-        start()
+        try start()
     }
 
     /// Start up the audio engine
-    @objc open static func start() {
+    @objc open static func start() throws {
         if output == nil {
-            AKLog("AudioKit: No output node has been set yet, no processing will happen.")
+            AKLog("No output node has been set yet, no processing will happen.")
         }
         // Start the engine.
-        do {
-            engine.prepare()
+        engine.prepare()
 
-            #if os(iOS)
+        #if os(iOS)
 
-                if AKSettings.enableRouteChangeHandling {
-                    NotificationCenter.default.addObserver(
-                        self,
-                        selector: #selector(AudioKit.restartEngineAfterRouteChange),
-                        name: .AVAudioSessionRouteChange,
-                        object: nil)
-                }
+            if AKSettings.enableRouteChangeHandling {
+                NotificationCenter.default.addObserver(forName: .AVAudioSessionRouteChange,
+                                                       object: nil,
+                                                       queue: OperationQueue.main,
+                                                       using: { (notification) in
+                                                        AudioKit.restartEngineAfterRouteChange(notification)
+                })
 
-                if AKSettings.enableCategoryChangeHandling {
-                    NotificationCenter.default.addObserver(
-                        self,
-                        selector: #selector(AudioKit.restartEngineAfterConfigurationChange),
-                        name: .AVAudioEngineConfigurationChange,
-                        object: engine)
-                }
-                updateSessionCategoryAndOptions()
-                try AVAudioSession.sharedInstance().setActive(true)
-            #endif
+            }
 
-            try engine.start()
-            shouldBeRunning = true
+            if AKSettings.enableCategoryChangeHandling {
+                NotificationCenter.default.addObserver(forName: .AVAudioEngineConfigurationChange,
+                                                       object: engine,
+                                                       queue: OperationQueue.main,
+                                                       using: { (notification) in
+                                                        AudioKit.restartEngineAfterConfigurationChange(notification)
+                })
+            }
+            try updateSessionCategoryAndOptions()
+            try AVAudioSession.sharedInstance().setActive(true)
+        #endif
 
-        } catch {
-            fatalError("AudioKit: Could not start engine. error: \(error).")
-        }
+        try engine.start()
+        shouldBeRunning = true
     }
 
-    @objc fileprivate static func updateSessionCategoryAndOptions() {
+    @objc fileprivate static func updateSessionCategoryAndOptions() throws {
         #if !os(macOS)
-            do {
-                let sessionCategory = AKSettings.computedSessionCategory()
-                let sessionOptions = AKSettings.computedSessionOptions()
+            let sessionCategory = AKSettings.computedSessionCategory()
+            let sessionOptions = AKSettings.computedSessionOptions()
 
-                #if os(iOS)
-                    try AKSettings.setSession(category: sessionCategory,
-                                              with: sessionOptions)
-                #elseif os(tvOS)
-                    try AKSettings.setSession(category: sessionCategory)
-                #endif
-            } catch {
-                fatalError("AudioKit: Could not update AVAudioSession category and options. error: \(error).")
-            }
+            #if os(iOS)
+                try AKSettings.setSession(category: sessionCategory,
+                                          with: sessionOptions)
+            #elseif os(tvOS)
+                try AKSettings.setSession(category: sessionCategory)
+            #endif
         #endif
     }
 
     /// Stop the audio engine
-    @objc open static func stop() {
+    @objc open static func stop() throws {
         // Stop the engine.
         engine.stop()
         shouldBeRunning = false
@@ -278,6 +276,7 @@ public typealias AKCallback = () -> Void
             try AVAudioSession.sharedInstance().setActive(false)
         } catch {
             AKLog("couldn't stop session \(error)")
+            throw error
         }
         #endif
     }
@@ -293,31 +292,27 @@ public typealias AKCallback = () -> Void
     ///   - node: AKNode to test
     ///   - duration: Number of seconds to test (accurate to the sample)
     ///
-    @objc open static func test(node: AKNode, duration: Double, afterStart: () -> Void = {}) {
+    @objc open static func test(node: AKNode, duration: Double, afterStart: () -> Void = {}) throws {
         #if swift(>=3.2)
-        if #available(iOS 11, macOS 10.13, tvOS 11, *) {
-            let samples = Int(duration * AKSettings.sampleRate)
+            if #available(iOS 11, macOS 10.13, tvOS 11, *) {
+                let samples = Int(duration * AKSettings.sampleRate)
 
-            tester = AKTester(node, samples: samples)
-            output = tester
+                tester = AKTester(node, samples: samples)
+                output = tester
 
-            do {
                 // maximum number of frames the engine will be asked to render in any single render call
                 let maxNumberOfFrames: AVAudioFrameCount = 4_096
                 engine.reset()
                 try engine.enableManualRenderingMode(.offline, format: format, maximumFrameCount: maxNumberOfFrames)
                 try engine.start()
-            } catch {
-                fatalError("could not enable manual rendering mode, \(error)")
-            }
-            afterStart()
-            tester?.play()
 
-            let buffer: AVAudioPCMBuffer = AVAudioPCMBuffer(pcmFormat: engine.manualRenderingFormat,
-                                                            frameCapacity: engine.manualRenderingMaximumFrameCount)!
+                afterStart()
+                tester?.play()
 
-            while engine.manualRenderingSampleTime < samples {
-                do {
+                let buffer: AVAudioPCMBuffer = AVAudioPCMBuffer(pcmFormat: engine.manualRenderingFormat,
+                                                                frameCapacity: engine.manualRenderingMaximumFrameCount)!
+
+                while engine.manualRenderingSampleTime < samples {
                     let framesToRender = buffer.frameCapacity
                     let status = try engine.renderOffline(framesToRender, to: buffer)
                     switch status {
@@ -337,12 +332,9 @@ public typealias AKCallback = () -> Void
                         // error occurred while rendering
                         fatalError("render failed")
                     }
-                } catch {
-                    fatalError("render failed, \(error)")
                 }
+                tester?.stop()
             }
-            tester?.stop()
-        }
         #endif
     }
 
@@ -352,15 +344,15 @@ public typealias AKCallback = () -> Void
     ///   - node: AKNode to test
     ///   - duration: Number of seconds to test (accurate to the sample)
     ///
-    @objc open static func auditionTest(node: AKNode, duration: Double) {
+    @objc open static func auditionTest(node: AKNode, duration: Double) throws {
         output = node
-        start()
+        try start()
         if let playableNode = node as? AKToggleable {
             playableNode.play()
         }
         usleep(UInt32(duration * 1_000_000))
-        stop()
-        start()
+        try stop()
+        try start()
     }
 
     // MARK: - Configuration Change Response
@@ -368,45 +360,39 @@ public typealias AKCallback = () -> Void
     // Listen to changes in audio configuration
     // and restart the audio engine if it stops and should be playing
     @objc fileprivate static func restartEngineAfterConfigurationChange(_ notification: Notification) {
-        DispatchQueue.main.async {
+        do {
             if shouldBeRunning && !engine.isRunning {
-                do {
+                #if !os(macOS)
+                    let appIsNotActive = UIApplication.shared.applicationState != .active
+                    let appDoesNotSupportBackgroundAudio = !AKSettings.appSupportsBackgroundAudio
 
-                    #if !os(macOS)
-                        let appIsNotActive = UIApplication.shared.applicationState != .active
-                        let appDoesNotSupportBackgroundAudio = !AKSettings.appSupportsBackgroundAudio
-
-                        if appIsNotActive && appDoesNotSupportBackgroundAudio {
-                            AKLog("engine not restarted after configuration change since app was not active and does not support background audio")
-                            return
-                        }
-                    #endif
-
-                    try engine.start()
-                    dump(engine.outputNode.audioUnit)
-
-                    // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
-                    if AKSettings.notificationsEnabled {
-                        NotificationCenter.default.post(
-                            name: .AKEngineRestartedAfterConfigurationChange,
-                            object: nil,
-                            userInfo: notification.userInfo)
+                    if appIsNotActive && appDoesNotSupportBackgroundAudio {
+                        AKLog("engine not restarted after configuration change since app was not active and does not support background audio")
+                        return
                     }
+                #endif
 
-                } catch {
-                    AKLog("couldn't start engine after configuration change \(error)")
+                try engine.start()
+
+                // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
+                if AKSettings.notificationsEnabled {
+                    NotificationCenter.default.post(
+                        name: .AKEngineRestartedAfterConfigurationChange,
+                        object: nil,
+                        userInfo: notification.userInfo)
                 }
             }
+        } catch {
+            AKLog("error restarting engine after route change")
+            // Note: doesn't throw since this is called from a notification observer
         }
     }
 
     // Restarts the engine after audio output has been changed, like headphones plugged in.
     @objc fileprivate static func restartEngineAfterRouteChange(_ notification: Notification) {
-        DispatchQueue.main.async {
-            if shouldBeRunning && !engine.isRunning {
-                do {
-
-                    #if !os(macOS)
+        if shouldBeRunning && !engine.isRunning {
+            do {
+                #if !os(macOS)
                     let appIsNotActive = UIApplication.shared.applicationState != .active
                     let appDoesNotSupportBackgroundAudio = !AKSettings.appSupportsBackgroundAudio
 
@@ -414,20 +400,20 @@ public typealias AKCallback = () -> Void
                         AKLog("engine not restarted after route change since app was not active and does not support background audio")
                         return
                     }
-                    #endif
+                #endif
 
-                    try engine.start()
+                try engine.start()
 
-                    // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
-                    if AKSettings.notificationsEnabled {
-                        NotificationCenter.default.post(
-                            name: .AKEngineRestartedAfterRouteChange,
-                            object: nil,
-                            userInfo: notification.userInfo)
-                    }
-                } catch {
-                    AKLog("error restarting engine after route change")
+                // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
+                if AKSettings.notificationsEnabled {
+                    NotificationCenter.default.post(
+                        name: .AKEngineRestartedAfterRouteChange,
+                        object: nil,
+                        userInfo: notification.userInfo)
                 }
+            } catch {
+                AKLog("error restarting engine after route change")
+                // Note: doesn't throw since this is called from a notification observer
             }
         }
     }
@@ -499,7 +485,7 @@ extension AudioKit {
         guard let mixer = node as? AVAudioMixerNode,
             engine.isRunning,
             !engine.mixerHasInputs(mixer: mixer) else {
-            return nil
+                return nil
         }
 
         let dummy = AVAudioUnitSampler()

--- a/AudioKit/Common/Internals/CoreAudio/AudioUnit+Helpers.swift
+++ b/AudioKit/Common/Internals/CoreAudio/AudioUnit+Helpers.swift
@@ -18,23 +18,24 @@ public extension AudioUnit {
     //swiftlint:disable force_try
 
     /// Get value for a property
-    func getValue<T>(forProperty property: AudioUnitPropertyID) -> T {
-        let (dataSize, _) = try! getPropertyInfo(propertyID: property)
-        return try! getProperty(propertyID: property, dataSize: dataSize)
+    func getValue<T>(forProperty property: AudioUnitPropertyID) throws -> T {
+        let (dataSize, _) = try getPropertyInfo(propertyID: property)
+        return try getProperty(propertyID: property, dataSize: dataSize)
     }
 
     /// Set value for a property
-    func setValue<T>(value: T, forProperty property: AudioUnitPropertyID) {
-        let (dataSize, _) = try! getPropertyInfo(propertyID: property)
-        return try! setProperty(propertyID: property, dataSize: dataSize, data: value)
+    func setValue<T>(value: T, forProperty property: AudioUnitPropertyID) throws {
+        let (dataSize, _) = try getPropertyInfo(propertyID: property)
+        return try setProperty(propertyID: property, dataSize: dataSize, data: value)
     }
 
     /// Add a listener to a property
-    func add(listener: AudioUnitPropertyListener, toProperty property: AudioUnitPropertyID) {
+    func add(listener: AudioUnitPropertyListener, toProperty property: AudioUnitPropertyID) throws {
         do {
             try addPropertyListener(listener: listener, toProperty: property)
         } catch {
             AKLog("Error Adding Property Listener")
+            throw error
         }
     }
 

--- a/AudioKit/Common/Nodes/Playback/Sampler/AKSampler+SoundFont.swift
+++ b/AudioKit/Common/Nodes/Playback/Sampler/AKSampler+SoundFont.swift
@@ -9,7 +9,8 @@
 public extension AKSampler {
     fileprivate func loadSoundFont(_ file: String, preset: Int, type: Int) throws {
         guard let url = Bundle.main.url(forResource: file, withExtension: "sf2") else {
-            fatalError("file not found.")
+            AKLog("File not found: \(file)")
+            throw NSError(domain: NSURLErrorDomain, code: NSFileReadUnknownError, userInfo: nil)
         }
         do {
             try samplerUnit.loadSoundBankInstrument(
@@ -32,7 +33,8 @@ public extension AKSampler {
     ///
     @objc public func loadSoundFont(_ file: String, preset: Int, bank: Int) throws {
         guard let url = Bundle.main.url(forResource: file, withExtension: "sf2") else {
-            fatalError("file not found.")
+            AKLog("File not found: \(file)")
+            throw NSError(domain: NSURLErrorDomain, code: NSFileReadUnknownError, userInfo: nil)
         }
         do {
             var bMSB: Int

--- a/AudioKit/Common/Nodes/Playback/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Sampler/AKSampler.swift
@@ -107,18 +107,20 @@ open class AKSampler: AKNode {
     ///
     /// - parameter filePath: Name of the file with the extension
     ///
-    @objc open func loadPath(_ filePath: String) {
+    @objc open func loadPath(_ filePath: String) throws {
         do {
             try samplerUnit.loadInstrument(at: URL(fileURLWithPath: filePath))
         } catch {
             AKLog("Error loading audio file at \(filePath)")
+            throw error
         }
     }
 
     internal func loadInstrument(_ file: String, type: String) throws {
         //AKLog("filename is \(file)")
         guard let url = Bundle.main.url(forResource: file, withExtension: type) else {
-            fatalError("file not found.")
+            AKLog("File not found: \(file)")
+            throw NSError(domain: NSURLErrorDomain, code: NSFileReadUnknownError, userInfo: nil)
         }
         do {
             try samplerUnit.loadInstrument(at: url)


### PR DESCRIPTION
In an attempt to be more Swifty and ultimately give users more control over audio routing related exceptions and errors this PR allows AudioKit to throw many of the exceptions or errors it previously consumed or crashed on using fatalExceptions. 

This likely isn't perfect and should be considered a breaking change so more eyes would be apprecaited! Thank you for the encouragement to do this, @dave234. 