### PR TITLE
Allow AKSamplePlayer rate to become negative during playback

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayerDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayerDSPKernel.hpp
@@ -212,14 +212,18 @@ public:
     float startPointViaRate(){
         if (rate == 0) {return 0;}
         if (useTempStartPoint){
-            return tempStartPoint;
+            float currentEndPoint = endPoint;
+            if (useTempEndPoint) {
+                currentEndPoint = tempEndPoint;
+            }
+            return (rate > 0 ? tempStartPoint : currentEndPoint);
         }
         return (rate > 0 ? startPoint : endPoint);
     }
     float endPointViaRate(){
         if (rate == 0) {return 0;}
         if (useTempEndPoint){
-            return tempEndPoint;
+            return (rate > 0 ? tempEndPoint : tempStartPoint);
         }
         return (rate > 0 ? endPoint : startPoint);
     }


### PR DESCRIPTION
This edit allows the rate variable to change to negative during playback when we call play(from:), play(from: length:), and play(from: to:). The current version only allows this behaviour when calling the play() method.

Ready to send us a pull request? Please make sure your request is based on the [develop](https://github.com/audiokit/AudioKit/tree/develop) branch of the repository as `master` only holds stable releases.

Here are some resources that we use to develop our coding choices and core philosophies:

## Avoid code smell

* [Code Smell in Swift](http://www.bartjacobs.com/five-code-smells-in-swift-and-objective-c/)
* [Code Smell in Objective-C](http://qualitycoding.org/objective-c-code-smells/)
* [Code Smell of the Preprocessor](http://qualitycoding.org/preprocessor/)
