### PR TITLE
AKTimeSignature and reading time signature events from MIDI file (re issue: #1353, PR #1354)

### DIFF
--- a/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKSequencer.swift
@@ -285,7 +285,7 @@ open class AKSequencer {
     /// returns the tempo at a given position in beats
     /// - parameter at: Position at which the tempo is desired
     ///
-    /// if there are more than one events precisely at the requested position
+    /// if there is more than one event precisely at the requested position
     /// it will return the most recently added
     open func getTempo(at position: MusicTimeStamp) -> Double {
         // MIDI file with no tempo events defaults to 120 bpm
@@ -362,8 +362,9 @@ open class AKSequencer {
     /// returns the time signature at a given position in beats
     /// - parameter at: Position at which the time signature is desired
     ///
-    /// if there are more than one events precisely at the requested position
-    /// it will return the most recently added
+    /// If there is more than one event precisely at the requested position
+    /// it will return the most recently added.
+    /// Will return 4/4 if there is no Time Signature event at or before position
     open func getTimeSignature(at position: MusicTimeStamp) -> AKTimeSignature {
         var outTimeSignature = AKTimeSignature() // 4/4, by default
         for event in allTimeSignatureEvents {

--- a/AudioKit/Common/MIDI/Sequencer/AKTimeSignature.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKTimeSignature.swift
@@ -1,0 +1,33 @@
+//
+//  AKTimeSignature.swift
+//  AudioKit
+//
+//  Created by Jeff Holtzkener on 2018/05/12.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+public struct AKTimeSignature: CustomStringConvertible, Equatable {
+    public enum TimeSignatureBottomValue: UInt8 {
+        // According to MIDI spec, second byte is log base 2 of time signature 'denominator'
+        case two = 1
+        case four = 2
+        case eight = 3
+        case sixteen = 4
+    }
+
+    public var topValue: UInt8 = 4
+    public var bottomValue: TimeSignatureBottomValue = .four
+
+    public init(topValue: UInt8 = 4, bottomValue: TimeSignatureBottomValue = .four) {
+        self.topValue = topValue
+        self.bottomValue = bottomValue
+    }
+
+    public var readableTimeSignature: (Int, Int) {
+        return (Int(topValue), Int(pow(2.0, Double(bottomValue.rawValue))))
+    }
+
+    public var description: String {
+        return "\(readableTimeSignature.0)/\(readableTimeSignature.1)"
+    }
+}

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 		C4198D5A1DCD9BB700D7C13F /* save.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4198D591DCD9BB700D7C13F /* save.swift */; };
 		C4198D5C1DCD9C4300D7C13F /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4198D5B1DCD9C4300D7C13F /* count.swift */; };
 		C421DCDF1D39650000E15879 /* AKPhaseDistortionOscillator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C421DCDB1D39650000E15879 /* AKPhaseDistortionOscillator.swift */; };
+		C42371EF20A7F5CB00507E72 /* AKAudioUnitManager+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42371EE20A7F5CB00507E72 /* AKAudioUnitManager+Utilities.swift */; };
 		C42858F21E90B647009B737D /* AKDynamicRangeCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42858EE1E90B647009B737D /* AKDynamicRangeCompressor.swift */; };
 		C42859041E90B6BC009B737D /* AKZitaReverb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42859001E90B6BC009B737D /* AKZitaReverb.swift */; };
 		C42BF6CC1CE80E6600155BE7 /* Numeric.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42BF6CB1CE80E6600155BE7 /* Numeric.swift */; };
@@ -1356,6 +1357,7 @@
 		C4198D591DCD9BB700D7C13F /* save.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = save.swift; sourceTree = "<group>"; };
 		C4198D5B1DCD9C4300D7C13F /* count.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = count.swift; sourceTree = "<group>"; };
 		C421DCDB1D39650000E15879 /* AKPhaseDistortionOscillator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKPhaseDistortionOscillator.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		C42371EE20A7F5CB00507E72 /* AKAudioUnitManager+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "AKAudioUnitManager+Utilities.swift"; path = "AudioUnit Host/AKAudioUnitManager+Utilities.swift"; sourceTree = "<group>"; };
 		C426BF351E3443AA008EFCB5 /* AKBluetoothMIDIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKBluetoothMIDIButton.swift; sourceTree = "<group>"; };
 		C42858EE1E90B647009B737D /* AKDynamicRangeCompressor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKDynamicRangeCompressor.swift; sourceTree = "<group>"; };
 		C42859001E90B6BC009B737D /* AKZitaReverb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKZitaReverb.swift; sourceTree = "<group>"; };
@@ -2500,6 +2502,7 @@
 			children = (
 				B19AE7731F30FC4700F9DC25 /* AKAudioUnitInstrument.swift */,
 				B19AE7741F30FC4700F9DC25 /* AKAudioUnitManager.swift */,
+				C42371EE20A7F5CB00507E72 /* AKAudioUnitManager+Utilities.swift */,
 			);
 			name = "AudioUnit Host";
 			sourceTree = "<group>";
@@ -5774,6 +5777,7 @@
 				C49B13EE204A06B7009C7C8E /* bitcrush.c in Sources */,
 				551AAC621F620A8D00A14C0D /* AKTiming.swift in Sources */,
 				C49B14AF204A06B8009C7C8E /* streson.c in Sources */,
+				C42371EF20A7F5CB00507E72 /* AKAudioUnitManager+Utilities.swift in Sources */,
 				C411BF471CBD93DF00C83556 /* AKFMOscillatorPresets.swift in Sources */,
 				C49B13ED204A06B7009C7C8E /* zitarev.c in Sources */,
 				C49B1446204A06B7009C7C8E /* plumber.c in Sources */,

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		07C0F21B1F13EE1200F928C9 /* AKMIDITransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C0F21A1F13EE1200F928C9 /* AKMIDITransformer.swift */; };
 		1F2DAD7420845EC800F1C9E3 /* AKMIDINoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2DAD7320845EC700F1C9E3 /* AKMIDINoteData.swift */; };
+		1FADCF1C20A6F4AB008D2A73 /* AKTimeSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FADCF1B20A6F4AB008D2A73 /* AKTimeSignature.swift */; };
 		3404A79920507B1500A2C9E4 /* ADSREnvelope.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3404A78420507B1500A2C9E4 /* ADSREnvelope.hpp */; };
 		3404A79A20507B1500A2C9E4 /* ResonantLowPassFilter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3404A78520507B1500A2C9E4 /* ResonantLowPassFilter.hpp */; };
 		3404A79B20507B1500A2C9E4 /* SustainPedalLogic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3404A78620507B1500A2C9E4 /* SustainPedalLogic.cpp */; };
@@ -92,7 +93,6 @@
 		8D6C6C531D421EBB008BFA4A /* AKAudioFile+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6C6C521D421EBB008BFA4A /* AKAudioFile+Utilities.swift */; };
 		B12B88A7201C1B2C008F196D /* AKExponentialParameterRamp.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B12B88A6201C1B2C008F196D /* AKExponentialParameterRamp.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		B15770482093C86A00830A3E /* AKParameterRamp.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B15770472093C86A00830A3E /* AKParameterRamp.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
-		B16F09FE20A4C25F003C3950 /* AKAudioUnitManager+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16F09FD20A4C25E003C3950 /* AKAudioUnitManager+Utilities.swift */; };
 		B184847A1FD9ADB100F65DA6 /* AKPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18484791FD9ADB100F65DA6 /* AKPlayer.swift */; };
 		B19AE7751F30FC4700F9DC25 /* AKAudioUnitInstrument.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19AE7731F30FC4700F9DC25 /* AKAudioUnitInstrument.swift */; };
 		B19AE7761F30FC4700F9DC25 /* AKAudioUnitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19AE7741F30FC4700F9DC25 /* AKAudioUnitManager.swift */; };
