### PR TITLE
Ensure VST2 Sampler demo still builds

### DIFF
--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
@@ -7,17 +7,21 @@
 //
 
 #ifdef __cplusplus
+#ifdef _WIN32
+#include "AKSampler_Typedefs.h"
+#include <memory>
+#else
 #import "AKSampler_Typedefs.h"
-
 #import <memory>
+#endif
 
 // process samples in "chunks" this size
 #define AKCORESAMPLER_CHUNKSIZE 16
 
 
 namespace AudioKitCore {
-    class SamplerVoice;
-    class KeyMappedSampleBuffer;
+    struct SamplerVoice;
+    struct KeyMappedSampleBuffer;
 }
 
 class AKCoreSampler

--- a/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/source/AKSamplerDSP.cpp
+++ b/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/source/AKSamplerDSP.cpp
@@ -62,18 +62,18 @@ AKSamplerDSP::AKSamplerDSP (audioMasterCallback audioMaster, VstInt32 numProgram
     buildSimpleKeyMap();
     loopThruRelease = true;
 
-    adsrEnvelopeParameters.setAttackTimeSeconds(0.01f);
-    adsrEnvelopeParameters.setDecayTimeSeconds(0.1f);
-    adsrEnvelopeParameters.sustainFraction = 0.8f;
-    adsrEnvelopeParameters.setReleaseTimeSeconds(0.5f);
+    setADSRAttackDurationSeconds(0.01f);
+    setADSRDecayDurationSeconds(0.1f);
+    setADSRSustainFraction(0.8f);
+    setADSRReleaseDurationSeconds(0.5f);
 
     isFilterEnabled = false;
     cutoffMultiple = 1000.0f;
     linearResonance = 1.0f;
-    filterEnvelopeParameters.setAttackTimeSeconds(2.0f);
-    filterEnvelopeParameters.setDecayTimeSeconds(2.0f);
-    filterEnvelopeParameters.sustainFraction = 0.1f;
-    filterEnvelopeParameters.setReleaseTimeSeconds(10.0f);
+    setFilterAttackDurationSeconds(2.0f);
+    setFilterDecayDurationSeconds(2.0f);
+    setFilterSustainFraction(0.1f);
+    setFilterReleaseDurationSeconds(10.0f);
 
     // Set up preset folder path
     char baseDir[100];
@@ -164,7 +164,7 @@ void AKSamplerDSP::loadAifDemoSamples()
     char baseDir[100];
     GetDesktopFolderPath(baseDir);
     char pathBuffer[200];
-    const char* samplePrefix = "Sounds\\ROMPlayer Sampler Instruments\\samples\\TX LoTine81z_ms";
+    const char* samplePrefix = "Sounds\\ROMPlayer AKCoreSampler Instruments\\samples\\TX LoTine81z_ms";
 
     AKSampleFileDescriptor sfd;
     sfd.path = pathBuffer;
@@ -404,6 +404,7 @@ bool AKSamplerDSP::loadPreset()
     if (!pfile) return false;
 
     int lokey, hikey, pitch, lovel, hivel;
+    float lorand, hirand;
     bool bLoop;
     float fLoopStart, fLoopEnd;
     char sampleFileName[100];
@@ -453,10 +454,28 @@ bool AKSamplerDSP::loadPreset()
             p += 8;
             lovel = 0;
             hivel = 127;
+            lorand = 0.0f;
+            hirand = 1.0f;
             sampleFileName[0] = 0;
             bLoop = false;
             fLoopStart = 0.0f;
             fLoopEnd = 0.0f;
+
+            pp = strstr(p, "lorand");
+            if (pp)
+            {
+                pp = strchr(pp, '=');
+                if (pp) pp++;
+                if (pp) lorand = atof(pp);
+            }
+
+            pp = strstr(p, "hirand");
+            if (pp)
+            {
+                pp = strchr(pp, '=');
+                if (pp) pp++;
+                if (pp) hirand = atof(pp);
+            }
 
             pp = strstr(p, "lovel");
             if (pp)
@@ -508,6 +527,12 @@ bool AKSamplerDSP::loadPreset()
                 strcpy(sampleFileName, pp);
             }
 
