### PR TITLE
Add Documentation files for Chorus/Flanger

### DIFF
--- a/Documentation/ModDelay.svg
+++ b/Documentation/ModDelay.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="700px" height="300px" viewBox="0 0 700 300" enable-background="new 0 0 700 300" xml:space="preserve">
+<g>
+	<defs>
+		<rect id="SVGID_1_" x="31" y="16" width="637" height="267"/>
+	</defs>
+	<clipPath id="SVGID_2_">
+		<use xlink:href="#SVGID_1_"  overflow="visible"/>
+	</clipPath>
+	<path clip-path="url(#SVGID_2_)" fill="#FFFFFF" d="M180.313,112.687c6.249,6.248,6.249,16.379,0,22.627
+		c-6.248,6.249-16.379,6.249-22.627,0c-6.249-6.248-6.249-16.379,0-22.627C163.935,106.438,174.065,106.438,180.313,112.687"/>
+	
+		<path clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M180.313,112.687c6.249,6.248,6.249,16.379,0,22.627c-6.248,6.249-16.379,6.249-22.627,0c-6.249-6.248-6.249-16.379,0-22.627
+		C163.935,106.438,174.065,106.438,180.313,112.687"/>
+	
+		<polyline clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		169.5,116 169.5,132 169,132 	"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="161" y1="124.5" x2="177" y2="124.5"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="185" y1="124.5" x2="239.1" y2="124.5"/>
+	<polygon clip-path="url(#SVGID_2_)" points="247.1,124.5 239.1,121.5 239.1,127.5 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="247.1,124.5 239.1,121.5 
+		239.1,127.5 	"/>
+	<rect x="249.5" y="108.5" clip-path="url(#SVGID_2_)" fill="#FFFFFF" width="176" height="32"/>
+	
+		<rect x="249.5" y="108.5" clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="176" height="32"/>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 304.457 128.8047)" font-family="'HelveticaNeue'" font-size="14">Delay Line</text>
+	</g>
+	<path clip-path="url(#SVGID_2_)" fill="#FFFFFF" d="M564.313,112.687c6.249,6.248,6.249,16.379,0,22.627
+		c-6.248,6.249-16.379,6.249-22.627,0c-6.249-6.248-6.249-16.379,0-22.627C547.935,106.438,558.065,106.438,564.313,112.687"/>
+	
+		<path clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M564.314,112.687c6.248,6.248,6.248,16.379,0,22.627c-6.25,6.249-16.38,6.249-22.629,0c-6.248-6.248-6.248-16.379,0-22.627
+		C547.935,106.438,558.064,106.438,564.314,112.687"/>
+	
+		<polyline clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		553.5,116 553.5,132 553,132 	"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="545" y1="124.5" x2="561" y2="124.5"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="569" y1="124.5" x2="607.1" y2="124.5"/>
+	<polygon clip-path="url(#SVGID_2_)" points="615.1,124.5 607.1,121.5 607.1,127.5 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="615.1,124.5 607.1,121.5 
+		607.1,127.5 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="#FFFFFF" points="473.5,82 513,61 473.5,40 	"/>
+	
+		<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		473.5,82 513,61 473.5,40 	"/>
+	
+		<polyline clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		512.385,60.677 553.5,60 553.5,98.1 	"/>
+	<polygon clip-path="url(#SVGID_2_)" points="553.5,106.1 556.5,98.1 550.5,98.1 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="553.5,106.1 556.5,98.1 
+		550.5,98.1 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="#FFFFFF" points="473.5,257 513,236 473.5,215 	"/>
+	
+		<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		473.5,257 513,236 473.5,215 	"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="337.5" y1="236" x2="337.5" y2="149.9"/>
+	<polygon clip-path="url(#SVGID_2_)" points="337.5,141.9 334.5,149.9 340.5,149.9 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="337.5,141.9 334.5,149.9 
+		340.5,149.9 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="#FFFFFF" points="233.5,215 193,236 233.5,257 	"/>
+	
+		<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		233.5,215 193,236 233.5,257 	"/>
+	
+		<polyline clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		193,236.5 169.5,236.5 169.5,149.9 	"/>
+	<polygon clip-path="url(#SVGID_2_)" points="169.5,141.9 166.5,149.9 172.5,149.9 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="169.5,141.9 166.5,149.9 
+		172.5,149.9 	"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="233" y1="236.5" x2="473" y2="236.5"/>
+	
+		<polyline clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		513,236.5 553.5,236.5 553.5,149.9 	"/>
+	<polygon clip-path="url(#SVGID_2_)" points="553.5,141.9 550.5,149.9 556.5,149.9 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="553.5,141.9 550.5,149.9 
+		556.5,149.9 	"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="73" y1="124.5" x2="143.1" y2="124.5"/>
+	<polygon clip-path="url(#SVGID_2_)" points="151.1,124.5 143.1,121.5 143.1,127.5 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="151.1,124.5 143.1,121.5 
+		143.1,127.5 	"/>
+	
+		<polyline clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		121.424,124 121,60 463.1,60.919 	"/>
+	<polygon clip-path="url(#SVGID_2_)" points="471.1,60.941 463.108,57.919 463.092,63.919 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="471.1,60.941 463.108,57.919 
+		463.092,63.919 	"/>
+	<path clip-path="url(#SVGID_2_)" fill="#FFFFFF" d="M453.385,169.857c10.153,7.811,10.153,20.475,0,28.285s-26.616,7.811-36.77,0
+		s-10.153-20.475,0-28.285C426.769,162.048,443.231,162.048,453.385,169.857"/>
+	
+		<path clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M453.385,169.857c10.153,7.811,10.153,20.475,0,28.285c-10.153,7.81-26.616,7.81-36.77,0c-10.153-7.811-10.153-20.475,0-28.285
+		C426.769,162.048,443.231,162.048,453.385,169.857"/>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 421.7695 188.8047)" font-family="'HelveticaNeue'" font-size="14">LFO</text>
+	</g>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-dasharray="4,4" x1="377.5" y1="236" x2="377.5" y2="149.9"/>
+	<polygon clip-path="url(#SVGID_2_)" points="377.5,141.9 374.5,149.9 380.5,149.9 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="377.5,141.9 374.5,149.9 
+		380.5,149.9 	"/>
+	
+		<line clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-dasharray="4,4" x1="296.75" y1="236" x2="296.974" y2="149.9"/>
+	<polygon clip-path="url(#SVGID_2_)" points="296.995,141.9 293.974,149.893 299.974,149.908 	"/>
+	<polygon clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-miterlimit="10" points="296.995,141.9 293.974,149.893 
+		299.974,149.908 	"/>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 36.3062 128.3047)" font-family="'HelveticaNeue-Italic'" font-size="14">input</text>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 622.1367 128.8047)" font-family="'HelveticaNeue-Italic'" font-size="14">output</text>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 462.0977 34.3047)" font-family="'HelveticaNeue-Italic'" font-size="14">Dry Level</text>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 462.1758 274.3047)"><tspan x="0" y="0" font-family="'HelveticaNeue-Italic'" font-size="14">W</tspan><tspan x="12.18" y="0" font-family="'HelveticaNeue-Italic'" font-size="14">et Level</tspan></text>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 190.4028 274.3047)" font-family="'HelveticaNeue-Italic'" font-size="14">Feedback</text>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 258.6802 250.3047)" font-family="'HelveticaNeue-Italic'" font-size="14">min delay</text>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<text transform="matrix(1 0 0 1 357.126 250.3047)" font-family="'HelveticaNeue-Italic'" font-size="14">max delay</text>
+	</g>
+	
+		<polyline clip-path="url(#SVGID_2_)" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+		337,160.465 399,184.5 409,184.5 	"/>
+</g>
+</svg>

