### PR TITLE
Divide by file duration if endTime - startTime is zero

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -308,7 +308,7 @@ import AVFoundation
     @objc public var currentTime: Double {
         let currentDuration = (endTime - startTime == 0) ? duration : (endTime - startTime)
         let current = startTime + playerTime.truncatingRemainder(dividingBy: currentDuration)
-        
+
         return current
     }
 

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -306,7 +306,9 @@ import AVFoundation
 
     /// - Returns: Current time of the player in seconds while playing.
     @objc public var currentTime: Double {
-        let current = startTime + playerTime.truncatingRemainder(dividingBy: (endTime - startTime))
+        let currentDuration = (endTime - startTime == 0) ? duration : (endTime - startTime)
+        let current = startTime + playerTime.truncatingRemainder(dividingBy: currentDuration)
+        
         return current
     }
 


### PR DESCRIPTION
When calculating `currentTime`, there is a division by `endTime - startTime` which, before playing the audio file, is 0.0. This fix checks for this and sets it to `duration` if true, as `duration` is set when loading the file.

fixes #1577.