+            // If there's anything after '.wav' or '.wv', truncate it
+            pp = strstr(sampleFileName, ".wav ");
+            if (pp) pp[4] = 0;
+            pp = strstr(sampleFileName, ".wv ");
+            if (pp) pp[3] = 0;
+
             sprintf(buf, "%s\\%s", presetFolderPath, sampleFileName);
 
             AKSampleFileDescriptor sfd;
@@ -523,7 +548,8 @@ bool AKSamplerDSP::loadPreset()
             sfd.sampleDescriptor.maximumNoteNumber = hikey;
             sfd.sampleDescriptor.minimumVelocity = lovel;
             sfd.sampleDescriptor.maximumVelocity = hivel;
-            loadSoundFile(sfd);
+
+            if (lorand == 0.0f) loadSoundFile(sfd);
         }
     }
     fclose(pfile);
@@ -689,28 +715,28 @@ void AKSamplerDSP::getParameterDisplay (VstInt32 index, char* text)
                 vst_strncpy(text, "OFF", kVstMaxParamStrLen);
             break;
         case kAmpAttackTime:
-            float2string(adsrEnvelopeParameters.getAttackTimeSeconds(), text, kVstMaxParamStrLen);
+            float2string(getADSRAttackDurationSeconds(), text, kVstMaxParamStrLen);
             break;
         case kAmpDecayTime:
-            float2string(adsrEnvelopeParameters.getDecayTimeSeconds(), text, kVstMaxParamStrLen);
+            float2string(getADSRDecayDurationSeconds(), text, kVstMaxParamStrLen);
             break;
         case kAmpSustainLevel:
-            float2string(adsrEnvelopeParameters.sustainFraction, text, kVstMaxParamStrLen);
+            float2string(getADSRSustainFraction(), text, kVstMaxParamStrLen);
             break;
         case kAmpReleaseTime:
-            float2string(adsrEnvelopeParameters.getReleaseTimeSeconds(), text, kVstMaxParamStrLen);
+            float2string(getADSRReleaseDurationSeconds(), text, kVstMaxParamStrLen);
             break;
         case kFilterAttackTime:
-            float2string(filterEnvelopeParameters.getAttackTimeSeconds(), text, kVstMaxParamStrLen);
+            float2string(getFilterAttackDurationSeconds(), text, kVstMaxParamStrLen);
             break;
         case kFilterDecayTime:
-            float2string(filterEnvelopeParameters.getDecayTimeSeconds(), text, kVstMaxParamStrLen);
+            float2string(getFilterDecayDurationSeconds(), text, kVstMaxParamStrLen);
             break;
         case kFilterSustainLevel:
-            float2string(filterEnvelopeParameters.sustainFraction, text, kVstMaxParamStrLen);
+            float2string(getFilterSustainFraction(), text, kVstMaxParamStrLen);
             break;
         case kFilterReleaseTime:
-            float2string(filterEnvelopeParameters.getReleaseTimeSeconds(), text, kVstMaxParamStrLen);
+            float2string(getFilterReleaseDurationSeconds(), text, kVstMaxParamStrLen);
             break;
         case kLoopThruRelease:
             if (loopThruRelease)
@@ -763,28 +789,28 @@ void AKSamplerDSP::getParamString(VstInt32 index, char* text)
         sprintf(text, "%s", isFilterEnabled ? "enabled" : "disabled");
         break;
     case kAmpAttackTime:
-        sprintf(text, "%.2f sec", adsrEnvelopeParameters.getAttackTimeSeconds());
+        sprintf(text, "%.2f sec", getADSRAttackDurationSeconds());
         break;
     case kAmpDecayTime:
