### PR TITLE
BufferedAudioUnit as base class for AKAudioUnitBase and AKGeneratorAudioUnitBase

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
@@ -12,8 +12,9 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import "AKDSPBase.hpp"
+#import "BufferedAudioUnit.h"
 
-@interface AKAudioUnitBase : AUAudioUnit
+@interface AKAudioUnitBase : BufferedAudioUnit
 
 /**
  This method should be overridden by the specific AU code, because it knows how to set up
@@ -49,12 +50,6 @@
 
 @property (readonly) BOOL isPlaying;
 @property (readonly) BOOL isSetUp;
-
-// These three properties are what are in the Apple example code.
-
-@property AUAudioUnitBus *outputBus;
-@property AUAudioUnitBusArray *inputBusArray;
-@property AUAudioUnitBusArray *outputBusArray;
 
 @end
 

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -7,7 +7,6 @@
 //
 
 #import "AKAudioUnitBase.h"
-#import "BufferedAudioBus.hpp"
 
 #import <AudioKit/AudioKit-Swift.h>
 
@@ -19,7 +18,6 @@
 
 @implementation AKAudioUnitBase {
     // C++ members need to be ivars; they would be copied on access if they were properties.
-    BufferedInputBus _inputBus;
     AKDSPBase *_kernel;
 }
 
@@ -104,38 +102,17 @@
     if (self == nil) { return nil; }
 
     // Initialize a default format for the busses.
-    AVAudioFormat *defaultFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate
-                                                                                  channels:AKSettings.channelCount];
+    AVAudioFormat *arbitraryFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate
+                                                                                    channels:AKSettings.channelCount];
 
-    _kernel = (AKDSPBase*)[self initDSPWithSampleRate:defaultFormat.sampleRate
-                                         channelCount:defaultFormat.channelCount];
-
-    // Create the input and output busses.
-    _inputBus.init(defaultFormat, 8);
-    _outputBus = [[AUAudioUnitBus alloc] initWithFormat:defaultFormat error:nil];
-
-    // Create the input and output bus arrays.
-    _inputBusArray  = [[AUAudioUnitBusArray alloc] initWithAudioUnit:self
-                                                             busType:AUAudioUnitBusTypeInput
-                                                              busses: @[_inputBus.bus]];
-
-    _outputBusArray = [[AUAudioUnitBusArray alloc] initWithAudioUnit:self
-                                                             busType:AUAudioUnitBusTypeOutput
-                                                              busses: @[self.outputBus]];
+    _kernel = (AKDSPBase*)[self initDSPWithSampleRate:arbitraryFormat.sampleRate
+                                         channelCount:arbitraryFormat.channelCount];
 
     // Create a default empty parameter tree.
     _parameterTree = [AUParameterTree createTreeWithChildren:@[]];
 
-    self.maximumFramesToRender = 512;
-
     return self;
 }
-
-// ----- BEGIN UNMODIFIED COPY FROM APPLE CODE -----
-
-- (AUAudioUnitBusArray *)inputBusses { return _inputBusArray; }
-
-- (AUAudioUnitBusArray *)outputBusses { return _outputBusArray; }
 
 // Allocate resources required to render.
 // Hosts must call this to initialize the AU before beginning to render.
@@ -144,82 +121,32 @@
         return NO;
     }
 
-    if (self.outputBus.format.channelCount != _inputBus.bus.format.channelCount) {
-        if (outError) {
-            *outError = [NSError errorWithDomain:NSOSStatusErrorDomain code:kAudioUnitErr_FailedInitialization userInfo:nil];
-        }
-        // Notify superclass that initialization was not successful
-        self.renderResourcesAllocated = NO;
-        return NO;
-    }
-
-    _inputBus.allocateRenderResources(self.maximumFramesToRender);
-    _kernel->init(self.outputBus.format.channelCount, self.outputBus.format.sampleRate);
+    AVAudioFormat *format = self.outputBusses[0].format;
+    _kernel->init(format.channelCount, format.sampleRate);
     _kernel->reset();
     return YES;
+}
+
+-(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format {
+    
+    __block AKDSPBase *state = _kernel;
+    return ^(AudioBufferList       *inBuffer,
+             AudioBufferList       *outBuffer,
+             const AudioTimeStamp  *timestamp,
+             AVAudioFrameCount     frameCount,
+             const AURenderEvent   *eventListHead) {
+
+        state->setBuffers(inBuffer, outBuffer);
+        state->processWithEvents(timestamp, frameCount, eventListHead);
+    };
 }
 
 // Deallocate resources allocated by allocateRenderResourcesAndReturnError:
 // Hosts should call this after finishing rendering.
 
 - (void)deallocateRenderResources {
-    _inputBus.deallocateRenderResources();
     _kernel->deinit();
     [super deallocateRenderResources];
-}
-
-// Subclassers must provide a AUInternalRenderBlock (via a getter) to implement rendering.
-
-- (AUInternalRenderBlock)internalRenderBlock {
-    // Capture in locals to avoid ObjC member lookups.
-    // Specify captured objects are mutable.
-    __block AKDSPBase *state = _kernel;
-    __block BufferedInputBus *input = &_inputBus;
-
-    return ^AUAudioUnitStatus(
-                              AudioUnitRenderActionFlags *actionFlags,
-                              const AudioTimeStamp       *timestamp,
-                              AVAudioFrameCount           frameCount,
-                              NSInteger                   outputBusNumber,
-                              AudioBufferList            *outputData,
-                              const AURenderEvent        *realtimeEventListHead,
-                              AURenderPullInputBlock      pullInputBlock) {
-        AudioUnitRenderActionFlags pullFlags = 0;
-
-        AUAudioUnitStatus err = input->pullInput(&pullFlags, timestamp, frameCount, 0, pullInputBlock);
-
-        if (err != 0) { return err; }
-
-        AudioBufferList *inAudioBufferList = input->mutableAudioBufferList;
-
-        /*
-         Important:
-         If the caller passed non-null output pointers (outputData->mBuffers[x].mData), use those.
-
-         If the caller passed null output buffer pointers, process in memory owned by the Audio Unit
-         and modify the (outputData->mBuffers[x].mData) pointers to point to this owned memory.
-         The Audio Unit is responsible for preserving the validity of this memory until the next call to render,
-         or deallocateRenderResources is called.
-
-         If your algorithm cannot process in-place, you will need to preallocate an output buffer
-         and use it here.
-
-         See the description of the canProcessInPlace property.
-         */
-
-        // If passed null output buffer pointers, process in-place in the input buffer.
-        AudioBufferList *outAudioBufferList = outputData;
-        if (outAudioBufferList->mBuffers[0].mData == nullptr) {
-            for (UInt32 i = 0; i < outAudioBufferList->mNumberBuffers; ++i) {
-                outAudioBufferList->mBuffers[i].mData = inAudioBufferList->mBuffers[i].mData;
-            }
-        }
-
-        state->setBuffers(inAudioBufferList, outAudioBufferList);
-        state->processWithEvents(timestamp, frameCount, realtimeEventListHead);
-
-        return noErr;
-    };
 }
 
 // Expresses whether an audio unit can process in place.

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
@@ -12,8 +12,9 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import "AKDSPBase.hpp"
+#import "BufferedAudioUnit.h"
 
