### PR TITLE
Added NSMicrophoneUsageDescription to Info.plist

### DIFF
--- a/Playgrounds/AudioKitPlaygrounds/Info.plist
+++ b/Playgrounds/AudioKitPlaygrounds/Info.plist
@@ -22,5 +22,7 @@
 	<string>Copyright © 2018 AudioKit. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone permission is used to capture Input Device Audio streams.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Otherwise, macOS Mojave doesn't allow to capture any Input Device Audio.
