### PR TITLE
Various fixes to Basics.playground

### DIFF
--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Connecting Nodes Part 2.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Connecting Nodes Part 2.xcplaygroundpage/Contents.swift
@@ -35,7 +35,7 @@ class AudioEngine {
         }
         player = AKPlayer(audioFile: file)
         player.isLooping = true
-        player.isBuffered = true
+        player.buffering = .always
 
         // Next we'll connect the audio player to a delay effect
         delay = AKDelay(player)

--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Metronome.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Metronome.xcplaygroundpage/Contents.swift
@@ -74,3 +74,5 @@ class LiveView: AKLiveViewController {
 import PlaygroundSupport
 PlaygroundPage.current.needsIndefiniteExecution = true
 PlaygroundPage.current.liveView = view
+
+//: [TOC](Table%20Of%20Contents) | [Previous](@previous) | [Next](@next)

--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Non-Audio Tutorial.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Non-Audio Tutorial.xcplaygroundpage/Contents.swift
@@ -20,7 +20,7 @@ import AudioKitUI
 //: This just means you haven't built AudioKitPlaygrounds yet, in which case pressing Cmd-B or
 //: accessing the "Product" menu and choosing "Build".
 
-//: To use a file, copy it intot playground's "Resources" folder and refer to it by name:
+//: To use a file, copy it into the playground's "Resources" folder and refer to it by name:
 let file = try AKAudioFile(readFileName: "mixloop.wav")
 
 //: You are not limited to using the sound files provided with AudioKit, in fact

--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Parameter Ramping.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Parameter Ramping.xcplaygroundpage/Contents.swift
@@ -39,7 +39,7 @@ import AudioKitUI
 class LiveView: AKLiveViewController {
 
     override func viewDidLoad() {
-        addTitle("Parameter Ramp Duration")
+        addTitle("Parameter Ramping")
 
         addView(AKSlider(property: "Ramp Duration", value: filter.rampDuration, format: "%0.3f s") { sliderValue in
             filter.rampDuration = sliderValue

--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Playgrounds to Production.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Playgrounds to Production.xcplaygroundpage/Contents.swift
@@ -43,7 +43,11 @@ class AudioEngine {
     init() {
         oscillator = AKOscillator()
         AudioKit.output = oscillator
-        try AudioKit.start()
+        do {
+            try AudioKit.start()
+        } catch {
+            AKLog("AudioKit did not start")
+        }
     }
 }
 

--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Stereo Operation.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Stereo Operation.xcplaygroundpage/Contents.swift
@@ -1,3 +1,7 @@
+//: [TOC](Table%20Of%20Contents) | [Previous](@previous) | [Next](@next)
+//:
+//: ---
+//:
 //: ## Stereo Operation
 //: This is an example of building a stereo sound generator.
 import AudioKitPlaygrounds
@@ -23,3 +27,5 @@ generator.start()
 
 import PlaygroundSupport
 PlaygroundPage.current.needsIndefiniteExecution = true
+
+//: [TOC](Table%20Of%20Contents) | [Previous](@previous) | [Next](@next)

--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/contents.xcplayground
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/contents.xcplayground
@@ -11,7 +11,7 @@
         <page name='Dry Wet Mixer'/>
         <page name='Balancing Nodes'/>
         <page name='Stereo Panning'/>
-        <page name='Parameter Ramp Duration'/>
+        <page name='Parameter Ramping'/>
         <page name='Tables'/>
         <page name='Metronome'/>
         <page name='Low-Frequency Oscillating of Parameters'/>


### PR DESCRIPTION
Various fixes to the Basics.playground for problems that I encountered while working through the playground. The changes addressed navigation problems, compilation errors, syntax errors and typos. Refer to the individual commits for more detail.