### PR TITLE
Fix for double callback call in `exportAsynchronously` in `AKAudioFile`.

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
@@ -328,24 +328,24 @@ extension AKAudioFile {
         // In and OUT times trimming settings
         let inFrame: Int64
         let outFrame: Int64
-        
+
         if toSample == 0 {
             outFrame = samplesCount
         } else {
             outFrame = min(samplesCount, toSample)
         }
-        
+
         inFrame = abs(min(samplesCount, fromSample))
-        
+
         if outFrame <= inFrame {
             AKLog("ERROR AKAudioFile export: In time must be less than Out time")
-            
+
             callback(nil,
                      NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil))
-            
+
             return
         }
-        
+
         let asset = url.isFileURL ? AVURLAsset(url: url) : AVURLAsset(url: URL(fileURLWithPath: url.absoluteString))
         if let internalExportSession = AVAssetExportSession(asset: asset, presetName: avExportPreset) {
             AKLog("internalExportSession session created")
@@ -405,7 +405,7 @@ extension AKAudioFile {
             internalExportSession.outputURL = URL(fileURLWithPath: filePath)
             // Sets the output file encoding (avoid .wav encoded as m4a...)
             internalExportSession.outputFileType = AVFileType(rawValue: exportFormat.UTI as String as String)
-        
+
             let startTime = CMTimeMake(inFrame, Int32(sampleRate))
             let stopTime = CMTimeMake(outFrame, Int32(sampleRate))
             let timeRange = CMTimeRangeFromTimeToTime(startTime, stopTime)

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
@@ -325,6 +325,27 @@ extension AKAudioFile {
             }
         }
 
+        // In and OUT times trimming settings
+        let inFrame: Int64
+        let outFrame: Int64
+        
+        if toSample == 0 {
+            outFrame = samplesCount
+        } else {
+            outFrame = min(samplesCount, toSample)
+        }
+        
+        inFrame = abs(min(samplesCount, fromSample))
+        
+        if outFrame <= inFrame {
+            AKLog("ERROR AKAudioFile export: In time must be less than Out time")
+            
+            callback(nil,
+                     NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil))
+            
+            return
+        }
+        
         let asset = url.isFileURL ? AVURLAsset(url: url) : AVURLAsset(url: URL(fileURLWithPath: url.absoluteString))
         if let internalExportSession = AVAssetExportSession(asset: asset, presetName: avExportPreset) {
             AKLog("internalExportSession session created")
@@ -384,24 +405,7 @@ extension AKAudioFile {
             internalExportSession.outputURL = URL(fileURLWithPath: filePath)
             // Sets the output file encoding (avoid .wav encoded as m4a...)
             internalExportSession.outputFileType = AVFileType(rawValue: exportFormat.UTI as String as String)
-
-            // In and OUT times triming settings
-            let inFrame: Int64
-            let outFrame: Int64
-
-            if toSample == 0 {
-                outFrame = samplesCount
-            } else {
-                outFrame = min(samplesCount, toSample)
-            }
-
-            inFrame = abs(min(samplesCount, fromSample))
-
-            if outFrame <= inFrame {
-                AKLog("ERROR AKAudioFile export: In time must be less than Out time")
-                callback(nil,
-                         NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotCreateFile, userInfo: nil))
-            }
+        
             let startTime = CMTimeMake(inFrame, Int32(sampleRate))
             let stopTime = CMTimeMake(outFrame, Int32(sampleRate))
             let timeRange = CMTimeRangeFromTimeToTime(startTime, stopTime)


### PR DESCRIPTION
This PR should solve the double callback mentioned in issue #1387.