### PR TITLE
avoid 'is ambiguos for type lookup' error under Xcode 10

### DIFF
--- a/AudioKit/iOS/AudioKit/User Interface/MultitouchGestureRecognizer.swift
+++ b/AudioKit/iOS/AudioKit/User Interface/MultitouchGestureRecognizer.swift
@@ -85,7 +85,7 @@ open class MultitouchGestureRecognizer: UIGestureRecognizer {
     public lazy private(set) var touches = [UITouch]()
 
     /// The current gesture recognizer state, as it pertains to the `sustain` setting.
-    public enum State {
+    public enum MultitouchState {
 
         /// All touches are ended, and none are being sustained.
         case ready
@@ -99,7 +99,7 @@ open class MultitouchGestureRecognizer: UIGestureRecognizer {
     }
 
     /// The current multitouch gesture recognizer state.
-    public var multitouchState: State {
+    public var multitouchState: MultitouchState {
         if touches.isEmpty {
             return .ready
         } else if touches.filter({ $0.phase != .ended }).isNotEmpty {


### PR DESCRIPTION
I'm getting the following error when running build_frameworks.sh with Xcode 10 beta 5:

/Users/andrew/code/AudioKit/AudioKit/iOS/AudioKit/User Interface/MultitouchGestureRecognizer.swift:102:33: error: 'State' is ambiguous for type lookup in this context
    public var multitouchState: State {
                                ^~~~~
/Users/andrew/code/AudioKit/AudioKit/iOS/AudioKit/User Interface/MultitouchGestureRecognizer.swift:88:17: note: found this candidate
    public enum State {
                ^
UIKit.UIGestureRecognizer:2:17: note: found this candidate
    public enum State : Int {
                ^
