### PR TITLE
CallbackInstrument can set name correctly

### DIFF
--- a/AudioKit/Common/MIDI/AKCallbackInstrument.swift
+++ b/AudioKit/Common/MIDI/AKCallbackInstrument.swift
@@ -24,6 +24,7 @@ open class AKCallbackInstrument: AKMIDIInstrument {
     ///
     public init(midiInputName: String = "AudioKit Callback Instrument", callback: AKMIDICallback? = nil) {
         super.init(midiInputName: midiInputName)
+        self.name = midiInputName
         self.callback = callback
         avAudioNode = AVAudioMixerNode()
         AudioKit.engine.attach(self.avAudioNode)

--- a/AudioKit/Common/MIDI/AKMIDIInstrument.swift
+++ b/AudioKit/Common/MIDI/AKMIDIInstrument.swift
@@ -27,6 +27,7 @@ open class AKMIDIInstrument: AKPolyphonicNode, AKMIDIListener {
     ///
     public init(midiInputName: String? = nil) {
         super.init()
+        name = midiInputName ?? name
         enableMIDI(name: midiInputName ?? name)
         hideVirtualMIDIPort()
     }


### PR DESCRIPTION
fix for: https://github.com/AudioKit/AudioKit/issues/1126
"Callback instruments can't be renamed or assigned to proper MIDI client #1126"

The last pull-request also should address many of these issues