### PR TITLE
 Further refinement of sysex handling (retry #1449)

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDI+ReceivingMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+ReceivingMIDI.swift
@@ -76,7 +76,8 @@ extension AKMIDI {
                         // treat it like an array of events that can be transformed
                         let events = [AKMIDIEvent](packet) //uses makeiterator
                         let transformedMIDIEventList = self.transformMIDIEventList(events)
-                        for transformedEvent in transformedMIDIEventList where transformedEvent.length > 0 {
+                        // Note: incomplete sysex packets will not have a status
+                        for transformedEvent in transformedMIDIEventList where transformedEvent.status != nil {
                             self.handleMIDIMessage(transformedEvent)
                         }
                         packetCount += 1

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -236,7 +236,11 @@ public struct AKMIDIEvent {
     ///   - data:  [MIDIByte] bluetooth packet
     ///
     public init(data: [MIDIByte]) {
-        if let command = AKMIDISystemCommand(rawValue: data[0]) {
+        if AudioKit.midi.isReceivingSysex {
+            if let sysexEndIndex = data.index(of: AKMIDISystemCommand.sysexEnd.rawValue) {
+                internalData = Array(data[0...sysexEndIndex])
+            }
+        } else if let command = AKMIDISystemCommand(rawValue: data[0]) {
             internalData = []
             // is sys command
             if command == .sysex {

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -64,8 +64,11 @@ public struct AKMIDIEvent {
 
     /// Status
     public var status: AKMIDIStatus? {
-        let status = internalData[0] >> 4
-        return AKMIDIStatus(rawValue: Int(status))
+        if let statusByte = internalData.first {
+            let status = statusByte >> 4
+            return AKMIDIStatus(rawValue: Int(status))
+        }
+        return nil
     }
 
     /// System Command

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -66,7 +66,12 @@ public struct AKMIDIEvent {
     public var status: AKMIDIStatus? {
         if let statusByte = internalData.first {
             let status = statusByte >> 4
-            return AKMIDIStatus(rawValue: Int(status))
+            if statusByte == AKMIDISystemCommand.sysex.rawValue,
+                !internalData.contains(AKMIDISystemCommand.sysexEnd.rawValue) {
+                return nil //incomplete sysex
+            } else {
+                return AKMIDIStatus(rawValue: Int(status))
+            }
         }
         return nil
     }
@@ -157,7 +162,7 @@ public struct AKMIDIEvent {
                     AudioKit.midi.startReceivingSysex(with: midiBytes)
                     internalData += midiBytes
                     if let sysexEndIndex = midiBytes.index(of: AKMIDISystemCommand.sysexEnd.rawValue) {
-                        setLength(sysexEndIndex)
+                        setLength(sysexEndIndex + 1)
                         AudioKit.midi.stopReceivingSysex()
                     } else {
                         internalData.removeAll()

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -91,8 +91,7 @@ public struct AKMIDIEvent {
     /// MIDI Channel
     public var channel: MIDIChannel? {
         if let statusByte = internalData.first{
-            let status = statusByte >> 4
-            if status < 16, let channel = internalData.first?.lowbit() {
+            if let channel = channelFrom(rawByte: statusByte) {
                 return channel
             }
         }
@@ -103,12 +102,12 @@ public struct AKMIDIEvent {
         return AKMIDIStatus(rawValue: Int(rawByte >> 4))
     }
 
-    func channelFrom(rawByte: MIDIByte) -> MIDIChannel {
+    func channelFrom(rawByte: MIDIByte) -> MIDIChannel? {
         let status = rawByte >> 4
         if status < 16 {
             return MIDIChannel(rawByte.lowbit())
         }
-        return 0
+        return nil
     }
 
     /// MIDI Note Number
@@ -259,7 +258,7 @@ public struct AKMIDIEvent {
         } else if let status = statusFrom(rawByte: data[0]) {
             // is regular MIDI status
             let channel = channelFrom(rawByte: data[0])
-            fillData(status: status, channel: channel, byte1: data[1], byte2: data[2])
+            fillData(status: status, channel: channel ?? 0, byte1: data[1], byte2: data[2])
         }
     }
 

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -78,11 +78,14 @@ public struct AKMIDIEvent {
 
     /// System Command
     public var command: AKMIDISystemCommand? {
-        let status = internalData[0] >> 4
-        if status < 15 {
-            return .none
+        if let statusByte = internalData.first{
+            let status = statusByte >> 4
+            if status < 15 {
+                return .none
+            }
+            return AKMIDISystemCommand(rawValue: statusByte)
         }
-        return AKMIDISystemCommand(rawValue: internalData[0])
+        return nil
     }
 
     /// MIDI Channel

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -153,7 +153,7 @@ public struct AKMIDIEvent {
                 if let midiBytes = AKMIDIEvent.decode(packet: packet) {
                     AudioKit.midi.startReceivingSysex(with: midiBytes)
                     internalData += midiBytes
-                    if let sysexEndIndex = midiBytes.index(of: 247) {
+                    if let sysexEndIndex = midiBytes.index(of: AKMIDISystemCommand.sysexEnd.rawValue) {
                         setLength(sysexEndIndex)
                         AudioKit.midi.stopReceivingSysex()
                     } else {
@@ -419,7 +419,7 @@ public struct AKMIDIEvent {
     static func appendIncomingSysex(packet: MIDIPacket) -> AKMIDIEvent? {
         if let midiBytes = AKMIDIEvent.decode(packet: packet) {
             AudioKit.midi.incomingSysex += midiBytes
-            if midiBytes.contains(247) {
+            if midiBytes.contains(AKMIDISystemCommand.sysexEnd.rawValue) {
                 let sysexEvent = AKMIDIEvent(data: AudioKit.midi.incomingSysex)
                 AudioKit.midi.stopReceivingSysex()
                 return sysexEvent

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -90,9 +90,11 @@ public struct AKMIDIEvent {
 
     /// MIDI Channel
     public var channel: MIDIChannel? {
-        let status = internalData[0] >> 4
-        if status < 16 {
-            return internalData[0].lowbit()
+        if let statusByte = internalData.first{
+            let status = statusByte >> 4
+            if status < 16, let channel = internalData.first?.lowbit() {
+                return channel
+            }
         }
         return nil
     }

--- a/AudioKit/Common/MIDI/Packets/MIDIPacket+SequenceType.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacket+SequenceType.swift
@@ -38,7 +38,9 @@ extension MIDIPacket: Sequence {
                 return byte
             }
             let status = pop()
-            if AKMIDIEvent.isStatusByte(status) {
+            if AudioKit.midi.isReceivingSysex {
+                return AKMIDIEvent.appendIncomingSysex(packet: self) //will be nil until sysex is done
+            } else if AKMIDIEvent.isStatusByte(status) {
                 var data1: MIDIByte = 0
                 var data2: MIDIByte = 0
                 var mstat = AKMIDIEvent.statusFromValue(status)
@@ -81,8 +83,6 @@ extension MIDIPacket: Sequence {
                 default:
                     return AKMIDIEvent(packet: self)
                 }
-            } else if AudioKit.midi.isReceivingSysex {
-                return AKMIDIEvent.appendIncomingSysex(packet: self) //will be nil until sysex is done
             } else {
                 return nil
             }

--- a/Examples/macOS/MIDIUtility/MIDIUtility/ViewController.swift
+++ b/Examples/macOS/MIDIUtility/MIDIUtility/ViewController.swift
@@ -22,12 +22,15 @@ class ViewController: NSViewController, AKMIDIListener {
         midi.addListener(self)
 
         sourcePopUpButton.removeAllItems()
+        sourcePopUpButton.addItem(withTitle: "(select input)")
         sourcePopUpButton.addItems(withTitles: midi.inputNames)
     }
 
     @IBAction func sourceChanged(_ sender: NSPopUpButton) {
-        midi.closeAllInputs()
-        midi.openInput(midi.inputNames[sender.indexOfSelectedItem])
+        if sender.indexOfSelectedItem > 0 {
+            midi.closeAllInputs()
+            midi.openInput(midi.inputNames[sender.indexOfSelectedItem - 1])
+        }
     }
 
     func receivedMIDINoteOn(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel) {


### PR DESCRIPTION
Found a few cases where we weren't properly truncating sysex. Made status lookup / computation more robust and accurate. Updated macOS midi utility to default to a blank midi device so user must select one.

This is a retry of a failed PR