@@ -240,7 +240,7 @@
 		C433230A1FE05F0200330AEC /* TPCircularBuffer+Unit.h in Headers */ = {isa = PBXBuildFile; fileRef = C43323021FE05F0100330AEC /* TPCircularBuffer+Unit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C433230B1FE05F0200330AEC /* TPCircularBuffer+AudioBufferList.h in Headers */ = {isa = PBXBuildFile; fileRef = C43323031FE05F0100330AEC /* TPCircularBuffer+AudioBufferList.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C43622CD1CCDC70B00DB41DE /* AKMIDISampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43622CC1CCDC70B00DB41DE /* AKMIDISampler.swift */; };
-		C43DBECD20A1603700E3704A /* (null) in Sources */ = {isa = PBXBuildFile; };
+		C43DBECD20A1603700E3704A /* AKDualButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2FC5C62094E0BB007334A4 /* AKDualButton.swift */; };
 		C4414F701F5E7D0900D8DB8E /* AKPropertyControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4414F6F1F5E7D0800D8DB8E /* AKPropertyControl.swift */; };
 		C443E0E120312CC700407CF9 /* AKChorusAudioUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C443E0DF20312CC700407CF9 /* AKChorusAudioUnit.swift */; };
 		C443E0E720312CE400407CF9 /* AKModulatedDelayDSP.mm in Sources */ = {isa = PBXBuildFile; fileRef = C443E0E420312CE400407CF9 /* AKModulatedDelayDSP.mm */; };
@@ -1093,7 +1093,6 @@
 		F4CA85831EB666260066BE5C /* AKTuningTable+Scala.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CA857C1EB666260066BE5C /* AKTuningTable+Scala.swift */; };
 		F4CA85841EB666260066BE5C /* AKTuningTable+Wilson.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CA857D1EB666260066BE5C /* AKTuningTable+Wilson.swift */; };
 		F4CA85851EB666260066BE5C /* AKTuningTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CA857E1EB666260066BE5C /* AKTuningTable.swift */; };
-		FE05428420983BA500034DAB /* AKTweaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE05428220983B8800034DAB /* AKTweaker.swift */; };
 		FE1F57A9209235F8006B34CF /* AKWaveTableAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = FE1F57A5209235F8006B34CF /* AKWaveTableAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE1F57AA209235F8006B34CF /* AKWaveTableAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = FE1F57A6209235F8006B34CF /* AKWaveTableAudioUnit.mm */; };
 		FE1F57AB209235F8006B34CF /* AKWaveTableDSPKernel.hpp in Headers */ = {isa = PBXBuildFile; fileRef = FE1F57A7209235F8006B34CF /* AKWaveTableDSPKernel.hpp */; };
@@ -1109,7 +1108,6 @@
 		FE72B21D208AA6C600D861BC /* AudioKit+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE72B21C208AA6C600D861BC /* AudioKit+Testing.swift */; };
 		FE72B21F208AA72C00D861BC /* AudioKit+StartStop.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE72B21E208AA72B00D861BC /* AudioKit+StartStop.swift */; };
 		FEBD4F6F1C5D47550007B60D /* AKMIDIListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBD4F6E1C5D47550007B60D /* AKMIDIListener.swift */; };
-		FED713AB20A3A77F00F837F8 /* AKCoarseFineSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED713AA20A3A77F00F837F8 /* AKCoarseFineSlider.swift */; };
 		FED92BE31ED1331D00E93264 /* AKSamplePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED92BDF1ED1331D00E93264 /* AKSamplePlayer.swift */; };
 		FED92BE41ED1331D00E93264 /* AKSamplePlayerAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = FED92BE01ED1331D00E93264 /* AKSamplePlayerAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FED92BE51ED1331D00E93264 /* AKSamplePlayerAudioUnit.mm in Sources */ = {isa = PBXBuildFile; fileRef = FED92BE11ED1331D00E93264 /* AKSamplePlayerAudioUnit.mm */; };
@@ -1129,6 +1127,7 @@
 /* Begin PBXFileReference section */
 		07C0F21A1F13EE1200F928C9 /* AKMIDITransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMIDITransformer.swift; sourceTree = "<group>"; };
 		1F2DAD7320845EC700F1C9E3 /* AKMIDINoteData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMIDINoteData.swift; sourceTree = "<group>"; };
+		1FADCF1B20A6F4AB008D2A73 /* AKTimeSignature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKTimeSignature.swift; sourceTree = "<group>"; };
 		3404A78220507B1500A2C9E4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3404A78420507B1500A2C9E4 /* ADSREnvelope.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ADSREnvelope.hpp; sourceTree = "<group>"; };
 		3404A78520507B1500A2C9E4 /* ResonantLowPassFilter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ResonantLowPassFilter.hpp; sourceTree = "<group>"; };
@@ -1217,7 +1216,6 @@
 		8D6C6C521D421EBB008BFA4A /* AKAudioFile+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKAudioFile+Utilities.swift"; sourceTree = "<group>"; };
 		B12B88A6201C1B2C008F196D /* AKExponentialParameterRamp.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKExponentialParameterRamp.hpp; sourceTree = "<group>"; };
 		B15770472093C86A00830A3E /* AKParameterRamp.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKParameterRamp.hpp; sourceTree = "<group>"; };
-		B16F09FD20A4C25E003C3950 /* AKAudioUnitManager+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "AKAudioUnitManager+Utilities.swift"; path = "AudioUnit Host/AKAudioUnitManager+Utilities.swift"; sourceTree = "<group>"; };
 		B18484791FD9ADB100F65DA6 /* AKPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKPlayer.swift; sourceTree = "<group>"; };
 		B19AE7731F30FC4700F9DC25 /* AKAudioUnitInstrument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AKAudioUnitInstrument.swift; path = "AudioUnit Host/AKAudioUnitInstrument.swift"; sourceTree = "<group>"; };
 		B19AE7741F30FC4700F9DC25 /* AKAudioUnitManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AKAudioUnitManager.swift; path = "AudioUnit Host/AKAudioUnitManager.swift"; sourceTree = "<group>"; };
@@ -2285,13 +2283,13 @@
 		F4CA857C1EB666260066BE5C /* AKTuningTable+Scala.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Scala.swift"; sourceTree = "<group>"; };
 		F4CA857D1EB666260066BE5C /* AKTuningTable+Wilson.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Wilson.swift"; sourceTree = "<group>"; };
 		F4CA857E1EB666260066BE5C /* AKTuningTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKTuningTable.swift; sourceTree = "<group>"; };
-		FE05428220983B8800034DAB /* AKTweaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKTweaker.swift; sourceTree = "<group>"; };
 		FE1F57A5209235F8006B34CF /* AKWaveTableAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKWaveTableAudioUnit.h; sourceTree = "<group>"; };
 		FE1F57A6209235F8006B34CF /* AKWaveTableAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKWaveTableAudioUnit.mm; sourceTree = "<group>"; };
 		FE1F57A7209235F8006B34CF /* AKWaveTableDSPKernel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKWaveTableDSPKernel.hpp; sourceTree = "<group>"; };
 		FE1F57A8209235F8006B34CF /* AKWaveTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKWaveTable.swift; sourceTree = "<group>"; };
 		FE2FC5C02093D4B5007334A4 /* AKColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKColor.swift; sourceTree = "<group>"; };
 		FE2FC5C32093EB7E007334A4 /* AKNudger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKNudger.swift; sourceTree = "<group>"; };
+		FE2FC5C62094E0BB007334A4 /* AKDualButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKDualButton.swift; sourceTree = "<group>"; };
 		FE2FC5C82094F23B007334A4 /* AudioKitHelpers+Approximation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioKitHelpers+Approximation.swift"; sourceTree = "<group>"; };
 		FE5839712080FA78008DBCE6 /* AKError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKError.swift; sourceTree = "<group>"; };
 		FE72B20320895B9E00D861BC /* AudioKit+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioKit+Status.swift"; sourceTree = "<group>"; };
@@ -2300,7 +2298,6 @@
 		FE72B21C208AA6C600D861BC /* AudioKit+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioKit+Testing.swift"; sourceTree = "<group>"; };
 		FE72B21E208AA72B00D861BC /* AudioKit+StartStop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioKit+StartStop.swift"; sourceTree = "<group>"; };
 		FEBD4F6E1C5D47550007B60D /* AKMIDIListener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMIDIListener.swift; sourceTree = "<group>"; };
-		FED713AA20A3A77F00F837F8 /* AKCoarseFineSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKCoarseFineSlider.swift; sourceTree = "<group>"; };
 		FED92BDF1ED1331D00E93264 /* AKSamplePlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKSamplePlayer.swift; sourceTree = "<group>"; };
 		FED92BE01ED1331D00E93264 /* AKSamplePlayerAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSamplePlayerAudioUnit.h; sourceTree = "<group>"; };
 		FED92BE11ED1331D00E93264 /* AKSamplePlayerAudioUnit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKSamplePlayerAudioUnit.mm; sourceTree = "<group>"; };
@@ -2503,7 +2500,6 @@
 			children = (
 				B19AE7731F30FC4700F9DC25 /* AKAudioUnitInstrument.swift */,
 				B19AE7741F30FC4700F9DC25 /* AKAudioUnitManager.swift */,
