### PR TITLE
Ensure any previously created timers are invalidated before creating a new instance

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKPlayer.swift
@@ -618,6 +618,7 @@ public class AKPlayer: AKNode {
         AKLog("starting fade in", triggerTime, "seconds")
 
         DispatchQueue.main.async {
+            self.faderTimer?.invalidate()
             self.faderTimer = Timer.scheduledTimer(timeInterval: triggerTime,
                                                    target: self,
                                                    selector: #selector(self.startFade),
@@ -666,6 +667,7 @@ public class AKPlayer: AKNode {
             when /= rate
 
             DispatchQueue.main.async {
+                self.faderTimer?.invalidate()
                 self.faderTimer = Timer.scheduledTimer(timeInterval: when,
                                                        target: self,
                                                        selector: #selector(self.fadeOut),
@@ -700,6 +702,8 @@ public class AKPlayer: AKNode {
     // if the file is scheduled, start a timer to determine when to start the completion timer
     private func startPrerollTimer(_ prerollTime: Double) {
         DispatchQueue.main.async {
+            // ensure any previously created time has been invalidated before starting a new one
+            self.prerollTimer?.invalidate()
             self.prerollTimer = Timer.scheduledTimer(timeInterval: prerollTime,
                                                      target: self,
                                                      selector: #selector(self.startCompletionTimer),
@@ -716,6 +720,8 @@ public class AKPlayer: AKNode {
         }
 
         DispatchQueue.main.async {
+            // ensure any previously created time has been invalidated before starting a new one
+            self.completionTimer?.invalidate()
             self.completionTimer = Timer.scheduledTimer(timeInterval: segmentDuration,
                                                         target: self,
                                                         selector: #selector(self.handleComplete),

--- a/AudioKit/Common/Nodes/Playback/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Player/AKPlayer.swift
@@ -588,9 +588,12 @@ public class AKPlayer: AKNode {
     public func stop() {
         playerNode.stop()
         resetFader(false)
-        completionTimer?.invalidate()
-        prerollTimer?.invalidate()
-        faderTimer?.invalidate()
+
+        DispatchQueue.main.async {
+            self.completionTimer?.invalidate()
+            self.prerollTimer?.invalidate()
+            self.faderTimer?.invalidate()
+        }
 
         // the time strecher draws a fair bit of CPU when it isn't bypassed, so auto bypass it
         timePitchNode?.bypass()
@@ -603,7 +606,9 @@ public class AKPlayer: AKNode {
         // AKLog(fade, faderNode.rampDuration, faderNode.gain, audioTime, hostTime)
 
         if faderTimer?.isValid ?? false {
-            faderTimer?.invalidate()
+            DispatchQueue.main.async {
+                self.faderTimer?.invalidate()
+            }
         }
 
         guard fade.inTime != 0 || fade.outTime != 0 else {
@@ -651,7 +656,10 @@ public class AKPlayer: AKNode {
         }
         // set target gain and begin ramping
         faderNode.gain = fade.maximumGain
-        faderTimer?.invalidate()
+
+        DispatchQueue.main.async {
+            self.faderTimer?.invalidate()
+        }
 
         guard fade.outTime > 0 else { return }
 
@@ -740,8 +748,10 @@ public class AKPlayer: AKNode {
         if #available(iOS 11, macOS 10.13, tvOS 11, *) {
             // nothing further is needed as the completion is specified in the scheduler
         } else {
-            completionTimer?.invalidate()
-            prerollTimer?.invalidate()
+            DispatchQueue.main.async {
+                self.completionTimer?.invalidate()
+                self.prerollTimer?.invalidate()
+            }
 
             if let audioTime = audioTime, let hostTime = hostTime {
                 let prerollTime = audioTime.toSeconds(hostTime: hostTime)


### PR DESCRIPTION
The creation and invalidation of timers should be balanced so that any previously created timers that haven't fired yet are invalidated and removed from the run loop before creating a new one to ensure the previous one will not fire.

Also, the timers should be invalidated on the same thread where they were created, as per the special considerations note on `NSTimer` docs.

When calling `setPosition` on the player after a `resume` call has been made, because the timers are being created and invalidated on different threads, the old timers aren't always removed from the run loop and still fire.