-@interface AKGeneratorAudioUnitBase : AUAudioUnit
+@interface AKGeneratorAudioUnitBase : BufferedAudioUnit
 
 /**
  This method should be overridden by the specific AU code, because it knows how to set up
@@ -57,11 +58,6 @@
 
 @property (readonly) BOOL isPlaying;
 @property (readonly) BOOL isSetUp;
-
-// These three properties are what are in the Apple example code.
-
-@property AUAudioUnitBus *outputBus;
-@property AUAudioUnitBusArray *outputBusArray;
 
 @end
 

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.h
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.h
@@ -1,0 +1,32 @@
+//
+//  BufferedAudioUnit.h
+//  AudioKit
+//
+//  Created by Dave O'Neill., revision history on Github.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <AudioToolbox/AudioToolbox.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^ProcessEventsBlock)(AudioBufferList        * _Nullable inBuffer,
+                                  AudioBufferList        * _Nonnull  outBuffer,
+                                  const AudioTimeStamp   * _Nonnull  timestamp,
+                                  AVAudioFrameCount                  frameCount,
+                                  const AURenderEvent    * _Nullable eventsListHead);
+
+
+@interface BufferedAudioUnit : AUAudioUnit
+
+// Override and do processing in this block.
+-(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format;
+
+// Generators should return false;
+-(BOOL)shouldAllocateInputBus;
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
@@ -1,0 +1,192 @@
+//
+//  BufferedAudioUnit.m
+//  AudioKit
+//
+//  Created by Dave O'Neill., revision history on Github.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+#import "BufferedAudioUnit.h"
+
+const int kMaxChannelCount = 16;
+
+// Private AudioBufferList helpers.
+static void    bufferListPrepare(AudioBufferList *audioBufferList, int channelCount, int frameCount);
+static size_t  bufferListByteSize(int channelCount);
+static Boolean bufferListHasNullData(AudioBufferList *bufferList);
+static void    bufferListPointChannelDataToBuffer(AudioBufferList *bufferList, float *buffer);
+
+
+@implementation BufferedAudioUnit {
+    float               *_inputBuffer;
+    float               *_ouputBuffer;
+    AUAudioUnitBusArray *_inputBusArray;
+    AUAudioUnitBusArray *_outputBusArray;
+    ProcessEventsBlock  _processEventsBlock;
+}
+
+- (instancetype)initWithComponentDescription:(AudioComponentDescription)componentDescription
+                                     options:(AudioComponentInstantiationOptions)options
+                                       error:(NSError **)outError {
+
+    self = [super initWithComponentDescription:componentDescription options:options error:outError];
+    if (self != nil) {
+
+        AVAudioFormat *arbitraryFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:44100 channels:2];
+        if ([self shouldAllocateInputBus]) {
+            _inputBusArray  = [[AUAudioUnitBusArray alloc] initWithAudioUnit:self
+                                                                     busType:AUAudioUnitBusTypeInput
+                                                                      busses: @[[[AUAudioUnitBus alloc]initWithFormat:arbitraryFormat error:NULL]]];
+        }
+
+        _outputBusArray = [[AUAudioUnitBusArray alloc] initWithAudioUnit:self
+                                                                 busType:AUAudioUnitBusTypeOutput
+                                                                  busses: @[[[AUAudioUnitBus alloc]initWithFormat:arbitraryFormat error:NULL]]];
+    }
+    return self;
+}
+
+-(BOOL)shouldAllocateInputBus {
+    return true;
+}
+
+
+- (BOOL)allocateRenderResourcesAndReturnError:(NSError **)outError {
+    if (![super allocateRenderResourcesAndReturnError:outError]) {
+        return NO;
+    }
+
+    AVAudioFormat *format = _outputBusArray[0].format;
+    if (_inputBusArray != NULL && [_inputBusArray[0].format isEqual: format] == false) {
+        if (outError) {
+            *outError = [NSError errorWithDomain:NSOSStatusErrorDomain code:kAudioUnitErr_FormatNotSupported userInfo:nil];
+        }
+        NSLog(@"%@ input format must match output format", self.class);
+        self.renderResourcesAllocated = NO;
+        return NO;
+    }
+
+    assert(_inputBuffer == NULL && _ouputBuffer == NULL);
+
+    size_t bufferSize = sizeof(float) * format.channelCount * self.maximumFramesToRender;
+    if (self.shouldAllocateInputBus) {
+        _inputBuffer = malloc(bufferSize);
+    }
+
+    if (self.canProcessInPlace == false || self.shouldAllocateInputBus == false) {
+        _ouputBuffer = malloc(bufferSize);
+    }
+
+    _processEventsBlock = [self processEventsBlock: format];
+    return YES;
+}
+
+-(void)deallocateRenderResources {
+    if (_inputBuffer != NULL) {
+        free(_inputBuffer);
+    }
+
+    if (_ouputBuffer != NULL) {
+        free(_ouputBuffer);
+    }
+    _inputBuffer = NULL;
+    _ouputBuffer = NULL;
+    [super deallocateRenderResources];
+}
+
+-(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format {
+    
+    return ^(AudioBufferList       *inBuffer,
+             AudioBufferList       *outBuffer,
+             const AudioTimeStamp  *timestamp,
+             AVAudioFrameCount     frameCount,
+             const AURenderEvent   *realtimeEventListHead) {
+
+        for (int i = 0; i < inBuffer->mNumberBuffers; i++) {
+            memcpy(outBuffer->mBuffers[i].mData, inBuffer->mBuffers[i].mData, inBuffer->mBuffers[i].mDataByteSize);
+        }
+    };
+}
+
+- (AUInternalRenderBlock)internalRenderBlock {
+
+    // Use untracked pointer and ivars to avoid Obj methods + ARC.
+    __unsafe_unretained BufferedAudioUnit *welf = self;
+    return  ^AUAudioUnitStatus(AudioUnitRenderActionFlags    *actionFlags,
+                               const AudioTimeStamp          *timestamp,
+                               AVAudioFrameCount             frameCount,
+                               NSInteger                     outputBusNumber,
+                               AudioBufferList               *outputBufferList,
+                               const AURenderEvent           *realtimeEventListHead,
+                               AURenderPullInputBlock        pullInputBlock) {
+
+        int channelCount = outputBufferList->mNumberBuffers;
+
+        // Guard against potential stack overflow.
+        assert(channelCount <= kMaxChannelCount);
+
+        char inputBufferAllocation[bufferListByteSize(outputBufferList->mNumberBuffers)];
+        AudioBufferList *inputBufferList = NULL;
+        
+        if (welf->_inputBuffer != NULL) {
+
+            // Prepare buffer for pull input.
+            inputBufferList = (AudioBufferList *)inputBufferAllocation;
+            bufferListPrepare(inputBufferList, channelCount, frameCount);
+            bufferListPointChannelDataToBuffer(inputBufferList, welf->_inputBuffer);
+
+            // Pull input into _inputBuffer.
+            AudioUnitRenderActionFlags flags = 0;
+            AUAudioUnitStatus status = pullInputBlock(&flags, timestamp, frameCount, 0, inputBufferList);
+            if (status) return status;
+        }
+
+        // If outputBufferList has null data, point to valid buffer before processing.
+        if (bufferListHasNullData(outputBufferList)) {
+            float *buffer = welf->_ouputBuffer ?: welf->_inputBuffer;
+            bufferListPointChannelDataToBuffer(outputBufferList, buffer);
+        }
+
+        welf->_processEventsBlock(inputBufferList, outputBufferList, timestamp, frameCount, realtimeEventListHead);
+        return noErr;
+    };
+}
+
+-(AUAudioUnitBusArray *)inputBusses {
+    return _inputBusArray;
+}
+
+-(AUAudioUnitBusArray *)outputBusses {
+    return _outputBusArray;
+}
+
+@end
+
+
+// Private AudioBufferList helpers.
+static void bufferListPrepare(AudioBufferList *audioBufferList,
+                       int             channelCount,
+                       int             frameCount) {
+
+    audioBufferList->mNumberBuffers = channelCount;
+    for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+        audioBufferList->mBuffers[channelIndex].mNumberChannels = 1;
+        audioBufferList->mBuffers[channelIndex].mDataByteSize = frameCount * sizeof(float);
+    }
+}
+
+static size_t  bufferListByteSize(int channelCount) {
+    return sizeof(AudioBufferList) + (sizeof(AudioBuffer) * (channelCount - 1));
+}
+
+static Boolean bufferListHasNullData(AudioBufferList *bufferList) {
+    return bufferList->mBuffers[0].mData == NULL;
+}
+
+static void bufferListPointChannelDataToBuffer(AudioBufferList *bufferList, float *buffer) {
+    int frameCount = bufferList->mBuffers[0].mDataByteSize / sizeof(float);
+    for (int channelIndex = 0; channelIndex < bufferList->mNumberBuffers; channelIndex++) {
+        int offset = channelIndex * frameCount;
+        bufferList->mBuffers[channelIndex].mData = buffer + offset;
+    }
+}

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		551AAC611F620A7F00A14C0D /* AKClipRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551AAC2F1F61F59700A14C0D /* AKClipRecorder.swift */; };
 		551AAC621F620A8D00A14C0D /* AKTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551AAC2A1F61F48300A14C0D /* AKTiming.swift */; };
 		552FBD431F3F6A5600C02C08 /* AKConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552FBD421F3F6A5600C02C08 /* AKConnection.swift */; };
