### PR TITLE
Changes to AKSequencer.loadMIDIFile() for issue 1155

### DIFF
--- a/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
@@ -365,7 +365,7 @@ open class AKSequencer {
         return Int(count)
     }
 
-    /// Load a MIDI file from the bundle
+    /// Load a MIDI file from the bundle (removes old tracks, if present)
     open func loadMIDIFile(_ filename: String) {
         let bundle = Bundle.main
         guard let file = bundle.path(forResource: filename, ofType: "mid") else {
@@ -376,7 +376,7 @@ open class AKSequencer {
         loadMIDIFile(fromUrl: fileURL)
     }
 
-    /// Load a MIDI file given a URL
+    /// Load a MIDI file given a URL (removes old tracks, if present)
     open func loadMIDIFile(fromUrl fileURL: URL) {
         removeTracks()
         if let existingSequence = sequence {


### PR DESCRIPTION
Re: https://github.com/AudioKit/AudioKit/issues/1155
Getting rid of old tracks using MusicSequenceDisposeTrack seems to be necessary before replacing the sequence with the one generated by the new MIDI file.  Repeated calls to AKSequencer.loadMIDIFile() will now remove old tracks, create the new sequence, then build new tracks from the new sequence, which seems like expected default behaviour.  I think this addresses the issue.

The other idea (i.e., overlaying a new tracks over the old ones) is a useful idea, and I will add it in the future with a different name (e.g.,  overlayNewMIDIFile) once I've tested it more thoroughly.

Also, I changed loopEnabled to private because it just keeps track of what the setter methods have done.