### PR TITLE
Choose bundle based on the location of AKAudioFile so we can load fil…

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
@@ -196,7 +196,7 @@ extension AVAudioCommonFormat: CustomStringConvertible {
             case (.documents, _):
               return NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] + "/" + path
             case (.resources, false):
-              return try Bundle.main.path(forResource: path, ofType: "") ??
+                return try Bundle(for: AKAudioFile.self).path(forResource: path, ofType: "") ??
                          NSError.fileCreateError
             case (.custom, _):
               AKLog("ERROR AKAudioFile: custom creation directory not implemented yet")


### PR DESCRIPTION
…es inside XCTest, which consumes resources in a different bundle that the main bundle

Couldn't load files from XCTest because it was using the Main Bundle by default, and the resources were located in a different bundle. Basically used this solution: https://stackoverflow.com/questions/19151420/load-files-in-xcode-unit-tests/31651573