### PR TITLE
Get normalised position in the same range as old AKSamplePlayer

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayerAudioUnit.mm
+++ b/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayerAudioUnit.mm
@@ -60,7 +60,8 @@
     return _kernel.ftbl_size;
 }
 - (double)position {
-    return _kernel.position;
+    float normalized = (_kernel.position - _kernel.startPointViaRate()) / (_kernel.endPointViaRate() - _kernel.startPointViaRate());
+    return _kernel.rate > 0 ? normalized : 1 - normalized;
 }
 standardKernelPassthroughs()
 


### PR DESCRIPTION
The previous version took its normalised position from the phasor, which no longer exists. The position was then calculated based on normalised position * total samples. This new version checks if the rate is positive or negative and returns a normalised number based on:  (position - startpoint) / (endpoint - startpoint) if rate is positive, or 1 - that value if rate is negative.

Ready to send us a pull request? Please make sure your request is based on the [develop](https://github.com/audiokit/AudioKit/tree/develop) branch of the repository as `master` only holds stable releases.

Here are some resources that we use to develop our coding choices and core philosophies:

## Avoid code smell

* [Code Smell in Swift](http://www.bartjacobs.com/five-code-smells-in-swift-and-objective-c/)
* [Code Smell in Objective-C](http://qualitycoding.org/objective-c-code-smells/)
* [Code Smell of the Preprocessor](http://qualitycoding.org/preprocessor/)