--- a/Documentation/ModulatedDelayEffects.md
+++ b/Documentation/ModulatedDelayEffects.md
@@ -1,0 +1,36 @@
+# Modulated Delay Effects
+
+## Overview
+
+Modulated-delay effects include **chorus**, **flanging**, and **vibrato**. These are all achieved by mixing an input signal with a delayed version of itself, and modulating the delay-time with a low-frequency oscillator (LFO).
+
+<img src="ModDelay.svg" width=100%>
+
+The LFO's output (typically a sinusoid or triangle wave) sets the instantaneous delay-time (i.e., the position of the output tap along the  delay-line's length), which then varies cyclically between limits *min _delay* and *max_delay*, about a midpoint *mid_delay*.
+
+The balance between the "dry" (input) signal and the "wet" (delayed) signal is usually set based on a user-selected fraction *wf* applied as a scaling factor (*Wet Level* in the diagram) on the wet signal, with the corresponding *Dry Level* set as *1.0 − f*, so there is no net gain.
+
+A user-selected *Rate* parameter sets the LFO frequency, and a *Depth* parameter sets the difference between *max_delay* and *min_delay*.
+
+For some effects, a fraction (indicated as *Feedback* in the diagram) of the delayed signal is fed back into the delay line.
+
+## Chorus
+For a chorus effect, the delay time varies about *mid_delay* which is fixed at the midpoint of the delay-line, whose total length is typically 20-40 ms. A user-selected *Depth* parameter controls how far *mid_delay* and *max_delay* deviate from this central value, from a minimum of zero (no change) to the point where *min_delay* becomes zero. No feedback is used.
+
+In the **AKChorus** effect, *mid_delay* is fixed at 14 ms. Setting the *Depth* parameter to 1.0 (maximum) results in actual delay values of 14 ± 10 ms, i.e. *min_delay* = 4 ms, *max_delay* = 24 ms. The *Feedback* parameter will normally be left at the default value of 0, but can be set as high as 0.25. **AKChorus** uses a sine-wave LFO, range 0.1 Hz to 10.0 Hz.
+
+## Flanger
+For a flanging effect, *min_delay* is fixed at nearly zero, and the user-selected *Depth* parameter controls *max_delay*, from a minimum of zero to a maximum of about 7-10 ms. Typical settings include a 50/50 wet/dry mix, and at least some feedback.
+
+The *Feedback* parameter is a signed fraction in the range -1.0 to + 1.0, where negative values indicate that the signal is inverted before begin fed back. This is important because when the delay time gets very close to zero, the low-frequency parts of the wet and dry signals overlap almost perfectly, so positive feedback can result in a sudden increase in volume. Using negative feedback instead yields a momentary reduction in volume, which is less noticeable.
+
+In the **AKFlanger** effect, setting the *Depth* parameter to 1.0 results in *max_delay* = 10 ms. *Feedback* may vary from -0.95 to +0.95. LFO is a triangle wave, 0.1 - 10 Hz.
+
+## Vibrato
+With a modulated-delay effect in either chorus (*mid_delay* fixed at midpoint of delay-line) or flanger (*min_delay* fixed at near-zero) configuration, setting the *Wet Level* to 100% will yield a vibrato effect. This is due to the effect of the LFO modulating the delay time. When the delay-time is decreasing, the short fragment of sound in the delay-line is effectively resampled at a rate faster than its original sample rate, so the pitch rises. When the delay-time is increasing, the sound is resampled at a rate slower than its original sampling rate, so the pitch drops.
+
+## Stereo Chorus and Flanging
+Both **AKChorus** and **AKFlanger** are actually stereo effects. The DSP structure shown in the above diagram is duplicated for each of the Left and Right channels. The two LFOs run in lock-step at the same frequency (set by the *Rate* parameter) and amplitude (set by *Depth*), but offset in phase by 90 degrees. This technique, called *quadrature modulation*, is quite common in stereo modulation effects.
+
+## For more information
+Modulated-delay effects are described in detail in Chapter 10 of [Designing Audio Effect Plug-Ins in C++](https://www.amazon.com/Designing-Audio-Effect-Plug-Ins-Processing/dp/0240825152) by Will Pirkle.


### PR DESCRIPTION
Note my ModDelay.svg diagram is included in the Documentation directory itself. You may want to move it to AudioKit.io/images, in which case you'll need to update the link in the .md file.

Keeping all related files together might make Git(Hub)-based management easier, however.