### PR TITLE
AudioEngineUnit

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AudioEngineUnit.h
+++ b/AudioKit/Common/Internals/CoreAudio/AudioEngineUnit.h
@@ -1,0 +1,18 @@
+//
+//  AudioEngineUnit.h
+//  AudioKit
+//
+//  Created by Dave O'Neill, revision history on Github.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+#import "BufferedAudioUnit.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_AVAILABLE(macos(10.13), ios(11.0), tvos(11.0))
+@interface AudioEngineUnit : BufferedAudioUnit
+@property (readonly) AVAudioEngine *audioEngine;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AudioKit/Common/Internals/CoreAudio/AudioEngineUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/AudioEngineUnit.m
@@ -1,0 +1,78 @@
+//
+//  AudioEngineUnit.m
+//  AudioKit
+//
+//  Created by Dave O'Neill, revision history on Github.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+#import "AudioEngineUnit.h"
+
+@implementation AudioEngineUnit {
+    AudioBufferList *inputNodeBufferlist;
+}
+
+-(instancetype)initWithComponentDescription:(AudioComponentDescription)componentDescription options:(AudioComponentInstantiationOptions)options error:(NSError * _Nullable __autoreleasing *)outError {
+    self = [super initWithComponentDescription:componentDescription options:options error:outError];
+    if (self) {
+        _audioEngine = [[AVAudioEngine alloc]init];
+    }
+    return self;
+}
+
+-(BOOL)allocateRenderResourcesAndReturnError:(NSError * _Nullable __autoreleasing *)outError {
+    if (![super allocateRenderResourcesAndReturnError:outError]) return false;
+
+    AVAudioFormat *format = self.outputBusses[0].format;
+    NSError *error = NULL;
+    BOOL success = [self.audioEngine enableManualRenderingMode:AVAudioEngineManualRenderingModeRealtime
+                                                           format:format
+                                                maximumFrameCount:self.maximumFramesToRender
+                                                            error: &error];
+    if (!success) {
+        NSLog(@"AudioEngine enableManualRenderingMode failed: %@", error.localizedDescription);
+        return false;
+    }
+
+    if (self.shouldAllocateInputBus) {
+        __unsafe_unretained AudioEngineUnit *welf = self;
+        [self.audioEngine.inputNode setManualRenderingInputPCMFormat:format inputBlock:^const AudioBufferList * _Nullable(AVAudioFrameCount inNumberOfFrames) {
+            return welf->inputNodeBufferlist;
+        }];
+    }
+
+    if (![self.audioEngine startAndReturnError:&error]) {
+        NSLog(@"AudioEngine start() failed: %@", error.localizedDescription);
+        return false;
+    }
+
+    return true;
+}
+
+-(void)deallocateRenderResources {
+    [self.audioEngine stop];
+    [self.audioEngine disableManualRenderingMode];
+    [super deallocateRenderResources];
+}
+
+-(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format {
+
+    AVAudioEngineManualRenderingBlock manualRenderingBlock = self.audioEngine.manualRenderingBlock;
+    __unsafe_unretained AudioEngineUnit *welf = self;
+    ProcessEventsBlock passThrough = [super processEventsBlock:format];
+
+    return ^(AudioBufferList       *inBuffer,
+             AudioBufferList       *outBuffer,
+             const AudioTimeStamp  *timestamp,
+             AVAudioFrameCount     frameCount,
+             const AURenderEvent   *eventListHead) {
+
+        welf->inputNodeBufferlist = inBuffer;
+        AVAudioEngineManualRenderingStatus status = manualRenderingBlock(frameCount, outBuffer, NULL);
+        if (status != AVAudioEngineManualRenderingStatusSuccess) {
+            passThrough(inBuffer, outBuffer, timestamp, frameCount, eventListHead);
+        }
+    };
+}
+
+@end

--- a/AudioKit/Common/Internals/CoreAudio/AudioEngineUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/AudioEngineUnit.m
@@ -26,9 +26,9 @@
     AVAudioFormat *format = self.outputBusses[0].format;
     NSError *error = NULL;
     BOOL success = [self.audioEngine enableManualRenderingMode:AVAudioEngineManualRenderingModeRealtime
-                                                           format:format
-                                                maximumFrameCount:self.maximumFramesToRender
-                                                            error: &error];
+                                                        format:format
+                                            maximumFrameCount:self.maximumFramesToRender
+                                                        error: &error];
     if (!success) {
         NSLog(@"AudioEngine enableManualRenderingMode failed: %@", error.localizedDescription);
         return false;
@@ -36,7 +36,7 @@
 
     if (self.shouldAllocateInputBus) {
         __unsafe_unretained AudioEngineUnit *welf = self;
-        [self.audioEngine.inputNode setManualRenderingInputPCMFormat:format inputBlock:^const AudioBufferList * _Nullable(AVAudioFrameCount inNumberOfFrames) {
+        [self.audioEngine.inputNode setManualRenderingInputPCMFormat:format inputBlock:^const AudioBufferList *(AVAudioFrameCount _) {
             return welf->inputNodeBufferlist;
         }];
     }

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.h
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.h
@@ -2,7 +2,7 @@
 //  BufferedAudioUnit.h
 //  AudioKit
 //
-//  Created by Dave O'Neill., revision history on Github.
+//  Created by Dave O'Neill, revision history on Github.
 //  Copyright © 2018 AudioKit. All rights reserved.
 //
 

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
@@ -2,7 +2,7 @@
 //  BufferedAudioUnit.m
 //  AudioKit
 //
-//  Created by Dave O'Neill., revision history on Github.
+//  Created by Dave O'Neill, revision history on Github.
 //  Copyright © 2018 AudioKit. All rights reserved.
 //
 

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
@@ -102,7 +102,7 @@ static void    bufferListPointChannelDataToBuffer(AudioBufferList *bufferList, f
              AVAudioFrameCount     frameCount,
              const AURenderEvent   *realtimeEventListHead) {
 
-        if (inBuffer != NULL) {
+        if (inBuffer == NULL) {
             for (int i = 0; i < inBuffer->mNumberBuffers; i++) {
                 memset(outBuffer->mBuffers[i].mData, 0, outBuffer->mBuffers[i].mDataByteSize);
             }

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
@@ -102,8 +102,14 @@ static void    bufferListPointChannelDataToBuffer(AudioBufferList *bufferList, f
              AVAudioFrameCount     frameCount,
              const AURenderEvent   *realtimeEventListHead) {
 
-        for (int i = 0; i < inBuffer->mNumberBuffers; i++) {
-            memcpy(outBuffer->mBuffers[i].mData, inBuffer->mBuffers[i].mData, inBuffer->mBuffers[i].mDataByteSize);
+        if (inBuffer != NULL) {
+            for (int i = 0; i < inBuffer->mNumberBuffers; i++) {
+                memset(outBuffer->mBuffers[i].mData, 0, outBuffer->mBuffers[i].mDataByteSize);
+            }
+        } else {
+            for (int i = 0; i < inBuffer->mNumberBuffers; i++) {
+                memcpy(outBuffer->mBuffers[i].mData, inBuffer->mBuffers[i].mData, inBuffer->mBuffers[i].mDataByteSize);
+            }
         }
     };
 }

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		552FBD431F3F6A5600C02C08 /* AKConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552FBD421F3F6A5600C02C08 /* AKConnection.swift */; };
 		558FC73F21ABA7C7009C05B0 /* BufferedAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC73D21ABA7C6009C05B0 /* BufferedAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558FC74021ABA7C7009C05B0 /* BufferedAudioUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC73E21ABA7C7009C05B0 /* BufferedAudioUnit.m */; };
+		558FC78721AD0CF6009C05B0 /* AudioEngineUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC78521AD0CF5009C05B0 /* AudioEngineUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		558FC78821AD0CF6009C05B0 /* AudioEngineUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC78621AD0CF5009C05B0 /* AudioEngineUnit.m */; };
 		55B95B2F1FEDC07E00C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B2C1FEDBFA800C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5211F57CB540088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F51F1F57CB540088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5221F57CB540088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5201F57CB540088018A /* AKSamplerMetronome.m */; };
@@ -1253,6 +1255,8 @@
 		552FBD421F3F6A5600C02C08 /* AKConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKConnection.swift; sourceTree = "<group>"; };
 		558FC73D21ABA7C6009C05B0 /* BufferedAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedAudioUnit.h; sourceTree = "<group>"; };
 		558FC73E21ABA7C7009C05B0 /* BufferedAudioUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BufferedAudioUnit.m; sourceTree = "<group>"; };
+		558FC78521AD0CF5009C05B0 /* AudioEngineUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioEngineUnit.h; sourceTree = "<group>"; };
+		558FC78621AD0CF5009C05B0 /* AudioEngineUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AudioEngineUnit.m; sourceTree = "<group>"; };
 		55B95B2C1FEDBFA800C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F51F1F57CB540088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5201F57CB540088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSamplerMetronome.m; sourceTree = "<group>"; };
@@ -2658,6 +2662,8 @@
 		C40C41221C40E344009D870B /* CoreAudio */ = {
 			isa = PBXGroup;
 			children = (
+				558FC78521AD0CF5009C05B0 /* AudioEngineUnit.h */,
+				558FC78621AD0CF5009C05B0 /* AudioEngineUnit.m */,
 				558FC73D21ABA7C6009C05B0 /* BufferedAudioUnit.h */,
 				558FC73E21ABA7C7009C05B0 /* BufferedAudioUnit.m */,
 				EAF71D8B20249A880018946B /* AKAudioEffect.h */,
@@ -5534,6 +5540,7 @@
 				34BB674F205AC238000E5450 /* wavpack_version.h in Headers */,
 				C49B153F204A06B8009C7C8E /* MidiFileIn.h in Headers */,
 				C49B14D6204A06B8009C7C8E /* ugens.h in Headers */,
+				558FC78721AD0CF6009C05B0 /* AudioEngineUnit.h in Headers */,
 				C49B13A2204A06B7009C7C8E /* vocwrapper.h in Headers */,
 				C49B1545204A06B8009C7C8E /* FM.h in Headers */,
 				C49B138C204A06B7009C7C8E /* soundpipe.h in Headers */,
@@ -5969,6 +5976,7 @@
 				C49B147B204A06B8009C7C8E /* oscmorph.c in Sources */,
 				C4D1FCFD1CE5BCC80043209E /* AKTremolo.swift in Sources */,
 				C4537FEA1C3A438D00A51738 /* AKStringResonator.swift in Sources */,
+				558FC78821AD0CF6009C05B0 /* AudioEngineUnit.m in Sources */,
 				C49B13AF204A06B7009C7C8E /* talkbox.c in Sources */,
 				C49E9E021D2B491500E5E8BF /* AKAudioFile.swift in Sources */,
 				C49B13AD204A06B7009C7C8E /* fof.c in Sources */,

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		555857E11F62184600C73F59 /* AKTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857E01F62184100C73F59 /* AKTiming.swift */; };
 		558FC74421ABACF6009C05B0 /* BufferedAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC74221ABACF5009C05B0 /* BufferedAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558FC74521ABACF6009C05B0 /* BufferedAudioUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC74321ABACF6009C05B0 /* BufferedAudioUnit.m */; };
+		558FC78B21AD108A009C05B0 /* AudioEngineUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC78921AD108A009C05B0 /* AudioEngineUnit.m */; };
+		558FC78C21AD108A009C05B0 /* AudioEngineUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC78A21AD108A009C05B0 /* AudioEngineUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55B95B331FEDC34F00C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B321FEDC34700C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5291F57DAC30088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F5271F57DAC30088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F52A1F57DAC30088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5281F57DAC30088018A /* AKSamplerMetronome.m */; };
@@ -1236,6 +1238,8 @@
 		555857E01F62184100C73F59 /* AKTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKTiming.swift; sourceTree = "<group>"; };
 		558FC74221ABACF5009C05B0 /* BufferedAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedAudioUnit.h; sourceTree = "<group>"; };
 		558FC74321ABACF6009C05B0 /* BufferedAudioUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BufferedAudioUnit.m; sourceTree = "<group>"; };
+		558FC78921AD108A009C05B0 /* AudioEngineUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AudioEngineUnit.m; sourceTree = "<group>"; };
+		558FC78A21AD108A009C05B0 /* AudioEngineUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioEngineUnit.h; sourceTree = "<group>"; };
 		55B95B321FEDC34700C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F5271F57DAC30088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AKSamplerMetronome.h; path = ../AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5281F57DAC30088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AKSamplerMetronome.m; path = ../AKSamplerMetronome.m; sourceTree = "<group>"; };
@@ -2817,6 +2821,8 @@
 		C45662C61D448D7D00D26565 /* CoreAudio */ = {
 			isa = PBXGroup;
 			children = (
+				558FC78A21AD108A009C05B0 /* AudioEngineUnit.h */,
+				558FC78921AD108A009C05B0 /* AudioEngineUnit.m */,
 				558FC74221ABACF5009C05B0 /* BufferedAudioUnit.h */,
 				558FC74321ABACF6009C05B0 /* BufferedAudioUnit.m */,
 				C4AC0B551FC9460300EDA024 /* AK4 */,
@@ -5464,6 +5470,7 @@
 				C456695C1D448D7E00D26565 /* AKOperationGeneratorDSPKernel.hpp in Headers */,
 				C456698B1D448D7E00D26565 /* AKPWMOscillatorBankAudioUnit.h in Headers */,
 				34BB66D2205ABBC0000E5450 /* wavpack_version.h in Headers */,
+				558FC78C21AD108A009C05B0 /* AudioEngineUnit.h in Headers */,
 				C45666C71D448D7E00D26565 /* EZOutput.h in Headers */,
 				C49B1B3F204A0C48009C7C8E /* Effect.h in Headers */,
 				C49B1B1C204A0C48009C7C8E /* RtAudio.h in Headers */,
@@ -6347,6 +6354,7 @@
 				C456690E1D448D7E00D26565 /* AKLowPassFilter.swift in Sources */,
 				FE4BDB2921925906007E3DA3 /* AKCallbackInstrumentAudioUnit.mm in Sources */,
 				C4077B732008802600E5923C /* AKThreePoleLowpassFilterAudioUnit.swift in Sources */,
+				558FC78B21AD108A009C05B0 /* AudioEngineUnit.m in Sources */,
 				C49B189C204A0AD1009C7C8E /* OnePoleLPF.cpp in Sources */,
 				C458BFEC202FEB37006428C9 /* AKPinkNoiseDSP.mm in Sources */,
 				C45669D71D448D7E00D26565 /* sineWave.swift in Sources */,

--- a/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
+++ b/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		555857F11F6218C000C73F59 /* AKTiming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555857F01F6218BB00C73F59 /* AKTiming.swift */; };
 		558FC74821ABAD71009C05B0 /* BufferedAudioUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC74621ABAD71009C05B0 /* BufferedAudioUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		558FC74921ABAD71009C05B0 /* BufferedAudioUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC74721ABAD71009C05B0 /* BufferedAudioUnit.m */; };