-				B16F09FD20A4C25E003C3950 /* AKAudioUnitManager+Utilities.swift */,
 			);
 			name = "AudioUnit Host";
 			sourceTree = "<group>";
@@ -3009,6 +3005,7 @@
 				C486B3311DFD395F009A25C4 /* MultitouchGestureRecognizer.swift */,
 				C49A09FC1D529742007D8ADB /* AKADSRView.swift */,
 				C4E120AB1D4DBD6300CD3572 /* AKButton.swift */,
+				FE2FC5C62094E0BB007334A4 /* AKDualButton.swift */,
 				C4F8D08F1D588E0300D85987 /* AKKeyboardView.swift */,
 				FE2FC5C32093EB7E007334A4 /* AKNudger.swift */,
 				C446B3E71D454AB6000AEFCA /* AKPlaygroundLoop.swift */,
@@ -3022,8 +3019,6 @@
 				C470476D1E75314B00D9906F /* AKStepper.swift */,
 				C46B142E1F2E656C00847655 /* AKTableView.swift */,
 				C4DABC431D4E858100A8942F /* AKTelephoneView.swift */,
-				FED713AA20A3A77F00F837F8 /* AKCoarseFineSlider.swift */,
-				FE05428220983B8800034DAB /* AKTweaker.swift */,
 			);
 			name = iOS;
 			path = "AudioKit/User Interface";
@@ -3913,6 +3908,7 @@
 				C49E9DF41D2B1F9100E5E8BF /* AKMusicTrack.swift */,
 				1F2DAD7320845EC700F1C9E3 /* AKMIDINoteData.swift */,
 				C49E9DF51D2B1F9100E5E8BF /* AKSequencer.swift */,
+				1FADCF1B20A6F4AB008D2A73 /* AKTimeSignature.swift */,
 			);
 			path = Sequencer;
 			sourceTree = "<group>";
@@ -5778,7 +5774,6 @@
 				C49B13EE204A06B7009C7C8E /* bitcrush.c in Sources */,
 				551AAC621F620A8D00A14C0D /* AKTiming.swift in Sources */,
 				C49B14AF204A06B8009C7C8E /* streson.c in Sources */,
-				B16F09FE20A4C25F003C3950 /* AKAudioUnitManager+Utilities.swift in Sources */,
 				C411BF471CBD93DF00C83556 /* AKFMOscillatorPresets.swift in Sources */,
 				C49B13ED204A06B7009C7C8E /* zitarev.c in Sources */,
 				C49B1446204A06B7009C7C8E /* plumber.c in Sources */,
@@ -5805,6 +5800,7 @@
 				C49B1490204A06B8009C7C8E /* mincer.c in Sources */,
 				C49B13C6204A06B7009C7C8E /* dust.c in Sources */,
 				C4537FF21C3A438D00A51738 /* AKToneComplementFilter.swift in Sources */,
+				1FADCF1C20A6F4AB008D2A73 /* AKTimeSignature.swift in Sources */,
 				C49B13B1204A06B7009C7C8E /* butbr.c in Sources */,
 				C49B145A204A06B7009C7C8E /* autowah.c in Sources */,
 				C43622CD1CCDC70B00DB41DE /* AKMIDISampler.swift in Sources */,
@@ -6264,10 +6260,9 @@
 				EA7D071A1F4E63FA00707706 /* AKStepper.swift in Sources */,
 				EA7D07141F4E63FA00707706 /* AKADSRView.swift in Sources */,
 				EA7D07171F4E63FA00707706 /* AKPlaygroundLoop.swift in Sources */,
-				FE05428420983BA500034DAB /* AKTweaker.swift in Sources */,
 				FE2FC5CA2094F23B007334A4 /* AudioKitHelpers+Approximation.swift in Sources */,
 				EA7D07121F4E63FA00707706 /* MultitouchGestureRecognizer.swift in Sources */,
-				C43DBECD20A1603700E3704A /* (null) in Sources */,
+				C43DBECD20A1603700E3704A /* AKDualButton.swift in Sources */,
 				EA7D07261F4E655200707706 /* EZAudioDisplayLink.m in Sources */,
 				EA7D07111F4E63F400707706 /* AKNodeFFTPlot.swift in Sources */,
 				EA7D07191F4E63FA00707706 /* AKPresetLoaderView.swift in Sources */,
@@ -6276,7 +6271,6 @@
 				EA7D07101F4E63F400707706 /* AKNodeOutputPlot.swift in Sources */,
 				EA7D07161F4E63FA00707706 /* AKKeyboardView.swift in Sources */,
 				EA7D071F1F4E63FA00707706 /* AKResourceAudioFileLoaderView.swift in Sources */,
-				FED713AB20A3A77F00F837F8 /* AKCoarseFineSlider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		C419101B2009A5E00067B5E0 /* AKStereoFieldLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41910172009A5DF0067B5E0 /* AKStereoFieldLimiter.swift */; };
 		C419101C2009A5E00067B5E0 /* AKStereoFieldLimiterAudioUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41910182009A5E00067B5E0 /* AKStereoFieldLimiterAudioUnit.swift */; };
 		C419B22C1EEE814D0041474F /* vocalTract.swift in Sources */ = {isa = PBXBuildFile; fileRef = C419B22B1EEE814D0041474F /* vocalTract.swift */; };
+		C42371F120A7F65B00507E72 /* AKTimeSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42371F020A7F65A00507E72 /* AKTimeSignature.swift */; };
 		C42899921D552E2C00B941B5 /* smoothDelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899911D552E2C00B941B5 /* smoothDelay.swift */; };
 		C42899941D552F9F00B941B5 /* lowPassButterworthFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899931D552F9F00B941B5 /* lowPassButterworthFilter.swift */; };
 		C42899961D5543E400B941B5 /* korgLowPassFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42899951D5543E400B941B5 /* korgLowPassFilter.swift */; };
@@ -1294,6 +1295,7 @@
 		C41910172009A5DF0067B5E0 /* AKStereoFieldLimiter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKStereoFieldLimiter.swift; sourceTree = "<group>"; };
 		C41910182009A5E00067B5E0 /* AKStereoFieldLimiterAudioUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKStereoFieldLimiterAudioUnit.swift; sourceTree = "<group>"; };
 		C419B22B1EEE814D0041474F /* vocalTract.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = vocalTract.swift; sourceTree = "<group>"; };
+		C42371F020A7F65A00507E72 /* AKTimeSignature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKTimeSignature.swift; sourceTree = "<group>"; };
 		C42899911D552E2C00B941B5 /* smoothDelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = smoothDelay.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C42899931D552F9F00B941B5 /* lowPassButterworthFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = lowPassButterworthFilter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C42899951D5543E400B941B5 /* korgLowPassFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = korgLowPassFilter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -2835,6 +2837,7 @@
 				C4CC303B208484E1004E91CB /* AKMIDINoteData.swift */,
 				C45664E91D448D7E00D26565 /* AKMusicTrack.swift */,
 				C4C378FE1F0C55640085F876 /* AKSequencer.swift */,
