### PR TITLE
Add a hard shutdown option to AudioKit (e.g. for Media Service Resets)

### DIFF
--- a/AudioKit/Common/Internals/AudioKit+StartStop.swift
+++ b/AudioKit/Common/Internals/AudioKit+StartStop.swift
@@ -96,6 +96,13 @@ extension AudioKit {
         }
         #endif
     }
+    
+    @objc public static func shutdown() throws {
+        engine = AVAudioEngine()
+        finalMixer = AKMixer()
+        output = nil
+        shouldBeRunning = false
+    }
 
     // MARK: - Configuration Change Response
 

--- a/AudioKit/Common/Internals/AudioKit.swift
+++ b/AudioKit/Common/Internals/AudioKit.swift
@@ -23,7 +23,7 @@ public typealias AKCallback = () -> Void
     // MARK: - Internal audio engine mechanics
 
     /// Reference to the AV Audio Engine
-    @objc public static let engine = AVAudioEngine()
+    @objc public static internal(set) var engine = AVAudioEngine()
 
     /// Reference to singleton MIDI
 

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -234,8 +234,14 @@ extension AKPlayer {
                 self.pauseTime = nil
                 return
             }
-            if self.currentFrame >= self.frameCount {
-                self.handleComplete()
+            do {
+                try AKTry {
+                    if self.currentFrame >= self.frameCount {
+                        self.handleComplete()
+                    }
+                }
+            } catch let error {
+                AKLog("Failed to check currentFrame and call completion handler: \(error)... Possible Media Service Reset?")
             }
         }
     }


### PR DESCRIPTION
This PR fixes #1474 (Crash / Failure When Handling MediaServicesReset on iOS).

It does so by adding a `shutdown` function to `AudioKit+StartStop.swift` which completely resets the core `AVAudioEngine` and `AKMixer`, setting `output` to nil, and marking `shouldBeRunning` as false.

This allows a user to then redo all of their internal / app-specific `AudioKit` setup after calling `shutdown()`, calling `start()` again when ready, and have a working `AudioKit` instance even if they have experienced a Media Services Reset (see http://devstreaming.apple.com/videos/wwdc/2016/507n0zrhzxdzmg20zcl/507/507_delivering_an_exceptional_audio_experience.pdf?dl=1 for more discussion / description on these events and how they should be handled).

It also adds an `AKTry` around `AKPlayer`'s `handleCallbackComplete` as we found a related potential crash / exception while testing this fix / workflow in our app (which uses `AKPlayer` heavily).

Let me know if this is not something you wish to have in core; completely understandable if that is the case but thought I'd offer it up both in case you wish to integrate it and as a way of wrapping up / closing out #1474 .