### PR TITLE
AKPlayer: bug fix update

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
@@ -18,14 +18,11 @@ public class AKDynamicPlayer: AKPlayer {
         }
 
         set {
-            // timePitch is only installed if it is requested. This saves CPU resources.
-            if newValue == 1 && timePitchNode != nil {
+            // timePitch is only installed if it is requested. This saves resources.
+            if timePitchNode != nil && newValue == 1 {
                 removeTimePitch()
                 return
-            }
-
-            if timePitchNode == nil && newValue != 1 {
-                stop()
+            } else if timePitchNode == nil && newValue != 1 {
                 timePitchNode = AKTimePitch()
                 initialize()
             }
@@ -45,19 +42,16 @@ public class AKDynamicPlayer: AKPlayer {
         }
 
         set {
-            // timePitch is only installed if it is requested. This saves CPU resources.
-            if newValue == 0 && timePitchNode != nil {
+            // timePitch is only installed if it is requested. This saves resources.
+            if timePitchNode != nil && newValue == 0 {
                 removeTimePitch()
                 return
-            }
-
-            if timePitchNode == nil && newValue != 0 {
+            } else if timePitchNode == nil && newValue != 0 {
                 timePitchNode = AKTimePitch()
                 initialize()
             }
 
             guard let timePitchNode = timePitchNode else { return }
-
             timePitchNode.pitch = newValue
             if timePitchNode.isBypassed && timePitchNode.pitch != 0 {
                 timePitchNode.start()
@@ -87,6 +81,11 @@ public class AKDynamicPlayer: AKPlayer {
             AudioKit.connect(timePitchNode.avAudioNode, to: faderNode.avAudioNode, format: processingFormat)
             AudioKit.connect(faderNode.avAudioNode, to: mixer, format: processingFormat)
             timePitchNode.bypass() // bypass timePitch by default to save CPU
+
+        } else if let timePitchNode = timePitchNode, faderNode == nil {
+            AudioKit.connect(playerNode, to: timePitchNode.avAudioNode, format: processingFormat)
+            AudioKit.connect(timePitchNode.avAudioNode, to: mixer, format: processingFormat)
+            timePitchNode.bypass()
 
         } else if let faderNode = faderNode {
             // if the timePitchNode isn't created connect the player directly to the faderNode

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Fader.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Fader.swift
@@ -11,7 +11,7 @@ extension AKPlayer {
     internal func createFader() {
         AKLog("Creating AKBooster")
         faderNode = AKBooster()
-        faderNode?.gain = Fade.minimumGain
+        faderNode?.gain = gain
         faderNode?.rampType = rampType
         initialize()
     }

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -60,6 +60,7 @@ extension AKPlayer {
         // clear the frame count in the player
         playerNode.stop()
         play(from: pauseTime)
+        AKLog("Resuming at \(pauseTime)")
     }
     /// Stop playback and cancel any pending scheduled playback or completion events
     public func stop() {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -221,12 +221,12 @@ public class AKPlayer: AKNode {
         }
 
         set {
+            // this is the value that the fader will fade to
+            fade.maximumGain = newValue
+
             if newValue != 1 && faderNode == nil {
                 createFader()
             }
-
-            // this is the value that the fader will fade to
-            fade.maximumGain = newValue
             // this is the current value of the fader, set immediately
             faderNode?.gain = newValue
         }
@@ -371,10 +371,17 @@ public class AKPlayer: AKNode {
     public convenience init(audioFile: AVAudioFile) {
         self.init()
         self.audioFile = audioFile
+        loop.start = 0
+        loop.end = duration
         initialize()
     }
 
     internal func initialize() {
+        let wasPlaying = isPlaying
+        if wasPlaying {
+            pause()
+        }
+
         if mixer.engine == nil {
             AudioKit.engine.attach(mixer)
         }
@@ -392,13 +399,10 @@ public class AKPlayer: AKNode {
                 faderNode.disconnectOutput()
             }
         }
-
-        loop.start = 0
-        loop.end = duration
-        buffer = nil
-
         connectNodes()
-        // preroll(from: 0, to: duration)
+        if wasPlaying {
+            resume()
+        }
     }
 
     internal func connectNodes() {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/README.md
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/README.md
@@ -1,12 +1,13 @@
 # AKPlayer
 
 AKPlayer is meant to be a simple yet powerful audio player that just works. It supports
-scheduling of sounds, looping, fading, time-stretching, pitch-shifting and reversing.
+scheduling of sounds, looping, fading and reversing.
 Players can be locked to a common clock as well as video by using hostTime in the various play functions.
 By default the player will buffer audio if needed, otherwise stream from disk. Reversing the audio will cause the
-file to buffer. For seamless looping use buffered playback.
+file to buffer. For seamless looping use buffered ram based playback.
 
 # AKDynamicPlayer
 
 The dynamic player adds pitch shifting and time stretching to AKPlayer. Due to the relatively high cost of rendering these 
-effects, it has been moved to its own subclass.
+effects, it has been moved to its own subclass. Regardless of that, both pitch and rate are disabled until you actually set
+a valid value for them - only at this point is the internal AKTimePitch unit added.


### PR DESCRIPTION
I've fixed a few bugs. player wasn't adding AKTimePitch if faderNode wasn't present. Player resumes after route change if it was already playing.