+				C42371F020A7F65A00507E72 /* AKTimeSignature.swift */,
 			);
 			path = Sequencer;
 			sourceTree = "<group>";
@@ -6044,6 +6047,7 @@
 				C49B1944204A0AD1009C7C8E /* expon.c in Sources */,
 				C4DF6ADE2029575300984C87 /* AKKorgLowPassFilterDSP.mm in Sources */,
 				C44EA23920186DBF0072399F /* AKPhaser.swift in Sources */,
+				C42371F120A7F65B00507E72 /* AKTimeSignature.swift in Sources */,
 				C49B187E204A0AD0009C7C8E /* fog.c in Sources */,
 				C49B1875204A0AD0009C7C8E /* streson.c in Sources */,
 				C45669001D448D7E00D26565 /* AKHighPassButterworthFilter.swift in Sources */,

--- a/Examples/iOS/MIDIFileEditAndSync/MIDIFileEditAndSync/ViewControllers/SequencerSettingsVC.swift
+++ b/Examples/iOS/MIDIFileEditAndSync/MIDIFileEditAndSync/ViewControllers/SequencerSettingsVC.swift
@@ -70,7 +70,7 @@ extension SequencerSettingsVC: UITextFieldDelegate {
         case timeSigTextField:
             if 1 ..< 60 ~= value {
                 let timeSig = AKTimeSignature(topValue: UInt8(value),
-                                              bottomValue: AKTimeSignature.TimeSignatureBottomValue = .four)
+                                              bottomValue: AKTimeSignature.TimeSignatureBottomValue.four)
                 sequencerDelegate?.addTimeSignatureEvent(at: 0.0,
                                                          timeSignature: timeSig,
                                                          ticksPerMetronomeClick: 24,

--- a/Examples/iOS/MIDIFileEditAndSync/MIDIFileEditAndSync/ViewControllers/SequencerSettingsVC.swift
+++ b/Examples/iOS/MIDIFileEditAndSync/MIDIFileEditAndSync/ViewControllers/SequencerSettingsVC.swift
@@ -69,10 +69,13 @@ extension SequencerSettingsVC: UITextFieldDelegate {
             }
         case timeSigTextField:
             if 1 ..< 60 ~= value {
-                sequencerDelegate?.addTimeSignatureEvent(timeSignatureTop: UInt8(value),
-                                                         timeSignatureBottom: .four,
+                let timeSig = AKTimeSignature(topValue: UInt8(value),
+                                              bottomValue: AKTimeSignature.TimeSignatureBottomValue = .four)
+                sequencerDelegate?.addTimeSignatureEvent(at: 0.0,
+                                                         timeSignature: timeSig,
                                                          ticksPerMetronomeClick: 24,
-                                                         thirtySecondNotesPerQuarter: 8)
+                                                         thirtySecondNotesPerQuarter: 8,
+                                                         clearExistingEvents: true)
                 moveTextField(textField, moveDistance: -200, up: false)
                 return true
             }
@@ -112,10 +115,11 @@ protocol SequencerDelegate: class {
     var tempo: Double { get }
     var length: AKDuration { get }
 
-    func addTimeSignatureEvent(timeSignatureTop: UInt8,
-                               timeSignatureBottom: AKSequencer.TimeSignatureBottomValue,
+    func addTimeSignatureEvent(at timeStamp: MusicTimeStamp,
+                               timeSignature: AKTimeSignature,
                                ticksPerMetronomeClick: UInt8,
-                               thirtySecondNotesPerQuarter: UInt8)
+                               thirtySecondNotesPerQuarter: UInt8,
+                               clearExistingEvents: Bool)
     func setTempo(_ bpm: Double)
     func enableLooping()
     func disableLooping()

--- a/Tests/TestCases/AKSequencerTests.swift
+++ b/Tests/TestCases/AKSequencerTests.swift
@@ -11,114 +11,133 @@ import XCTest
 
 class AKSequencerTests: AKTestCase  {
     var seq: AKSequencer!
-    
+
     override func setUp() {
         super.setUp()
         seq = AKSequencer()
     }
-    
+
     // MARK: - Basic AKSequencer behaviour
     func testAKSequencerDefault_newlyCreatedSequencerHasNoTracks() {
         XCTAssertEqual(seq.trackCount, 0)
     }
-    
+
     func testAKSequencerDefault_newlyCreatedSequencerLengthis0() {
         XCTAssertEqual(seq.length, AKDuration(beats: 0))
     }
-    
+
     func testNewTrack_addingTrackWillIncreaseTrackCount() {
         let _ = seq.newTrack()
         
         XCTAssertEqual(seq.trackCount, 1)
     }
-    
+
     func testNewTrack_addingNewEmptyTrackWillNotAffectLength() {
         let _ = seq.newTrack()
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: 0))
     }
-    
+
     // MARK: - Length
     func testSetLength_settingLengthHasNoEffectIfThereAreNoTracks() {
         seq.setLength(AKDuration(beats: 4.0))
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: 0))
     }
-    
+
     func testSetLength_settingLengthHasEffectsOnSequenceWithEmptyTrack() {
         let _ = seq.newTrack()
         seq.setLength(AKDuration(beats: 4.0))
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: 4.0))
     }
-    
+
     func testSetLength_settingLengthSetsTheLengthOfEachInternalMusicTrack() {
         let _ = seq.newTrack()
         let _ = seq.newTrack()
-        
+
         seq.setLength(AKDuration(beats: 4.0))
-        
+
         for track in seq.tracks {
             XCTAssertEqual(track.length, 4.0)
         }
     }
-    
+
     func testSetLength_shouldTruncateInternalMusicTracks() {
         let originalLength: Double = 8
         let trackA = seq.newTrack()
         trackA?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: Int(originalLength)))
-        
+
         XCTAssertEqual(trackA!.length, originalLength)
         XCTAssertEqual(trackA!.getMIDINoteData().count, Int(originalLength))
-        
+
         let newLength: Double = 4.0
         seq.setLength(AKDuration(beats: newLength))
-        
+
         XCTAssertEqual(trackA!.length, newLength)
         XCTAssertEqual(trackA!.getMIDINoteData().count, Int(newLength))
     }
-    
+
     func testLength_durationOfLongestTrackDeterminesSequenceLength() {
         let trackA = seq.newTrack()
         trackA?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 2))
-        
+
         // longest track is 8 beats
         let trackB = seq.newTrack()
         trackB?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 8))
-        
+
         let trackC = seq.newTrack()
         trackC?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 4))
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: 8.0))
     }
-    
+
     func testLength_settingLengthThenAddingShorterTrackDoesNOTAffectLength() {
         let _ = seq.newTrack()
         let originalLength = AKDuration(beats: 4.0)
         seq.setLength(originalLength)
-        
+
         let trackA = seq.newTrack()
         trackA?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 2))
-        
+
         XCTAssertEqual(seq.length, originalLength)
     }
-    
+
     func testLength_settingLengthThenAddingLongerTrackWillIncreaseLength() {
         let _ = seq.newTrack()
         let originalLength = AKDuration(beats: 4.0)
         seq.setLength(originalLength)
-        
+
         let trackA = seq.newTrack()
         trackA?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 8))
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: 8))
     }