-        sprintf(text, "%.2f sec", adsrEnvelopeParameters.getDecayTimeSeconds());
+        sprintf(text, "%.2f sec", getADSRDecayDurationSeconds());
         break;
     case kAmpSustainLevel:
-        sprintf(text, "%.1f %%", 100.0f * adsrEnvelopeParameters.sustainFraction);
+        sprintf(text, "%.1f %%", 100.0f * getADSRSustainFraction());
         break;
     case kAmpReleaseTime:
-        sprintf(text, "%.2f sec", adsrEnvelopeParameters.getReleaseTimeSeconds());
+        sprintf(text, "%.2f sec", getADSRReleaseDurationSeconds());
         break;
     case kFilterAttackTime:
-        sprintf(text, "%.2f sec", filterEnvelopeParameters.getAttackTimeSeconds());
+        sprintf(text, "%.2f sec", getFilterAttackDurationSeconds());
         break;
     case kFilterDecayTime:
-        sprintf(text, "%.2f sec", filterEnvelopeParameters.getDecayTimeSeconds());
+        sprintf(text, "%.2f sec", getFilterDecayDurationSeconds());
         break;
     case kFilterSustainLevel:
-        sprintf(text, "%.1f %%", 100.0f * filterEnvelopeParameters.sustainFraction);
+        sprintf(text, "%.1f %%", 100.0f * getFilterSustainFraction());
         break;
     case kFilterReleaseTime:
-        sprintf(text, "%.2f sec", filterEnvelopeParameters.getReleaseTimeSeconds());
+        sprintf(text, "%.2f sec", getFilterReleaseDurationSeconds());
         break;
     case kLoopThruRelease:
         sprintf(text, "%s", loopThruRelease ? "yes" : "no");
@@ -828,28 +854,28 @@ void AKSamplerDSP::setParamFraction(VstInt32 index, float value)
         isFilterEnabled = value > 0.5f;
         break;
     case kAmpAttackTime:
-        adsrEnvelopeParameters.setAttackTimeSeconds(value * 10.0f);
+        setADSRAttackDurationSeconds(value * 10.0f);
         break;
     case kAmpDecayTime:
-        adsrEnvelopeParameters.setDecayTimeSeconds(value * 10.0f);
+        setADSRDecayDurationSeconds(value * 10.0f);
         break;
     case kAmpSustainLevel:
-        adsrEnvelopeParameters.sustainFraction = value;
+        setADSRSustainFraction(value);
         break;
     case kAmpReleaseTime:
-        adsrEnvelopeParameters.setReleaseTimeSeconds(value * 10.0f);
+        setADSRReleaseDurationSeconds(value * 10.0f);
         break;
     case kFilterAttackTime:
-        filterEnvelopeParameters.setAttackTimeSeconds(value * 10.0f);
+        setFilterAttackDurationSeconds(value * 10.0f);
         break;
     case kFilterDecayTime:
-        filterEnvelopeParameters.setDecayTimeSeconds(value * 10.0f);
+        setFilterDecayDurationSeconds(value * 10.0f);
         break;
     case kFilterSustainLevel:
-        filterEnvelopeParameters.sustainFraction = value;
+        setFilterSustainFraction(value);
         break;
     case kFilterReleaseTime:
-        filterEnvelopeParameters.setReleaseTimeSeconds(value * 10.0f);
+        setFilterReleaseDurationSeconds(value * 10.0f);
         break;
     case kLoopThruRelease:
         loopThruRelease = value > 0.5f;
@@ -899,28 +925,28 @@ float AKSamplerDSP::getParameter (VstInt32 index)
             value = isFilterEnabled ? 1.0f : 0.0f;
             break;
         case kAmpAttackTime:
-            value = adsrEnvelopeParameters.getAttackTimeSeconds() / 10.0f;
+            value = getADSRAttackDurationSeconds() / 10.0f;
             break;
         case kAmpDecayTime:
