### PR TITLE
BufferedAudioUnit as base class for AKAudioUnitBase and AKGeneratorAudioUnitBase (again)

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
@@ -12,8 +12,9 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import "AKDSPBase.hpp"
+#import "BufferedAudioUnit.h"
 
-@interface AKAudioUnitBase : AUAudioUnit
+@interface AKAudioUnitBase : BufferedAudioUnit
 
 /**
  This method should be overridden by the specific AU code, because it knows how to set up
@@ -49,12 +50,6 @@
 
 @property (readonly) BOOL isPlaying;
 @property (readonly) BOOL isSetUp;
-
-// These three properties are what are in the Apple example code.
-
-@property AUAudioUnitBus *outputBus;
-@property AUAudioUnitBusArray *inputBusArray;
-@property AUAudioUnitBusArray *outputBusArray;
 
 @end
 

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -7,7 +7,6 @@
 //
 
 #import "AKAudioUnitBase.h"
-#import "BufferedAudioBus.hpp"
 
 #import <AudioKit/AudioKit-Swift.h>
 
@@ -19,7 +18,6 @@
 
 @implementation AKAudioUnitBase {
     // C++ members need to be ivars; they would be copied on access if they were properties.
-    BufferedInputBus _inputBus;
     AKDSPBase *_kernel;
 }
 
@@ -104,38 +102,17 @@
     if (self == nil) { return nil; }
 
     // Initialize a default format for the busses.
-    AVAudioFormat *defaultFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate
-                                                                                  channels:AKSettings.channelCount];
+    AVAudioFormat *arbitraryFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate
+                                                                                    channels:AKSettings.channelCount];
 
-    _kernel = (AKDSPBase*)[self initDSPWithSampleRate:defaultFormat.sampleRate
-                                         channelCount:defaultFormat.channelCount];
-
-    // Create the input and output busses.
-    _inputBus.init(defaultFormat, 8);
-    _outputBus = [[AUAudioUnitBus alloc] initWithFormat:defaultFormat error:nil];
-
-    // Create the input and output bus arrays.
-    _inputBusArray  = [[AUAudioUnitBusArray alloc] initWithAudioUnit:self
-                                                             busType:AUAudioUnitBusTypeInput
-                                                              busses: @[_inputBus.bus]];
-
-    _outputBusArray = [[AUAudioUnitBusArray alloc] initWithAudioUnit:self
-                                                             busType:AUAudioUnitBusTypeOutput
-                                                              busses: @[self.outputBus]];
+    _kernel = (AKDSPBase*)[self initDSPWithSampleRate:arbitraryFormat.sampleRate
+                                         channelCount:arbitraryFormat.channelCount];
 
     // Create a default empty parameter tree.
     _parameterTree = [AUParameterTree createTreeWithChildren:@[]];
 
-    self.maximumFramesToRender = 512;
-
     return self;
 }
-
-// ----- BEGIN UNMODIFIED COPY FROM APPLE CODE -----
-
-- (AUAudioUnitBusArray *)inputBusses { return _inputBusArray; }
-
-- (AUAudioUnitBusArray *)outputBusses { return _outputBusArray; }
 
 // Allocate resources required to render.
 // Hosts must call this to initialize the AU before beginning to render.
@@ -144,82 +121,32 @@
         return NO;
     }
 
-    if (self.outputBus.format.channelCount != _inputBus.bus.format.channelCount) {
-        if (outError) {
-            *outError = [NSError errorWithDomain:NSOSStatusErrorDomain code:kAudioUnitErr_FailedInitialization userInfo:nil];
-        }
-        // Notify superclass that initialization was not successful
-        self.renderResourcesAllocated = NO;
-        return NO;
-    }
-
-    _inputBus.allocateRenderResources(self.maximumFramesToRender);
-    _kernel->init(self.outputBus.format.channelCount, self.outputBus.format.sampleRate);
+    AVAudioFormat *format = self.outputBusses[0].format;
+    _kernel->init(format.channelCount, format.sampleRate);
     _kernel->reset();
     return YES;
+}
+
+-(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format {
+    
+    __block AKDSPBase *state = _kernel;
+    return ^(AudioBufferList       *inBuffer,
+             AudioBufferList       *outBuffer,
+             const AudioTimeStamp  *timestamp,
+             AVAudioFrameCount     frameCount,
+             const AURenderEvent   *eventListHead) {
+
+        state->setBuffers(inBuffer, outBuffer);
+        state->processWithEvents(timestamp, frameCount, eventListHead);
+    };
 }
 
 // Deallocate resources allocated by allocateRenderResourcesAndReturnError:
 // Hosts should call this after finishing rendering.
 
 - (void)deallocateRenderResources {
-    _inputBus.deallocateRenderResources();
     _kernel->deinit();
     [super deallocateRenderResources];
-}
-
-// Subclassers must provide a AUInternalRenderBlock (via a getter) to implement rendering.
-
-- (AUInternalRenderBlock)internalRenderBlock {
-    // Capture in locals to avoid ObjC member lookups.
-    // Specify captured objects are mutable.
-    __block AKDSPBase *state = _kernel;
-    __block BufferedInputBus *input = &_inputBus;
-
-    return ^AUAudioUnitStatus(
-                              AudioUnitRenderActionFlags *actionFlags,
-                              const AudioTimeStamp       *timestamp,
-                              AVAudioFrameCount           frameCount,
-                              NSInteger                   outputBusNumber,
-                              AudioBufferList            *outputData,
-                              const AURenderEvent        *realtimeEventListHead,
-                              AURenderPullInputBlock      pullInputBlock) {
-        AudioUnitRenderActionFlags pullFlags = 0;
-
-        AUAudioUnitStatus err = input->pullInput(&pullFlags, timestamp, frameCount, 0, pullInputBlock);
-
-        if (err != 0) { return err; }
-
-        AudioBufferList *inAudioBufferList = input->mutableAudioBufferList;
-
-        /*
-         Important:
-         If the caller passed non-null output pointers (outputData->mBuffers[x].mData), use those.
-
-         If the caller passed null output buffer pointers, process in memory owned by the Audio Unit
-         and modify the (outputData->mBuffers[x].mData) pointers to point to this owned memory.
-         The Audio Unit is responsible for preserving the validity of this memory until the next call to render,
-         or deallocateRenderResources is called.
-
-         If your algorithm cannot process in-place, you will need to preallocate an output buffer
-         and use it here.
-
-         See the description of the canProcessInPlace property.
-         */
-
-        // If passed null output buffer pointers, process in-place in the input buffer.
-        AudioBufferList *outAudioBufferList = outputData;
-        if (outAudioBufferList->mBuffers[0].mData == nullptr) {
-            for (UInt32 i = 0; i < outAudioBufferList->mNumberBuffers; ++i) {
-                outAudioBufferList->mBuffers[i].mData = inAudioBufferList->mBuffers[i].mData;
-            }
-        }
-
-        state->setBuffers(inAudioBufferList, outAudioBufferList);
-        state->processWithEvents(timestamp, frameCount, realtimeEventListHead);
-
-        return noErr;
-    };
 }
 
 // Expresses whether an audio unit can process in place.

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
@@ -97,8 +97,8 @@ public:
      Handles the event list processing and rendering loop. Should be called from AU renderBlock
      From Apple Example code
      */
