### PR TITLE
Continuous Deployments from new staging branch

### DIFF
--- a/Frameworks/build_frameworks.sh
+++ b/Frameworks/build_frameworks.sh
@@ -7,6 +7,7 @@ set -o pipefail
 PROJECT_NAME=AudioKit
 PROJECT_UI_NAME=AudioKitUI
 CONFIGURATION=${CONFIGURATION:-"Release"}
+STAGING_BRANCH="staging"
 BUILD_DIR="$PWD/build"
 
 if [ ! -f build_frameworks.sh ]; then
@@ -17,7 +18,7 @@ fi
 VERSION=`cat ../VERSION`
 PLATFORMS=${PLATFORMS:-"iOS macOS tvOS"}
 
-if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "" && test "$TRAVIS_BRANCH" != "staging";
+if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "" && test "$TRAVIS_BRANCH" != "$STAGING_BRANCH";
 then
 	echo "Travis detected, build #$TRAVIS_BUILD_NUMBER"
 	ACTIVE_ARCH=YES
@@ -53,7 +54,7 @@ create_universal_framework()
 		cp -v fix-framework.sh "${DIR}/${PROJECT_NAME}.framework/"
 	fi
 	
-	if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "";
+	if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "" && test "$TRAVIS_BRANCH" != "$STAGING_BRANCH";
 	then # Only build for simulator on Travis CI, unless we're building a release
 		cp -v "${BUILD_DIR}/${CONFIGURATION}-$2/${PROJECT_NAME}.framework/${PROJECT_NAME}" "${DIR}/${PROJECT_NAME}.framework/"
 		cp -v "${BUILD_DIR}/${CONFIGURATION}-$2/${PROJECT_UI_NAME}.framework/${PROJECT_UI_NAME}" "${DIR}/${PROJECT_UI_NAME}.framework/"

--- a/Frameworks/build_frameworks.sh
+++ b/Frameworks/build_frameworks.sh
@@ -17,7 +17,7 @@ fi
 VERSION=`cat ../VERSION`
 PLATFORMS=${PLATFORMS:-"iOS macOS tvOS"}
 
-if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "";
+if test "$TRAVIS" = true && test "$TRAVIS_TAG" = "" && test "$TRAVIS_BRANCH" != "staging";
 then
 	echo "Travis detected, build #$TRAVIS_BUILD_NUMBER"
 	ACTIVE_ARCH=YES

--- a/Frameworks/build_packages.sh
+++ b/Frameworks/build_packages.sh
@@ -8,6 +8,7 @@ VERSION=$(cat ../VERSION)
 PLATFORMS=${PLATFORMS:-"iOS tvOS macOS"}
 SKIP_JAZZY=1 # Broken for now
 SUBDIR=${SUBDIR:-"packages"}
+STAGING_BRANCH="staging"
 
 if ! which gsed > /dev/null 2>&1;
 then
@@ -45,6 +46,7 @@ create_package()
 	rm -f ${DIR}-${VERSION}.zip
 	mkdir -p "Carthage/$os"
 	cp -a "$DIR/AudioKit.framework" "$DIR/AudioKitUI.framework" "Carthage/$os/"
+	test "$TRAVIS_BRANCH" = "$STAGING_BRANCH" && return
 	cd $DIR
 	mkdir -p Examples
 	cp -a ../../Examples/$1/* Examples/
@@ -84,9 +86,9 @@ do
 	create_package $os
 done
 
-create_playgrounds
+test "$TRAVIS_BRANCH" != "$STAGING_BRANCH" && create_playgrounds
 
-# Create binary framework zip for Carthage, to be uploaded to Github along with release
+# Create binary framework zip for Carthage/CocoaPods, to be uploaded to S3 or GitHub along with release
 
 echo "Packaging AudioKit frameworks version $VERSION for Carthage ..."
 rm -f AudioKit.framework.zip

--- a/Frameworks/build_packages.sh
+++ b/Frameworks/build_packages.sh
@@ -90,7 +90,7 @@ test "$TRAVIS_BRANCH" != "$STAGING_BRANCH" && create_playgrounds
 
 # Create binary framework zip for Carthage/CocoaPods, to be uploaded to S3 or GitHub along with release
 
-echo "Packaging AudioKit frameworks version $VERSION for Carthage ..."
+echo "Packaging AudioKit frameworks version $VERSION for CocoaPods and Carthage ..."
 rm -f AudioKit.framework.zip
 cd Carthage
 cp ../../LICENSE ../../README.md .

--- a/Tests/travis.sh
+++ b/Tests/travis.sh
@@ -18,14 +18,14 @@ if test "$TRAVIS_TAG" != "" || test "$TRAVIS_BRANCH" = "staging"; then
    if test "$TRAVIS_TAG" != ""; then
    	echo "Deploying for release tagged $TRAVIS_TAG ..."
    else
-   	echo "Deploying staging release build for version $VERSION..."
+   	echo "Deploying staging release build for v$VERSION..."
    fi
    ./build_packages.sh || exit 1
    echo "Uploading CocoaPods archive to S3 ..."
    if test "$TRAVIS_TAG" != ""; then
    	s3cmd --access_key=$AWS_ACCESS_KEY --secret_key=$AWS_SECRET put packages/AudioKit.framework.zip s3://files.audiokit.io/releases/${TRAVIS_TAG}/AudioKit.framework.zip
    else
-   	s3cmd --access_key=$AWS_ACCESS_KEY --secret_key=$AWS_SECRET put packages/AudioKit.framework.zip s3://files.audiokit.io/staging/${VERSION}/AudioKit.framework.zip
+   	s3cmd --access_key=$AWS_ACCESS_KEY --secret_key=$AWS_SECRET put packages/AudioKit.framework.zip s3://files.audiokit.io/staging/v${VERSION}/AudioKit.framework.zip
    fi
    exit
 else


### PR DESCRIPTION
Building on the last scripts to automate builds, this will allow us to make builds on demand from the develop branch. In turn this should make it easier in the future to have separate projects use these binaries for their develop branches.

How to use this:
- Fork the `develop` branch into a new `staging` branch.
- Whenever you want to trigger a new build, simply merge the develop branch into staging and push it to GitHub.
- The build gets uploaded automatically to `https://files.audiokit.io/staging/<version>/AudioKit.framework.zip` - the version is picked up from the VERSION file in the repo.

No other archives are created, and there is no need to tag the repo.

We may want to explore merging this branch daily, possibly automatically.