### PR TITLE
Fix how route/category change observers are managed

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -189,7 +189,7 @@
 #if !os(macOS)
 extension AKSettings {
 
-  /// Shortcut for AVAudioSession.sharedInstance()
+    /// Shortcut for AVAudioSession.sharedInstance()
     @objc open static let session = AVAudioSession.sharedInstance()
 
     /// Convenience method accessible from Objective-C
@@ -295,9 +295,10 @@ extension AKSettings {
     /// Returns true if headPhones are connected, otherwise return false
     @objc static open var headPhonesPlugged: Bool {
         return session.currentRoute.outputs.contains {
-            [AVAudioSessionPortHeadphones,
-             AVAudioSessionPortBluetoothHFP,
-             AVAudioSessionPortBluetoothA2DP].contains($0.portType)
+            let headphonePortTypes = [AVAudioSessionPortHeadphones,
+                                      AVAudioSessionPortBluetoothHFP,
+                                      AVAudioSessionPortBluetoothA2DP]
+            return headphonePortTypes.contains($0.portType)
         }
     }
 

--- a/AudioKit/Common/Internals/AudioKit+StartStop.swift
+++ b/AudioKit/Common/Internals/AudioKit+StartStop.swift
@@ -32,32 +32,22 @@ extension AudioKit {
         }
         
         #if os(iOS)
-        
-        if AKSettings.enableRouteChangeHandling {
-            
-            let routeChangeObserver = NotificationCenter.default.addObserver(forName: .AVAudioSessionRouteChange,
-                                                                             object: nil,
-                                                                             queue: OperationQueue.main,
-                                                                             using: { (notification) in
-                                                                                AudioKit.restartEngineAfterRouteChange(notification)
-            })
-            notificationObservers.append(routeChangeObserver)
-            
-        }
-        
-        if AKSettings.enableCategoryChangeHandling {
-            let configurationChangeObserver = NotificationCenter.default.addObserver(forName: .AVAudioEngineConfigurationChange,
-                                                                                     object: engine,
-                                                                                     queue: OperationQueue.main,
-                                                                                     using: { (notification) in
-                                                                                        AudioKit.restartEngineAfterConfigurationChange(notification)
-            })
-            notificationObservers.append(configurationChangeObserver)
-        }
         try updateSessionCategoryAndOptions()
         try AVAudioSession.sharedInstance().setActive(true)
+
+        /// Notification observers
+
+        // Subscribe to route changes that may affect our engine
+        // Automatic handling of this change can be disabled via AKSettings.enableRouteChangeHandling
+        NotificationCenter.default.removeObserver(self, name: .AVAudioSessionRouteChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(restartEngineAfterRouteChange), name: .AVAudioSessionRouteChange, object: nil)
+
+        // Subscribe to session/configuration changes to our engine
+        // Automatic handling of this change can be disabled via AKSettings.enableCategoryChangeHandling
+        NotificationCenter.default.removeObserver(self, name: .AVAudioEngineConfigurationChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(restartEngineAfterConfigurationChange), name: .AVAudioEngineConfigurationChange, object: nil)
         #endif
-        
+
         try AKTry {
             try engine.start()
         }
@@ -87,11 +77,9 @@ extension AudioKit {
         shouldBeRunning = false
         
         #if os(iOS)
-        notificationObservers.forEach { (observer) in
-            NotificationCenter.default.removeObserver(observer)
-        }
-        
         do {
+            NotificationCenter.default.removeObserver(self, name: .AVAudioSessionRouteChange, object: nil)
+            NotificationCenter.default.removeObserver(self, name: .AVAudioEngineConfigurationChange, object: nil)
             try AVAudioSession.sharedInstance().setActive(false)
         } catch {
             AKLog("couldn't stop session \(error)")
@@ -101,64 +89,77 @@ extension AudioKit {
     }
     
     // MARK: - Configuration Change Response
-    
+
     // Listen to changes in audio configuration
     // and restart the audio engine if it stops and should be playing
     @objc fileprivate static func restartEngineAfterConfigurationChange(_ notification: Notification) {
-        do {
-            if shouldBeRunning && !engine.isRunning {
-                #if !os(macOS)
-                let appIsNotActive = UIApplication.shared.applicationState != .active
-                let appDoesNotSupportBackgroundAudio = !AKSettings.appSupportsBackgroundAudio
-                
-                if appIsNotActive && appDoesNotSupportBackgroundAudio {
-                    AKLog("engine not restarted after configuration change since app was not active and does not support background audio")
-                    return
-                }
-                #endif
-                
-                try engine.start()
-                
-                // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
-                if AKSettings.notificationsEnabled {
-                    NotificationCenter.default.post(
-                        name: .AKEngineRestartedAfterConfigurationChange,
-                        object: nil,
-                        userInfo: notification.userInfo)
-                }
-            }
-        } catch {
-            AKLog("error restarting engine after route change")
-            // Note: doesn't throw since this is called from a notification observer
-        }
-    }
-    
-    // Restarts the engine after audio output has been changed, like headphones plugged in.
-    @objc fileprivate static func restartEngineAfterRouteChange(_ notification: Notification) {
-        if shouldBeRunning && !engine.isRunning {
+        // Notifications aren't guaranteed to be on the main thread
+        DispatchQueue.main.sync {
             do {
-                #if !os(macOS)
-                let appIsNotActive = UIApplication.shared.applicationState != .active
-                let appDoesNotSupportBackgroundAudio = !AKSettings.appSupportsBackgroundAudio
-                
-                if appIsNotActive && appDoesNotSupportBackgroundAudio {
-                    AKLog("engine not restarted after route change since app was not active and does not support background audio")
+                // By checking the notification sender in this block rather than during observer configuration we avoid needing to create a new observer if the engine somehow changes
+                guard let notifyingEngine = notification.object as? AVAudioEngine, notifyingEngine == engine else {
                     return
                 }
-                #endif
-                
-                try engine.start()
-                
-                // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
-                if AKSettings.notificationsEnabled {
-                    NotificationCenter.default.post(
-                        name: .AKEngineRestartedAfterRouteChange,
-                        object: nil,
-                        userInfo: notification.userInfo)
+
+                if AKSettings.enableCategoryChangeHandling && !engine.isRunning && shouldBeRunning {
+
+                    #if !os(macOS)
+                    let appIsNotActive = UIApplication.shared.applicationState != .active
+                    let appDoesNotSupportBackgroundAudio = !AKSettings.appSupportsBackgroundAudio
+
+                    if appIsNotActive && appDoesNotSupportBackgroundAudio {
+                        AKLog("engine not restarted after configuration change since app was not active and does not support background audio")
+                        return
+                    }
+                    #endif
+
+                    try engine.start()
+
+                    // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
+                    if AKSettings.notificationsEnabled {
+                        NotificationCenter.default.post(
+                            name: .AKEngineRestartedAfterConfigurationChange,
+                            object: nil,
+                            userInfo: notification.userInfo)
+                    }
                 }
             } catch {
                 AKLog("error restarting engine after route change")
                 // Note: doesn't throw since this is called from a notification observer
+            }
+        }
+    }
+
+    // Restarts the engine after audio output has been changed, like headphones plugged in.
+    @objc fileprivate static func restartEngineAfterRouteChange(_ notification: Notification) {
+        // Notifications aren't guaranteed to come in on the main thread
+        DispatchQueue.main.sync {
+
+            if AKSettings.enableRouteChangeHandling && shouldBeRunning && !engine.isRunning {
+                do {
+                    #if !os(macOS)
+                    let appIsNotActive = UIApplication.shared.applicationState != .active
+                    let appDoesNotSupportBackgroundAudio = !AKSettings.appSupportsBackgroundAudio
+
+                    if appIsNotActive && appDoesNotSupportBackgroundAudio {
+                        AKLog("engine not restarted after route change since app was not active and does not support background audio")
+                        return
+                    }
+                    #endif
+
+                    try engine.start()
+
+                    // Sends notification after restarting the engine, so it is safe to resume AudioKit functions.
+                    if AKSettings.notificationsEnabled {
+                        NotificationCenter.default.post(
+                            name: .AKEngineRestartedAfterRouteChange,
+                            object: nil,
+                            userInfo: notification.userInfo)
+                    }
+                } catch {
+                    AKLog("error restarting engine after route change")
+                    // Note: doesn't throw since this is called from a notification observer
+                }
             }
         }
     }

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -33,11 +33,8 @@ public typealias AKCallback = () -> Void
 
     @objc static var finalMixer = AKMixer()
 
-    /// Notification observers
-    internal static var notificationObservers: [Any] = []
-
     // MARK: - Device Management
-    
+
     /// An audio output operation that most applications will need to use last
     @objc open static var output: AKNode? {
         didSet {
@@ -45,7 +42,8 @@ public typealias AKCallback = () -> Void
                 try updateSessionCategoryAndOptions()
                 output?.connect(to: finalMixer)
                 engine.connect(finalMixer.avAudioNode, to: engine.outputNode)
-            } catch {
+
+                } catch {
                 AKLog("Could not set output: \(error)")
             }
         }
@@ -136,7 +134,7 @@ public typealias AKCallback = () -> Void
         return nil
     }
 
-    /// Change the preferred input device, giving it one of the names from the list of available inputs.
+        /// Change the preferred input device, giving it one of the names from the list of available inputs.
     @objc open static func setInputDevice(_ input: AKDevice) throws {
         #if os(macOS)
             try AKTry {
@@ -211,16 +209,5 @@ public typealias AKCallback = () -> Void
     /// Disconnect all inputs
     @objc open static func disconnectAllInputs() {
         engine.disconnectNodeInput(finalMixer.avAudioNode)
-    }
-
-    // MARK: - Deinitialization
-
-    deinit {
-        #if os(iOS)
-            NotificationCenter.default.removeObserver(
-                self,
-                name: .AKEngineRestartedAfterRouteChange,
-                object: nil)
-        #endif
     }
 }


### PR DESCRIPTION
** UPDATED **

In my attempt to move from selector to block based notification observers in #1188 I inadvertently introduced the ability to add the same observer multiple times. Once a route change did happen and multiple route change observers were in place and `restartEngineAfterRouteChange(…)` could be called multiple times in quick secession ~~which in turn called `start()` and seemingly causing a cascade of restarts. A fun symptom of this was "volume thrashing" in control center:~~

…this was actually due to issues in _my_ code related to poor management of a `AKMicrophoneTracker` singleton. Engine restart thrashing was a thing for me but there's no evidence so far to suggest this affected users of AudioKit otherwise! Regardless this refactor should be an improvement to how these two notifications are managed. 
![untitled](https://user-images.githubusercontent.com/220240/38590841-88ac0e26-3ce8-11e8-9845-ca321f60fc97.gif)

### Merge once…

- [x] Replace both TODO comments with explanations for future contributors.
- [x] Potentially find a Swiftier way to check if the observers exist before attempting to remove them.
- [x] Confirm that replacing an observer reference so that it loses scope removes it.