### PR TITLE
AkAudioUnitBase inheritance improvements

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
@@ -17,6 +17,9 @@
 
 @interface AKAudioUnitBase : BufferedAudioUnit
 
+/** Pointer to AKDSPBase subclass. */
+@property (readonly) AKDSPRef dsp;
+
 /**
  This method should be overridden by the specific AU code, because it knows how to set up
  the DSP code. It should also be declared as public in the h file, but that causes problems

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -10,41 +10,37 @@
 
 #import <AudioKit/AudioKit-Swift.h>
 
-@interface AKAudioUnitBase ()
+@implementation AKAudioUnitBase
 
-@property AKDSPBase *kernel;
-
-@end
-
-@implementation AKAudioUnitBase {
-    // C++ members need to be ivars; they would be copied on access if they were properties.
-    AKDSPBase *_kernel;
+// Convenience for casting (AKDSPRef)_dsp to AKDSPBase;
+- (AKDSPBase *)kernel {
+    return (AKDSPBase *)_dsp;
 }
 
 @synthesize parameterTree = _parameterTree;
 
 - (float) getParameterWithAddress: (AUParameterAddress) address; {
-    return _kernel->getParameter(address);
+    return self.kernel->getParameter(address);
 }
 - (void) setParameterWithAddress:(AUParameterAddress)address value:(AUValue)value {
-    _kernel->setParameter(address, value);
+    self.kernel->setParameter(address, value);
 }
 
 - (void) setParameterImmediatelyWithAddress:(AUParameterAddress)address value:(AUValue)value {
-    _kernel->setParameter(address, value, true);
+    self.kernel->setParameter(address, value, true);
 }
 
-- (void)start { _kernel->start(); }
-- (void)stop { _kernel->stop(); }
-- (void)clear { _kernel->clear(); };
-- (void)initializeConstant:(AUValue)value { _kernel->initializeConstant(value); }
-- (BOOL)isPlaying { return _kernel->isPlaying(); }
-- (BOOL)isSetUp { return _kernel->isSetup(); }
+- (void)start { self.kernel->start(); }
+- (void)stop { self.kernel->stop(); }
+- (void)clear { self.kernel->clear(); };
+- (void)initializeConstant:(AUValue)value { self.kernel->initializeConstant(value); }
+- (BOOL)isPlaying { return self.kernel->isPlaying(); }
+- (BOOL)isSetUp { return self.kernel->isSetup(); }
 - (void)setupWaveform:(int)size {
-    _kernel->setupWaveform((uint32_t)size);
+    self.kernel->setupWaveform((uint32_t)size);
 }
 - (void)setWaveformValue:(float)value atIndex:(UInt32)index; {
-    _kernel->setWaveformValue(index, value);
+    self.kernel->setWaveformValue(index, value);
 }
 
 /**
@@ -53,7 +49,7 @@
  */
 
 - (AKDSPRef)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count {
-    return (AKDSPRef)(_kernel = NULL);
+    return (_dsp = NULL);
 }
 
 /**
@@ -69,7 +65,7 @@
     _parameterTree = tree;
 
     // Make a local pointer to the kernel to avoid capturing self.
-    __block AKDSPBase *kernel = _kernel;
+    __block AKDSPBase *kernel = self.kernel;
 
     // implementorValueObserver is called when a parameter changes value.
     _parameterTree.implementorValueObserver = ^(AUParameter *param, AUValue value) {
@@ -105,8 +101,8 @@
     AVAudioFormat *arbitraryFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate
                                                                                     channels:AKSettings.channelCount];
 
-    _kernel = (AKDSPBase*)[self initDSPWithSampleRate:arbitraryFormat.sampleRate
-                                         channelCount:arbitraryFormat.channelCount];
+    _dsp = [self initDSPWithSampleRate:arbitraryFormat.sampleRate
+                          channelCount:arbitraryFormat.channelCount];
 
     // Create a default empty parameter tree.
     _parameterTree = [AUParameterTree createTreeWithChildren:@[]];
@@ -122,22 +118,22 @@
     }
 
     AVAudioFormat *format = self.outputBusses[0].format;
-    _kernel->init(format.channelCount, format.sampleRate);
-    _kernel->reset();
+    self.kernel->init(format.channelCount, format.sampleRate);
+    self.kernel->reset();
     return YES;
 }
 
 -(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format {
     
-    __block AKDSPBase *state = _kernel;
+    __block AKDSPBase *kernel = self.kernel;
     return ^(AudioBufferList       *inBuffer,
              AudioBufferList       *outBuffer,
              const AudioTimeStamp  *timestamp,
              AVAudioFrameCount     frameCount,
              const AURenderEvent   *eventListHead) {
 
-        state->setBuffers(inBuffer, outBuffer);
-        state->processWithEvents(timestamp, frameCount, eventListHead);
+        kernel->setBuffers(inBuffer, outBuffer);
+        kernel->processWithEvents(timestamp, frameCount, eventListHead);
     };
 }
 
@@ -145,7 +141,7 @@
 // Hosts should call this after finishing rendering.
 
 - (void)deallocateRenderResources {
-    _kernel->deinit();
+    self.kernel->deinit();
     [super deallocateRenderResources];
 }
 
@@ -163,7 +159,7 @@
 // ----- END UNMODIFIED COPY FROM APPLE CODE -----
 
 - (void)dealloc {
-    delete _kernel;
+    delete self.kernel;
 }
 
 @end

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
@@ -13,36 +13,9 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import "AKDSPBase.hpp"
 #import "BufferedAudioUnit.h"
+#import "AKAudioUnitBase.h"
 
-@interface AKGeneratorAudioUnitBase : BufferedAudioUnit
-
-/**
- This method should be overridden by the specific AU code, because it knows how to set up
- the DSP code. It should also be declared as public in the h file, but that causes problems
- because Swift wants to process as a bridging header, and it doesn't understand what a DSPBase
- is. I'm not sure the standard way to deal with this.
- */
-
-- (AKDSPRef)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count;
-
-/**
- Sets the parameter tree. The important piece here is that setting the parameter tree
- triggers the setup of the blocks for observer, provider, and string representation. See
- the .m file. There may be a better way to do what is needed here.
- */
-
-- (void)setParameterTree: (AUParameterTree*) tree;
-
-- (float)getParameterWithAddress:(AUParameterAddress)address;
-- (void)setParameterWithAddress:(AUParameterAddress)address value:(AUValue)value;
-- (void)setParameterImmediatelyWithAddress:(AUParameterAddress)address value:(AUValue)value;
-
-// Add for compatibility with AKAudioUnit
-
-- (void)start;
-- (void)stop;
-- (void)clear;
-- (void)initializeConstant:(AUValue)value;
+@interface AKGeneratorAudioUnitBase : AKAudioUnitBase
 
 // Common for oscillators
 - (void)setupWaveform:(int)size;
