### PR TITLE
Fix incorrect removal of observers in EZMicrophone

### DIFF
--- a/AudioKit/Common/Internals/AudioKit+StartStop.swift
+++ b/AudioKit/Common/Internals/AudioKit+StartStop.swift
@@ -96,7 +96,7 @@ extension AudioKit {
     // and restart the audio engine if it stops and should be playing
     @objc fileprivate static func restartEngineAfterConfigurationChange(_ notification: Notification) {
         // Notifications aren't guaranteed to be on the main thread
-        let checkRestart = {
+        let attemptRestart = {
             do {
                 // By checking the notification sender in this block rather than during observer configuration we avoid needing to create a new observer if the engine somehow changes
                 guard let notifyingEngine = notification.object as? AVAudioEngine, notifyingEngine == engine else {
@@ -131,9 +131,9 @@ extension AudioKit {
             }
         }
         if Thread.isMainThread {
-            checkRestart()
+            attemptRestart()
         } else {
-            DispatchQueue.main.async(execute: checkRestart)
+            DispatchQueue.main.async(execute: attemptRestart)
         }
     }
 
@@ -141,7 +141,7 @@ extension AudioKit {
     @objc fileprivate static func restartEngineAfterRouteChange(_ notification: Notification) {
         // Notifications aren't guaranteed to come in on the main thread
 
-        let checkRestart = {
+        let attemptRestart = {
 
             if AKSettings.enableRouteChangeHandling && shouldBeRunning && !engine.isRunning {
                 do {
@@ -171,9 +171,9 @@ extension AudioKit {
             }
         }
         if Thread.isMainThread {
-            checkRestart()
+            attemptRestart()
         } else {
-            DispatchQueue.main.async(execute: checkRestart)
+            DispatchQueue.main.async(execute: attemptRestart)
         }
     }
 }

--- a/AudioKit/Common/Internals/EZAudio/EZMicrophone.m
+++ b/AudioKit/Common/Internals/EZAudio/EZMicrophone.m
@@ -69,7 +69,8 @@ static OSStatus EZAudioMicrophoneCallback(void                       *inRefCon,
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionInterruptionNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionRouteChangeNotification object:nil];
     [EZAudioUtilities checkResult:AudioUnitUninitialize(self.info->audioUnit)
                         operation:"Failed to unintialize audio unit for microphone"];
     [EZAudioUtilities freeBufferList:self.info->audioBufferList];
@@ -299,6 +300,8 @@ static OSStatus EZAudioMicrophoneCallback(void                       *inRefCon,
 
 - (void)microphoneWasInterrupted:(NSNotification *)notification
 {
+
+
     AVAudioSessionInterruptionType type = [notification.userInfo[AVAudioSessionInterruptionTypeKey] unsignedIntegerValue];
     switch (type)
     {

--- a/AudioKit/Common/Internals/EZAudio/EZMicrophone.m
+++ b/AudioKit/Common/Internals/EZAudio/EZMicrophone.m
@@ -69,8 +69,11 @@ static OSStatus EZAudioMicrophoneCallback(void                       *inRefCon,
 
 - (void)dealloc
 {
+    #if TARGET_OS_IPHONE
     [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionInterruptionNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionRouteChangeNotification object:nil];
+    #elif TARGET_OS_MAC
+    #endif
     [EZAudioUtilities checkResult:AudioUnitUninitialize(self.info->audioUnit)
                         operation:"Failed to unintialize audio unit for microphone"];
     [EZAudioUtilities freeBufferList:self.info->audioBufferList];


### PR DESCRIPTION
**TL;DR*:* As far as I could tell `EZMicrophone` instances were not being deallocated and could cause a memory leak or mess with other active AudioEngine instances. I believe this only affects people using `AKMicrophoneTrackerEngine`, of which I might be the only one. 😅

### What was happening? 
`EZMicrophone` adds two observers via `NSNotificationCenter`. These are later removed in `dealloc` via `[[NSNotificationCenter] removeObserver:self]`. Except that that method does not do what it appears to do. `removeObserver:` should be deprecated and cordoned off with digital yellow caution tape but until it is the cycle of forgetting its danger and being lured by it's convenience will continue to seduce. What does `removeObserver:` actually expect and do? It expects the notification object returned by `addObserver:name:object:` as a parameter, not the actual observer passed in the `addObserver` param aka what you'd expect from symmetric looking methods – super super unintuitive and wonderful because it fails silently too.

Apparently if the deployment target is iOS 9.0+ removing observers in `dealloc` isn't necessary but this is not what I observed (no pun intended).  Happy to learn and be corrected!

@syedhali I know EZMicrophone is deprecated but if you'd like me to open a PR over there please let me know!