### PR TITLE
DSP Object Leak Fix

### DIFF
--- a/AudioKit/Common/Internals/AKSoundpipeDSPBase.hpp
+++ b/AudioKit/Common/Internals/AKSoundpipeDSPBase.hpp
@@ -46,10 +46,6 @@ public:
     virtual void setParameter(AUParameterAddress address, AUValue value, bool immediate) override {}
     virtual AUValue getParameter(AUParameterAddress address) override { return 0.0f; }
 
-    void destroy() {
-        //printf("AKSoundpipeKernel.destroy(), &sp is %p\n", (void *)sp);
-    }
-
     virtual void processSample(int channel, float* in, float* out) {
         *out = *in;
     }

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -165,6 +165,7 @@
 - (void)deallocateRenderResources {
     _inputBus.deallocateRenderResources();
     _kernel->deinit();
+    delete _kernel;
     [super deallocateRenderResources];
 }
 

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
@@ -34,7 +34,10 @@ protected:
     int64_t _now = 0;  // current time in samples
 
 public:
-
+    
+    /// Virtual destructor allows child classes to be deleted with only AKDSPBase* pointer
+    virtual ~AKDSPBase() {}
+    
     /// The Render function.
     virtual void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) = 0;
 

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
@@ -159,6 +159,8 @@
 
 - (void)deallocateRenderResources {
     _outputBusBuffer.deallocateRenderResources();
+    _kernel->deinit();
+    delete _kernel;
     [super deallocateRenderResources];
 }
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
@@ -46,7 +46,7 @@ public:
     
     void init(int _channels, double _sampleRate) override;
 
-    void destroy();
+    void deinit() override;
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
 };

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
@@ -30,7 +30,6 @@ private:
  
 public:
     AKClipperDSP();
-    ~AKClipperDSP();
 
     float limitLowerBound = 0.0;
     float limitUpperBound = 1.0;

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
@@ -59,10 +59,9 @@ void AKClipperDSP::init(int _channels, double _sampleRate) {
     _private->_clip1->lim = defaultLimit;
 }
 
-void AKClipperDSP::destroy() {
+void AKClipperDSP::deinit() {
     sp_clip_destroy(&_private->_clip0);
     sp_clip_destroy(&_private->_clip1);
-    AKSoundpipeDSPBase::destroy();
 }
 
 void AKClipperDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {


### PR DESCRIPTION
Fixes leaking of DSP objects when nodes are removed and cleans up leaked soundpipe objects. **This required some changes in AKDSPBase (adding a virtual destructor) and AKSoundpipeDSPBase (removing the `destroy()` function) which causes the current commit to not compile without first altering child classes.** AKClipperDSP was modified as an example of what needs to be changed. As a quick summary: if a child class declares a destructor but never defines the destructor, this will now cause a linking error. The destructor declaration should be removed. However, it is no problem if a child class declares _and_ defines a destructor. Additionally, if the DSP class derives from AKSoundpipeDSPBase, the `destroy()` function should be renamed to `deinit() override`, and the function should no longer call `AKSoundpipieDSPBase::destroy()`.