@@ -55,9 +28,6 @@
 // STK Methods
 - (void)trigger;
 - (void)triggerFrequency:(float)frequency amplitude:(float)amplitude;
-
-@property (readonly) BOOL isPlaying;
-@property (readonly) BOOL isSetUp;
 
 @end
 

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
@@ -8,177 +8,29 @@
 
 #import "AKGeneratorAudioUnitBase.h"
 
-@interface AKGeneratorAudioUnitBase ()
+@implementation AKGeneratorAudioUnitBase
 
-@property AKDSPBase *kernel;
-
-@end
-
-@implementation AKGeneratorAudioUnitBase {
-    // C++ members need to be ivars; they would be copied on access if they were properties.
-    AKDSPBase *_kernel;
-}
-
-@synthesize parameterTree = _parameterTree;
-
-- (float) getParameterWithAddress: (AUParameterAddress) address; {
-    return _kernel->getParameter(address);
-}
-- (void) setParameterWithAddress:(AUParameterAddress)address value:(AUValue)value {
-    _kernel->setParameter(address, value);
-}
-
-- (void) setParameterImmediatelyWithAddress:(AUParameterAddress)address value:(AUValue)value {
-    _kernel->setParameter(address, value, true);
-}
-
-- (void)start { _kernel->start(); }
-- (void)stop { _kernel->stop(); }
-- (void)clear { _kernel->clear(); };
-- (void)initializeConstant:(AUValue)value { _kernel->initializeConstant(value); }
-- (BOOL)isPlaying { return _kernel->isPlaying(); }
-- (BOOL)isSetUp { return _kernel->isSetup(); }
 - (void)setupWaveform:(int)size {
-    _kernel->setupWaveform((uint32_t)size);
+    ((AKDSPBase *)self.dsp)->setupWaveform((uint32_t)size);
 }
 - (void)setWaveformValue:(float)value atIndex:(UInt32)index; {
-    _kernel->setWaveformValue(index, value);
+    ((AKDSPBase *)self.dsp)->setWaveformValue(index, value);
 }
 - (void)setupIndividualWaveform:(UInt32)waveform size:(int)size {
-    _kernel->setupIndividualWaveform(waveform, (uint32_t)size);
+    ((AKDSPBase *)self.dsp)->setupIndividualWaveform(waveform, (uint32_t)size);
 }