+		558FC73F21ABA7C7009C05B0 /* BufferedAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC73D21ABA7C6009C05B0 /* BufferedAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		558FC74021ABA7C7009C05B0 /* BufferedAudioUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC73E21ABA7C7009C05B0 /* BufferedAudioUnit.m */; };
 		55B95B2F1FEDC07E00C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B2C1FEDBFA800C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5211F57CB540088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F51F1F57CB540088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5221F57CB540088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5201F57CB540088018A /* AKSamplerMetronome.m */; };
@@ -1249,6 +1251,8 @@
 		551AAC2E1F61F59700A14C0D /* AKClipMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKClipMerger.swift; sourceTree = "<group>"; };
 		551AAC2F1F61F59700A14C0D /* AKClipRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKClipRecorder.swift; sourceTree = "<group>"; };
 		552FBD421F3F6A5600C02C08 /* AKConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKConnection.swift; sourceTree = "<group>"; };
+		558FC73D21ABA7C6009C05B0 /* BufferedAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedAudioUnit.h; sourceTree = "<group>"; };
+		558FC73E21ABA7C7009C05B0 /* BufferedAudioUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BufferedAudioUnit.m; sourceTree = "<group>"; };
 		55B95B2C1FEDBFA800C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F51F1F57CB540088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5201F57CB540088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSamplerMetronome.m; sourceTree = "<group>"; };
@@ -2654,6 +2658,8 @@
 		C40C41221C40E344009D870B /* CoreAudio */ = {
 			isa = PBXGroup;
 			children = (
+				558FC73D21ABA7C6009C05B0 /* BufferedAudioUnit.h */,
+				558FC73E21ABA7C7009C05B0 /* BufferedAudioUnit.m */,
 				EAF71D8B20249A880018946B /* AKAudioEffect.h */,
 				EAF71D8C20249A880018946B /* AKAudioEffect.mm */,
 				C4AC0B351FC944E300EDA024 /* AK4 */,
@@ -5264,6 +5270,7 @@
 				C49B1548204A06B8009C7C8E /* FileLoop.h in Headers */,
 				C49B1563204A06B8009C7C8E /* WvOut.h in Headers */,
 				C49B1577204A06B8009C7C8E /* Envelope.h in Headers */,
+				558FC73F21ABA7C7009C05B0 /* BufferedAudioUnit.h in Headers */,
 				C49B1430204A06B7009C7C8E /* FFTRealPassInverse.hpp in Headers */,
 				C45380411C3A599F00A51738 /* AKFrequencyTrackerAudioUnit.h in Headers */,
 				C49B1434204A06B7009C7C8E /* FFTRealFixLen.hpp in Headers */,
@@ -6438,6 +6445,7 @@
 				C49B14DB204A06B8009C7C8E /* parse.c in Sources */,
 				C42FFBE41C3D195000823BD4 /* AKBooster.swift in Sources */,
 				C49B14C6204A06B8009C7C8E /* tblrec.c in Sources */,
+				558FC74021ABA7C7009C05B0 /* BufferedAudioUnit.m in Sources */,
 				C47AE4F11D3A09010091118F /* AKMIDICallbackInstrument.swift in Sources */,
 				C45380521C3A5A4300A51738 /* AKOperationGenerator.swift in Sources */,
 				C49B14CB204A06B8009C7C8E /* bitwise.c in Sources */,

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		555857DD1F62180900C73F59 /* AKClipPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857D91F6217FF00C73F59 /* AKClipPlayer.swift */; };
 		555857DE1F62180C00C73F59 /* AKClipRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857DA1F6217FF00C73F59 /* AKClipRecorder.swift */; };
 		555857E11F62184600C73F59 /* AKTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857E01F62184100C73F59 /* AKTiming.swift */; };