+		558FC78F21AD10AF009C05B0 /* AudioEngineUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FC78D21AD10AE009C05B0 /* AudioEngineUnit.m */; };
+		558FC79021AD10AF009C05B0 /* AudioEngineUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 558FC78E21AD10AF009C05B0 /* AudioEngineUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55B95B351FEDC37600C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B341FEDC37100C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5321F57DB2D0088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F5301F57DB2D0088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5331F57DB2D0088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5311F57DB2D0088018A /* AKSamplerMetronome.m */; };
@@ -1131,6 +1133,8 @@
 		555857F01F6218BB00C73F59 /* AKTiming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKTiming.swift; sourceTree = "<group>"; };
 		558FC74621ABAD71009C05B0 /* BufferedAudioUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedAudioUnit.h; sourceTree = "<group>"; };
 		558FC74721ABAD71009C05B0 /* BufferedAudioUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BufferedAudioUnit.m; sourceTree = "<group>"; };
+		558FC78D21AD10AE009C05B0 /* AudioEngineUnit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AudioEngineUnit.m; sourceTree = "<group>"; };
+		558FC78E21AD10AF009C05B0 /* AudioEngineUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioEngineUnit.h; sourceTree = "<group>"; };
 		55B95B341FEDC37100C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F5301F57DB2D0088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AKSamplerMetronome.h; path = Playback/AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5311F57DB2D0088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AKSamplerMetronome.m; path = Playback/AKSamplerMetronome.m; sourceTree = "<group>"; };
@@ -2395,6 +2399,8 @@
 		C40C41E41C40E5C2009D870B /* CoreAudio */ = {
 			isa = PBXGroup;
 			children = (
+				558FC78E21AD10AF009C05B0 /* AudioEngineUnit.h */,
+				558FC78D21AD10AE009C05B0 /* AudioEngineUnit.m */,
 				558FC74621ABAD71009C05B0 /* BufferedAudioUnit.h */,
 				558FC74721ABAD71009C05B0 /* BufferedAudioUnit.m */,
 				C4AC0B111FC9419900EDA024 /* AK4 */,
@@ -4967,6 +4973,7 @@
 				EA13F1A4207232530090288E /* wavpack.h in Headers */,
 				C49B20C1204A0D57009C7C8E /* Simple.h in Headers */,
 				C457CC0F213C6E2200AFDEBC /* DrawbarsOscillator.hpp in Headers */,
+				558FC79021AD10AF009C05B0 /* AudioEngineUnit.h in Headers */,
 				C49B1E7A204A0CFA009C7C8E /* Array.h in Headers */,
 				C49B20F2204A0D57009C7C8E /* ModalBar.h in Headers */,
 				C49B2115204A0D57009C7C8E /* Fir.h in Headers */,
@@ -5659,6 +5666,7 @@
 				C49B1E9F204A0CFB009C7C8E /* dtrig.c in Sources */,
 				C49B1E0E204A0CFA009C7C8E /* pluck.c in Sources */,
 				C4D4C4F51EB7176600134B39 /* AKTuningTable+EqualTemperament.swift in Sources */,
+				558FC78F21AD10AF009C05B0 /* AudioEngineUnit.m in Sources */,
 				C49B1EC5204A0CFB009C7C8E /* tone.c in Sources */,
 				C40C129B1F08B0CE00F4C7F1 /* AudioUnit+Helpers.swift in Sources */,
 				C49B1EF7204A0CFB009C7C8E /* maytrig.c in Sources */,


### PR DESCRIPTION
AudioEngineUnit is an BufferAudioUnit subclass that contains an internal AVAudioEngine. This allows for a single audio unit that contains multiple audio units within. In this form it is intended to be used as a base class, but there's nothing stopping a client from accessing the (public) internal audio engine and making connections directly.

Subclass and override `shouldAllocateInputBus` to return `false` if using as a generator.