-
 - (void)setIndividualWaveform:(UInt32)waveform withValue:(float)value atIndex:(UInt32)index {
-    _kernel->setIndividualWaveformValue(waveform, index, value);
+    ((AKDSPBase *)self.dsp)->setIndividualWaveformValue(waveform, index, value);
 }
 - (void)trigger {
-    _kernel->trigger();
+    ((AKDSPBase *)self.dsp)->trigger();
 }
 - (void)triggerFrequency:(float)frequency amplitude:(float)amplitude {
-    _kernel->triggerFrequencyAmplitude(frequency, amplitude);
-}
-/**
- This should be overridden. All the base class does is make sure that the pointer to the
- DSP is invalid.
- */
-
-- (AKDSPRef)initDSPWithSampleRate:(double) sampleRate channelCount:(AVAudioChannelCount) count {
-    return (AKDSPRef)(_kernel = NULL);
-}
-
-/**
- Sets up the parameter tree. The reason this method must exist explicitly is that the blocks
- associated with the parameter tree must be set up here. This is because the pointer to the
- parameterTree is being changed. If we set up the blocks in the init function, they would be
- associated with the "old" parameterTree when the parameterTree is setup for real.
-
- Otherwise, this code is just the same as what is in the Apple example code init function.
- */
-
-- (void) setParameterTree: (AUParameterTree*) tree {
-    _parameterTree = tree;
-
-    // Make a local pointer to the kernel to avoid capturing self.
-    __block AKDSPBase *kernel = _kernel;
-
-    // implementorValueObserver is called when a parameter changes value.
-    _parameterTree.implementorValueObserver = ^(AUParameter *param, AUValue value) {
-        kernel->setParameter(param.address, value);
-    };
-
-    // implementorValueProvider is called when the value needs to be refreshed.
-    _parameterTree.implementorValueProvider = ^(AUParameter *param) {
-        return kernel->getParameter(param.address);
-    };
-
-    // implementorStringFromValueCallback is called to provide string representations of parameter values.
-    _parameterTree.implementorStringFromValueCallback = ^(AUParameter *param, const AUValue *__nullable valuePtr) {
-        // If value is nil, use the current value of the parameter.
-        AUValue value = valuePtr == nil ? param.value : *valuePtr;
-        return [NSString stringWithFormat:@"%.2f", value];
-    };
-}
-
-/**
- Much simpler than the Apple example code version. We don't deal with presets, we don't set up
- a specific parameterTree, etc. The block set for parameterTree is moved to setParameterTree
- */
-
-- (instancetype)initWithComponentDescription:(AudioComponentDescription)componentDescription
-                                     options:(AudioComponentInstantiationOptions)options
-                                       error:(NSError **)outError {
-
-    self = [super initWithComponentDescription:componentDescription options:options error:outError];
-    if (self == nil) { return nil; }
-
-    // Initialize a default format for the busses.
-    AVAudioFormat *arbitraryFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:44100.0
-                                                                                    channels:2];
-
-    _kernel = (AKDSPBase *)[self initDSPWithSampleRate:arbitraryFormat.sampleRate
-                                          channelCount:arbitraryFormat.channelCount];
-
-    // Create a default empty parameter tree.
-    _parameterTree = [AUParameterTree createTreeWithChildren:@[]];
-    return self;
-}
-
-// ----- BEGIN UNMODIFIED COPY FROM APPLE CODE -----
-
-
-// Allocate resources required to render.
-// Hosts must call this to initialize the AU before beginning to render.
-- (BOOL)allocateRenderResourcesAndReturnError:(NSError **)outError {
-    if (![super allocateRenderResourcesAndReturnError:outError]) {
-        return NO;
-    }
-    AVAudioFormat *format = self.outputBusses[0].format;
-    _kernel->init(format.channelCount, format.sampleRate);
-    _kernel->reset();
-    return YES;
+    ((AKDSPBase *)self.dsp)->triggerFrequencyAmplitude(frequency, amplitude);
 }
 
 -(BOOL)shouldAllocateInputBus {
     return false;
-}
-
--(ProcessEventsBlock)processEventsBlock:(AVAudioFormat *)format {
-    
-    __block AKDSPBase *state = _kernel;
-    return ^(AudioBufferList       *inBuffer,
-             AudioBufferList       *outBuffer,
-             const AudioTimeStamp  *timestamp,
-             AVAudioFrameCount     frameCount,
-             const AURenderEvent   *eventListHead) {
-
-        state->setBuffer(outBuffer);
-        state->processWithEvents(timestamp, frameCount, eventListHead);
-    };
-}
-
-// Deallocate resources allocated by allocateRenderResourcesAndReturnError:
-// Hosts should call this after finishing rendering.
-
-- (void)deallocateRenderResources {
-    _kernel->deinit();
-    [super deallocateRenderResources];
-}
-
-// Expresses whether an audio unit can process in place.
-// In-place processing is the ability for an audio unit to transform an input signal to an
-// output signal in-place in the input buffer, without requiring a separate output buffer.
-// A host can express its desire to process in place by using null mData pointers in the output
-// buffer list. The audio unit may process in-place in the input buffers.
-// See the discussion of renderBlock.
-// Partially bridged to the v2 property kAudioUnitProperty_InPlaceProcessing, the v3 property is not settable.
-- (BOOL)canProcessInPlace {
-    return NO;   // OK THIS IS DIFFERENT FROM APPLE EXAMPLE CODE
-}
-
-// ----- END UNMODIFIED COPY FROM APPLE CODE -----
-
-- (void)dealloc {
-    delete _kernel;
 }
 
 @end

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -9,9 +9,7 @@
 import AVFoundation
 
 public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