-            value = adsrEnvelopeParameters.getDecayTimeSeconds() / 10.0f;
+            value = getADSRDecayDurationSeconds() / 10.0f;
             break;
         case kAmpSustainLevel:
-            value = adsrEnvelopeParameters.sustainFraction;
+            value = getADSRSustainFraction();
             break;
         case kAmpReleaseTime:
-            value = adsrEnvelopeParameters.getReleaseTimeSeconds() / 10.0f;
+            value = getADSRReleaseDurationSeconds() / 10.0f;
             break;
         case kFilterAttackTime:
-            value = filterEnvelopeParameters.getAttackTimeSeconds() / 10.0f;
+            value = getFilterAttackDurationSeconds() / 10.0f;
             break;
         case kFilterDecayTime:
-            value = filterEnvelopeParameters.getDecayTimeSeconds() / 10.0f;
+            value = getFilterDecayDurationSeconds() / 10.0f;
             break;
         case kFilterSustainLevel:
-            value = filterEnvelopeParameters.sustainFraction;
+            value = getFilterSustainFraction();
             break;
         case kFilterReleaseTime:
-            value = filterEnvelopeParameters.getReleaseTimeSeconds() / 10.0f;
+            value = getFilterReleaseDurationSeconds() / 10.0f;
             break;
         case kLoopThruRelease:
             value = loopThruRelease ? 1.0f : 0.0f;
@@ -957,21 +983,21 @@ float AKSamplerDSP::getParamValue(VstInt32 index)
     case kFilterEnable:
         return isFilterEnabled ? 1.0f : 0.0f;
     case kAmpAttackTime:
-        return adsrEnvelopeParameters.getAttackTimeSeconds();
+        return getADSRAttackDurationSeconds();
     case kAmpDecayTime:
-        return adsrEnvelopeParameters.getDecayTimeSeconds();
+        return getADSRDecayDurationSeconds();
     case kAmpSustainLevel:
-        return adsrEnvelopeParameters.sustainFraction;
+        return getADSRSustainFraction();
     case kAmpReleaseTime:
-        return adsrEnvelopeParameters.getReleaseTimeSeconds();
+        return getADSRReleaseDurationSeconds();
     case kFilterAttackTime:
-        return filterEnvelopeParameters.getAttackTimeSeconds();
+        return getFilterAttackDurationSeconds();
     case kFilterDecayTime:
-        return filterEnvelopeParameters.getDecayTimeSeconds();
+        return getFilterDecayDurationSeconds();
     case kFilterSustainLevel:
-        return filterEnvelopeParameters.sustainFraction;
+        return getFilterSustainFraction();
     case kFilterReleaseTime:
-        return filterEnvelopeParameters.getReleaseTimeSeconds();
+        return getFilterReleaseDurationSeconds();
     case kLoopThruRelease:
         return loopThruRelease ? 1.0f : 0.0f;
     case kMonophonic:
@@ -1001,6 +1027,8 @@ enum {
     // lots more to add here...
     kMidiCCAllSoundOff      = 120   // this or anything higher means all notes off
 };
+
+#define MIDI_NOTENUMBERS 128
 
 VstInt32 AKSamplerDSP::processEvents (VstEvents* ev)
 {
@@ -1065,6 +1093,8 @@ VstInt32 AKSamplerDSP::processEvents (VstEvents* ev)
 	return 1;
 }
 
