### PR TITLE
Threshold variable in init of AKAmplitudeTracker.

### DIFF
--- a/AudioKit/Common/Nodes/Analysis/Amplitude Tracker/AKAmplitudeTracker.swift
+++ b/AudioKit/Common/Nodes/Analysis/Amplitude Tracker/AKAmplitudeTracker.swift
@@ -84,7 +84,8 @@ open class AKAmplitudeTracker: AKNode, AKToggleable, AKComponent, AKInput {
             self?.avAudioNode = avAudioUnit
             self?.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
             self!.internalAU!.thresholdCallback = thresholdCallback
-
+            self!.threshold = threshold
+                                                                    
             if let au = self?.internalAU {
                 au.setHalfPowerPoint(Float(halfPowerPoint))
             }


### PR DESCRIPTION
Unallocated threshold variable within init.

Ready to send us a pull request? Please make sure your request is based on the [develop](https://github.com/audiokit/AudioKit/tree/develop) branch of the repository as `master` only holds stable releases.

Here are some resources that we use to develop our coding choices and core philosophies:

## Avoid code smell

* [Code Smell in Swift](http://www.bartjacobs.com/five-code-smells-in-swift-and-objective-c/)
* [Code Smell in Objective-C](http://qualitycoding.org/objective-c-code-smells/)
* [Code Smell of the Preprocessor](http://qualitycoding.org/preprocessor/)