+		558FC74421ABACF6009C05B0 /* BufferedAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC74221ABACF5009C05B0 /* BufferedAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		558FC74521ABACF6009C05B0 /* BufferedAudioUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC74321ABACF6009C05B0 /* BufferedAudioUnit.m */; };
 		55B95B331FEDC34F00C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B321FEDC34700C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5291F57DAC30088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F5271F57DAC30088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F52A1F57DAC30088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5281F57DAC30088018A /* AKSamplerMetronome.m */; };
@@ -1232,6 +1234,8 @@
 		555857D91F6217FF00C73F59 /* AKClipPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKClipPlayer.swift; sourceTree = "<group>"; };
 		555857DA1F6217FF00C73F59 /* AKClipRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKClipRecorder.swift; sourceTree = "<group>"; };
 		555857E01F62184100C73F59 /* AKTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKTiming.swift; sourceTree = "<group>"; };
+		558FC74221ABACF5009C05B0 /* BufferedAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedAudioUnit.h; sourceTree = "<group>"; };
+		558FC74321ABACF6009C05B0 /* BufferedAudioUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BufferedAudioUnit.m; sourceTree = "<group>"; };
 		55B95B321FEDC34700C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F5271F57DAC30088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AKSamplerMetronome.h; path = ../AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5281F57DAC30088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AKSamplerMetronome.m; path = ../AKSamplerMetronome.m; sourceTree = "<group>"; };
@@ -2813,6 +2817,8 @@
 		C45662C61D448D7D00D26565 /* CoreAudio */ = {
 			isa = PBXGroup;
 			children = (
+				558FC74221ABACF5009C05B0 /* BufferedAudioUnit.h */,
+				558FC74321ABACF6009C05B0 /* BufferedAudioUnit.m */,
 				C4AC0B551FC9460300EDA024 /* AK4 */,
 				C4AC0B5D1FC9460400EDA024 /* Apple Code */,
 				C4AC0B591FC9460400EDA024 /* Bank */,
@@ -5194,6 +5200,7 @@
 				C410F1452030409A002EA801 /* AKMorphingOscillatorDSP.hpp in Headers */,
 				C49B18A9204A0AD1009C7C8E /* FFTRealUseTrigo.hpp in Headers */,
 				C456697B1D448D7E00D26565 /* AKOscillatorBankAudioUnit.h in Headers */,
+				558FC74421ABACF6009C05B0 /* BufferedAudioUnit.h in Headers */,
 				C4AC4ECE200AEB480095694F /* AKPhaseDistortionOscillatorDSP.hpp in Headers */,
 				C4A579BE1EC1B87F0072D48A /* AKMicrophoneTrackerEngine.h in Headers */,
 				C49B1B2F204A0C48009C7C8E /* FileWvOut.h in Headers */,
@@ -5556,7 +5563,7 @@
 					};
 				};
 			};
