### PR TITLE
Fix bug in loading SFZ file with AKSampler

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
@@ -73,7 +73,7 @@ extension AKSampler {
                         } else if part.hasPrefix("loop_end") {
                             loopEndPoint = Float32(part.components(separatedBy: "=")[1])!
                         } else if part.hasPrefix("sample") {
-                            sample = trimmed.components(separatedBy: "sample=")[1]
+                            sample = part.components(separatedBy: "sample=")[1]
                         }
                     }
 


### PR DESCRIPTION
Fixes #1573

This PR removes the assumption that the sample attribute associated with the `region` tag has to be at the end of the list of attributes. This should hopefully make the `loadSFZ` function compatible with a few more SFZ files.
