### PR TITLE
Fix bypass bug in filters

### DIFF
--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
@@ -103,6 +103,7 @@ void AKVariableDelayDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
@@ -103,6 +103,7 @@ void AKBitCrusherDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bu
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
@@ -89,6 +89,7 @@ void AKClipperDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffe
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
@@ -131,6 +131,7 @@ void AKTanhDistortionDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCoun
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
@@ -131,6 +131,7 @@ void AKDynamicRangeCompressorDSP::process(AUAudioFrameCount frameCount, AUAudioF
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
@@ -103,6 +103,7 @@ void AKBandPassButterworthFilterDSP::process(AUAudioFrameCount frameCount, AUAud
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
@@ -103,6 +103,7 @@ void AKBandRejectButterworthFilterDSP::process(AUAudioFrameCount frameCount, AUA
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
@@ -57,6 +57,7 @@ void AKDCBlockDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffe
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
@@ -117,6 +117,7 @@ void AKEqualizerFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCou
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
@@ -117,6 +117,7 @@ void AKFormantFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
@@ -89,6 +89,7 @@ void AKHighPassButterworthFilterDSP::process(AUAudioFrameCount frameCount, AUAud
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
@@ -119,6 +119,7 @@ void AKHighShelfParametricEqualizerFilterDSP::process(AUAudioFrameCount frameCou
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
@@ -117,6 +117,7 @@ void AKKorgLowPassFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameC
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
@@ -89,6 +89,7 @@ void AKLowPassButterworthFilterDSP::process(AUAudioFrameCount frameCount, AUAudi
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
@@ -119,6 +119,7 @@ void AKLowShelfParametricEqualizerFilterDSP::process(AUAudioFrameCount frameCoun
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
@@ -103,6 +103,7 @@ void AKModalResonanceFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFra
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
@@ -103,6 +103,7 @@ void AKMoogLadderDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bu
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
@@ -119,6 +119,7 @@ void AKPeakingParametricEqualizerFilterDSP::process(AUAudioFrameCount frameCount
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
@@ -103,6 +103,7 @@ void AKResonantFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCoun
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
@@ -131,6 +131,7 @@ void AKRolandTB303FilterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameC
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
@@ -103,6 +103,7 @@ void AKStringResonatorDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCou
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
@@ -117,6 +117,7 @@ void AKThreePoleLowpassFilterDSP::process(AUAudioFrameCount frameCount, AUAudioF
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
@@ -89,6 +89,7 @@ void AKToneComplementFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFra
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
@@ -89,6 +89,7 @@ void AKToneFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bu
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
@@ -117,6 +117,7 @@ void AKAutoWahDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffe
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
@@ -117,6 +117,7 @@ void AKPitchShifterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount 
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
@@ -57,6 +57,7 @@ void AKChowningReverbDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCoun
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
 
             if (channel == 0) {

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.hpp
@@ -107,6 +107,7 @@ public:
                 }
                 if (!_playing) {
                     *out = *in;
+                    continue;
                 }
                 if (channel == 0) {
                     sp_comb_compute(_sp, _comb0, in, out);

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
@@ -97,6 +97,7 @@ void AKFlatFrequencyResponseReverbDSP::process(AUAudioFrameCount frameCount, AUA
             }
             if (!_playing) {
                 *out = *in;
+                continue;
             }
             if (channel == 0) {
                 sp_allpass_compute(_sp, _private->_allpass0, in, out);


### PR DESCRIPTION
I think this PR fixes a bug in AudioKit.

The process function in the filters is ignoring the `isPlaying` property.
So if a filter had `bypass` enabled it would still process the frames
that were sent through it.

I considered refactoring to make a cleaner solution, but decided to do as little as possible to get this reviewed by you guys first. If this is a valid fix we can discuss options on how to implement the `isPlaying`-check in a better way. But that should probably be a separate PR so we can get this fix in production.

Keep up the good work!