-			buildConfigurationList = C42F36C61C0582E6000E937C /* Build configuration list for PBXProject "AudioKit for macOS" */;
+			buildConfigurationList = C42F36C61C0582E6000E937C /* Build configuration list for PBXProject "AudioKit For macOS" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -5840,6 +5847,7 @@
 				C477582D202FCF0C00159BA7 /* AKOscillatorDSP.mm in Sources */,
 				C49B1935204A0AD1009C7C8E /* buthp.c in Sources */,
 				C464079320117D1200299119 /* AKVocalTractAudioUnit.swift in Sources */,
+				558FC74521ABACF6009C05B0 /* BufferedAudioUnit.m in Sources */,
 				531CD8F3207BA1B0006C15E0 /* CDelay.cpp in Sources */,
 				C4812AEF202854B800D4AFB1 /* AKLowPassButterworthFilterDSP.mm in Sources */,
 				C45669E91D448D7E00D26565 /* pan.swift in Sources */,
@@ -6653,7 +6661,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		C42F36C61C0582E6000E937C /* Build configuration list for PBXProject "AudioKit for macOS" */ = {
+		C42F36C61C0582E6000E937C /* Build configuration list for PBXProject "AudioKit For macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C42F36D21C0582E6000E937C /* Debug */,

--- a/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
+++ b/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		555857ED1F6218A000C73F59 /* AKClipPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857E91F62189700C73F59 /* AKClipPlayer.swift */; };
 		555857EE1F6218A400C73F59 /* AKClipRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857EA1F62189700C73F59 /* AKClipRecorder.swift */; };
 		555857F11F6218C000C73F59 /* AKTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857F01F6218BB00C73F59 /* AKTiming.swift */; };
