### PR TITLE
More helpful error msg when MIDISourceCreate fails

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI.swift
@@ -114,6 +114,7 @@ open class AKMIDI {
             MIDIObjectSetIntegerProperty(virtualInput, kMIDIPropertyUniqueID, uniqueID)
         } else {
             AKLog("Error Creating Virtual Input Port: \(virtualPortname) -- \(virtualInput)")
+            CheckError(result)
         }
     }
 
@@ -127,6 +128,7 @@ open class AKMIDI {
             MIDIObjectSetIntegerProperty(virtualInput, kMIDIPropertyUniqueID, uniqueID + 1)
         } else {
             AKLog("Error Creating Virtual Output Port: \(virtualPortname) -- \(virtualOutput)")
+            CheckError(result)
         }
     }
 


### PR DESCRIPTION
re: https://stackoverflow.com/questions/52725999/sending-midi-notes-through-a-virtual-port-within-ios-using-audiokit/52837943#52837943

MIDISourceCreate fails when audio in background mode is not enabled, but this wasn't made clear in the error msg