-    
+
+    func testSetLength_willNotTruncateTempoEventsOutsideOfRange() {
+        let _ = seq.newTrack()
+        seq.addTempoEventAt(tempo: 200, position: AKDuration(beats: 8.0))
+
+        seq.setLength(AKDuration(beats: 4.0))
+        XCTAssertEqual(seq.allTempoEvents.count, 1)
+    }
+
+    func testSetLength_willNotTruncateTimeSignatureEventsOutsideOfRange() {
+        let _ = seq.newTrack()
+        seq.addTimeSignatureEvent(at: 8.0,
+                                  timeSignature: AKTimeSignature(topValue: 7,
+                                                                 bottomValue: AKTimeSignature.TimeSignatureBottomValue.eight))
+
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
+        seq.setLength(AKDuration(beats: 4.0))
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
+    }
+
     // MARK: - Getting and Setting Tempo
     func testAllTempoEvents_noTempoEventsShouldYieldEmptyArray() {
         XCTAssertEqual(seq.allTempoEvents.isEmpty, true)
     }
-    
+
     func testGetTempoAt_noTempoEventsYieldsDefault120BPMAtAnyPoint() {
         seq.setLength(AKDuration(beats: 4.0))
         XCTAssertEqual(seq.getTempo(at: 0.0), 120.0)
@@ -127,20 +146,20 @@ class AKSequencerTests: AKTestCase  {
         XCTAssertEqual(seq.getTempo(at: 12.0), 120.0)
         XCTAssertEqual(seq.getTempo(at: -4.0), 120.0)
     }
-    
+
     func testAllTempoEvents_shouldCreateSingleTempoEventAt0() {
         seq.setTempo(200.0)
         XCTAssertEqual(seq.allTempoEvents.count, 1)
         XCTAssertEqual(seq.allTempoEvents[0].0, 0.0) // position
         XCTAssertEqual(seq.allTempoEvents[0].1, 200.0) // bpm
     }
-    
+
     func testGetTempoAt_shouldReturnCorrectValueAfterSetTempo() {
         seq.setTempo(200.0)
         XCTAssertEqual(seq.getTempo(at: 0.0), 200.0)
         XCTAssertEqual(seq.getTempo(at: seq.currentPosition.beats), 200.0)
     }
-    
+
     func testSetTempo_shouldClearPreviousTempoEvents() {
         seq.setLength(AKDuration(beats: 4.0))
         seq.setTempo(100.0)
@@ -150,122 +169,121 @@ class AKSequencerTests: AKTestCase  {
         XCTAssertEqual(seq.allTempoEvents[0].0, 0.0) // position
         XCTAssertEqual(seq.allTempoEvents[0].1, 200.0) // bpm
     }
-    
+
     func testSetTempo_shouldPreserveTimeSignature() {
         seq.setLength(AKDuration(beats: 4.0))
-        seq.addTimeSignatureEvent(timeSignatureTop: 7, timeSignatureBottom: AKSequencer.TimeSignatureBottomValue.eight)
-        XCTAssertEqual(seq.countTimeSignatureEvents(), 1)
+        seq.addTimeSignatureEvent(timeSignature: sevenEight)
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
         seq.setTempo(200.0)
-        XCTAssertEqual(seq.countTimeSignatureEvents(), 1)
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
     }
-    
+
     func testSetTempoGetTempoAt_returnsLastSetEvent() {
         seq.setTempo(100.0)
         seq.setTempo(50.0)
         seq.setTempo(200.0)
         XCTAssertEqual(seq.getTempo(at: 0.0), 200.0)
     }
-    
+
     func testAddTempoEventAtAllTempoEvents_addingFourEventsYieldsForEventsInArray() {
         seq.setLength(AKDuration(beats: 4.0))
         seq.addTempoEventAt(tempo: 100.0, position: AKDuration(beats: 0.0))
         seq.addTempoEventAt(tempo: 110.0, position: AKDuration(beats: 1.0))
         seq.addTempoEventAt(tempo: 120.0, position: AKDuration(beats: 2.0))
         seq.addTempoEventAt(tempo: 130.0, position: AKDuration(beats: 3.0))
-        
+
         XCTAssertEqual(seq.allTempoEvents.count, 4)
     }
-    
+
     func testAddTempoEventAtGetTempoAt_getTempoAtGivesTempoForEventWhenTimeStampIsEqual() {
         seq.setLength(AKDuration(beats: 4.0))
         seq.addTempoEventAt(tempo: 130.0, position: AKDuration(beats: 3.0))
-        
+
         XCTAssertEqual(seq.getTempo(at: 3.0), 130.0)
     }
-    
+
     func testAddTempoEventAtGetTempoAt_givesTempoForEarlierEventWhenBetweenEvents() {
         seq.setLength(AKDuration(beats: 4.0))
         seq.addTempoEventAt(tempo: 100.0, position: AKDuration(beats: 0.0))
         seq.addTempoEventAt(tempo: 130.0, position: AKDuration(beats: 3.0))
-        
+
         XCTAssertEqual(seq.getTempo(at: 2.0), 100.0)
     }
-    
+
     func testSetTempo_shouldClearEventsAddedByAddTempoEventAt() {
         seq.setLength(AKDuration(beats: 4.0))
-        
+
         for i in 0 ..< 4 {
             seq.addTempoEventAt(tempo: 100.0, position: AKDuration(beats: Double(i)))
         }
-        
+
         seq.setTempo(200.0)
         XCTAssertEqual(seq.allTempoEvents.count, 1)
     }
-    
+
     func testAddTempoEventAt_shouldLeaveEventAddedBySetTempo() {
         seq.setLength(AKDuration(beats: 4.0))
         seq.setTempo(100.0)
         seq.addTempoEventAt(tempo: 200.0, position: AKDuration(beats: 2.0))
-        
+
         XCTAssertEqual(seq.allTempoEvents.count, 2)
     }
-    
+
     func testAddTempoEventAt_shouldOverrideButNotDeleteExistingEvent() {
         seq.setLength(AKDuration(beats: 4.0))
         seq.setTempo(100.0) // sets at 0.0
         seq.addTempoEventAt(tempo: 200.0, position: AKDuration(beats: 0.0))
-        
+
         XCTAssertEqual(seq.allTempoEvents.count, 2)
         XCTAssertEqual(seq.getTempo(at: 0.0), 200.0)
     }
-    
-    
+
     // MARK: - Delete Tracks
     func testDeleteTrack_shouldReduceTrackCount() {
         let _ = seq.newTrack()
         let _ = seq.newTrack()
-        
+
         XCTAssertEqual(seq.trackCount, 2)
-        
+
         seq.deleteTrack(trackIndex: 0)
-        
+
         XCTAssertEqual(seq.trackCount, 1)
     }
-    
+
     func testDeleteTrack_attemptingToDeleteBadIndexWillHaveNoEffect() {
         // default seq has no tracks
         seq.deleteTrack(trackIndex: 3)
-        
+    
         // no effect, i.e., it doesn't crash
         XCTAssertEqual(seq.trackCount, 0)
     }
-    
+
     func testDeleteTrack_deletingLongerTrackWillChangeSequencerLength() {
         let trackA = seq.newTrack()
         trackA?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 8))
-        
+
         let trackB = seq.newTrack()
         trackB?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 4))
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: 8.0))
-        
+
         seq.deleteTrack(trackIndex: 0)
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: 4.0))
     }
-    
+
     func testDeleteTrack_indexOfTracksWithHigherIndicesWillDecrement() {
         let _ = seq.newTrack()
         let _ = seq.newTrack()
         seq.tracks[1].replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 4, noteNumber: 72))
         let originalTrack1Data = seq.tracks[1].getMIDINoteData()
-        
+
         seq.deleteTrack(trackIndex: 0)
-        
+
         // track 1 decrements to track 0
         XCTAssertEqual(seq.tracks[0].getMIDINoteData(), originalTrack1Data)
     }