+		558FC74821ABAD71009C05B0 /* BufferedAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC74621ABAD71009C05B0 /* BufferedAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		558FC74921ABAD71009C05B0 /* BufferedAudioUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC74721ABAD71009C05B0 /* BufferedAudioUnit.m */; };
 		55B95B351FEDC37600C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B341FEDC37100C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5321F57DB2D0088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F5301F57DB2D0088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5331F57DB2D0088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5311F57DB2D0088018A /* AKSamplerMetronome.m */; };
@@ -1127,6 +1129,8 @@
 		555857E91F62189700C73F59 /* AKClipPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKClipPlayer.swift; sourceTree = "<group>"; };
 		555857EA1F62189700C73F59 /* AKClipRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKClipRecorder.swift; sourceTree = "<group>"; };
 		555857F01F6218BB00C73F59 /* AKTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKTiming.swift; sourceTree = "<group>"; };
+		558FC74621ABAD71009C05B0 /* BufferedAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedAudioUnit.h; sourceTree = "<group>"; };
+		558FC74721ABAD71009C05B0 /* BufferedAudioUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BufferedAudioUnit.m; sourceTree = "<group>"; };
 		55B95B341FEDC37100C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F5301F57DB2D0088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AKSamplerMetronome.h; path = Playback/AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5311F57DB2D0088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AKSamplerMetronome.m; path = Playback/AKSamplerMetronome.m; sourceTree = "<group>"; };
@@ -2391,6 +2395,8 @@
 		C40C41E41C40E5C2009D870B /* CoreAudio */ = {
 			isa = PBXGroup;
 			children = (
+				558FC74621ABAD71009C05B0 /* BufferedAudioUnit.h */,
+				558FC74721ABAD71009C05B0 /* BufferedAudioUnit.m */,
 				C4AC0B111FC9419900EDA024 /* AK4 */,
 				C4AC0B1D1FC9423900EDA024 /* Apple Code */,
 				C4AC0B261FC9427200EDA024 /* Bank */,
@@ -5029,6 +5035,7 @@
 				C49B20B2204A0D57009C7C8E /* Voicer.h in Headers */,
 				C49B20FA204A0D57009C7C8E /* Bowed.h in Headers */,
 				C47048081E78FDFA00D9906F /* AKRhodesPianoDSPKernel.hpp in Headers */,
+				558FC74821ABAD71009C05B0 /* BufferedAudioUnit.h in Headers */,
 				C470CF82201747A7003D1AFA /* AKTanhDistortionDSP.hpp in Headers */,
 				C470D00F201749B8003D1AFA /* AKToneFilterDSP.hpp in Headers */,
 				C49B20DC204A0D57009C7C8E /* Moog.h in Headers */,
@@ -5965,6 +5972,7 @@
 				C49DCD4C1D2100B400BF018A /* AKMorphingOscillatorBankAudioUnit.mm in Sources */,
 				C470CFD2201748F6003D1AFA /* AKLowPassButterworthFilterAudioUnit.swift in Sources */,
 				C45381A41C3A5CBD00A51738 /* AKDynamicsProcessor.swift in Sources */,
+				558FC74921ABAD71009C05B0 /* BufferedAudioUnit.m in Sources */,
 				C49B1DF3204A0CFA009C7C8E /* butbr.c in Sources */,
 				C49B1DEA204A0CFA009C7C8E /* maygate.c in Sources */,
 				C49B1DF0204A0CFA009C7C8E /* phaser.c in Sources */,


### PR DESCRIPTION
BufferedAudioUnit is a base AUAudioUnit class that only deals with the buffer management aspect of an AUAudioUnit subclass. 

Subclasses should now override `processEventsBlock` instead of internalRenderBlock. ProcessEventsBlock is a pared down version of internalRenderBlock where the output buffer is always valid, and the input buffer is valid unless `shouldAllocateInputBus` is overridden  to return false (Generator).

Ideally BufferedAudioUnit should handle multiple inputs, but I don't currently have the time to implement a system for dynamically adding/removing busses and connections. That being said, BufferedAudioUnit is a good place to add this functionality in the future. My only reservation about this implementation is that processEventsBlock is set up for a single input. It might be better to change the block signature so that we have multiple input buffers available, but just render one for now. I'm all ears. 