-    
-    var pDSP: AKDSPRef?
-    
+
     func setParameter(_ address: AKSamplerParameter, value: Double) {
         setParameterWithAddress(AUParameterAddress(address.rawValue), value: Float(value))
     }
@@ -110,9 +108,7 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
     
     public override func initDSP(withSampleRate sampleRate: Double,
                                  channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        guard let dsp = createAKSamplerDSP(Int32(count), sampleRate) else { fatalError() }
-        pDSP = dsp
-        return dsp
+        return createAKSamplerDSP(Int32(count), sampleRate)
     }
     
     override init(componentDescription: AudioComponentDescription,
@@ -399,51 +395,51 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
     public override var canProcessInPlace: Bool { return true }
     
     public func stopAllVoices() {
-        doAKSamplerStopAllVoices(pDSP)
+        doAKSamplerStopAllVoices(dsp)
     }
     
     public func restartVoices() {
-        doAKSamplerRestartVoices(pDSP)
+        doAKSamplerRestartVoices(dsp)
     }
     
     public func loadSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) {
         var copy = sampleDataDescriptor
-        doAKSamplerLoadData(pDSP, &copy)
+        doAKSamplerLoadData(dsp, &copy)
     }
     
     public func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) {
         var copy = sampleFileDescriptor
-        doAKSamplerLoadCompressedFile(pDSP, &copy)
+        doAKSamplerLoadCompressedFile(dsp, &copy)
     }
     
     public func unloadAllSamples() {
-        doAKSamplerUnloadAllSamples(pDSP)
+        doAKSamplerUnloadAllSamples(dsp)
     }
     
     public func buildSimpleKeyMap() {
-        doAKSamplerBuildSimpleKeyMap(pDSP)
+        doAKSamplerBuildSimpleKeyMap(dsp)
     }
     
     public func buildKeyMap() {
-        doAKSamplerBuildKeyMap(pDSP)
+        doAKSamplerBuildKeyMap(dsp)
     }
     
     public func setLoop(thruRelease: Bool) {
-        doAKSamplerSetLoopThruRelease(pDSP, thruRelease)
+        doAKSamplerSetLoopThruRelease(dsp, thruRelease)
     }
     
     public func playNote(noteNumber: UInt8,
                          velocity: UInt8,
                          noteFrequency: Float) {
-        doAKSamplerPlayNote(pDSP, noteNumber, velocity, noteFrequency)
+        doAKSamplerPlayNote(dsp, noteNumber, velocity, noteFrequency)
     }
     
     public func stopNote(noteNumber: UInt8, immediate: Bool) {
-        doAKSamplerStopNote(pDSP, noteNumber, immediate)
+        doAKSamplerStopNote(dsp, noteNumber, immediate)
     }
     
     public func sustainPedal(down: Bool) {
-        doAKSamplerSustainPedal(pDSP, down)
+        doAKSamplerSustainPedal(dsp, down)
     }
 
     override public func shouldClearOutputBuffer() -> Bool {


### PR DESCRIPTION
Moves AKDSPBase ivar from C++ ivar in implementation file to AKDSPRef property in Base class. This allows subclasses to access the DSP kernel. 