### PR TITLE
Add filterEnvelopeVelocityScaling parameter to AKSampler

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
@@ -447,7 +447,8 @@
         self.internalAU?.setParameterImmediately(.monophonic, value: isMonophonic ? 1.0 : 0.0)
         self.internalAU?.setParameterImmediately(.legato, value: isLegato ? 1.0 : 0.0)
         self.internalAU?.setParameterImmediately(.keyTrackingFraction, value: keyTracking)
-        self.internalAU?.setParameterImmediately(.filterEnvelopeVelocityScaling, value: filterEnvelopeVelocityScaling)    }
+        self.internalAU?.setParameterImmediately(.filterEnvelopeVelocityScaling, value: filterEnvelopeVelocityScaling)
+    }
 
     @objc open func loadAKAudioFile(from sampleDescriptor: AKSampleDescriptor, file: AKAudioFile) {
         let sampleRate = Float(file.sampleRate)

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
@@ -296,8 +296,8 @@
     /// filterEnvelopeVelocityScaling (fraction 0.0 to 1.0)
     @objc open dynamic var filterEnvelopeVelocityScaling: Double = 0.0 {
         willSet {
-            if (filterEnvelopeVelocityScaling != newValue) {
-                internalAU?.filterEnvelopeVelocityScaling = newValue;
+            if filterEnvelopeVelocityScaling != newValue {
+                internalAU?.filterEnvelopeVelocityScaling = newValue
             }
         }
     }

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -103,6 +103,10 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
     var keyTrackingFraction: Double = 1.0 {
         didSet { setParameter(.keyTrackingFraction, value: keyTrackingFraction) }
     }
+
+    var filterEnvelopeVelocityScaling: Double = 0.0 {
+        didSet { setParameter(.filterEnvelopeVelocityScaling, value: filterEnvelopeVelocityScaling) }
+    }
     
     public override func initDSP(withSampleRate sampleRate: Double,
                                  channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
@@ -336,6 +340,17 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
             flags: nonRampFlags,
             valueStrings: nil, dependentParameters: nil)
 
+        parameterAddress += 1
+
+        let filterEnvelopeVelocityScalingParameter = AUParameterTree.createParameter(
+            withIdentifier: "filterEnvelopeVelocityScaling",
+            name: "Filter Envelope Velocity Scaling",
+            address: AUParameterAddress(parameterAddress),
+            min: 0.0, max: 1.0,
+            unit: .generic, unitName: nil,
+            flags: nonRampFlags,
+            valueStrings: nil, dependentParameters: nil)
+
         setParameterTree(AUParameterTree.createTree(withChildren: [masterVolumeParameter,
                                                                    pitchBendParameter,
                                                                    vibratoDepthParameter,
@@ -355,7 +370,8 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
                                                                    loopThruReleaseParameter,
                                                                    monophonicParameter,
                                                                    legatoParameter,
-                                                                   keyTrackingParameter]))
+                                                                   keyTrackingParameter,
+                                                                   filterEnvelopeVelocityScalingParameter]))
         masterVolumeParameter.value = 1.0
         pitchBendParameter.value = 0.0
         vibratoDepthParameter.value = 0.0
@@ -376,6 +392,7 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         monophonicParameter.value = 0.0
         legatoParameter.value = 0.0
         keyTrackingParameter.value = 1.0
+        filterEnvelopeVelocityScalingParameter.value = 0.0
     }
     
     public override var canProcessInPlace: Bool { return true }

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
@@ -35,6 +35,7 @@ typedef NS_ENUM(AUParameterAddress, AKSamplerParameter)
     AKSamplerParameterMonophonic,
     AKSamplerParameterLegato,
     AKSamplerParameterKeyTrackingFraction,
+    AKSamplerParameterFilterEnvelopeVelocityScaling,
     
     // ensure this is always last in the list, to simplify parameter addressing
     AKSamplerParameterRampDuration,

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -193,6 +193,9 @@ void AKSamplerDSP::setParameter(AUParameterAddress address, float value, bool im
         case AKSamplerParameterKeyTrackingFraction:
             keyTracking = value;
             break;
+        case AKSamplerParameterFilterEnvelopeVelocityScaling:
+            filterEnvelopeVelocityScaling = value;
+            break;
     }
 }
 
