### PR TITLE
Renamed node 'disconnect' function overrides to instead override 'detach'

### DIFF
--- a/AudioKit/Common/Nodes/Effects/Distortion/Complex Distortion/AKDistortion.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Complex Distortion/AKDistortion.swift
@@ -253,7 +253,7 @@ open class AKDistortion: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
         AudioKit.detach(nodes: [self.avAudioNode])
     }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Decimator/AKDecimator.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Decimator/AKDecimator.swift
@@ -101,7 +101,7 @@ open class AKDecimator: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
         AudioKit.detach(nodes: [self.avAudioNode])
     }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Ring Modulator/AKRingModulator.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Ring Modulator/AKRingModulator.swift
@@ -110,7 +110,7 @@ open class AKRingModulator: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
         AudioKit.detach(nodes: [self.avAudioNode])
     }

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Compressor/AKCompressor.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Compressor/AKCompressor.swift
@@ -160,7 +160,7 @@ open class AKCompressor: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
         AudioKit.detach(nodes: [inputGain.avAudioNode, effectGain.avAudioNode, mixer.avAudioNode])
         AudioKit.engine.detach(self.internalEffect)

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamics Processor/AKDynamicsProcessor.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamics Processor/AKDynamicsProcessor.swift
@@ -201,7 +201,7 @@ open class AKDynamicsProcessor: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
 
         AudioKit.detach(nodes: [inputMixer.avAudioNode,

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Expander/AKExpander.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Expander/AKExpander.swift
@@ -169,7 +169,7 @@ open class AKExpander: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
 
         AudioKit.detach(nodes: [inputGain.avAudioNode, effectGain.avAudioNode, mixer.avAudioNode])

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Peak Limiter/AKPeakLimiter.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Peak Limiter/AKPeakLimiter.swift
@@ -129,7 +129,7 @@ open class AKPeakLimiter: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
 
         AudioKit.detach(nodes: [inputMixer.avAudioNode,

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Filter/AKHighPassFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Filter/AKHighPassFilter.swift
@@ -118,7 +118,7 @@ open class AKHighPassFilter: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
 
         AudioKit.detach(nodes: [inputMixer.avAudioNode,

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Filter/AKHighShelfFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Filter/AKHighShelfFilter.swift
@@ -117,7 +117,7 @@ open class AKHighShelfFilter: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
 
         AudioKit.detach(nodes: [inputMixer.avAudioNode,

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Filter/AKLowPassFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Filter/AKLowPassFilter.swift
@@ -118,7 +118,7 @@ open class AKLowPassFilter: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
 
         AudioKit.detach(nodes: [inputMixer.avAudioNode,

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Filter/AKLowShelfFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Filter/AKLowShelfFilter.swift
@@ -119,7 +119,7 @@ open class AKLowShelfFilter: AKNode, AKToggleable, AUEffect, AKInput {
     }
 
     /// Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         stop()
 
         AudioKit.detach(nodes: [inputMixer.avAudioNode,

--- a/AudioKit/Common/Nodes/Mixing/Dry Wet Mixer/AKDryWetMixer.swift
+++ b/AudioKit/Common/Nodes/Mixing/Dry Wet Mixer/AKDryWetMixer.swift
@@ -60,7 +60,7 @@ open class AKDryWetMixer: AKNode, AKInput {
     }
 
     // Disconnect the node
-    override open func disconnect() {
+    override open func detach() {
         AudioKit.detach(nodes: [mixer.avAudioNode, dryGain.avAudioNode, wetGain.avAudioNode])
     }
 

--- a/AudioKit/Common/Nodes/Playback/Players/AKAudioPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/AKAudioPlayer.swift
@@ -694,7 +694,7 @@ open class AKAudioPlayer: AKNode, AKToggleable {
     }
 
     // Disconnect the node
-    open override func disconnect() {
+    open override func detach() {
         AudioKit.detach(nodes: [self.avAudioNode])
         AudioKit.engine.detach(internalPlayer)
     }


### PR DESCRIPTION
This updates nodes which had not been changed to reflect the depreciation of disconnect(). This will allow easier node cleanup for all nodes with a single node.detach() call as designed.