### PR TITLE
Resume AKDynamicPlayer if it was playing before TimePitch was removed

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
@@ -113,11 +113,15 @@ public class AKDynamicPlayer: AKPlayer {
 
     private func removeTimePitch() {
         guard let timePitchNode = timePitchNode else { return }
+        let wasPlaying = isPlaying
         stop()
         timePitchNode.disconnectOutput()
         AudioKit.detach(nodes: [timePitchNode.avAudioNode])
         self.timePitchNode = nil
         initialize()
+        if wasPlaying {
+            play()
+        }
     }
 
     public override func play(from startingTime: Double, to endingTime: Double, at audioTime: AVAudioTime?, hostTime: UInt64?) {


### PR DESCRIPTION
This pr simply resumes AKDynamicPlayer if it was playing when setting pitch or rate back to default value. Currently playing will stop in these situations as play() isn't called after stop() in removeTimePitch().