### PR TITLE
Fix EXC_BAD_ACCESS in AKConvolution processing

### DIFF
--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolution.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolution.swift
@@ -67,12 +67,12 @@ open class AKConvolution: AKNode, AKToggleable, AKComponent, AKInput {
     @objc open func start() {
         internalAU?.start()
     }
-    
+
     /// Function to stop or bypass the node, both are equivalent
     @objc open func stop() {
         internalAU?.stop()
     }
-    
+
     private func readAudioFile() {
         Exit: do {
             var err: OSStatus = noErr

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolution.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolution.swift
@@ -55,6 +55,9 @@ open class AKConvolution: AKNode, AKToggleable, AKComponent, AKInput {
             strongSelf.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
             input?.connect(to: strongSelf)
             strongSelf.internalAU?.setPartitionLength(Int32(partitionLength))
+            strongSelf.readAudioFile()
+            strongSelf.internalAU?.initConvolutionEngine()
+            strongSelf.internalAU?.start()
         }
     }
 
@@ -62,6 +65,15 @@ open class AKConvolution: AKNode, AKToggleable, AKComponent, AKInput {
 
     /// Function to start, play, or activate the node, all do the same thing
     @objc open func start() {
+        internalAU?.start()
+    }
+    
+    /// Function to stop or bypass the node, both are equivalent
+    @objc open func stop() {
+        internalAU?.stop()
+    }
+    
+    private func readAudioFile() {
         Exit: do {
             var err: OSStatus = noErr
             var theFileLengthInFrames: Int64 = 0
@@ -139,7 +151,6 @@ open class AKConvolution: AKNode, AKToggleable, AKComponent, AKInput {
                     // success
                     let data = UnsafeMutablePointer<Float>(bufferList.mBuffers.mData?.assumingMemoryBound(to: Float.self))
                     internalAU?.setupAudioFileTable(data, size: ioNumberFrames)
-                    internalAU?.start()
                 } else {
                     // failure
                     theData?.deallocate()
@@ -148,11 +159,6 @@ open class AKConvolution: AKNode, AKToggleable, AKComponent, AKInput {
                 }
             }
         }
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.h
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.h
@@ -12,5 +12,6 @@
 @interface AKConvolutionAudioUnit : AKAudioUnit
 - (void)setupAudioFileTable:(float *)data size:(UInt32)size;
 - (void)setPartitionLength:(int)partitionLength;
+- (void)initConvolutionEngine;
 @end
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.mm
@@ -27,6 +27,11 @@
 - (void)setPartitionLength:(int)partitionLength {
     _kernel.setPartitionLength(partitionLength);
 }
+
+- (void)initConvolutionEngine {
+    _kernel.initConvolutionEngine();
+}
+
 standardKernelPassthroughs()
 
 - (void)createParameters {

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSPKernel.hpp
@@ -18,9 +18,6 @@ public:
 
     void init(int _channels, double _sampleRate) override {
         AKSoundpipeKernel::init(_channels, _sampleRate);
-        sp_conv_create(&conv0);
-        sp_conv_create(&conv1);
-
     }
 
     void setPartitionLength(int partLength) {
@@ -29,8 +26,6 @@ public:
 
     void start() {
         started = true;
-        sp_conv_init(sp, conv0, ftbl, (float)partitionLength);
-        sp_conv_init(sp, conv1, ftbl, (float)partitionLength);
     }
 
     void stop() {
@@ -41,6 +36,13 @@ public:
         ftbl_size = size;
         sp_ftbl_create(sp, &ftbl, ftbl_size);
         ftbl->tbl = table;
+    }
+    
+    void initConvolutionEngine() {
+        sp_conv_create(&conv0);
+        sp_conv_create(&conv1);
+        sp_conv_init(sp, conv0, ftbl, (float)partitionLength);
+        sp_conv_init(sp, conv1, ftbl, (float)partitionLength);
     }
 
     void destroy() {
@@ -105,7 +107,7 @@ private:
     UInt32 ftbl_size = 4096;
 
 public:
-    bool started = true;
+    bool started = false;
     bool resetted = true;
 };
 


### PR DESCRIPTION
Before this fix, if start() is called on an instance of AKConvolution
before inserting it into the audio processing chain, there will be an
EXC_BAD_ACCESS in sp_conv_compute. If start() is called immediately
after inserting it into the chain, a race condition will cause the same
failure to occur inconsistently.

The fix does not change functionality or interface of any AudioKit Swift
classes. It does add one new member function and changes the
functionality of the internal AU classes AKConvolutionAudioUnit and
AKConvolutionDSPKernel.

The bug is caused by resources (conv0, conv1) being allocated in the
init() function of the AKConvolutionDSPKernel, and initialized in the
start() function. As init() gets called again when the AKNode is
inserted into the sound chain, new resources are allocated for the same
variables, and then used uninitialized during sound processing. This
could be solved by moving both allocation and initialization into the
start() function, but this may cause further race conditions, and if
start() is called again during processing, new EXC_BAD_ACCESS faults
will probably occur.

This fix instead ensures both allocation and initialization is performed
during construction of the AKConvolution class, so the object is
ready-to-use after construction. However, this must be done in a
callback method which is not guaranteed to be finished when the
constructor returns. For this reason, the fix makes
AKConvolutionDSPKernel turned off by default after construction, and
then it's turned on at the end of the callback, when all resources are
allocated and initialized.