### PR TITLE
AKPlayer: Fader/Gain optimization

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
@@ -82,16 +82,18 @@ public class AKDynamicPlayer: AKPlayer {
     internal override func connectNodes() {
         guard let processingFormat = processingFormat else { return }
 
-        if let timePitchNode = timePitchNode {
+        if let timePitchNode = timePitchNode, let faderNode = faderNode {
             AudioKit.connect(playerNode, to: timePitchNode.avAudioNode, format: processingFormat)
             AudioKit.connect(timePitchNode.avAudioNode, to: faderNode.avAudioNode, format: processingFormat)
             AudioKit.connect(faderNode.avAudioNode, to: mixer, format: processingFormat)
             timePitchNode.bypass() // bypass timePitch by default to save CPU
 
-        } else {
+        } else if let faderNode = faderNode {
             // if the timePitchNode isn't created connect the player directly to the faderNode
             AudioKit.connect(playerNode, to: faderNode.avAudioNode, format: processingFormat)
             AudioKit.connect(faderNode.avAudioNode, to: mixer, format: processingFormat)
+        } else {
+            AudioKit.connect(playerNode, to: mixer, format: processingFormat)
         }
     }
 
@@ -119,7 +121,6 @@ public class AKDynamicPlayer: AKPlayer {
 
     public override func detach() {
         super.detach()
-        AudioKit.detach(nodes: [faderNode.avAudioNode])
         if let timePitchNode = timePitchNode {
             AudioKit.detach(nodes: [timePitchNode.avAudioNode])
         }

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Fader.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Fader.swift
@@ -11,6 +11,8 @@ extension AKPlayer {
     internal func createFader() {
         AKLog("Creating AKBooster")
         faderNode = AKBooster()
+        faderNode?.gain = Fade.minimumGain
+        faderNode?.rampType = rampType
         initialize()
     }
 
@@ -57,7 +59,7 @@ extension AKPlayer {
 
         let inTime = fade.inTime - fade.inTimeOffset
 
-        AKLog("Fading in to", fade.maximumGain)
+        AKLog("Fading in to", fade.maximumGain, ", shape:", fade.inRampType.rawValue)
 
         faderNode.rampDuration = AKSettings.rampDuration
 
@@ -107,7 +109,7 @@ extension AKPlayer {
             faderNode.rampType = fade.outRampType
             faderNode.rampDuration = time / rate
             faderNode.gain = Fade.minimumGain
-            AKLog("Fading out to", Fade.minimumGain)
+            AKLog("Fading out to", Fade.minimumGain, ", shape:", fade.outRampType.rawValue)
         }
     }
 

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Fader.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Fader.swift
@@ -8,12 +8,16 @@
 
 extension AKPlayer {
 
-    internal func initFader(at audioTime: AVAudioTime?, hostTime: UInt64?) {
-        // AKLog(fade, faderNode.rampDuration, faderNode.gain, audioTime, hostTime)
+    internal func createFader() {
+        AKLog("Creating AKBooster")
+        faderNode = AKBooster()
+        initialize()
+    }
 
-        if faderTimer?.isValid ?? false {
-            faderTimer?.invalidate()
-        }
+    internal func initFader(at audioTime: AVAudioTime?, hostTime: UInt64?) {
+        guard faderNode != nil else { return }
+
+        // AKLog(fade, faderNode.rampDuration, faderNode.gain, audioTime, hostTime)
 
         guard fade.inTime != 0 || fade.outTime != 0 else {
             return
@@ -38,6 +42,7 @@ extension AKPlayer {
     }
 
     internal func resetFader(_ state: Bool) {
+        guard let faderNode = faderNode else { return }
         var state = state
         if fade.inTime == 0 {
             state = true
@@ -48,6 +53,8 @@ extension AKPlayer {
     }
 
     @objc private func startFade() {
+        guard let faderNode = faderNode else { return }
+
         let inTime = fade.inTime - fade.inTimeOffset
 
         AKLog("Fading in to", fade.maximumGain)
@@ -93,6 +100,8 @@ extension AKPlayer {
     }
 
     private func fadeOutWithTime(_ time: Double) {
+        guard let faderNode = faderNode else { return }
+
         if time > 0 {
             // at this point init the faderNode with the correct settings for fade out
             faderNode.rampType = fade.outRampType

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -64,7 +64,7 @@ extension AKPlayer {
     /// Stop playback and cancel any pending scheduled playback or completion events
     public func stop() {
         playerNode.stop()
-        faderNode.stop()
+        faderNode?.stop()
         completionTimer?.invalidate()
         prerollTimer?.invalidate()
         faderTimer?.invalidate()

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -148,7 +148,7 @@ public class AKPlayer: AKNode {
     // I've found that using the apple completion handlers for AVAudioPlayerNode can introduce some instability.
     // if you don't need them, you can disable them off here
     internal var useCompletionHandler: Bool {
-        return isLooping || completionHandler != nil
+        return (isLooping && !isBuffered) || completionHandler != nil
     }
 
     // startTime and endTime may be accessed from multiple thread contexts
@@ -424,7 +424,7 @@ public class AKPlayer: AKNode {
 
         if to == 0 { to = duration }
 
-        AKLog(from, to)
+        // AKLog(from, to)
 
         if from > to {
             from = 0

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -128,8 +128,8 @@ public class AKPlayer: AKNode {
     /// The main output
     public let mixer = AVAudioMixerNode()
 
-    /// The underlying gain booster which controls fades as well
-    public var faderNode: AKBooster? // = AKBooster()
+    /// The underlying gain booster which controls fades as well. Created on demand.
+    public var faderNode: AKBooster?
 
     // MARK: - Private Parts
 

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -393,8 +393,6 @@ public class AKPlayer: AKNode {
             }
         }
 
-        faderNode?.gain = Fade.minimumGain
-        faderNode?.rampType = .linear
         loop.start = 0
         loop.end = duration
         buffer = nil
@@ -482,7 +480,6 @@ public class AKPlayer: AKNode {
         if let faderNode = faderNode {
             AudioKit.detach(nodes: [faderNode.avAudioNode])
         }
-
         faderNode = nil
     }
 

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/Base.lproj/Main.storyboard
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="system font weights other than Regular or Bold" minToolsVersion="7.0"/>
@@ -837,7 +837,7 @@ IA
                                 <font key="titleFont" size="10" name=".AppleSystemUIFont"/>
                             </box>
                             <box fixedFrame="YES" boxType="custom" borderType="bezel" cornerRadius="3" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="E8H-Q8-BWY" userLabel="Time">
-                                <rect key="frame" x="155" y="222" width="86" height="18"/>
+                                <rect key="frame" x="155" y="224" width="86" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <view key="contentView" ambiguous="YES" id="NYn-zo-yxK">
                                     <rect key="frame" x="1" y="1" width="84" height="16"/>
@@ -855,7 +855,7 @@ IA
                                     </subviews>
                                 </view>
                                 <color key="borderColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <color key="fillColor" red="1" green="1" blue="1" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="fillColor" red="1" green="1" blue="1" alpha="0.896484375" colorSpace="custom" customColorSpace="sRGB"/>
                                 <font key="titleFont" size="10" name=".AppleSystemUIFont"/>
                             </box>
                         </subviews>


### PR DESCRIPTION
Have made it so the AKBooster that controls gain and fading is only created if these features are requested. I'm trying to optimize AKPlayer for situations in which there are 200+ players in a timeline. Eliminating 200 unnecessary AKBoosters is significant in terms of the AVAudioEngine's impact. I may consider putting all the fading code into the AKDynamicPlayer class.

I'm not sure but am now wondering if there is an I/O problem with AKBooster. More on that later...

Thanks!