### PR TITLE
Allow AKSamplePlayer to load and reload files of different sizes

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayer.swift
@@ -308,8 +308,8 @@ open class AKSamplePlayer: AKNode, AKComponent {
         let sizeToUse = UInt32(file.samplesCount * 2)
         if maximumSamples == 0 {
             maximumSamples = Int(file.samplesCount)
-            internalAU?.setupAudioFileTable(sizeToUse)
         }
+        internalAU?.setupAudioFileTable(sizeToUse)
         let buf = AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: AVAudioFrameCount(file.length))
         try! file.read(into: buf!)
         let data = buf!.floatChannelData

--- a/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayerDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Sample Player/AKSamplePlayerDSPKernel.hpp
@@ -55,6 +55,12 @@ public:
     }
 
     void setUpTable(UInt32 size) {
+        if (ftbl1 != nil) {
+            sp_ftbl_destroy(&ftbl1);
+            sp_ftbl_destroy(&ftbl2);
+            current_size = 2;
+        }
+        
         if (current_size <= 2) {
             current_size = size / 2;
             ftbl_size = size / 2;


### PR DESCRIPTION
...rather than setting the maximum size to the first file loaded.

Currently the user specifies maximumSamples at init time, or if not specified, the maximumSamples property is set by the size of the first file loaded. This means loading a new file that's longer than the previous file will cause a crash.
This new approach resizes the buffer by clearing out the sp_ftbl objects if they've already been initialised and creating new ones each time a file is loaded. I was worried this might cause a memory leak, but haven't seen any evidence of such. 