### PR TITLE
Fix unhandled exception when sending SysEx messages larger than 258

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDI+SendingMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+SendingMIDI.swift
@@ -106,6 +106,14 @@ extension AKMIDI {
         // Create a buffer that is big enough to hold the data to be sent and
         // all the necessary headers.
         let bufferSize = data.count + sizeOfMIDICombinedHeaders
+        
+        // the discussion section of MIDIPacketListAdd states that "The maximum
+        // size of a packet list is 65536 bytes." Checking for that limit here.
+        if bufferSize > 65536 {
+            AKLog("error sending midi : data array is too large, requires a buffer larger than 65536")
+            return
+        }
+
         var buffer = Data(count: bufferSize)
         
         // Use Data (a.k.a NSData) to create a block where we have access to a

--- a/AudioKit/Common/MIDI/AKMIDI+SendingMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+SendingMIDI.swift
@@ -6,6 +6,27 @@
 //  Copyright © 2017 AudioKit. All rights reserved.
 //
 
+private let sizeOfMIDIPacketList = MemoryLayout<MIDIPacketList>.size
+private let sizeOfMIDIPacket = MemoryLayout<MIDIPacket>.size
+
+/// The `MIDIPacketList` struct consists of two fields, numPackets(`UInt32`) and
+/// packet(an Array of 1 instance of `MIDIPacket`). The packet is supposed to be a "An open-ended
+/// array of variable-length MIDIPackets." but for convenience it is instaciated with
+/// one instance of a `MIDIPacket`. To figure out the size of the header portion of this struct,
+/// we can get the size of a UInt32, or subtract the size of a single packet from the size of a
+/// packet list. I opted for the latter.
+private let sizeOfMIDIPacketListHeader = sizeOfMIDIPacketList - sizeOfMIDIPacket
+
+/// The MIDIPacket struct consists of a timestamp (`MIDITimeStamp`), a length (`UInt16`) and
+/// data (an Array of 256 instances of `Byte`). The data field is supposed to be a "A variable-length
+/// stream of MIDI messages." but for convenience it is instaciated as 256 bytes. To figure out the
+/// size of the header portion of this struct, we can add the size of the `timestamp` and `length`
+/// fields, or subtract the size of the 256 `Byte`s from the size of the whole packet. I opted for
+/// the former.
+private let sizeOfMIDIPacketHeader = MemoryLayout<MIDITimeStamp>.size + MemoryLayout<UInt16>.size
+private let sizeOfMIDICombinedHeaders = sizeOfMIDIPacketListHeader + sizeOfMIDIPacketHeader
+
+
 internal extension Collection where Index == Int {
     var startIndex: Index {
         return 0
@@ -81,23 +102,37 @@ extension AKMIDI {
     }
     /// Send Message with data
     public func sendMessage(_ data: [MIDIByte]) {
-        let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)
+        
+        // Create a buffer that is big enough to hold the data to be sent and
+        // all the necessary headers.
+        let bufferSize = data.count + sizeOfMIDICombinedHeaders
+        var buffer = Data(count: bufferSize)
+        
+        // Use Data (a.k.a NSData) to create a block where we have access to a
+        // pointer where we can create the packetlist and send it. No need for
+        // explicit alloc and dealloc.
+        buffer.withUnsafeMutableBytes { (packetListPointer:UnsafeMutablePointer<MIDIPacketList>) -> Void in
+            let packet = MIDIPacketListInit(packetListPointer)
+            let nextPacket:UnsafeMutablePointer<MIDIPacket>? = MIDIPacketListAdd(packetListPointer, bufferSize, packet, 0, data.count, data)
 
-        var packet = MIDIPacketListInit(packetListPointer)
-        packet = MIDIPacketListAdd(packetListPointer, 1_024, packet, 0, data.count, data)
-        for endpoint in endpoints.values {
-            let result = MIDISend(outputPort, endpoint, packetListPointer)
-            if result != noErr {
-                AKLog("error sending midi : \(result)")
+            // I would prefer stronger error handling here, perhaps throwing
+            // to force the app developer to handle the error.
+            if nextPacket == nil {
+                AKLog("error sending midi : Failed to add packet to packet list.")
+                return
+            }
+            
+            for endpoint in endpoints.values {
+                let result = MIDISend(outputPort, endpoint, packetListPointer)
+                if result != noErr {
+                    AKLog("error sending midi : \(result)")
+                }
+            }
+            
+            if virtualOutput != 0 {
+                MIDIReceived(virtualOutput, packetListPointer)
             }
         }
-
-        if virtualOutput != 0 {
-            MIDIReceived(virtualOutput, packetListPointer)
-        }
-
-        packetListPointer.deinitialize()
-        packetListPointer.deallocate(capacity: 1)//necessary? wish i could do this without the alloc above
     }
 
     /// Clear MIDI destinations


### PR DESCRIPTION
**NOTE** ~~While I verified that this fix worked on v4.0.4, I am currently having trouble compiling `develop` itself (as noted in https://github.com/AudioKit/AudioKit/issues/1254.) So I recommend not merging this PR until it can be verified against `develop`~~ Added the missing `-lstdc++` linker flag. Verified against `develop` now

This PR should fix the issue in https://github.com/AudioKit/AudioKit/issues/1163

The exception was being thrown whenever deallocating `packetListPointer` but the problem really was caused earlier. These are the things that I found to be off:
1. `packetListPointer` was allocated using `UnsafeMutablePointer`'s `allocate(capacity:)` function with a capacity of 1. This created a memory allocation of 272 bytes as that is the size of a single `MIDIPacketList` (at least on a mac) This buffer size did not take into account the size of the incoming data which works in a majority of case, as most MIDI messages tend to be relatively small.
2. The `listSize` parameter of `MIDIPacketListAdd()` was hardwired to 1_024. This value is larger than the actual buffer allocated in 1. and therefore the function can't properly determine that data with more than the available 258 bytes (272 bytes in buffer - 14 bytes of headers from MIDIPacketList and MIDIPacket) but less than 1014, should have not been allowed and returned with null. Instead, it just goes ahead an writes to memory beyond what was allocated, which is why dealloc throws an exception later. Running Address Sanitizer pinpoints the actual location of the error.

To fix it, I took the following steps:
1) Computed the size of the necessary headers. Since this value should not change from time to time, I just calculated this value once. (perhaps there is a better place for me to store these constants? I'm new to this project and I'm getting my bearings)
2) Allocated the memory necessary by using Data (the bridged class formerly known as NSData.) This avoided the need to alloc and dealloc (which would have work as well, this just seemed nicer)
3) Made sure the size of the buffer was passed properly to `MIDIPacketListAdd()`
4) Report an error and bail if `MIDIPacketListAdd()` returns a null (it shouldn't since the buffer is always allocated to be just the necessary size)
5) Check that the buffer size required will not be greater than the maximum allowed 65536 (as documented in the *discussion* section of `MIDIPacketListAdd()` 