### PR TITLE
Add smoothing to ADSR envelopes in AKCoreSampler

### DIFF
--- a/AudioKit/Core/AudioKitCore/Common/ADSREnvelope.h
+++ b/AudioKit/Core/AudioKitCore/Common/ADSREnvelope.h
@@ -61,6 +61,11 @@ namespace AudioKitCore
         bool isPreStarting() { return env.getCurrentSegmentIndex() == kSilence; }
         bool isReleasing() { return env.getCurrentSegmentIndex() == kRelease; }
 
+        inline float getValue()
+        {
+            return env.getValue();
+        }
+        
         inline float getSample()
         {
             float sample;

--- a/AudioKit/Core/AudioKitCore/Common/EnvelopeGeneratorBase.h
+++ b/AudioKit/Core/AudioKitCore/Common/EnvelopeGeneratorBase.h
@@ -26,6 +26,11 @@ namespace AudioKitCore
     public:
         void reset(double initialValue, double targetValue, double tco, int segmentLengthSamples);
 
+        inline float getValue()
+        {
+            return float(isHorizontal ? target : output);
+        }
+
         inline bool getSample(float& out)
         {
             if (isHorizontal)

--- a/AudioKit/Core/AudioKitCore/Common/LinearRamper.hpp
+++ b/AudioKit/Core/AudioKitCore/Common/LinearRamper.hpp
@@ -18,62 +18,56 @@ namespace AudioKitCore
         float value;            // current value
         float target;           // where it is headed
         float increment;        // per-sample increment
-        float constantValue;    // special case of horizontal ramp
+        int count;              // counts down samples
         
-        LinearRamper() : value(0.0f), target(0.0f), increment(0.0f), constantValue(flagValue) {}
+        LinearRamper() : value(0.0f), target(0.0f), increment(0.0f), count(0) {}
         
         // initialize to a stable value
         void init(float v)
         {
             value = target = v;
             increment = 0.0f;
-            constantValue = flagValue;
+            count = 0;
         }
         
         // initialize all parameters
-        void init(float startValue, float targetValue, float intervalSamples)
+        void init(float startValue, float targetValue, int intervalSamples)
         {
-            constantValue = flagValue;  // assume startValue != targetValue
+            count = intervalSamples;  // assume startValue != targetValue
             target = targetValue;
-            if (intervalSamples < 1.0f)
+            if (count < 1)
             {
                 // target has already been hit, we're already done
                 value = target;
                 increment = 0.0f;
             }
-            else if (startValue == targetValue)
-            {
-                // special case of horizontal ramp
-                constantValue = startValue; // remember the constant value here
-                value = 0.0f;               // and let value
-                increment = 1.0f;           // count samples
-                target = intervalSamples;   // to time the interval
-            }
             else
             {
                 // normal case: value ramps to target
                 value = startValue;
-                increment = (target - value) / intervalSamples;
+                increment = (target - value) / count;
             }
         }
         
         // reset new target and new interval, retaining current value
-        inline void reinit(float targetValue, float intervalSamples)
+        inline void reinit(float targetValue, int intervalSamples)
         {
             init(value, targetValue, intervalSamples);
         }
         
         inline float isRamping()
         {
-            if (increment == 0.0f) return false;
-            if (increment > 0.0f) return value < target;
-            else return value > target;
+            return count > 0;
         }
         
         inline float getNextValue()
         {
-            value += increment;
-            return (constantValue == flagValue) ? value : constantValue;
+            if (count > 0)
+            {
+                value += increment;
+                count--;
+            }
+            return value;
         }
         
         inline void getValues(int count, float *pOut)

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.hpp
@@ -13,6 +13,7 @@
 #include "SampleOscillator.hpp"
 #include "ADSREnvelope.h"
 #include "ResonantLowPassFilter.hpp"
+#include "LinearRamper.hpp"
 
 namespace AudioKitCore
 {
@@ -53,8 +54,11 @@ namespace AudioKitCore
         /// Next sample buffer to use at restart
         SampleBuffer *newSampleBuffer;
 
-        /// product of global volume, note volume, and amp EG
+        /// product of global volume, note volume
         float tempGain;
+
+        /// ramper to smooth subsampled output of adsrEnvelope
+        LinearRamper volumeRamper;
 
         /// true if filter should be used
         bool isFilterEnabled;

--- a/Developer/AKSampler/Mac AUv2 Plugin/AKSampler AUv2 Plugin.xcodeproj/xcshareddata/xcschemes/AKSampler.xcscheme
+++ b/Developer/AKSampler/Mac AUv2 Plugin/AKSampler AUv2 Plugin.xcodeproj/xcshareddata/xcschemes/AKSampler.xcscheme
@@ -44,7 +44,7 @@
       allowLocationSimulation = "YES">
       <PathRunnable
          runnableDebuggingMode = "0"
-         FilePath = "/Applications/Logic Pro X.app">
+         FilePath = "/Applications/Utilities/AU Lab.app">
       </PathRunnable>
       <MacroExpansion>
          <BuildableReference

--- a/Developer/AKSampler/Mac AUv2 Plugin/Plugin DSP/AKSampler_Plugin.cpp
+++ b/Developer/AKSampler/Mac AUv2 Plugin/Plugin DSP/AKSampler_Plugin.cpp
@@ -86,7 +86,7 @@ void AKSampler_Plugin::initForTesting()
     // load single-cycle saw waves so there's something to play
     AudioKitCore::FunctionTable ftable;
     ftable.init(1024);
-    ftable.sawtooth(0.2f);
+    ftable.sinusoid(0.4f);
     AKSampleDataDescriptor sdd;
     sdd.sampleDescriptor.noteNumber = 28;
     sdd.sampleDescriptor.noteFrequency = 44100.0f / 1024;


### PR DESCRIPTION
AKCoreSampler's ADSR envelopes update only every 16 samples for efficiency, but this resulted in a stair-step output which yielded audible modulation noise in certain cases. The ADSR volume envelope is now smoothed using a LinearRamper to eliminate this effect. The LinearRamper implementation has also been simplified and corrected.