### PR TITLE
adding function to AKTuningTable to return masterSet values in Cents

### DIFF
--- a/AudioKit/Common/Internals/Microtonality/AKTuningTable.swift
+++ b/AudioKit/Common/Internals/Microtonality/AKTuningTable.swift
@@ -205,4 +205,10 @@
         }
         //AKLog("etnn dictionary:\(etNNDictionary)")
     }
+    
+    /// Renders and returns the masterSet values as an array of cents
+    @objc public func masterSetInCents() -> [Cents] {
+        let cents = masterSet.map({log2($0) * 1200})
+        return cents
+    }
 }


### PR DESCRIPTION
Added a public API function to AKTuningTable.swift that provides a representation of the tuning table's master set represented in Cents.

Example usage:
` _  = AKPolyphonicNode.tuningTable.presetPersian17NorthIndian07Bhairavi()
        print(AKPolyphonicNode.tuningTable.masterSetInCents())`

returns:
`[0.0, 92.17871646099708, 296.08871819177193, 498.04499913461251, 701.95500086538743, 794.1337173263845, 996.08999826922502]`