### PR TITLE
Add clearSysexEvents

### DIFF
--- a/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
@@ -260,11 +260,11 @@ open class AKMusicTrack {
     func clearMetaEvents() {
         clearHelper(kMusicEventType_Meta, from: "clearMetaEvents")
     }
-    
+
     func clearSysexEvents() {
         clearHelper(kMusicEventType_MIDIRawData, from: "clearSysexEvents")
     }
-    
+
     private func clearHelper(_ eventType: UInt32, from functionName: String) {
         guard let track = internalMusicTrack else {
             AKLog("internalMusicTrack does not exist")

--- a/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKMusicTrack.swift
@@ -258,6 +258,14 @@ open class AKMusicTrack {
     }
 
     func clearMetaEvents() {
+        clearHelper(kMusicEventType_Meta, from: "clearMetaEvents")
+    }
+    
+    func clearSysexEvents() {
+        clearHelper(kMusicEventType_MIDIRawData, from: "clearSysexEvents")
+    }
+    
+    private func clearHelper(_ eventType: UInt32, from functionName: String) {
         guard let track = internalMusicTrack else {
             AKLog("internalMusicTrack does not exist")
             return
@@ -265,7 +273,7 @@ open class AKMusicTrack {
         var tempIterator: MusicEventIterator?
         NewMusicEventIterator(track, &tempIterator)
         guard let iterator = tempIterator else {
-            AKLog("Unable to create iterator in clearMetaEvents")
+            AKLog("Unable to create iterator in \(functionName)")
             return
         }
         var eventTime = MusicTimeStamp(0)
@@ -278,7 +286,7 @@ open class AKMusicTrack {
         while hasNextEvent.boolValue {
             MusicEventIteratorGetEventInfo(iterator, &eventTime, &eventType, &eventData, &eventDataSize)
 
-            if eventType == kMusicEventType_Meta {
+            if eventType == eventType {
                 MusicEventIteratorDeleteEvent(iterator)
             }
             MusicEventIteratorNextEvent(iterator)


### PR DESCRIPTION
I discovered that if there are Sysex events added to a track via `addSysex`, then `clear()` won't work properly. The track length remains the same and `MusicTrackClear` prints an error similar to "Invalid beat range or source track is empty".
The solution, for now, is to offer a way to conveniently remove those Sysex events. We already have an API to add those events so it makes sense to offer the reverse right?