### PR TITLE
Adjust access level for AKTiming methods to synchronizing multiple nodes

### DIFF
--- a/AudioKit/Common/Internals/Synchronization/AKTiming.swift
+++ b/AudioKit/Common/Internals/Synchronization/AKTiming.swift
@@ -55,7 +55,7 @@ extension AKTiming {
      - Parameter position: The position of the nodes when started.
      - Returns: The audioTime (in the future) that the nodes will be started at.
      */
-    static func syncStart(_ nodes: [AKTiming], at position: Double = 0) -> AVAudioTime {
+    public static func syncStart(_ nodes: [AKTiming], at position: Double = 0) -> AVAudioTime {
         for node in nodes {
             node.stop()
             node.setPosition(position)
@@ -77,7 +77,7 @@ extension AKTiming {
      - Parameter other: An already started AKTiming that position will be synchronized with.
      - Parameter audioTime: Future time in the audio render context that playback should begin.
      */
-    func synchronizeWith(other: AKTiming, at audioTime: AVAudioTime? = nil) {
+    public func synchronizeWith(other: AKTiming, at audioTime: AVAudioTime? = nil) {
         stop()
         guard other.isStarted else {
             return


### PR DESCRIPTION
In researching how to synchronize two AKTiming nodes I discovered that both the syncStart() and synchronizeWith() methods did not have access modifiers which allowed them to be called outside of AudioKit. 

I confirmed with @dave234 on Slack that these should be accessible and this PR is simply to make that adjustment.