-    
+
     // MARK: - LoadMIDIFile
     func testLoadMIDIFile_seqWillHaveSameNumberOfTracksAsMIDIFile() {
         let numTracks = 4
@@ -275,7 +293,7 @@ class AKSequencerTests: AKTestCase  {
         seq.loadMIDIFile(fromURL: midiURL)
         XCTAssertEqual(seq.trackCount, numTracks)
     }
-    
+
     func testLoadMIDIFile_shouldCompletlyOverwriteExistingContent() {
         // original seq will have three tracks, 8 beats long
         for _ in 0 ..< 3 {
@@ -284,41 +302,64 @@ class AKSequencerTests: AKTestCase  {
         }
         XCTAssertEqual(seq.trackCount, 3)
         XCTAssertEqual(seq.length, AKDuration(beats: 8))
-        
+
         // replacement has one track, 4 beats long
         let replacement = generatePopulatedSequencer(numBeats: 4, numTracks: 1)
         let midiURL = replacement.writeDataToURL()
         seq.loadMIDIFile(fromURL: midiURL)
-        
+
         XCTAssertEqual(seq.trackCount, 1)
         XCTAssertEqual(seq.length, AKDuration(beats: 4))
     }
-    
+
     func testLoadMIDIFile_shouldCopyTracksWithoutMIDINoteEvents() {
         let numTracks = 4
         let sourceSeq = generatePopulatedSequencer(numBeats: 8, numTracks: numTracks)
         let _ = sourceSeq.newTrack() // plus one empty track
         let midiURL = sourceSeq.writeDataToURL()
-        
+
         seq.loadMIDIFile(fromURL: midiURL)
         XCTAssertEqual(seq.trackCount, numTracks + 1)
     }
     
-    func testLoadMIDIFile_shouldCopyTempoEvents() {
+    func testLoadMIDIFile_shouldCopyTempoEventsRemovingOriginal() {
         let originalTempo = 90.0
         seq.setTempo(originalTempo)
+        // original seq has own tempo event
         XCTAssertEqual(seq.getTempo(at: seq.currentPosition.beats), originalTempo, accuracy: 0.1)
-        
+    
         let sourceSeqTempo: Double = 180.0
         let sourceSeq = generatePopulatedSequencer(numBeats: 8, numTracks: 2)
         sourceSeq.setTempo(sourceSeqTempo)
+        // copy source also has its own tempo event
         XCTAssertEqual(sourceSeq.getTempo(at: seq.currentPosition.beats), sourceSeqTempo, accuracy: 0.1)
+        let midiURL = sourceSeq.writeDataToURL()
+
+        seq.loadMIDIFile(fromURL: midiURL)
+        // result has only one tempo event, i.e., from the loaded MIDI file
+        XCTAssertEqual(seq.getTempo(at: seq.currentPosition.beats), sourceSeqTempo, accuracy: 0.1)
+        XCTAssertEqual(seq.allTempoEvents.count, 1)
+    }
+
+    func testLoadMIDIFile_shouldCopyTimeSignatureEventsRemovingOriginal() {
+        seq.addTimeSignatureEvent(at: 0.0, timeSignature: fourFour)
+        // original seq has one event of 4/4
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), fourFour)
+
+        let sourceSeq = generatePopulatedSequencer(numBeats: 8, numTracks: 2)
+        sourceSeq.addTimeSignatureEvent(timeSignature: sevenEight)
+        // copy source has one event of 7/8
+        XCTAssertEqual(sourceSeq.allTimeSignatureEvents.count, 1)
+        XCTAssertEqual(sourceSeq.getTimeSignature(at: 0.0), sevenEight)
         let midiURL = sourceSeq.writeDataToURL()
         
         seq.loadMIDIFile(fromURL: midiURL)
-        XCTAssertEqual(seq.getTempo(at: seq.currentPosition.beats), sourceSeqTempo, accuracy: 0.1)
+        // result has only one event, from the loaded MIDI file
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), sevenEight)
     }
-    
+
     // MARK: - AddMIDIFileTracks
     func testAddMIDIFileTracks_shouldNotAffectCurrentTracks() {
         // original sequencer
@@ -328,56 +369,74 @@ class AKSequencerTests: AKTestCase  {
         let originalTrack0NoteData = seq.tracks[0].getMIDINoteData()
         seq.tracks[1].replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 8, noteNumber: 40))
         let originalTrack1NoteData = seq.tracks[1].getMIDINoteData()
-        
+
         // add another MIDI File
         let newSeq = generatePopulatedSequencer(numBeats: 8, noteNumber: 60, numTracks: 1)
         let midiURL = newSeq.writeDataToURL()
         seq.addMIDIFileTracks(midiURL)
-        
+
+        // original track data is unchanged
         XCTAssertEqual(seq.tracks[0].getMIDINoteData(), originalTrack0NoteData)
         XCTAssertEqual(seq.tracks[1].getMIDINoteData(), originalTrack1NoteData)
     }
-    
+
     func testAddMIDIFileTracks_addsPopulatedMusicTracksToCurrentSequencer() {
         let numberOfOriginalTracks = 3
         for _ in 0 ..< numberOfOriginalTracks {
             let newTrack = seq.newTrack()
             newTrack?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 6, noteNumber: 50))
         }
-        
+
         // add 4 track MIDI file
         let numberOfTracksInNewFile = 4
         let newSeq = generatePopulatedSequencer(numBeats: 4, noteNumber: 60, numTracks: numberOfTracksInNewFile)
         let midiURL = newSeq.writeDataToURL()
         seq.addMIDIFileTracks(midiURL)
-        
+
         XCTAssertEqual(seq.trackCount, numberOfOriginalTracks + numberOfTracksInNewFile)
     }
-    
+
     func testAddMIDIFileTracks_shouldNotCopyTempoEvents() {
         let firstSequencerTempo: Double = 200
         seq.setTempo(firstSequencerTempo)
         XCTAssertEqual(seq.getTempo(at: seq.currentPosition.beats), firstSequencerTempo, accuracy: 0.1)
-        
+
         let secondSequencerTempo: Double = 90
         let newSeq = generatePopulatedSequencer(numBeats: 8, noteNumber: 60, numTracks: 1)
         newSeq.setTempo(secondSequencerTempo)
         // MIDI file tempo is 90
         XCTAssertEqual(newSeq.getTempo(at: seq.currentPosition.beats), secondSequencerTempo, accuracy: 0.1)
-        
+
         let midiURL = newSeq.writeDataToURL()
         seq.addMIDIFileTracks(midiURL)
-        
+
+        // tempo has not been changed by added tracks
         XCTAssertEqual(seq.getTempo(at: seq.currentPosition.beats), firstSequencerTempo, accuracy: 0.1)
     }
-    
+
+    func testAddMIDIFileTracks_shouldNotCopyTimeSigEvents() {
+        seq.addTimeSignatureEvent(timeSignature: sevenEight)
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), sevenEight)
+
+        let newSeq = generatePopulatedSequencer(numBeats: 8, noteNumber: 60, numTracks: 1)
+        newSeq.addTimeSignatureEvent(timeSignature: fourFour)
+        XCTAssertEqual(newSeq.getTimeSignature(at: 0.0), fourFour)
+
+        let midiURL = newSeq.writeDataToURL()
+        seq.addMIDIFileTracks(midiURL)
+
+        // Time sig unchanged by time dig in added tracks
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), sevenEight)
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
+    }
+
     func testAddMIDIFileTracks_tracksWithoutNoteEventsAreNotCopied() {
         let numberOfOriginalTracks = 3
         for _ in 0 ..< numberOfOriginalTracks {
             let newTrack = seq.newTrack()
             newTrack?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: 6, noteNumber: 50))
         }
