### PR TITLE
Add setting to prevent audio session deactivation

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -170,6 +170,9 @@
     /// Enable AudioKit AVAudioSession Category Management
     @objc public static var disableAVAudioSessionCategoryManagement: Bool = false
 
+    /// If set to true, AudioKit will not deactivate the AVAudioSession when stopping
+    @objc public static var disableAudioSessionDeactivationOnStop: Bool = false
+    
     /// If set to false, AudioKit will not handle the AVAudioSession route change
     /// notification (AVAudioSessionRouteChange) and will not restart the AVAudioEngine
     /// instance when such notifications are posted. The developer can instead subscribe

--- a/AudioKit/Common/Internals/AudioKit+StartStop.swift
+++ b/AudioKit/Common/Internals/AudioKit+StartStop.swift
@@ -82,7 +82,9 @@ extension AudioKit {
         do {
             NotificationCenter.default.removeObserver(self, name: .AVAudioSessionRouteChange, object: nil)
             NotificationCenter.default.removeObserver(self, name: .AVAudioEngineConfigurationChange, object: nil)
-            try AVAudioSession.sharedInstance().setActive(false)
+            if !AKSettings.disableAudioSessionDeactivationOnStop {
+                try AVAudioSession.sharedInstance().setActive(false)
+            }
         } catch {
             AKLog("couldn't stop session \(error)")
             throw error


### PR DESCRIPTION
Add a new setting to allow to disable AVAudioSession deactivation when stopping AudioKit engine.
This is useful when a project uses both AudioKit and other players like AVAudioPlayer or AVPlayer (ex for streaming audio). Otherwise the app crash when AudioKit deactivate the audio session while another player is playing.

Ready to send us a pull request? Please make sure your request is based on the [develop](https://github.com/audiokit/AudioKit/tree/develop) branch of the repository as `master` only holds stable releases.