-    void processWithEvents(AudioTimeStamp const *timestamp, AUAudioFrameCount frameCount,
-                           AURenderEvent const *events);
+    virtual void processWithEvents(AudioTimeStamp const *timestamp, AUAudioFrameCount frameCount,
+                                   AURenderEvent const *events);
 
 private:
 

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
@@ -12,8 +12,9 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import "AKDSPBase.hpp"
+#import "BufferedAudioUnit.h"
 
-@interface AKGeneratorAudioUnitBase : AUAudioUnit
+@interface AKGeneratorAudioUnitBase : BufferedAudioUnit
 
 /**
  This method should be overridden by the specific AU code, because it knows how to set up
@@ -57,11 +58,6 @@
 
 @property (readonly) BOOL isPlaying;
 @property (readonly) BOOL isSetUp;
-
-// These three properties are what are in the Apple example code.
-
-@property AUAudioUnitBus *outputBus;
-@property AUAudioUnitBusArray *outputBusArray;
 
 @end
 

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
@@ -103,7 +103,7 @@ static void    bufferListPointChannelDataToBuffer(AudioBufferList *bufferList, f
              const AURenderEvent   *realtimeEventListHead) {
 
         if (inBuffer == NULL) {
-            for (int i = 0; i < inBuffer->mNumberBuffers; i++) {
+            for (int i = 0; i < outBuffer->mNumberBuffers; i++) {
                 memset(outBuffer->mBuffers[i].mData, 0, outBuffer->mBuffers[i].mDataByteSize);
             }
         } else {

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
@@ -83,6 +83,8 @@ struct AKSamplerDSP : AKDSPBase, AKCoreSampler
 
     void handleMIDIEvent(AUMIDIEvent const& midiEvent) override;
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
+    void processWithEvents(const AudioTimeStamp *timestamp, AUAudioFrameCount frameCount, const AURenderEvent *events) override;
+
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -277,6 +277,14 @@ void AKSamplerDSP::handleMIDIEvent(const AUMIDIEvent &midiEvent)
     }
 }
 
+void AKSamplerDSP::processWithEvents(const AudioTimeStamp *timestamp, AUAudioFrameCount frameCount, const AURenderEvent *events)
+{
+    for (int i = 0; i < _outBufferListPtr->mNumberBuffers; i++) {
+        memset(_outBufferListPtr->mBuffers[i].mData, 0, _outBufferListPtr->mBuffers[i].mDataByteSize);
+    }
+    AKDSPBase::processWithEvents(timestamp, frameCount, events);
+}
+
 void AKSamplerDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset)
 {
     // process in chunks of maximum length AKCORESAMPLER_CHUNKSIZE


### PR DESCRIPTION
This is re-introducing the changes originally made in https://github.com/AudioKit/AudioKit/pull/1579. There was an incompatibility with AKSampler where notes would seemingly hang, so the existing base classes were reverted in https://github.com/AudioKit/AudioKit/pull/1587.  

The issue was that the existing base classes zeroed out the output buffer before rendering, whereas the new base class does not. This is addressed by zeroing the output buffer before rendering in AKSamplerDSP->processWithEvents. 