-        
+
         // add 4 track MIDI file with content
         let numberOfTracksWithContent = 4
         let newSeq = generatePopulatedSequencer(numBeats: 4,
@@ -388,87 +447,166 @@ class AKSequencerTests: AKTestCase  {
         XCTAssertEqual(newSeq.trackCount, numberOfTracksWithContent + 1)
         let midiURL = newSeq.writeDataToURL()
         seq.addMIDIFileTracks(midiURL)
-        
+
+        // track without content was not copied
         XCTAssertEqual(seq.trackCount, numberOfOriginalTracks + numberOfTracksWithContent)
     }
-    
-    func testAddMIDIFileTracks_addsShorterTracksWillNotAffectSequencerLength() {
+
+    func testAddMIDIFileTracks_addingShorterTracksWillNotAffectSequencerLength() {
         let originalLength = 8
         for _ in 0 ..< 2 {
             let newTrack = seq.newTrack()
             newTrack?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: originalLength, noteNumber: 50))
         }
-        
+
         let newSeq = generatePopulatedSequencer(numBeats: 4, noteNumber: 60, numTracks: 2)
         let midiURL = newSeq.writeDataToURL()
         seq.addMIDIFileTracks(midiURL)
-        
+
+        // sequence has not become shorter
         XCTAssertEqual(seq.length, AKDuration(beats: Double(originalLength)))
     }
-    
+
     func testAddMIDIFileTracks_useExistingSequencerLength_shouldTruncateNewTracks() {
         let originalLength = 8
         for _ in 0 ..< 2 {
             let newTrack = seq.newTrack()
             newTrack?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: originalLength, noteNumber: 50))
         }
-        
+
         let longerLength = 16
         let newSeq = generatePopulatedSequencer(numBeats: longerLength, noteNumber: 60, numTracks: 2)
         let midiURL = newSeq.writeDataToURL()
         seq.addMIDIFileTracks(midiURL, useExistingSequencerLength: true) // default
-        
+
         XCTAssertEqual(seq.length, AKDuration(beats: Double(originalLength)))
         XCTAssertEqual(seq.tracks[2].length, MusicTimeStamp(originalLength)) // truncated
         XCTAssertEqual(seq.tracks[3].length, MusicTimeStamp(originalLength)) // truncated
     }
-    
+
     func testAddMIDIFileTracks_NOTuseExistingSequencerLength_newTracksCanIncreaseLength() {
         let originalLength = 8
         for _ in 0 ..< 2 {
             let newTrack = seq.newTrack()
             newTrack?.replaceMIDINoteData(with: generateMIDINoteDataArray(numBeats: originalLength, noteNumber: 50))
         }
-        
+
         let longerLength = 16
         let newSeq = generatePopulatedSequencer(numBeats: longerLength, noteNumber: 60, numTracks: 2)
         let midiURL = newSeq.writeDataToURL()
         // useExistingSequencerLength = false
         seq.addMIDIFileTracks(midiURL, useExistingSequencerLength: false)
-        
+
+        // adding longer tracks has increased seq's length
         XCTAssertEqual(seq.length, AKDuration(beats: Double(longerLength)))
         XCTAssertEqual(seq.tracks[0].length, MusicTimeStamp(originalLength))
         XCTAssertEqual(seq.tracks[1].length, MusicTimeStamp(originalLength))
         XCTAssertEqual(seq.tracks[2].length, MusicTimeStamp(longerLength))
         XCTAssertEqual(seq.tracks[3].length, MusicTimeStamp(longerLength))
     }
-    
+
     // MARK: - Time Signature
     func testTimeSignature_tracksByDefaultHaveNoTimeSignatureEvents() {
-        XCTAssertEqual(seq.countTimeSignatureEvents(), 0)
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 0)
     }
-    
+
     func testAddTimeSignatureEvent_shouldAddSingleEvent() {
-        seq.addTimeSignatureEvent(timeSignatureTop: 5,
-                                  timeSignatureBottom: AKSequencer.TimeSignatureBottomValue.four)
-        XCTAssertEqual(seq.countTimeSignatureEvents(), 1)
+        seq.addTimeSignatureEvent(timeSignature: sevenEight)
+
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
+    }
+
+    func testAddTimeSignatureEvent_addingEventsWithClearFlagOnShouldClearEarlierEvents() {
+        seq.addTimeSignatureEvent(timeSignature: sevenEight)
+        seq.addTimeSignatureEvent(timeSignature: fourFour)
+
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 1)
+    }
+
+    func testAddTimeSignatureEvent_addingTwoEventsWithClearFlagOffShouldYieldTwoEvents() {
+        seq.addTimeSignatureEvent(at: 0.0,
+                                  timeSignature: sevenEight,
+                                  clearExistingEvents: false)
+        seq.addTimeSignatureEvent(at: 2.0,
+                                  timeSignature: fourFour,
+                                  clearExistingEvents: false)
+
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 2)
+    }
+
+    func testAddTimeSignatureEvent_shouldAddCorrectTimeSignature() {
+        seq.addTimeSignatureEvent(timeSignature: sevenEight)
+        let timeSig = seq.allTimeSignatureEvents[0]
+
+        XCTAssertEqual(timeSig.0, 0.0)
+        XCTAssertEqual(timeSig.1, sevenEight)
+    }
+
+    func testAddTimeSignatureEvent_canAddEventToNonZeroPositions() {
+        seq.addTimeSignatureEvent(at: 1.0, timeSignature: sevenEight)
+        let timeSig = seq.allTimeSignatureEvents[0]
+        XCTAssertEqual(timeSig.0, 1.0)
+        XCTAssertEqual(timeSig.1, sevenEight)
     }
     
-    func testAddTimeSignatureEvent_addingEventsShouldClearEarlierEvents() {
-        seq.addTimeSignatureEvent(timeSignatureTop: 5,
-                                  timeSignatureBottom: AKSequencer.TimeSignatureBottomValue.four)
-        seq.addTimeSignatureEvent(timeSignatureTop: 7,
-                                  timeSignatureBottom: AKSequencer.TimeSignatureBottomValue.sixteen)
-        XCTAssertEqual(seq.countTimeSignatureEvents(), 1)
+    func testAddTimeSignatureEvent_willAddMultipleEventsToSamePosition() {
+        for _ in 0 ..< 4 {
+            seq.addTimeSignatureEvent(at: 0.0,
+                                      timeSignature: sevenEight,
+                                      clearExistingEvents: false)
+        }
+
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 4)
+        for event in seq.allTimeSignatureEvents {
+            XCTAssertEqual(event.0, 0.0)
+        }
     }
-    
-    func testAddTimeSignatureEvent_shouldReadTimeSignature() {
-        seq.addTimeSignatureEvent(timeSignatureTop: 8,
-                                  timeSignatureBottom: AKSequencer.TimeSignatureBottomValue.sixteen)
-        
-        
+
+    func testGetTimeSignatureAt_noEventsWillYieldFourFour() {
+        XCTAssertEqual(seq.allTimeSignatureEvents.count, 0)
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), fourFour)
     }
