### PR TITLE
Add ability to override AKRotaryKnob bubble text color

### DIFF
--- a/AudioKit/iOS/AudioKit/User Interface/AKRotaryKnob.swift
+++ b/AudioKit/iOS/AudioKit/User Interface/AKRotaryKnob.swift
@@ -55,6 +55,9 @@ public enum AKRotaryKnobStyle {
     /// Bubble font size
     @IBInspectable open var bubbleFontSize: CGFloat = 12
 
+    // Bubble text color
+    @IBInspectable open var bubbleTextColor: UIColor?
+
     /// Slider style. Curvature is a value between -1.0 and 1.0, where 0.0 indicates no curves
     open var knobStyle: AKRotaryKnobStyle = AKRotaryKnobStyle.polygon(numberOfSides: 9, curvature: 0.0)
 
@@ -310,7 +313,7 @@ public enum AKRotaryKnobStyle {
             valueLabelStyle.alignment = .center
 
             let valueLabelFontAttributes = [NSAttributedStringKey.font: UIFont.boldSystemFont(ofSize: bubbleFontSize),
-                                            NSAttributedStringKey.foregroundColor: textColor,
+                                            NSAttributedStringKey.foregroundColor: bubbleTextColor ?? textColor,
                                             NSAttributedStringKey.paragraphStyle: valueLabelStyle]
 
             let valueLabelInset: CGRect = valueLabelRect.insetBy(dx: 0, dy: 0)


### PR DESCRIPTION
This adds the ability to override the text color of the value shown when dragging a knob to change the value. Whilst you can change the text color based on theme or via the `-textColor` property this doesn't always work when you do really custom styles to the knob (i.e. make the knob all dark and use the indicator dots as indication of the value changing).