### PR TITLE
Maintain sample rate on simulators

### DIFF
--- a/AudioKit/Common/Nodes/Input/AKMicrophone.swift
+++ b/AudioKit/Common/Nodes/Input/AKMicrophone.swift
@@ -86,7 +86,7 @@ open class AKMicrophone: AKNode, AKToggleable {
 
     // Here is where we actually check the device type and make the settings, if needed
     private func setFormatForDevice() -> AVAudioFormat? {
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(simulator)
         var desiredFS = AudioKit.engine.inputNode.inputFormat(forBus: 0).sampleRate
         let typeString = getIphoneType()
         let stringArray = typeString.components(separatedBy: CharacterSet.decimalDigits.inverted)


### PR DESCRIPTION
With the changes made on #1488 simulators get their sample rate updated to 48khz causing this crash: **Terminating app due to uncaught exception 'com.apple.coreaudio.avfaudio', reason: 'required condition is false: format.sampleRate == hwFormat.sampleRate'** mentioned on #1510. Simulators should keep the standard system sample rate as they didn't have the microphone clicking noise issue (#1311). 

This is not a final solution as simulators might get their hardware equivalent sample rate in the future but it will avoid the crash for now. 

I'd love to look for a better solution but I'm not yet familiar with all of AudioKit structure (project, examples, tests, etc) so perhaps I can give it a go with @eljeff if he's ok with it. 