@@ -244,6 +247,8 @@ float AKSamplerDSP::getParameter(AUParameterAddress address)
             return isLegato ? 1.0f : 0.0f;
         case AKSamplerParameterKeyTrackingFraction:
             return keyTracking;
+        case AKSamplerParameterFilterEnvelopeVelocityScaling:
+            return filterEnvelopeVelocityScaling;
     }
     return 0;
 }

--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
@@ -53,6 +53,7 @@ AKCoreSampler::AKCoreSampler()
 , cutoffMultiple(4.0f)
 , keyTracking(1.0f)
 , cutoffEnvelopeStrength(20.0f)
+, filterEnvelopeVelocityScaling(0.0f)
 , linearResonance(0.5f)
 , loopThruRelease(false)
 , stoppingAllVoices(false)
@@ -397,7 +398,7 @@ void AKCoreSampler::render(unsigned channelCount, unsigned sampleCount, float *o
         {
             if (stoppingAllVoices ||
                 pVoice->prepToGetSamples(sampleCount, masterVolume, pitchDev, cutoffMul, keyTracking,
-                                         cutoffEnvelopeStrength, linearResonance) ||
+                                         cutoffEnvelopeStrength, filterEnvelopeVelocityScaling, linearResonance) ||
                 (pVoice->getSamples(sampleCount, pOutLeft, pOutRight) && allowSampleRunout))
             {
                 stopNote(nn, true);

--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
@@ -119,6 +119,9 @@ protected:
     // how much filter EG adds on top of cutoffMultiple
     float cutoffEnvelopeStrength;
     
+    /// fraction 0.0 - 1.0, scaling note volume's effect on cutoffEnvelopeStrength
+    float filterEnvelopeVelocityScaling;
+
     // resonance [-20 dB, +20 dB] becomes linear [10.0, 0.1]
     float linearResonance;
     

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
@@ -118,7 +118,8 @@ namespace AudioKitCore
     }
 
     bool SamplerVoice::prepToGetSamples(int sampleCount, float masterVolume, float pitchOffset,
-                                        float cutoffMultiple, float keyTracking, float cutoffEnvelopeStrength,
+                                        float cutoffMultiple, float keyTracking,
+                                        float cutoffEnvelopeStrength, float cutoffEnvelopeVelocityScaling,
                                         float resLinear)
     {
         if (adsrEnvelope.isIdle()) return true;
@@ -170,7 +171,8 @@ namespace AudioKitCore
             isFilterEnabled = true;
             noteFrequency *= powf(2.0f, (pitchOffset + glideSemitones) / 12.0f);
             float baseFrequency = MIDDLE_C_HZ + keyTracking * (noteFrequency - MIDDLE_C_HZ);
-            double cutoffFrequency = baseFrequency * (1.0f + cutoffMultiple + cutoffEnvelopeStrength * filterEnvelope.getSample());
+            float envStrength = ((1.0f - cutoffEnvelopeVelocityScaling) + cutoffEnvelopeVelocityScaling * noteVolume);
+            double cutoffFrequency = baseFrequency * (1.0f + cutoffMultiple + cutoffEnvelopeStrength * envStrength * filterEnvelope.getSample());
             leftFilter.setParameters(cutoffFrequency, resLinear);
             rightFilter.setParameters(cutoffFrequency, resLinear);
         }

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.hpp
@@ -45,7 +45,7 @@ namespace AudioKitCore
 
         /// fraction 0.0 - 1.0, based on MIDI velocity
         float noteVolume;
-        
+
         // temporary holding variables
 
         /// Previous note volume while damping note before restarting
@@ -88,6 +88,7 @@ namespace AudioKitCore
                               float cutoffMultiple,
                               float keyTracking,
                               float cutoffEnvelopeStrength,
+                              float cutoffEnvelopeVelocityScaling,
                               float resLinear);
 
         bool getSamples(int sampleCount, float *leftOutput, float *rightOutput);


### PR DESCRIPTION
New _filterEnvelopeVelocityScaling_ parameter is a fraction (range 0.0 to 1.0) which sets to what degree the per-voice filter envelope strength parameter is scaled by MIDI note velocity. The default is 0.0, meaning velocity has no effect. A value of 1.0 means 100% scaling, i.e. the filter envelope strength only reaches the value set by the _filterStrength_ when note velocity is 127; note velocity 64 would result in an effective value of _filterStrength_/2.