### PR TITLE
Potential fix issue 1311

### DIFF
--- a/AudioKit/Common/Nodes/Input/AKMicrophone.swift
+++ b/AudioKit/Common/Nodes/Input/AKMicrophone.swift
@@ -40,14 +40,10 @@ open class AKMicrophone: AKNode, AKToggleable {
         super.init()
         self.avAudioNode = mixer
 
-        #if os(tvOS)
-        print("Microphone not avaiable on tvOS")
-        return
-        #endif
-
+        #if !os(tvOS)
         AKSettings.audioInputEnabled = true
         AudioKit.engine.inputNode.connect(to: self.avAudioNode)
-        AudioKit.engine.connect(<#T##node1: AVAudioNode##AVAudioNode#>, to: <#T##AVAudioNode#>)
+        #endif
     }
 
     deinit {

--- a/AudioKit/Common/Nodes/Input/AKMicrophone.swift
+++ b/AudioKit/Common/Nodes/Input/AKMicrophone.swift
@@ -38,13 +38,16 @@ open class AKMicrophone: AKNode, AKToggleable {
     /// Initialize the microphone
     override public init() {
         super.init()
-        #if !os(tvOS)
-            self.avAudioNode = mixer
-            AKSettings.audioInputEnabled = true
-            AudioKit.engine.attach(mixer)
-            AKLog("Mixer inputs", mixer.numberOfInputs)
-            AudioKit.engine.connect(AudioKit.engine.inputNode, to: self.avAudioNode, format: nil)
+        self.avAudioNode = mixer
+
+        #if os(tvOS)
+        print("Microphone not avaiable on tvOS")
+        return
         #endif
+
+        AKSettings.audioInputEnabled = true
+        AudioKit.engine.inputNode.connect(to: self.avAudioNode)
+        AudioKit.engine.connect(<#T##node1: AVAudioNode##AVAudioNode#>, to: <#T##AVAudioNode#>)
     }
 
     deinit {

--- a/AudioKit/Common/Nodes/Input/AKStereoInput.swift
+++ b/AudioKit/Common/Nodes/Input/AKStereoInput.swift
@@ -33,13 +33,10 @@
         super.init()
         self.avAudioNode = mixer
 
-        #if os(tvOS)
-        print("Microphone not avaiable on tvOS")
-        return
-        #endif
-
+        #if !os(tvOS)
         AKSettings.audioInputEnabled = true
         AudioKit.engine.inputNode.connect(to: self.avAudioNode)
+        #endif
     }
 
     deinit {

--- a/AudioKit/Common/Nodes/Input/AKStereoInput.swift
+++ b/AudioKit/Common/Nodes/Input/AKStereoInput.swift
@@ -31,12 +31,15 @@
     /// Initialize the microphone
     override public init() {
         super.init()
-        #if !os(tvOS)
-            self.avAudioNode = mixer
-            AKSettings.audioInputEnabled = true
-            AudioKit.engine.attach(mixer)
-            AudioKit.engine.connect(AudioKit.engine.inputNode, to: self.avAudioNode, format: nil)
+        self.avAudioNode = mixer
+
+        #if os(tvOS)
+        print("Microphone not avaiable on tvOS")
+        return
         #endif
+
+        AKSettings.audioInputEnabled = true
+        AudioKit.engine.inputNode.connect(to: self.avAudioNode)
     }
 
     deinit {


### PR DESCRIPTION
Use AKNode.connect(to:) for AVAudioEngine.inputNode connections. Clean up.
AKNode.connect(to:) using Audiokit.format for connection, while the previous syntax was using the input node's format.