### PR TITLE
Replace void* and UnsafeMutableRawPointer with AKDSPRef.

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
@@ -13,6 +13,7 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import "AKDSPBase.hpp"
 #import "BufferedAudioUnit.h"
+#import "AKInterop.h"
 
 @interface AKAudioUnitBase : BufferedAudioUnit
 
@@ -23,7 +24,7 @@
  is. I'm not sure the standard way to deal with this.
  */
 
-- (void*)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count;
+- (AKDSPRef)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count;
 
 /**
  Sets the parameter tree. The important piece here is that setting the parameter tree

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -52,8 +52,8 @@
  DSP is invalid.
  */
 
-- (void*)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count {
-    return (void*)(_kernel = NULL);
+- (AKDSPRef)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count {
+    return (AKDSPRef)(_kernel = NULL);
 }
 
 /**

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
@@ -13,7 +13,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import <algorithm>
-
+#import "AKInterop.h"
 /**
  Base class for DSPKernels. Many of the methods are virtual, because the base AudioUnit class
  does not know the type of the subclass at compile time.

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
@@ -23,7 +23,7 @@
  is. I'm not sure the standard way to deal with this.
  */
 
-- (void*)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count;
+- (AKDSPRef)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count;
 
 /**
  Sets the parameter tree. The important piece here is that setting the parameter tree

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
@@ -62,8 +62,8 @@
  DSP is invalid.
  */
 
-- (void*)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count {
-    return (void*)(_kernel = NULL);
+- (AKDSPRef)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count {
+    return (AKDSPRef)(_kernel = NULL);
 }
 
 /**

--- a/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
+++ b/AudioKit/Common/Internals/CoreAudio/BufferedAudioUnit.m
@@ -198,7 +198,7 @@ static void bufferListClear(AudioBufferList *audioBufferList) {
     }
 }
 
-static size_t  bufferListByteSize(int channelCount) {
+static size_t bufferListByteSize(int channelCount) {
     return sizeof(AudioBufferList) + (sizeof(AudioBuffer) * (channelCount - 1));
 }
 

--- a/AudioKit/Common/Internals/Utilities/AKInterop.h
+++ b/AudioKit/Common/Internals/Utilities/AKInterop.h
@@ -11,8 +11,10 @@
 
 #ifdef __OBJC__
 #define AK_ENUM(a) enum __attribute__((enum_extensibility(open))) a : int
+#define AK_SWIFT_TYPE __attribute((swift_newtype(struct)))
 #else
 #define AK_ENUM(a) enum a
+#define AK_SWIFT_TYPE
 #endif
 
 /* EXAMPLE
@@ -28,5 +30,8 @@
  Then use in Swift:
  let direction: AKDirection = .up
 */
+
+/** Pointer to an instance of an AKDSPBase subclass */
+typedef void* AKDSPRef AK_SWIFT_TYPE;
 
 #endif /* AKInterop_h */

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKVariableDelayAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createVariableDelayDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKVariableDelayParameter) {
 
 #ifndef __cplusplus
 
-void *createVariableDelayDSP(int nChannels, double sampleRate);
+AKDSPRef createVariableDelayDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
@@ -9,7 +9,7 @@
 #include "AKVariableDelayDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createVariableDelayDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createVariableDelayDSP(int nChannels, double sampleRate) {
     AKVariableDelayDSP *dsp = new AKVariableDelayDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKBitCrusherAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createBitCrusherDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKBitCrusherParameter) {
 
 #ifndef __cplusplus
 
-void *createBitCrusherDSP(int nChannels, double sampleRate);
+AKDSPRef createBitCrusherDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
@@ -9,7 +9,7 @@
 #include "AKBitCrusherDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createBitCrusherDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createBitCrusherDSP(int nChannels, double sampleRate) {
     AKBitCrusherDSP *dsp = new AKBitCrusherDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKClipperAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createClipperDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKClipperParameter) {
 
 #ifndef __cplusplus
 
-void *createClipperDSP(int nChannels, double sampleRate);
+AKDSPRef createClipperDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
@@ -9,7 +9,7 @@
 #include "AKClipperDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createClipperDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createClipperDSP(int nChannels, double sampleRate) {
     AKClipperDSP *dsp = new AKClipperDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKTanhDistortionAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createTanhDistortionDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKTanhDistortionParameter) {
 
 #ifndef __cplusplus
 
-void *createTanhDistortionDSP(int nChannels, double sampleRate);
+AKDSPRef createTanhDistortionDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
@@ -9,7 +9,7 @@
 #include "AKTanhDistortionDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createTanhDistortionDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createTanhDistortionDSP(int nChannels, double sampleRate) {
     AKTanhDistortionDSP *dsp = new AKTanhDistortionDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKDynamicRangeCompressorAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createDynamicRangeCompressorDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKDynamicRangeCompressorParameter) {
 
 #ifndef __cplusplus
 
-void *createDynamicRangeCompressorDSP(int nChannels, double sampleRate);
+AKDSPRef createDynamicRangeCompressorDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
@@ -9,7 +9,7 @@
 #include "AKDynamicRangeCompressorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createDynamicRangeCompressorDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createDynamicRangeCompressorDSP(int nChannels, double sampleRate) {
     AKDynamicRangeCompressorDSP *dsp = new AKDynamicRangeCompressorDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelope.mm
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelope.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createAmplitudeEnvelopeDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createAmplitudeEnvelopeDSP(int nChannels, double sampleRate) {
     AKAmplitudeEnvelopeDSP *dsp = new AKAmplitudeEnvelopeDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeAudioUnit.swift
@@ -36,7 +36,7 @@ public class AKAmplitudeEnvelopeAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createAmplitudeEnvelopeDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeDSP.hpp
@@ -22,7 +22,7 @@ typedef NS_ENUM(AUParameterAddress, AKAmplitudeEnvelopeParameter) {
 
 #ifndef __cplusplus
 
-void *createAmplitudeEnvelopeDSP(int nChannels, double sampleRate);
+AKDSPRef createAmplitudeEnvelopeDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremolo.mm
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremolo.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createTremoloDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createTremoloDSP(int nChannels, double sampleRate) {
     AKTremoloDSP *dsp = new AKTremoloDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloAudioUnit.swift
@@ -30,7 +30,7 @@ public class AKTremoloAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createTremoloDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKTremoloParameter) {
 
 #ifndef __cplusplus
 
-void *createTremoloDSP(int nChannels, double sampleRate);
+AKDSPRef createTremoloDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKBandPassButterworthFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createBandPassButterworthFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKBandPassButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createBandPassButterworthFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createBandPassButterworthFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKBandPassButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createBandPassButterworthFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createBandPassButterworthFilterDSP(int nChannels, double sampleRate) {
     AKBandPassButterworthFilterDSP *dsp = new AKBandPassButterworthFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKBandRejectButterworthFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createBandRejectButterworthFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKBandRejectButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createBandRejectButterworthFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createBandRejectButterworthFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKBandRejectButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createBandRejectButterworthFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createBandRejectButterworthFilterDSP(int nChannels, double sampleRate) {
     AKBandRejectButterworthFilterDSP *dsp = new AKBandRejectButterworthFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockAudioUnit.swift
@@ -23,7 +23,7 @@ public class AKDCBlockAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createDCBlockDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.hpp
@@ -16,7 +16,7 @@ typedef NS_ENUM(AUParameterAddress, AKDCBlockParameter) {
 
 #ifndef __cplusplus
 
-void *createDCBlockDSP(int nChannels, double sampleRate);
+AKDSPRef createDCBlockDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
@@ -9,7 +9,7 @@
 #include "AKDCBlockDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createDCBlockDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createDCBlockDSP(int nChannels, double sampleRate) {
     AKDCBlockDSP *dsp = new AKDCBlockDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKEqualizerFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createEqualizerFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKEqualizerFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createEqualizerFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createEqualizerFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createEqualizerFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createEqualizerFilterDSP(int nChannels, double sampleRate) {
     AKEqualizerFilterDSP *dsp = new AKEqualizerFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKFormantFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createFormantFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKFormantFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createFormantFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createFormantFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKFormantFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createFormantFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createFormantFilterDSP(int nChannels, double sampleRate) {
     AKFormantFilterDSP *dsp = new AKFormantFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKHighPassButterworthFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createHighPassButterworthFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKHighPassButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createHighPassButterworthFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createHighPassButterworthFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKHighPassButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createHighPassButterworthFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createHighPassButterworthFilterDSP(int nChannels, double sampleRate) {
     AKHighPassButterworthFilterDSP *dsp = new AKHighPassButterworthFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKHighShelfParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createHighShelfParametricEqualizerFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKHighShelfParametricEqualizerFilterParamete
 
 #ifndef __cplusplus
 
-void *createHighShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createHighShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKHighShelfParametricEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createHighShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createHighShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate) {
     AKHighShelfParametricEqualizerFilterDSP *dsp = new AKHighShelfParametricEqualizerFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKKorgLowPassFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createKorgLowPassFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKKorgLowPassFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createKorgLowPassFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createKorgLowPassFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKKorgLowPassFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createKorgLowPassFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createKorgLowPassFilterDSP(int nChannels, double sampleRate) {
     AKKorgLowPassFilterDSP *dsp = new AKKorgLowPassFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKLowPassButterworthFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createLowPassButterworthFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKLowPassButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createLowPassButterworthFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createLowPassButterworthFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKLowPassButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createLowPassButterworthFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createLowPassButterworthFilterDSP(int nChannels, double sampleRate) {
     AKLowPassButterworthFilterDSP *dsp = new AKLowPassButterworthFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKLowShelfParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createLowShelfParametricEqualizerFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKLowShelfParametricEqualizerFilterParameter
 
 #ifndef __cplusplus
 
-void *createLowShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createLowShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKLowShelfParametricEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createLowShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createLowShelfParametricEqualizerFilterDSP(int nChannels, double sampleRate) {
     AKLowShelfParametricEqualizerFilterDSP *dsp = new AKLowShelfParametricEqualizerFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKModalResonanceFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createModalResonanceFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKModalResonanceFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createModalResonanceFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createModalResonanceFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKModalResonanceFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createModalResonanceFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createModalResonanceFilterDSP(int nChannels, double sampleRate) {
     AKModalResonanceFilterDSP *dsp = new AKModalResonanceFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKMoogLadderAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createMoogLadderDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKMoogLadderParameter) {
 
 #ifndef __cplusplus
 
-void *createMoogLadderDSP(int nChannels, double sampleRate);
+AKDSPRef createMoogLadderDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
@@ -9,7 +9,7 @@
 #include "AKMoogLadderDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createMoogLadderDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createMoogLadderDSP(int nChannels, double sampleRate) {
     AKMoogLadderDSP *dsp = new AKMoogLadderDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKPeakingParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPeakingParametricEqualizerFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKPeakingParametricEqualizerFilterParameter)
 
 #ifndef __cplusplus
 
-void *createPeakingParametricEqualizerFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createPeakingParametricEqualizerFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKPeakingParametricEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createPeakingParametricEqualizerFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPeakingParametricEqualizerFilterDSP(int nChannels, double sampleRate) {
     AKPeakingParametricEqualizerFilterDSP *dsp = new AKPeakingParametricEqualizerFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKResonantFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createResonantFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKResonantFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createResonantFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createResonantFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKResonantFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createResonantFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createResonantFilterDSP(int nChannels, double sampleRate) {
     AKResonantFilterDSP *dsp = new AKResonantFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKRolandTB303FilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createRolandTB303FilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKRolandTB303FilterParameter) {
 
 #ifndef __cplusplus
 
-void *createRolandTB303FilterDSP(int nChannels, double sampleRate);
+AKDSPRef createRolandTB303FilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKRolandTB303FilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createRolandTB303FilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createRolandTB303FilterDSP(int nChannels, double sampleRate) {
     AKRolandTB303FilterDSP *dsp = new AKRolandTB303FilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKStringResonatorAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createStringResonatorDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKStringResonatorParameter) {
 
 #ifndef __cplusplus
 
-void *createStringResonatorDSP(int nChannels, double sampleRate);
+AKDSPRef createStringResonatorDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
@@ -9,7 +9,7 @@
 #include "AKStringResonatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createStringResonatorDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createStringResonatorDSP(int nChannels, double sampleRate) {
     AKStringResonatorDSP *dsp = new AKStringResonatorDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKThreePoleLowpassFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef! {
         return createThreePoleLowpassFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKThreePoleLowpassFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createThreePoleLowpassFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createThreePoleLowpassFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKThreePoleLowpassFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createThreePoleLowpassFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createThreePoleLowpassFilterDSP(int nChannels, double sampleRate) {
     AKThreePoleLowpassFilterDSP *dsp = new AKThreePoleLowpassFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKToneComplementFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createToneComplementFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKToneComplementFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createToneComplementFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createToneComplementFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKToneComplementFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createToneComplementFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createToneComplementFilterDSP(int nChannels, double sampleRate) {
     AKToneComplementFilterDSP *dsp = new AKToneComplementFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKToneFilterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createToneFilterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKToneFilterParameter) {
 
 #ifndef __cplusplus
 
-void *createToneFilterDSP(int nChannels, double sampleRate);
+AKDSPRef createToneFilterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKToneFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createToneFilterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createToneFilterDSP(int nChannels, double sampleRate) {
     AKToneFilterDSP *dsp = new AKToneFilterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKAutoWahAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createAutoWahDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKAutoWahParameter) {
 
 #ifndef __cplusplus
 
-void *createAutoWahDSP(int nChannels, double sampleRate);
+AKDSPRef createAutoWahDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
@@ -9,7 +9,7 @@
 #include "AKAutoWahDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createAutoWahDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createAutoWahDSP(int nChannels, double sampleRate) {
     AKAutoWahDSP *dsp = new AKAutoWahDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Modulation/Chorus/AKChorusAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Chorus/AKChorusAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKChorusAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createChorusDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.hpp
@@ -51,8 +51,8 @@ extern const float kAKFlanger_MaxDryWetMix;
 
 #ifndef __cplusplus
 
-void *createChorusDSP(int nChannels, double sampleRate);
-void *createFlangerDSP(int nChannels, double sampleRate);
+AKDSPRef createChorusDSP(int nChannels, double sampleRate);
+AKDSPRef createFlangerDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
@@ -13,12 +13,12 @@
 
 #include "AKModulatedDelayDSP.hpp"
 
-extern "C" void *createChorusDSP(int nChannels, double sampleRate)
+extern "C" AKDSPRef createChorusDSP(int nChannels, double sampleRate)
 {
     return new AKModulatedDelayDSP(kChorus);
 }
 
-extern "C" void *createFlangerDSP(int nChannels, double sampleRate)
+extern "C" AKDSPRef createFlangerDSP(int nChannels, double sampleRate)
 {
     return new AKModulatedDelayDSP(kFlanger);
 }

--- a/AudioKit/Common/Nodes/Effects/Modulation/Flanger/AKFlangerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Flanger/AKFlangerAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKFlangerAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createFlangerDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserAudioUnit.swift
@@ -59,7 +59,7 @@ public class AKPhaserAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPhaserDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.hpp
@@ -25,7 +25,7 @@ typedef NS_ENUM(AUParameterAddress, AKPhaserParameter) {
 
 #ifndef __cplusplus
 
-void *createPhaserDSP(int nChannels, double sampleRate);
+AKDSPRef createPhaserDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
@@ -9,7 +9,7 @@
 #include "AKPhaserDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createPhaserDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPhaserDSP(int nChannels, double sampleRate) {
     AKPhaserDSP *dsp = new AKPhaserDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterAudioUnit.swift
@@ -35,7 +35,7 @@ public class AKPitchShifterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPitchShifterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKPitchShifterParameter) {
 
 #ifndef __cplusplus
 
-void *createPitchShifterDSP(int nChannels, double sampleRate);
+AKDSPRef createPitchShifterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
@@ -9,7 +9,7 @@
 #include "AKPitchShifterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createPitchShifterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPitchShifterDSP(int nChannels, double sampleRate) {
     AKPitchShifterDSP *dsp = new AKPitchShifterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbAudioUnit.swift
@@ -23,7 +23,7 @@ public class AKChowningReverbAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createChowningReverbDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.hpp
@@ -16,7 +16,7 @@ typedef NS_ENUM(AUParameterAddress, AKChowningReverbParameter) {
 
 #ifndef __cplusplus
 
-void *createChowningReverbDSP(int nChannels, double sampleRate);
+AKDSPRef createChowningReverbDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
@@ -9,7 +9,7 @@
 #include "AKChowningReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createChowningReverbDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createChowningReverbDSP(int nChannels, double sampleRate) {
     AKChowningReverbDSP *dsp = new AKChowningReverbDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverb.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverb.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createCombFilterReverbDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createCombFilterReverbDSP(int nChannels, double sampleRate) {
     AKCombFilterReverbDSP *dsp = new AKCombFilterReverbDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKCombFilterReverbAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createCombFilterReverbDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKCombFilterReverbParameter) {
 
 #ifndef __cplusplus
 
-void *createCombFilterReverbDSP(int nChannels, double sampleRate);
+AKDSPRef createCombFilterReverbDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbAudioUnit.swift
@@ -31,7 +31,7 @@ public class AKCostelloReverbAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createCostelloReverbDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKCostelloReverbParameter) {
 
 #ifndef __cplusplus
 
-void *createCostelloReverbDSP(int nChannels, double sampleRate);
+AKDSPRef createCostelloReverbDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.mm
@@ -9,7 +9,7 @@
 #include "AKCostelloReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createCostelloReverbDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createCostelloReverbDSP(int nChannels, double sampleRate) {
     AKCostelloReverbDSP *dsp = new AKCostelloReverbDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKFlatFrequencyResponseReverbAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createFlatFrequencyResponseReverbDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKFlatFrequencyResponseReverbParameter) {
 
 #ifndef __cplusplus
 
-void *createFlatFrequencyResponseReverbDSP(int nChannels, double sampleRate);
+AKDSPRef createFlatFrequencyResponseReverbDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
@@ -9,7 +9,7 @@
 #include "AKFlatFrequencyResponseReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createFlatFrequencyResponseReverbDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createFlatFrequencyResponseReverbDSP(int nChannels, double sampleRate) {
     AKFlatFrequencyResponseReverbDSP *dsp = new AKFlatFrequencyResponseReverbDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbAudioUnit.swift
@@ -63,7 +63,7 @@ public class AKZitaReverbAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createZitaReverbDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.hpp
@@ -26,7 +26,7 @@ typedef NS_ENUM(AUParameterAddress, AKZitaReverbParameter) {
 
 #ifndef __cplusplus
 
-void *createZitaReverbDSP(int nChannels, double sampleRate);
+AKDSPRef createZitaReverbDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
@@ -9,7 +9,7 @@
 #include "AKZitaReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createZitaReverbDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createZitaReverbDSP(int nChannels, double sampleRate) {
     AKZitaReverbDSP *dsp = new AKZitaReverbDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKBrownianNoiseAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createBrownianNoiseDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKBrownianNoiseParameter) {
 
 #ifndef __cplusplus
 
-void *createBrownianNoiseDSP(int nChannels, double sampleRate);
+AKDSPRef createBrownianNoiseDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.mm
@@ -9,7 +9,7 @@
 #include "AKBrownianNoiseDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createBrownianNoiseDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createBrownianNoiseDSP(int nChannels, double sampleRate) {
     AKBrownianNoiseDSP *dsp = new AKBrownianNoiseDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKPinkNoiseAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPinkNoiseDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKPinkNoiseParameter) {
 
 #ifndef __cplusplus
 
-void *createPinkNoiseDSP(int nChannels, double sampleRate);
+AKDSPRef createPinkNoiseDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
@@ -9,7 +9,7 @@
 #include "AKPinkNoiseDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createPinkNoiseDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPinkNoiseDSP(int nChannels, double sampleRate) {
     AKPinkNoiseDSP *dsp = new AKPinkNoiseDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKWhiteNoiseAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createWhiteNoiseDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKWhiteNoiseParameter) {
 
 #ifndef __cplusplus
 
-void *createWhiteNoiseDSP(int nChannels, double sampleRate);
+AKDSPRef createWhiteNoiseDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
@@ -9,7 +9,7 @@
 #include "AKWhiteNoiseDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createWhiteNoiseDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createWhiteNoiseDSP(int nChannels, double sampleRate) {
     AKWhiteNoiseDSP *dsp = new AKWhiteNoiseDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorAudioUnit.swift
@@ -43,7 +43,7 @@ public class AKFMOscillatorAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createFMOscillatorDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.hpp
@@ -21,7 +21,7 @@ typedef NS_ENUM(AUParameterAddress, AKFMOscillatorParameter) {
 
 #ifndef __cplusplus
 
-void *createFMOscillatorDSP(int nChannels, double sampleRate);
+AKDSPRef createFMOscillatorDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.mm
@@ -9,7 +9,7 @@
 #include "AKFMOscillatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createFMOscillatorDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createFMOscillatorDSP(int nChannels, double sampleRate) {
     AKFMOscillatorDSP *dsp = new AKFMOscillatorDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorAudioUnit.swift
@@ -43,7 +43,7 @@ public class AKMorphingOscillatorAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createMorphingOscillatorDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.hpp
@@ -21,7 +21,7 @@ typedef NS_ENUM(AUParameterAddress, AKMorphingOscillatorParameter) {
 
 #ifndef __cplusplus
 
-void *createMorphingOscillatorDSP(int nChannels, double sampleRate);
+AKDSPRef createMorphingOscillatorDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
@@ -9,7 +9,7 @@
 #include "AKMorphingOscillatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createMorphingOscillatorDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createMorphingOscillatorDSP(int nChannels, double sampleRate) {
     AKMorphingOscillatorDSP *dsp = new AKMorphingOscillatorDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKOscillatorAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createOscillatorDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKOscillatorParameter) {
 
 #ifndef __cplusplus
 
-void *createOscillatorDSP(int nChannels, double sampleRate);
+AKDSPRef createOscillatorDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -9,7 +9,7 @@
 #include "AKOscillatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createOscillatorDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createOscillatorDSP(int nChannels, double sampleRate) {
     AKOscillatorDSP *dsp = new AKOscillatorDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillator.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillator.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createPWMOscillatorDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPWMOscillatorDSP(int nChannels, double sampleRate) {
     AKPWMOscillatorDSP *dsp = new AKPWMOscillatorDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKPWMOscillatorAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPWMOscillatorDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKPWMOscillatorParameter) {
 
 #ifndef __cplusplus
 
-void *createPWMOscillatorDSP(int nChannels, double sampleRate);
+AKDSPRef createPWMOscillatorDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillator.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillator.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createPhaseDistortionOscillatorDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPhaseDistortionOscillatorDSP(int nChannels, double sampleRate) {
     AKPhaseDistortionOscillatorDSP *dsp = new AKPhaseDistortionOscillatorDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKPhaseDistortionOscillatorAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPhaseDistortionOscillatorDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKPhaseDistortionOscillatorParameter) {
 
 #ifndef __cplusplus
 
-void *createPhaseDistortionOscillatorDSP(int nChannels, double sampleRate);
+AKDSPRef createPhaseDistortionOscillatorDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetAudioUnit.swift
@@ -30,7 +30,7 @@ public class AKClarinetAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createClarinetDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKClarinetParameter) {
 
 #ifndef __cplusplus
 
-void *createClarinetDSP(int nChannels, double sampleRate);
+AKDSPRef createClarinetDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.mm
@@ -12,7 +12,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createClarinetDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createClarinetDSP(int nChannels, double sampleRate) {
     AKClarinetDSP *dsp = new AKClarinetDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripAudioUnit.swift
@@ -51,7 +51,7 @@ public class AKDripAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createDripDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKDripParameter) {
 
 #ifndef __cplusplus
 
-void *createDripDSP(int nChannels, double sampleRate);
+AKDSPRef createDripDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.mm
@@ -9,7 +9,7 @@
 #include "AKDripDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createDripDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createDripDSP(int nChannels, double sampleRate) {
     AKDripDSP *dsp = new AKDripDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteAudioUnit.swift
@@ -30,7 +30,7 @@ public class AKFluteAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createFluteDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKFluteParameter) {
 
 #ifndef __cplusplus
 
-void *createFluteDSP(int nChannels, double sampleRate);
+AKDSPRef createFluteDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.mm
@@ -12,7 +12,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createFluteDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createFluteDSP(int nChannels, double sampleRate) {
     AKFluteDSP *dsp = new AKFluteDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarAudioUnit.swift
@@ -51,7 +51,7 @@ public class AKMetalBarAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createMetalBarDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKMetalBarParameter) {
 
 #ifndef __cplusplus
 
-void *createMetalBarDSP(int nChannels, double sampleRate);
+AKDSPRef createMetalBarDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.mm
@@ -9,7 +9,7 @@
 #include "AKMetalBarDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" void *createMetalBarDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createMetalBarDSP(int nChannels, double sampleRate) {
     AKMetalBarDSP *dsp = new AKMetalBarDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringAudioUnit.swift
@@ -30,7 +30,7 @@ public class AKPluckedStringAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPluckedStringDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKPluckedStringParameter) {
 
 #ifndef __cplusplus
 
-void *createPluckedStringDSP(int nChannels, double sampleRate);
+AKDSPRef createPluckedStringDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createPluckedStringDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPluckedStringDSP(int nChannels, double sampleRate) {
     AKPluckedStringDSP *dsp = new AKPluckedStringDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTract.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTract.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createVocalTractDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createVocalTractDSP(int nChannels, double sampleRate) {
     AKVocalTractDSP *dsp = new AKVocalTractDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractAudioUnit.swift
@@ -39,7 +39,7 @@ public class AKVocalTractAudioUnit: AKGeneratorAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createVocalTractDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKVocalTractParameter) {
 
 #ifndef __cplusplus
 
-void *createVocalTractDSP(int nChannels, double sampleRate);
+AKDSPRef createVocalTractDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterAudioUnit.swift
@@ -37,7 +37,7 @@ public class AKBoosterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createBoosterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.hpp
@@ -21,7 +21,7 @@ typedef NS_ENUM(AUParameterAddress, AKBoosterParameter) {
 
 #ifndef __cplusplus
 
-void *createBoosterDSP(int nChannels, double sampleRate);
+AKDSPRef createBoosterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.mm
@@ -8,7 +8,7 @@
 
 #include "AKBoosterDSP.hpp"
 
-extern "C" void *createBoosterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createBoosterDSP(int nChannels, double sampleRate) {
     AKBoosterDSP *dsp = new AKBoosterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPanner.mm
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPanner.mm
@@ -10,7 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" void *createPannerDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createPannerDSP(int nChannels, double sampleRate) {
     AKPannerDSP *dsp = new AKPannerDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKPannerAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createPannerDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKPannerParameter) {
 
 #ifndef __cplusplus
 
-void *createPannerDSP(int nChannels, double sampleRate);
+AKDSPRef createPannerDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiter.mm
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiter.mm
@@ -12,7 +12,7 @@
 // In this case a destructor is not needed, since the DSP object doesn't do any of
 // its own heap based allocation.
 
-extern "C" void *createStereoFieldLimiterDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createStereoFieldLimiterDSP(int nChannels, double sampleRate) {
     AKStereoFieldLimiterDSP *dsp = new AKStereoFieldLimiterDSP();
     dsp->init(nChannels, sampleRate);
     return dsp;

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterAudioUnit.swift
@@ -27,7 +27,7 @@ public class AKStereoFieldLimiterAudioUnit: AKAudioUnitBase {
     }
 
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createStereoFieldLimiterDSP(Int32(count), sampleRate)
     }
 

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKStereoFieldLimiterParameter) {
 
 #ifndef __cplusplus
 
-void *createStereoFieldLimiterDSP(int nChannels, double sampleRate);
+AKDSPRef createStereoFieldLimiterDSP(int nChannels, double sampleRate);
 
 #else
 

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -10,7 +10,7 @@ import AVFoundation
 
 public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
     
-    var pDSP: UnsafeMutableRawPointer?
+    var pDSP: AKDSPRef?
     
     func setParameter(_ address: AKSamplerParameter, value: Double) {
         setParameterWithAddress(AUParameterAddress(address.rawValue), value: Float(value))
@@ -109,9 +109,10 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
     }
     
     public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> UnsafeMutableRawPointer! {
-        pDSP = createAKSamplerDSP(Int32(count), sampleRate)
-        return pDSP
+                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
+        guard let dsp = createAKSamplerDSP(Int32(count), sampleRate) else { fatalError() }
+        pDSP = dsp
+        return dsp
     }
     
     override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
@@ -45,18 +45,18 @@ typedef NS_ENUM(AUParameterAddress, AKSamplerParameter)
 
 #include "AKSampler_Typedefs.h"
 
-void *createAKSamplerDSP(int nChannels, double sampleRate);
-void doAKSamplerLoadData(void *pDSP, AKSampleDataDescriptor *pSDD);
-void doAKSamplerLoadCompressedFile(void *pDSP, AKSampleFileDescriptor *pSFD);
-void doAKSamplerUnloadAllSamples(void *pDSP);
-void doAKSamplerBuildSimpleKeyMap(void *pDSP);
-void doAKSamplerBuildKeyMap(void *pDSP);
-void doAKSamplerSetLoopThruRelease(void *pDSP, bool value);
-void doAKSamplerPlayNote(void *pDSP, UInt8 noteNumber, UInt8 velocity, float noteFrequency);
-void doAKSamplerStopNote(void *pDSP, UInt8 noteNumber, bool immediate);
-void doAKSamplerStopAllVoices(void *pDSP);
-void doAKSamplerRestartVoices(void *pDSP);
-void doAKSamplerSustainPedal(void *pDSP, bool pedalDown);
+AKDSPRef createAKSamplerDSP(int nChannels, double sampleRate);
+void doAKSamplerLoadData(AKDSPRef pDSP, AKSampleDataDescriptor *pSDD);
+void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescriptor *pSFD);
+void doAKSamplerUnloadAllSamples(AKDSPRef pDSP);
+void doAKSamplerBuildSimpleKeyMap(AKDSPRef pDSP);
+void doAKSamplerBuildKeyMap(AKDSPRef pDSP);
+void doAKSamplerSetLoopThruRelease(AKDSPRef pDSP, bool value);
+void doAKSamplerPlayNote(AKDSPRef pDSP, UInt8 noteNumber, UInt8 velocity, float noteFrequency);
+void doAKSamplerStopNote(AKDSPRef pDSP, UInt8 noteNumber, bool immediate);
+void doAKSamplerStopAllVoices(AKDSPRef pDSP);
+void doAKSamplerRestartVoices(AKDSPRef pDSP);
+void doAKSamplerSustainPedal(AKDSPRef pDSP, bool pedalDown);
 
 #else
 

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -10,15 +10,15 @@
 #include "wavpack.h"
 #include <math.h>
 
-extern "C" void *createAKSamplerDSP(int nChannels, double sampleRate) {
+extern "C" AKDSPRef createAKSamplerDSP(int nChannels, double sampleRate) {
     return new AKSamplerDSP();
 }
 
-extern "C" void doAKSamplerLoadData(void *pDSP, AKSampleDataDescriptor* pSDD) {
+extern "C" void doAKSamplerLoadData(AKDSPRef pDSP, AKSampleDataDescriptor* pSDD) {
     ((AKSamplerDSP*)pDSP)->loadSampleData(*pSDD);
 }
 
-extern "C" void doAKSamplerLoadCompressedFile(void *pDSP, AKSampleFileDescriptor* pSFD)
+extern "C" void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescriptor* pSFD)
 {
     char errMsg[100];
     WavpackContext* wpc = WavpackOpenFileInput(pSFD->path, errMsg, OPEN_2CH_MAX, 0);
@@ -53,44 +53,44 @@ extern "C" void doAKSamplerLoadCompressedFile(void *pDSP, AKSampleFileDescriptor
     delete[] sdd.data;
 }
 
-extern "C" void doAKSamplerUnloadAllSamples(void *pDSP)
+extern "C" void doAKSamplerUnloadAllSamples(AKDSPRef pDSP)
 {
     ((AKSamplerDSP*)pDSP)->deinit();
 }
 
-extern "C" void doAKSamplerBuildSimpleKeyMap(void *pDSP) {
+extern "C" void doAKSamplerBuildSimpleKeyMap(AKDSPRef pDSP) {
     ((AKSamplerDSP*)pDSP)->buildSimpleKeyMap();
 }
 
-extern "C" void doAKSamplerBuildKeyMap(void *pDSP) {
+extern "C" void doAKSamplerBuildKeyMap(AKDSPRef pDSP) {
     ((AKSamplerDSP*)pDSP)->buildKeyMap();
 }
 
-extern "C" void doAKSamplerSetLoopThruRelease(void *pDSP, bool value) {
+extern "C" void doAKSamplerSetLoopThruRelease(AKDSPRef pDSP, bool value) {
     ((AKSamplerDSP*)pDSP)->setLoopThruRelease(value);
 }
 
-extern "C" void doAKSamplerPlayNote(void *pDSP, UInt8 noteNumber, UInt8 velocity, float noteFrequency)
+extern "C" void doAKSamplerPlayNote(AKDSPRef pDSP, UInt8 noteNumber, UInt8 velocity, float noteFrequency)
 {
     ((AKSamplerDSP*)pDSP)->playNote(noteNumber, velocity, noteFrequency);
 }
 
-extern "C" void doAKSamplerStopNote(void *pDSP, UInt8 noteNumber, bool immediate)
+extern "C" void doAKSamplerStopNote(AKDSPRef pDSP, UInt8 noteNumber, bool immediate)
 {
     ((AKSamplerDSP*)pDSP)->stopNote(noteNumber, immediate);
 }
 
-extern "C" void doAKSamplerStopAllVoices(void *pDSP)
+extern "C" void doAKSamplerStopAllVoices(AKDSPRef pDSP)
 {
     ((AKSamplerDSP*)pDSP)->stopAllVoices();
 }
 
-extern "C" void doAKSamplerRestartVoices(void *pDSP)
+extern "C" void doAKSamplerRestartVoices(AKDSPRef pDSP)
 {
     ((AKSamplerDSP*)pDSP)->restartVoices();
 }
 
-extern "C" void doAKSamplerSustainPedal(void *pDSP, bool pedalDown)
+extern "C" void doAKSamplerSustainPedal(AKDSPRef pDSP, bool pedalDown)
 {
     ((AKSamplerDSP*)pDSP)->sustainPedal(pedalDown);
 }


### PR DESCRIPTION
This PR replaces all occurrences of void* and UnsafeMutableRawPointer with AKDSPRef where the pointers is pointing to an AKDSPBase. AKDSPRef is typedef'd to a void* with clang's `swift_newtype` attribute. This offers some stronger typing in Swift as AKDSPRef is recognized as it's own type.