+#define CHUNKSIZE 32
+
 void AKSamplerDSP::processReplacing (float** inputs, float** outputs, VstInt32 nFrames)
 {
     float *outBuffers[2];
@@ -1082,7 +1112,7 @@ void AKSamplerDSP::processReplacing (float** inputs, float** outputs, VstInt32 n
 
         // Any ramping parameters would be updated here...
 
-        AudioKitCore::Sampler::render(2, chunkSize, outBuffers);
+        AKCoreSampler::render(2, chunkSize, outBuffers);
 
         outBuffers[0] += CHUNKSIZE;
         outBuffers[1] += CHUNKSIZE;

--- a/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/source/AKSamplerDSP.h
+++ b/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/source/AKSamplerDSP.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "public.sdk/source/vst2.x/audioeffectx.h"
-#include "Sampler.hpp"
+#include "AKCoreSampler.hpp"
 
 struct VSTFloatParam
 {
@@ -24,7 +24,7 @@ struct VSTBoolParam
     void setFraction(float f) { value = f < 0.5f; }
 };
 
-class AKSamplerDSP : public AudioEffectX, public AudioKitCore::Sampler
+class AKSamplerDSP : public AudioEffectX, public AKCoreSampler
 {
 public:
 	AKSamplerDSP (audioMasterCallback audioMaster, VstInt32 numPrograms);

--- a/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/win/AKSamplerVST.vcxproj
+++ b/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/win/AKSamplerVST.vcxproj
@@ -177,10 +177,10 @@
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Common\LinearRamper.hpp" />
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Common\ResonantLowPassFilter.hpp" />
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Common\SustainPedalLogic.hpp" />
+    <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\AKCoreSampler.hpp" />
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\AKSampler_Typedefs.h" />
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SampleBuffer.hpp" />
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SampleOscillator.hpp" />
-    <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\Sampler.hpp" />
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SamplerVoice.hpp" />
     <ClInclude Include="..\..\VST2_SDK\pluginterfaces\vst2.x\aeffect.h" />
     <ClInclude Include="..\..\VST2_SDK\pluginterfaces\vst2.x\aeffectx.h" />
@@ -198,8 +198,8 @@
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Common\FunctionTable.cpp" />
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Common\ResonantLowPassFilter.cpp" />
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Common\SustainPedalLogic.cpp" />
+    <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\AKCoreSampler.cpp" />
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SampleBuffer.cpp" />
-    <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\Sampler.cpp" />
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SamplerVoice.cpp" />
     <ClCompile Include="..\..\VST2_SDK\public.sdk\source\vst2.x\audioeffect.cpp" />
     <ClCompile Include="..\..\VST2_SDK\public.sdk\source\vst2.x\audioeffectx.cpp" />

--- a/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/win/AKSamplerVST.vcxproj.filters
+++ b/Developer/AKSampler/Windows VST2 Plugin/AKSamplerVST/win/AKSamplerVST.vcxproj.filters
@@ -58,9 +58,6 @@
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SampleOscillator.hpp">
       <Filter>Core Sampler\Sampler</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\Sampler.hpp">
-      <Filter>Core Sampler\Sampler</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SamplerVoice.hpp">
       <Filter>Core Sampler\Sampler</Filter>
     </ClInclude>
@@ -94,6 +91,9 @@
     <ClInclude Include="..\..\VST2_SDK\public.sdk\source\vst2.x\audioeffectx.h">
       <Filter>VST2_SDK\public.sdk</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\AKCoreSampler.hpp">
+      <Filter>Core Sampler\Sampler</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Common\ADSREnvelope.cpp">
@@ -109,9 +109,6 @@
       <Filter>Core Sampler\Common</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SampleBuffer.cpp">
-      <Filter>Core Sampler\Sampler</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\Sampler.cpp">
       <Filter>Core Sampler\Sampler</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\SamplerVoice.cpp">
@@ -131,6 +128,9 @@
     </ClCompile>
     <ClCompile Include="..\..\VST2_SDK\public.sdk\source\vst2.x\vstplugmain.cpp">
       <Filter>VST2_SDK\public.sdk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\AudioKit\Core\AudioKitCore\Sampler\AKCoreSampler.cpp">
+      <Filter>Core Sampler\Sampler</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Earlier updates to what is now called AKCoreSampler broke the Windows VST2 plug-in project under /Developer. Most of the changes required to fix it are in that project itself, but there was one change needed to AKCoreSampler.hpp: the Visual Studio 2017 C++ compiler can't handle #import in C++ headers, so for WIN32 builds only I change these to #include.

I'm planning to accept this PR myself.