### PR TITLE
Move buffer clearing to base class.

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
@@ -97,8 +97,8 @@ public:
      Handles the event list processing and rendering loop. Should be called from AU renderBlock
      From Apple Example code
      */
-    virtual void processWithEvents(AudioTimeStamp const *timestamp, AUAudioFrameCount frameCount,
-                                   AURenderEvent const *events);
+    void processWithEvents(AudioTimeStamp const *timestamp, AUAudioFrameCount frameCount,
+                           AURenderEvent const *events);
 
 private:
 

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.h
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.h
@@ -12,20 +12,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** No Swift or ObjC functions and property access. No ARC managed references/assignments. */
 typedef void(^ProcessEventsBlock)(AudioBufferList        * _Nullable inBuffer,
                                   AudioBufferList        * _Nonnull  outBuffer,
                                   const AudioTimeStamp   * _Nonnull  timestamp,
                                   AVAudioFrameCount                  frameCount,
                                   const AURenderEvent    * _Nullable eventsListHead);
 
-
 @interface BufferedAudioUnit : AUAudioUnit
 
-// Override and do processing in this block.
+/** Subclasses should overide this to return a block to do processing in. */
 -(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format;
 
-// Generators should return false;
+/** If true, an input bus will be allocated, intended for sunclasses to override, defaults to true. */
 -(BOOL)shouldAllocateInputBus;
+
+/** If true, the output buffer samples will be set to zero pre-render, Intended for sunclasses to override, defaults to false */
+-(BOOL)shouldClearOutputBuffer;
+
 @end
 
 

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -428,4 +428,8 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         doAKSamplerSustainPedal(pDSP, down)
     }
 
+    override public func shouldClearOutputBuffer() -> Bool {
+        return true;
+    }
+
 }

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
@@ -83,8 +83,6 @@ struct AKSamplerDSP : AKDSPBase, AKCoreSampler
 
     void handleMIDIEvent(AUMIDIEvent const& midiEvent) override;
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
-    void processWithEvents(const AudioTimeStamp *timestamp, AUAudioFrameCount frameCount, const AURenderEvent *events) override;
-
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -277,14 +277,6 @@ void AKSamplerDSP::handleMIDIEvent(const AUMIDIEvent &midiEvent)
     }
 }
 
-void AKSamplerDSP::processWithEvents(const AudioTimeStamp *timestamp, AUAudioFrameCount frameCount, const AURenderEvent *events)
-{
-    for (int i = 0; i < _outBufferListPtr->mNumberBuffers; i++) {
-        memset(_outBufferListPtr->mBuffers[i].mData, 0, _outBufferListPtr->mBuffers[i].mDataByteSize);
-    }
-    AKDSPBase::processWithEvents(timestamp, frameCount, events);
-}
-
 void AKSamplerDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset)
 {
     // process in chunks of maximum length AKCORESAMPLER_CHUNKSIZE


### PR DESCRIPTION
As discussed, this PR removes buffer clearing from DSP class, adds shouldClearOutputBuffer override to BufferedAudioUnit. 