### PR TITLE
Fix AVAudioFormat init bug

### DIFF
--- a/AudioKit/Common/Nodes/Input/AKMicrophone.swift
+++ b/AudioKit/Common/Nodes/Input/AKMicrophone.swift
@@ -84,13 +84,16 @@ open class AKMicrophone: AKNode, AKToggleable {
 
     // Here is where we actually check the device type and make the settings, if needed
     private func getFormatForDevice() -> AVAudioFormat? {
-        var channelCount: UInt32 = 2
         #if os(iOS) && !targetEnvironment(simulator)
-        channelCount = AudioKit.engine.inputNode.inputFormat(forBus: 0).channelCount
+        let currentFormat = AudioKit.engine.inputNode.inputFormat(forBus: 0)
         let desiredFS = AudioKit.deviceSampleRate
+        return AVAudioFormat(commonFormat: currentFormat.commonFormat,
+                             sampleRate: desiredFS,
+                             interleaved: currentFormat.isInterleaved,
+                             channelLayout: currentFormat.channelLayout!)
         #else
         let desiredFS = AKSettings.sampleRate
+        return AVAudioFormat(standardFormatWithSampleRate: desiredFS, channels: 2)
         #endif
-        return AVAudioFormat(standardFormatWithSampleRate: desiredFS, channels: channelCount)
     }
 }


### PR DESCRIPTION
When connecting a USB device with a complex channel layout the standard AVAudioFormat constructor will fail and return nil, crashing when it’s force-unwrapped in AKMicrophone init. This copies the input’s channel layout directly.