### PR TITLE
Changes to AKSequencer and AKMusicTrack: Set Time Signature, remove MetaEvents

### DIFF
--- a/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
@@ -416,6 +416,12 @@ open class AKSequencer {
     ///  Dispose of tracks associated with sequence
     func removeTracks() {
         if let existingSequence = sequence {
+            var tempoTrack: MusicTrack?
+            MusicSequenceGetTempoTrack(existingSequence, &tempoTrack)
+            if let track = tempoTrack {
+                MusicTrackClear(track, 0, length.musicTimeStamp)
+            }
+            
             for track in tracks {
                 if let internalTrack = track.internalMusicTrack {
                     MusicSequenceDisposeTrack(existingSequence, internalTrack)

--- a/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
@@ -280,6 +280,52 @@ open class AKSequencer {
         DisposeMusicEventIterator(iterator)
         return outBool
     }
+    
+    /// Possible values for the time signature lower value
+    public enum TimeSignatureBottomValue: UInt8 {
+        // According to MIDI spec, second byte is log base 2 of time signature 'denominator'
+        case two = 1
+        case four = 2
+        case eight = 3
+        case sixteen = 4
+    }
+    
+    /// Add a time signature event to start of a tempo track
+    /// NB: will affect MIDI file layout but NOT sequencer playback
+    ///
+    /// - Parameters:
+    ///   - timeSignatureTop: Number of beats per measure
+    ///   - timeSignatureBottom: Unit of beat
+    ///
+    
+    open func addTimeSignatureEvent(timeSignatureTop: UInt8, timeSignatureBottom: TimeSignatureBottomValue) {
+        var tempoTrack: MusicTrack?
+        if let existingSequence = sequence {
+            MusicSequenceGetTempoTrack(existingSequence, &tempoTrack)
+        }
+        
+        let ticksPerMetronomeClick: UInt8 = 24
+        let thirtySecondNotesPerQuarter: UInt8 = 8
+        let data: [MIDIByte] = [timeSignatureTop,
+                                timeSignatureBottom.rawValue,
+                                ticksPerMetronomeClick,
+                                thirtySecondNotesPerQuarter]
+        
+        var metaEvent = MIDIMetaEvent()
+        metaEvent.metaEventType = 0x58 // i.e, set time signature
+        metaEvent.dataLength = UInt32(data.count)
+        
+        withUnsafeMutablePointer(to: &metaEvent.data, { pointer in
+            for i in 0 ..< data.count {
+                pointer[i] = data[i]
+            }
+        })
+        
+        let result = MusicTrackNewMetaEvent(tempoTrack!, MusicTimeStamp(0), &metaEvent)
+        if result != 0 {
+            AKLog("Unable to set time signature")
+        }
+    }
 
     /// Convert seconds into AKDuration
     ///


### PR DESCRIPTION
Changes:

- Added method for setting time signature to AKSequencer's tempo track
- Added method for clearing existing time signature events from AKSequencer's tempo track
- Added generalised method for iterating thru CoreMIDI MusicTracks to improve readability and prevent future code repetition (I use this in the clearTimeSignature methods, and intend to use it for future methods that involve iterating thru AKMusicTrack's internalTrack)
- Made sure that AKSequencer's tempo track is wiped of any residual MetaEvents or ExtendedTempoEvents before a new MIDI file is loaded.
