### PR TITLE
Delete _kernel objects in destructor

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -165,7 +165,6 @@
 - (void)deallocateRenderResources {
     _inputBus.deallocateRenderResources();
     _kernel->deinit();
-    delete _kernel;
     [super deallocateRenderResources];
 }
 
@@ -236,7 +235,8 @@
 
 // ----- END UNMODIFIED COPY FROM APPLE CODE -----
 
-
-
+- (void)dealloc {
+    delete _kernel;
+}
 
 @end

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
@@ -160,7 +160,6 @@
 - (void)deallocateRenderResources {
     _outputBusBuffer.deallocateRenderResources();
     _kernel->deinit();
-    delete _kernel;
     [super deallocateRenderResources];
 }
 
@@ -200,8 +199,9 @@
 
 // ----- END UNMODIFIED COPY FROM APPLE CODE -----
 
-
-
+- (void)dealloc {
+    delete _kernel;
+}
 
 @end
 


### PR DESCRIPTION
Moved deleting _kernel DSP objects from `deallocateRenderResources` to destructor.