### PR TITLE
Automated releases with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,19 @@ env:
 - LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
 before_install:
 - pod repo update
-- brew install gnu-sed
+- brew install gnu-sed s3cmd
 - gem install xcpretty -N
 script: "./Tests/travis.sh"
 notifications:
   slack:
     secure: Bgfiib7NP2/98fjJvW+PraQQFnj5X23+Zmvy9XqIe9NetzyNqWVN6URRFdcjvSnpah1kg2gGhIdkT5gvBT8HcP8OS6x/2lMFQsOhuA0mMoJ3tK3vhve10s3Mt8JvWqnEI3OmnDF/Yx7FN0sGiTskLYvi7jCzLY1QNqdg52VTsNI=
+deploy:
+  provider: releases
+  api_key:
+    secure: TzjRJUQRWJIzIOB3THAgJW8XJqpVlvk7w8m1B1EpTVkF0/d3Bz8i9IYegiydLy5pSrXR7GhHwqkn/CrwBdTr0WrlyujWA4uhedAxZEwY2hJpQ5vzw9EK1UT3Uxcs0aibgWgz20FpVSPtu2HxSGTspCqrk7vdFxQFL8b1MB2SXERnBs1eYHLBDq5O8/3hNwvH1JLRyK+pUYZwty105DEGwLSnGDsivIloutcj0cNvbCW0WKf2UnYroFPyh+paex1cY1WzUPtzxm18TxV+2i3sXNHB0ANjM/br+88RjcqH8cbMj95jcHebl5qCURdH6ab4LroNMezt5HtifiPpFkKuMcXbDwrE0Bgrb8FU2iW5f8+G6N3RwRk+5tVBWhc747Iii1Zw9UEeKrx6KhypbVZaW5nknB6ixy/aol9Ne7Zru3XNqMwQBBukMRhd0TBQeGcioeqNJAzt0Q40WSWb2QWPQ7rqd7Ym3G3v7PMW49dAkrWi38hqyOjmuNCWLxMu+88/+btAugnWNJ5+FiMhXEObnlbrYwVKYgGp0fnSaUHl60ualmcaNmPHAr0YIKzwRTjl3yiQ0JpexxTimGq2R1wsbqX6OI7AVWESBpv9mLLt+6dYsLEaKexiEVdRNhHlyXTZQxM25BG/spOakatJc60DcCHOpAebCV0l+SrqLMxJhPI=
+  file_glob: true
+  skip_cleanup: true
+  file: Frameworks/packages/*.zip
+  on:
+    repo: catloafsoft/AudioKit
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,4 @@ deploy:
   skip_cleanup: true
   file: Frameworks/packages/*.zip
   on:
-    repo: catloafsoft/AudioKit
     tags: true

--- a/AudioKit.podspec.json
+++ b/AudioKit.podspec.json
@@ -13,7 +13,7 @@
     "documentation_url": "http://audiokit.io/docs/",
     "static_framework": true,
     "source": {
-        "http": "https://files.audiokit.io/releases/4.2.4/AudioKit.framework.zip"
+        "http": "https://files.audiokit.io/releases/v4.2.4/AudioKit.framework.zip"
     },
     "summary": "Open-source audio synthesis, processing, & analysis platform.",
     "platforms": {

--- a/Frameworks/build_frameworks.sh
+++ b/Frameworks/build_frameworks.sh
@@ -11,13 +11,13 @@ BUILD_DIR="$PWD/build"
 
 if [ ! -f build_frameworks.sh ]; then
     echo "This script needs to be run from the Frameworks folder"
-	exit 0
+    exit 0
 fi
 
 VERSION=`cat ../VERSION`
 PLATFORMS=${PLATFORMS:-"iOS macOS tvOS"}
 
-if test "$TRAVIS" = true;
+if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "";
 then
 	echo "Travis detected, build #$TRAVIS_BUILD_NUMBER"
 	ACTIVE_ARCH=YES
@@ -53,8 +53,8 @@ create_universal_framework()
 		cp -v fix-framework.sh "${DIR}/${PROJECT_NAME}.framework/"
 	fi
 	
-	if test "$TRAVIS" = true;
-	then # Only build for simulator on Travis CI
+	if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "";
+	then # Only build for simulator on Travis CI, unless we're building a release
 		cp -v "${BUILD_DIR}/${CONFIGURATION}-$2/${PROJECT_NAME}.framework/${PROJECT_NAME}" "${DIR}/${PROJECT_NAME}.framework/"
 		cp -v "${BUILD_DIR}/${CONFIGURATION}-$2/${PROJECT_UI_NAME}.framework/${PROJECT_UI_NAME}" "${DIR}/${PROJECT_UI_NAME}.framework/"
 		cp -v "${BUILD_DIR}/${CONFIGURATION}-$2/${PROJECT_NAME}.framework/Modules/${PROJECT_NAME}.swiftmodule/"* "${DIR}/${PROJECT_NAME}.framework/Modules/${PROJECT_NAME}.swiftmodule/"

--- a/Tests/travis.sh
+++ b/Tests/travis.sh
@@ -9,11 +9,15 @@ set -o pipefail
 echo "Building AudioKit Frameworks"
 cd Frameworks
 if test "$TRAVIS_TAG" != ""; then
+   if test "$AWS_ACCESS_KEY" = ""; then
+      echo "You must set the AWS_ACCESS_KEY and AWS_SECRET environment variables in Travis for automated builds!" >&2
+      exit 1
+   fi
    echo "Deploying for release tagged $TRAVIS_TAG ..."
    ./build_packages.sh || exit 1
    echo "Uploading CocoaPods archive to S3 ..."
    s3cmd --access_key=$AWS_ACCESS_KEY --secret_key=$AWS_SECRET put packages/AudioKit.framework.zip s3://files.audiokit.io/releases/${TRAVIS_TAG}/AudioKit.framework.zip
-   exit 0
+   exit
 else
    ./build_frameworks.sh || exit 1
 fi

--- a/Tests/travis.sh
+++ b/Tests/travis.sh
@@ -8,6 +8,10 @@ set -o pipefail
 
 echo "Building AudioKit Frameworks"
 cd Frameworks
+if test "$TRAVIS_TAG" != ""; then
+   ./build_packages.sh || exit 1
+   exit 0
+else
    ./build_frameworks.sh || exit 1
 cd ..
 

--- a/Tests/travis.sh
+++ b/Tests/travis.sh
@@ -9,7 +9,10 @@ set -o pipefail
 echo "Building AudioKit Frameworks"
 cd Frameworks
 if test "$TRAVIS_TAG" != ""; then
+   echo "Deploying for release tagged $TRAVIS_TAG ..."
    ./build_packages.sh || exit 1
+   echo "Uploading CocoaPods archive to S3 ..."
+   s3cmd --access_key=$AWS_ACCESS_KEY --secret_key=$AWS_SECRET put packages/AudioKit.framework.zip s3://files.audiokit.io/releases/${TRAVIS_TAG}/AudioKit.framework.zip
    exit 0
 else
    ./build_frameworks.sh || exit 1

--- a/Tests/travis.sh
+++ b/Tests/travis.sh
@@ -13,6 +13,7 @@ if test "$TRAVIS_TAG" != ""; then
    exit 0
 else
    ./build_frameworks.sh || exit 1
+fi
 cd ..
 
 echo "Building iOS HelloWorld"


### PR DESCRIPTION
This will make the task of pushing out releases a lot easier. Basically all you have to do is push out a new tag, and it will compile all the archives and upload them to the GitHub release tag, as well as to the S3 bucket for CocoaPods.

The GitHub secret maps to my account so it should be able to push releases to the main AudioKit repo. I am setting up the Travis environment variables with the authentication for the S3 bucket too.

Basically all you'll have to do to push out a new release will be something like this:

`git tag v2.4.4`
`git push --tags`
 ... and once that's done building, you can just update the release notes and push the pod!
