### PR TITLE
Fix AKAudioUnitManager.requestInstruments()

### DIFF
--- a/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitManager.swift
+++ b/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitManager.swift
@@ -15,7 +15,7 @@ extension Notification.Name {
 
 /// Audio Unit Manager
 open class AKAudioUnitManager: NSObject {
-    static let ComponentDescription = AudioComponentDescription(type: kAudioUnitType_MusicDevice, subType: 0)
+    //static let ComponentDescription = AudioComponentDescription(type: kAudioUnitType_MusicDevice, subType: 0)
 
     /// The notifications this class may generate
     public enum Notification {
@@ -268,9 +268,8 @@ open class AKAudioUnitManager: NSObject {
 
             /// Locating components can be a little slow, especially the first time.
             /// Do this work on a separate dispatch thread.
-            /// Make a component description matching any AU of the type.
-            self.availableInstruments = AVAudioUnitComponentManager.shared().components(matching:
-                AKAudioUnitManager.ComponentDescription)
+            let predicate = NSPredicate(format: "typeName == '\(AVAudioUnitTypeMusicDevice)'", argumentArray: [])
+            self.availableInstruments = AVAudioUnitComponentManager.shared().components(matching: predicate)
 
             self.availableInstruments = self.availableInstruments.sorted { $0.name < $1.name }
 


### PR DESCRIPTION
OS updates (Mac and iOS) seem to have broken AVAudioUnitComponentManager.components(matching: AudioComponentDescription). An equivalent predicate-based search still works.