-    
+
+    func testGetTimeSignatureAt_eventAtStartWillGiveCorrectTSAtAllPositions() {
+        seq.addTimeSignatureEvent(at: 0.0, timeSignature: sevenEight)
+
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), sevenEight)
+        XCTAssertEqual(seq.getTimeSignature(at: 3.0), sevenEight)
+    }
+
+    func testGetTimeSignatureAt_eventAtLaterPositionWillGiveFourFourBeforeEvent() {
+        seq.addTimeSignatureEvent(at: 1.0, timeSignature: sevenEight)
+
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), fourFour)
+        XCTAssertEqual(seq.getTimeSignature(at: 1.0), sevenEight)
+    }
+
+    func testGetTimeSignatureAt_willGiveCorrectResultForMultipleEventsAtExactPosition() {
+        seq.setLength(AKDuration(beats: 4))
+        seq.addTimeSignatureEvent(at: 0.0, timeSignature: sevenEight, clearExistingEvents: false)
+        seq.addTimeSignatureEvent(at: 1.0, timeSignature: fourFour, clearExistingEvents: false)
+        seq.addTimeSignatureEvent(at: 2.0, timeSignature: sevenEight, clearExistingEvents: false)
+        seq.addTimeSignatureEvent(at: 3.0, timeSignature: fourFour, clearExistingEvents: false)
+
+        XCTAssertEqual(seq.getTimeSignature(at: 0.0), sevenEight)
+        XCTAssertEqual(seq.getTimeSignature(at: 1.0), fourFour)
+        XCTAssertEqual(seq.getTimeSignature(at: 2.0), sevenEight)
+        XCTAssertEqual(seq.getTimeSignature(at: 3.0), fourFour)
+    }
+
+    func testGetTimeSignatureAt_willGiveCorrectResultForMultipleEventsBetweenPositions() {
+        seq.setLength(AKDuration(beats: 4))
+        seq.addTimeSignatureEvent(at: 0.0, timeSignature: sevenEight, clearExistingEvents: false)
+        seq.addTimeSignatureEvent(at: 1.0, timeSignature: fourFour, clearExistingEvents: false)
+        seq.addTimeSignatureEvent(at: 2.0, timeSignature: sevenEight, clearExistingEvents: false)
+        seq.addTimeSignatureEvent(at: 3.0, timeSignature: fourFour, clearExistingEvents: false)
+
+        XCTAssertEqual(seq.getTimeSignature(at: 0.5), sevenEight)
+        XCTAssertEqual(seq.getTimeSignature(at: 1.5), fourFour)
+        XCTAssertEqual(seq.getTimeSignature(at: 2.5), sevenEight)
+        XCTAssertEqual(seq.getTimeSignature(at: 3.5), fourFour)
+    }
+
     // MARK: - helper functions
     func generateMIDINoteDataArray(numBeats: Int, noteNumber: Int = 60) -> [AKMIDINoteData] {
         return (0 ..< numBeats).map { AKMIDINoteData(noteNumber: MIDINoteNumber(noteNumber),
@@ -478,7 +616,7 @@ class AKSequencerTests: AKTestCase  {
                                                      position: AKDuration(beats: Double($0)))
         }
     }
-    
+
     func generatePopulatedSequencer(numBeats: Int, noteNumber: Int = 60, numTracks: Int) -> AKSequencer {
         let newSeq = AKSequencer()
         for _ in 0 ..< numTracks {
@@ -488,6 +626,11 @@ class AKSequencerTests: AKTestCase  {
         }
         return newSeq
     }
+
+    let fourFour = AKTimeSignature(topValue: 4,
+                                   bottomValue: AKTimeSignature.TimeSignatureBottomValue.four)
+    let sevenEight = AKTimeSignature(topValue: 7,
+                                     bottomValue: AKTimeSignature.TimeSignatureBottomValue.eight)
 }
 
 extension AKSequencer {
@@ -498,73 +641,8 @@ extension AKSequencer {
         try! data?.write(to: url!)
         return url!
     }
-    
-    func countTimeSignatureEvents() -> Int {
-        var tempoTrack: MusicTrack?
-        if let existingSequence = sequence {
-            MusicSequenceGetTempoTrack(existingSequence, &tempoTrack)
-        }
-        
-        guard let unwrappedTempoTrack = tempoTrack else {
-            return 0
-        }
-        
-        var timeSigCount = 0
-        let timeSignatureMetaEventByte: UInt8 = 0x58
-        iterateMusicTrack(unwrappedTempoTrack) { _, _, eventType, eventData, _ in
-            guard eventType == kMusicEventType_Meta else { return }
-            let data = UnsafePointer<MIDIMetaEvent>(eventData?.assumingMemoryBound(to: MIDIMetaEvent.self))
-            guard let dataMetaEventType = data?.pointee.metaEventType else { return }
-            if dataMetaEventType == timeSignatureMetaEventByte {
-                timeSigCount += 1
-            }
-        }
-        return timeSigCount
-    }
-    
-    func getFirstTimeSignature() -> (UInt8, UInt8) {
-        struct TimeSignature {
-            var type: UInt8 = 0
-            var dataLength:UInt32 = 0
-            var data: (UInt8, UInt8, UInt8, UInt8) = (0, 0, 0, 0)
-        }
-        
-        var tempoTrack: MusicTrack?
-        var result: [(UInt8, UInt8)]  = [(0, 0)]
-        
-        if let existingSequence = sequence {
-            MusicSequenceGetTempoTrack(existingSequence, &tempoTrack)
-        }
-        
-        guard let unwrappedTempoTrack = tempoTrack else {
-            AKLog("Couldn't get tempo track")
-            return result[0]
-        }
-        
-        let timeSignatureMetaEventByte: UInt8 = 0x58
-        iterateMusicTrack(unwrappedTempoTrack) { _, _, eventType, eventData, dataSize in
-            guard let eventData = eventData else { return }
-            guard eventType == kMusicEventType_Meta else { return }
-            
-            let metaEventPointer = eventData.bindMemory(to: MIDIMetaEvent.self, capacity: Int(dataSize))
-            let metaEvent = metaEventPointer.pointee
-            if metaEvent.metaEventType == timeSignatureMetaEventByte {
-                let timeSigPointer = eventData.bindMemory(to: TimeSignature.self, capacity: Int(dataSize))
-                let rawTimeSig = timeSigPointer.pointee
-                let readableTimeSig = (rawTimeSig.data.0, UInt8(pow(2, Double(rawTimeSig.data.1))))
-                result.append(readableTimeSig)
-            }
-        }
-        // if no time signature events are found, use default 4/4
-        if result.count == 1 {
-            return (4,4)
-        } else {
-            // otherwise use first found time signature (possible later events are ignored)
-            return result[1]
-        }
-    }
-    
-    func iterateMusicTrack(_ track: MusicTrack, midiEventHandler: (MusicEventIterator, MusicTimeStamp, MusicEventType, UnsafeRawPointer?, UInt32) -> Void) {
+
+    func iterateMusicTrack(_ track: MusicTrack, midiEventHandler: (MusicEventIterator, MusicTimeStamp, MusicEventType, UnsafeRawPointer?, UInt32, inout Bool) -> Void) {
         var tempIterator: MusicEventIterator?
         NewMusicEventIterator(track, &tempIterator)
         guard let iterator = tempIterator else {
@@ -576,12 +654,13 @@ extension AKSequencer {
         var eventData: UnsafeRawPointer?
         var eventDataSize: UInt32 = 0
         var hasNextEvent: DarwinBoolean = false
+        var isReadyForNextEvent: Bool = true
         
         MusicEventIteratorHasCurrentEvent(iterator, &hasNextEvent)
         while hasNextEvent.boolValue {
             MusicEventIteratorGetEventInfo(iterator, &eventTime, &eventType, &eventData, &eventDataSize)
             
-            midiEventHandler(iterator, eventTime, eventType, eventData, eventDataSize)
+            midiEventHandler(iterator, eventTime, eventType, eventData, eventDataSize, &isReadyForNextEvent)
             
             MusicEventIteratorNextEvent(iterator)
             MusicEventIteratorHasCurrentEvent(iterator, &hasNextEvent)
@@ -589,3 +668,4 @@ extension AKSequencer {
         DisposeMusicEventIterator(iterator)
     }
 }
+


### PR DESCRIPTION
re https://github.com/AudioKit/AudioKit/issues/1353 and https://github.com/AudioKit/AudioKit/pull/1354
These changes provide a way to read all the time signatures events from a MIDI file, and get the relevant time signature event for a given position.  Time signature events for current position can be read accurately even if the event is at time stamp 0.0  and current position is 0.0.

- added struct ```AKTimeSignature```
- added ```allTimeSignatureEvents``` and ```getTimeSignature(at: )``` to ```AKSequencer```
- modified ```addTimeSignatureEvent``` to use ```AKTimeSignature```, to include the timeStamp for the event as an argument, and to have a flag for clearing existing events
- modified ```AKSequencer```'s ```removeTracks``` to explicitly clear tempo and time signature events
- added time signature tests to AKSequencerTests file
- updated MIDIFileEditAndSync example for modified ```addTimeSignatureEvent``` method
