### PR TITLE
Add new AudioKitCore::AKStereoDelay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ Dev.playground
 
 # During Development
 AudioUnits
+
+# JUCE related
+Builds/
+JuceLibraryCode/

--- a/AudioKit/Core/AudioKitCore/ModulatedDelay/AKStereoDelay.cpp
+++ b/AudioKit/Core/AudioKitCore/ModulatedDelay/AKStereoDelay.cpp
@@ -1,0 +1,70 @@
+//
+//  AKStereoDelay.cpp
+//  AudioKit Core
+//
+//  Created by Shane Dunne, revision history on Github.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+#include "AKStereoDelay.hpp"
+
+namespace AudioKitCore
+{
+    void AKStereoDelay::init(double sampleRate, double maxDelayMs)
+    {
+        delayLine1.init(sampleRate, maxDelayMs);
+        delayLine2.init(sampleRate, maxDelayMs);
+    }
+    
+    void AKStereoDelay::deinit()
+    {
+        delayLine1.deinit();
+        delayLine2.deinit();
+    }
+    
+    void AKStereoDelay::setPingPongMode(bool pingPong)
+    {
+        pingPongMode = pingPong;
+        setFeedback(feedbackFraction);
+    }
+
+    void AKStereoDelay::setDelayMs(double delayMs)
+    {
+        delayLine1.setDelayMs(delayMs);
+        delayLine2.setDelayMs(delayMs);
+    }
+
+    void AKStereoDelay::setFeedback(float fraction)
+    {
+        feedbackFraction = fraction;
+        delayLine1.setFeedback(pingPongMode ? 0.0f : fraction);
+        delayLine2.setFeedback(pingPongMode ? 0.0f : fraction);
+    }
+    
+    void AKStereoDelay::render(int sampleCount, const float *inBuffers[], float *outBuffers[])
+    {
+        if (pingPongMode)
+        {
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float inputSample = 0.5f * (inBuffers[0][i] + inBuffers[1][i]);
+                float leftSample = delayLine1.push(inputSample + feedbackFraction * delayLine2.getOutput());
+                float rightSample = delayLine2.push(leftSample);
+
+                outBuffers[0][i] = effectLevelFraction * leftSample + inBuffers[0][i];
+                outBuffers[1][i] = effectLevelFraction * rightSample + inBuffers[1][i];
+            }
+        }
+        else
+        {
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float leftSample = delayLine1.push(inBuffers[0][i]);
+                float rightSample = delayLine2.push(inBuffers[1][i]);
+
+                outBuffers[0][i] = effectLevelFraction * leftSample + inBuffers[0][i];
+                outBuffers[1][i] = effectLevelFraction * rightSample + inBuffers[1][i];
+            }
+        }
+    }
+}

--- a/AudioKit/Core/AudioKitCore/ModulatedDelay/AKStereoDelay.hpp
+++ b/AudioKit/Core/AudioKitCore/ModulatedDelay/AKStereoDelay.hpp
@@ -1,0 +1,37 @@
+//
+//  AKStereoDelay.hpp
+//  AudioKit Core
+//
+//  Created by Shane Dunne, revision history on Github.
+//  Copyright © 2018 AudioKit. All rights reserved.
+//
+
+#pragma once
+#include "AdjustableDelayLine.hpp"
+
+namespace AudioKitCore
+{
+    class AKStereoDelay {
+        double sampleRateHz;
+        float feedbackFraction;
+        float effectLevelFraction;
+        bool pingPongMode;
+
+        AdjustableDelayLine delayLine1, delayLine2;
+        
+    public:
+        AKStereoDelay() : feedbackFraction(0.0f), effectLevelFraction(0.5f), pingPongMode(false) {}
+        ~AKStereoDelay() { deinit(); }
+        
+        void init(double sampleRate, double maxDelayMs);
+        void deinit();
+        
+        void setPingPongMode(bool pingPong);
+        void setDelayMs(double delayMs);
+        void setEffectLevel(float fraction) { effectLevelFraction = fraction; }
+        void setFeedback(float fraction);
+
+        void render(int sampleCount, const float *inBuffers[], float *outBuffers[]);
+    };
+    
+}

--- a/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.cpp
+++ b/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.cpp
@@ -14,10 +14,10 @@ namespace AudioKitCore
     {
     }
     
-    void AdjustableDelayLine::init(double sampleRate, double maxDelayMs)
+    void AdjustableDelayLine::init(double sampleRate, double maxDelayMilliseconds)
     {
         sampleRateHz = sampleRate;
-        this->maxDelayMs = maxDelayMs;
+        maxDelayMs = maxDelayMilliseconds;
 
         capacity = int(maxDelayMs * sampleRateHz / 1000.0);
         if (pBuffer) delete[] pBuffer;

--- a/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.cpp
+++ b/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.cpp
@@ -17,12 +17,16 @@ namespace AudioKitCore
     void AdjustableDelayLine::init(double sampleRate, double maxDelayMs)
     {
         sampleRateHz = sampleRate;
+        this->maxDelayMs = maxDelayMs;
+
         capacity = int(maxDelayMs * sampleRateHz / 1000.0);
         if (pBuffer) delete[] pBuffer;
         pBuffer = new float[capacity];
         for (int i=0; i < capacity; i++) pBuffer[i] = 0.0f;
         writeIndex = 0;
         readIndex = (float)(capacity - 1);
+        fbFraction = 0.0f;
+        output = 0.0f;
     }
     
     void AdjustableDelayLine::deinit()
@@ -33,16 +37,14 @@ namespace AudioKitCore
     
     void AdjustableDelayLine::setDelayMs(double delayMs)
     {
+        if (delayMs > maxDelayMs) delayMs = maxDelayMs;
+        if (delayMs < 0.0f) delayMs = 0.0f;
+
         float fReadWriteGap = float(delayMs * sampleRateHz / 1000.0);
         if (fReadWriteGap < 0.0f) fReadWriteGap = 0.0f;
         if (fReadWriteGap > capacity) fReadWriteGap = (float)capacity;
         readIndex = writeIndex - fReadWriteGap;
         while (readIndex < 0.0f) readIndex += capacity;
-    }
-    
-    void AdjustableDelayLine::setFeedback(float feedback)
-    {
-        fbFraction = feedback;
     }
     
     float AdjustableDelayLine::push(float sample)
@@ -62,7 +64,7 @@ namespace AudioKitCore
         pBuffer[writeIndex++] = sample + fbFraction * outSample;
         if (writeIndex >= capacity) writeIndex = 0;
         
-        return outSample;
+        return (output = outSample);
     }
     
 }

--- a/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.hpp
+++ b/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.hpp
@@ -12,11 +12,13 @@ namespace AudioKitCore
 {
     class AdjustableDelayLine {
         double sampleRateHz;
+        double maxDelayMs;
         float fbFraction;
         float *pBuffer;
         int capacity;
         int writeIndex;
         float readIndex;
+        float output;
         
     public:
         AdjustableDelayLine();
@@ -24,10 +26,15 @@ namespace AudioKitCore
         
         void init(double sampleRate, double maxDelayMs);
         void deinit();
-        
+
+        double getMaxDelayMs() { return maxDelayMs; }
+
         void setDelayMs(double delayMs);
-        void setFeedback(float feedback);
+        void setFeedback(float feedback) { fbFraction = feedback; }
+ 
         float push(float sample);
+
+        float getOutput() { return output; }
     };
     
 }

--- a/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.hpp
+++ b/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.hpp
@@ -24,7 +24,7 @@ namespace AudioKitCore
         AdjustableDelayLine();
         ~AdjustableDelayLine() { deinit(); }
         
-        void init(double sampleRate, double maxDelayMs);
+        void init(double sampleRate, double maxDelayMilliseconds);
         void deinit();
 
         double getMaxDelayMs() { return maxDelayMs; }

--- a/Developer/AKStereoDelay/AKStereoDelay.jucer
+++ b/Developer/AKStereoDelay/AKStereoDelay.jucer
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <JUCERPROJECT id="Ah44Z7" name="AKStereoDelay" projectType="audioplug" jucerVersion="5.4.1"
-              pluginFormats="buildVST" headerPath="../../../../AudioKit/Core/AudioKitCore/ModulatedDelay">
+              pluginFormats="buildAU,buildVST" headerPath="../../../../AudioKit/Core/AudioKitCore/ModulatedDelay"
+              pluginManufacturer="AudioKit" pluginManufacturerCode="AKit" pluginCode="AKsd"
+              bundleIdentifier="io.audiokit.AKStereoDelay" companyName="AudioKit"
+              pluginChannelConfigs="{2,2}">
   <MAINGROUP id="ZfGFUI" name="AKStereoDelay">
     <GROUP id="{FEECB9C1-12DF-A37D-B1B4-312B39D894F0}" name="AudioKitCore">
       <FILE id="Ew2HWJ" name="AdjustableDelayLine.cpp" compile="1" resource="0"
@@ -47,6 +50,29 @@
         <MODULEPATH id="juce_video" path="C:/JUCE/modules"/>
       </MODULEPATHS>
     </VS2017>
+    <XCODE_MAC targetFolder="Builds/MacOSX">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_video" path="../../juce"/>
+        <MODULEPATH id="juce_opengl" path="../../juce"/>
+        <MODULEPATH id="juce_gui_extra" path="../../juce"/>
+        <MODULEPATH id="juce_gui_basics" path="../../juce"/>
+        <MODULEPATH id="juce_graphics" path="../../juce"/>
+        <MODULEPATH id="juce_events" path="../../juce"/>
+        <MODULEPATH id="juce_data_structures" path="../../juce"/>
+        <MODULEPATH id="juce_cryptography" path="../../juce"/>
+        <MODULEPATH id="juce_core" path="../../juce"/>
+        <MODULEPATH id="juce_audio_utils" path="../../juce"/>
+        <MODULEPATH id="juce_audio_processors" path="../../juce"/>
+        <MODULEPATH id="juce_audio_plugin_client" path="../../juce"/>
+        <MODULEPATH id="juce_audio_formats" path="../../juce"/>
+        <MODULEPATH id="juce_audio_devices" path="../../juce"/>
+        <MODULEPATH id="juce_audio_basics" path="../../juce"/>
+      </MODULEPATHS>
+    </XCODE_MAC>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
@@ -68,6 +94,7 @@
   </MODULES>
   <LIVE_SETTINGS>
     <WINDOWS/>
+    <OSX/>
   </LIVE_SETTINGS>
   <JUCEOPTIONS JUCE_VST3_CAN_REPLACE_VST2="0" JUCE_STRICT_REFCOUNTEDPOINTER="1"/>
 </JUCERPROJECT>

--- a/Developer/AKStereoDelay/AKStereoDelay.jucer
+++ b/Developer/AKStereoDelay/AKStereoDelay.jucer
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<JUCERPROJECT id="Ah44Z7" name="AKStereoDelay" projectType="audioplug" jucerVersion="5.4.1"
+              pluginFormats="buildVST" headerPath="../../../../AudioKit/Core/AudioKitCore/ModulatedDelay">
+  <MAINGROUP id="ZfGFUI" name="AKStereoDelay">
+    <GROUP id="{FEECB9C1-12DF-A37D-B1B4-312B39D894F0}" name="AudioKitCore">
+      <FILE id="Ew2HWJ" name="AdjustableDelayLine.cpp" compile="1" resource="0"
+            file="../../AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.cpp"/>
+      <FILE id="hYtJXH" name="AdjustableDelayLine.hpp" compile="0" resource="0"
+            file="../../AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.hpp"/>
+      <FILE id="RFCK7C" name="AKStereoDelay.cpp" compile="1" resource="0"
+            file="../../AudioKit/Core/AudioKitCore/ModulatedDelay/AKStereoDelay.cpp"/>
+      <FILE id="uBOFEl" name="AKStereoDelay.hpp" compile="0" resource="0"
+            file="../../AudioKit/Core/AudioKitCore/ModulatedDelay/AKStereoDelay.hpp"/>
+    </GROUP>
+    <GROUP id="{7E531ACC-A9F5-DEFD-1805-63F4F1310C9E}" name="Source">
+      <FILE id="QwQh8T" name="PluginProcessor.cpp" compile="1" resource="0"
+            file="Source/PluginProcessor.cpp"/>
+      <FILE id="OdMxG3" name="PluginProcessor.h" compile="0" resource="0"
+            file="Source/PluginProcessor.h"/>
+      <FILE id="xTgYs4" name="PluginEditor.cpp" compile="1" resource="0"
+            file="Source/PluginEditor.cpp"/>
+      <FILE id="n8tkb8" name="PluginEditor.h" compile="0" resource="0" file="Source/PluginEditor.h"/>
+    </GROUP>
+  </MAINGROUP>
+  <EXPORTFORMATS>
+    <VS2017 targetFolder="Builds/VisualStudio2017">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug" winArchitecture="Win32"/>
+        <CONFIGURATION isDebug="0" name="Release" winArchitecture="Win32"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_audio_basics" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_plugin_client" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_cryptography" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_opengl" path="C:/JUCE/modules"/>
+        <MODULEPATH id="juce_video" path="C:/JUCE/modules"/>
+      </MODULEPATHS>
+    </VS2017>
+  </EXPORTFORMATS>
+  <MODULES>
+    <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_devices" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_formats" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_plugin_client" showAllCode="1" useLocalCopy="0"
+            useGlobalPath="1"/>
+    <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_utils" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_cryptography" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_events" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_graphics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_gui_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_gui_extra" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_opengl" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_video" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+  </MODULES>
+  <LIVE_SETTINGS>
+    <WINDOWS/>
+  </LIVE_SETTINGS>
+  <JUCEOPTIONS JUCE_VST3_CAN_REPLACE_VST2="0" JUCE_STRICT_REFCOUNTEDPOINTER="1"/>
+</JUCERPROJECT>

--- a/Developer/AKStereoDelay/README.md
+++ b/Developer/AKStereoDelay/README.md
@@ -1,0 +1,4 @@
+# Using AKStereoDelay with JUCE
+The [JUCE framework](https://juce.com/) provides a fairly straightforward way to build standard DAW plug-ins from C++ DSP code (such as that in *AudioKitCore*). JUCE is commercial software, but offers several no-cost options, including very good support for fully open-source project which use the [GPL3](https://www.gnu.org/licenses/gpl-3.0.en.html) or a GPL3-compatible license.
+
+To build this example, you will need to obtain a copy of the JUCE framework, and sign up for a free "Personal" license, which will allow you to make use of the "Projucer" program to open the *AKStereoDelay.jucer* project file. Saving the project will cause the Projucer to generate as many IDE projects as necessary, for the plug-in types you have requested. You can open these in the usual way in e.g. Xcode for macOS/iOS or Visual Studio 2017 for Windows.

--- a/Developer/AKStereoDelay/Source/PluginEditor.cpp
+++ b/Developer/AKStereoDelay/Source/PluginEditor.cpp
@@ -1,0 +1,90 @@
+/*
+  ==============================================================================
+
+    This file was auto-generated!
+
+    It contains the basic framework code for a JUCE plugin editor.
+
+  ==============================================================================
+*/
+
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+//==============================================================================
+PingPongDelayAudioProcessorEditor::PingPongDelayAudioProcessorEditor (PingPongDelayAudioProcessor& p)
+    : AudioProcessorEditor (&p), processor (p)
+{
+    modeCombo.addItem("Stereo", 1);
+    modeCombo.addItem("Ping-Pong", 2);
+    addAndMakeVisible(&modeCombo);
+    modeAttachment = new AudioProcessorValueTreeState::ComboBoxAttachment(processor.paramTree, "pingpong", modeCombo);
+
+    delaySecSlider.setSliderStyle(Slider::SliderStyle::LinearHorizontal);
+    delaySecSlider.setRange(0.0, 2.0);
+    delaySecSlider.setValue(0.5f);
+    delaySecSlider.setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
+    addAndMakeVisible(&delaySecSlider);
+    delaySecAttachment = new AudioProcessorValueTreeState::SliderAttachment(processor.paramTree, "delaySec", delaySecSlider);
+
+    feedbackSlider.setSliderStyle(Slider::SliderStyle::LinearHorizontal);
+    feedbackSlider.setRange(0.0, 1.0);
+    feedbackSlider.setValue(0.0f);
+    feedbackSlider.setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
+    addAndMakeVisible(&feedbackSlider);
+    feedbackAttachment = new AudioProcessorValueTreeState::SliderAttachment(processor.paramTree, "feedback", feedbackSlider);
+
+    fxLevelSlider.setSliderStyle(Slider::SliderStyle::LinearHorizontal);
+    fxLevelSlider.setRange(0.0, 1.0);
+    fxLevelSlider.setValue(0.8f);
+    fxLevelSlider.setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
+    addAndMakeVisible(&fxLevelSlider);
+    fxLevelAttachment = new AudioProcessorValueTreeState::SliderAttachment(processor.paramTree, "fxLevel", fxLevelSlider);
+
+    modeLabel.setText("Mode", NotificationType::dontSendNotification);
+    modeLabel.setJustificationType(Justification::right);
+    addAndMakeVisible(modeLabel);
+
+    delaySecLabel.setText("Delay Time", NotificationType::dontSendNotification);
+    delaySecLabel.setJustificationType(Justification::right);
+    addAndMakeVisible(delaySecLabel);
+
+    feedbackLabel.setText("Feedback", NotificationType::dontSendNotification);
+    feedbackLabel.setJustificationType(Justification::right);
+    addAndMakeVisible(feedbackLabel);
+
+    fxLevelLabel.setText("Effect Level", NotificationType::dontSendNotification);
+    fxLevelLabel.setJustificationType(Justification::right);
+    addAndMakeVisible(fxLevelLabel);
+
+    setSize (400, 300);
+}
+
+PingPongDelayAudioProcessorEditor::~PingPongDelayAudioProcessorEditor()
+{
+}
+
+//==============================================================================
+void PingPongDelayAudioProcessorEditor::paint (Graphics& g)
+{
+    // (Our component is opaque, so we must completely fill the background with a solid colour)
+    g.fillAll (getLookAndFeel().findColour (ResizableWindow::backgroundColourId));
+}
+
+void PingPongDelayAudioProcessorEditor::resized()
+{
+    auto bounds = getLocalBounds().reduced(20);
+    auto row = bounds.removeFromTop(40);
+    modeLabel.setBounds(row.removeFromLeft(100)); row.removeFromLeft(10);
+    modeCombo.setBounds(row);
+    bounds.removeFromTop(10);
+    row = bounds.removeFromTop(40);
+    delaySecLabel.setBounds(row.removeFromLeft(100)); row.removeFromLeft(10);
+    delaySecSlider.setBounds(row);
+    row = bounds.removeFromTop(40);
+    feedbackLabel.setBounds(row.removeFromLeft(100)); row.removeFromLeft(10);
+    feedbackSlider.setBounds(row);
+    row = bounds.removeFromTop(40);
+    fxLevelLabel.setBounds(row.removeFromLeft(100)); row.removeFromLeft(10);
+    fxLevelSlider.setBounds(row);
+}

--- a/Developer/AKStereoDelay/Source/PluginEditor.cpp
+++ b/Developer/AKStereoDelay/Source/PluginEditor.cpp
@@ -12,7 +12,7 @@
 #include "PluginEditor.h"
 
 //==============================================================================
-PingPongDelayAudioProcessorEditor::PingPongDelayAudioProcessorEditor (PingPongDelayAudioProcessor& p)
+AKStereoDelayProcessorEditor::AKStereoDelayProcessorEditor (AKStereoDelayProcessor& p)
     : AudioProcessorEditor (&p), processor (p)
 {
     modeCombo.addItem("Stereo", 1);
@@ -60,18 +60,18 @@ PingPongDelayAudioProcessorEditor::PingPongDelayAudioProcessorEditor (PingPongDe
     setSize (400, 300);
 }
 
-PingPongDelayAudioProcessorEditor::~PingPongDelayAudioProcessorEditor()
+AKStereoDelayProcessorEditor::~AKStereoDelayProcessorEditor()
 {
 }
 
 //==============================================================================
-void PingPongDelayAudioProcessorEditor::paint (Graphics& g)
+void AKStereoDelayProcessorEditor::paint (Graphics& g)
 {
     // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (ResizableWindow::backgroundColourId));
 }
 
-void PingPongDelayAudioProcessorEditor::resized()
+void AKStereoDelayProcessorEditor::resized()
 {
     auto bounds = getLocalBounds().reduced(20);
     auto row = bounds.removeFromTop(40);

--- a/Developer/AKStereoDelay/Source/PluginEditor.h
+++ b/Developer/AKStereoDelay/Source/PluginEditor.h
@@ -1,0 +1,44 @@
+/*
+  ==============================================================================
+
+    This file was auto-generated!
+
+    It contains the basic framework code for a JUCE plugin editor.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "../JuceLibraryCode/JuceHeader.h"
+#include "PluginProcessor.h"
+
+//==============================================================================
+/**
+*/
+class PingPongDelayAudioProcessorEditor  : public AudioProcessorEditor
+{
+public:
+    PingPongDelayAudioProcessorEditor (PingPongDelayAudioProcessor&);
+    ~PingPongDelayAudioProcessorEditor();
+
+    //==============================================================================
+    void paint (Graphics&) override;
+    void resized() override;
+
+private:
+    // This reference is provided as a quick way for your editor to
+    // access the processor object that created it.
+    PingPongDelayAudioProcessor& processor;
+
+    ComboBox modeCombo;
+    Slider delaySecSlider, feedbackSlider, fxLevelSlider;
+    Label modeLabel, delaySecLabel, feedbackLabel, fxLevelLabel;
+
+    ScopedPointer<AudioProcessorValueTreeState::ComboBoxAttachment> modeAttachment;
+    ScopedPointer<AudioProcessorValueTreeState::SliderAttachment> delaySecAttachment;
+    ScopedPointer<AudioProcessorValueTreeState::SliderAttachment> feedbackAttachment;
+    ScopedPointer<AudioProcessorValueTreeState::SliderAttachment> fxLevelAttachment;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PingPongDelayAudioProcessorEditor)
+};

--- a/Developer/AKStereoDelay/Source/PluginEditor.h
+++ b/Developer/AKStereoDelay/Source/PluginEditor.h
@@ -16,11 +16,11 @@
 //==============================================================================
 /**
 */
-class PingPongDelayAudioProcessorEditor  : public AudioProcessorEditor
+class AKStereoDelayProcessorEditor  : public AudioProcessorEditor
 {
 public:
-    PingPongDelayAudioProcessorEditor (PingPongDelayAudioProcessor&);
-    ~PingPongDelayAudioProcessorEditor();
+    AKStereoDelayProcessorEditor (AKStereoDelayProcessor&);
+    ~AKStereoDelayProcessorEditor();
 
     //==============================================================================
     void paint (Graphics&) override;
@@ -29,7 +29,7 @@ public:
 private:
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
-    PingPongDelayAudioProcessor& processor;
+    AKStereoDelayProcessor& processor;
 
     ComboBox modeCombo;
     Slider delaySecSlider, feedbackSlider, fxLevelSlider;
@@ -40,5 +40,5 @@ private:
     ScopedPointer<AudioProcessorValueTreeState::SliderAttachment> feedbackAttachment;
     ScopedPointer<AudioProcessorValueTreeState::SliderAttachment> fxLevelAttachment;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PingPongDelayAudioProcessorEditor)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AKStereoDelayProcessorEditor)
 };

--- a/Developer/AKStereoDelay/Source/PluginProcessor.cpp
+++ b/Developer/AKStereoDelay/Source/PluginProcessor.cpp
@@ -1,0 +1,195 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+PingPongDelayAudioProcessor::PingPongDelayAudioProcessor()
+#ifndef JucePlugin_PreferredChannelConfigurations
+    : AudioProcessor(BusesProperties()
+#if ! JucePlugin_IsMidiEffect
+#if ! JucePlugin_IsSynth
+        .withInput("Input", AudioChannelSet::stereo(), true)
+#endif
+        .withOutput("Output", AudioChannelSet::stereo(), true)
+#endif
+    )
+#endif
+    , paramTree(*this, nullptr, "PARAMETERS", {
+            std::make_unique<AudioParameterBool>("pingpong", "Ping-Pong", false),
+            std::make_unique<AudioParameterFloat>("delaySec", "DelaySec", 0.0f, 2.0f, 0.5f),
+            std::make_unique<AudioParameterFloat>("feedback", "Feedback", 0.0f, 1.0f, 0.0f),
+            std::make_unique<AudioParameterFloat>("fxLevel", "Effect Level", 0.0f, 1.0f, 0.8f),
+        })
+{
+    paramTree.addParameterListener("pingpong", this);
+    paramTree.addParameterListener("delaySec", this);
+    paramTree.addParameterListener("feedback", this);
+    paramTree.addParameterListener("fxLevel", this);
+}
+
+PingPongDelayAudioProcessor::~PingPongDelayAudioProcessor()
+{
+}
+
+void PingPongDelayAudioProcessor::parameterChanged(const String& parameterID, float newValue)
+{
+    if (parameterID == "pingpong")
+    {
+        delay.setPingPongMode(newValue > 0.5f);
+    }
+    else if (parameterID == "delaySec")
+    {
+        delay.setDelayMs(1000.0f * newValue);
+    }
+    else if (parameterID == "feedback")
+    {
+        delay.setFeedback(newValue);
+    }
+    else if (parameterID == "fxLevel")
+    {
+        delay.setEffectLevel(newValue);
+    }
+}
+
+const String PingPongDelayAudioProcessor::getName() const
+{
+    return JucePlugin_Name;
+}
+
+bool PingPongDelayAudioProcessor::acceptsMidi() const
+{
+   #if JucePlugin_WantsMidiInput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool PingPongDelayAudioProcessor::producesMidi() const
+{
+   #if JucePlugin_ProducesMidiOutput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool PingPongDelayAudioProcessor::isMidiEffect() const
+{
+   #if JucePlugin_IsMidiEffect
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+double PingPongDelayAudioProcessor::getTailLengthSeconds() const
+{
+    return 0.0;
+}
+
+int PingPongDelayAudioProcessor::getNumPrograms()
+{
+    return 1;   // NB: some hosts don't cope very well if you tell them there are 0 programs,
+                // so this should be at least 1, even if you're not really implementing programs.
+}
+
+int PingPongDelayAudioProcessor::getCurrentProgram()
+{
+    return 0;
+}
+
+void PingPongDelayAudioProcessor::setCurrentProgram (int /*index*/)
+{
+}
+
+const String PingPongDelayAudioProcessor::getProgramName (int /*index*/)
+{
+    return {};
+}
+
+void PingPongDelayAudioProcessor::changeProgramName (int /*index*/, const String& /*newName*/)
+{
+}
+
+void PingPongDelayAudioProcessor::prepareToPlay (double sampleRate, int /*samplesPerBlock*/)
+{
+    bool pingPong = *paramTree.getRawParameterValue("pingpong") > 0.5f;
+    float delayTimeSeconds = *paramTree.getRawParameterValue("delaySec");
+    float feedbackFraction = *paramTree.getRawParameterValue("feedback");
+    float effectLevelFraction = *paramTree.getRawParameterValue("fxLevel");
+
+    DBG("prepareToPlay: pingPong is " + String(pingPong ? "TRUE" : "FALSE"));
+
+    delay.init(sampleRate, 2000.0);
+    delay.setPingPongMode(pingPong);
+    delay.setDelayMs(float(1000.0 * delayTimeSeconds));
+    delay.setFeedback(feedbackFraction);
+    delay.setEffectLevel(effectLevelFraction);
+}
+
+void PingPongDelayAudioProcessor::releaseResources()
+{
+    delay.deinit();
+}
+
+#ifndef JucePlugin_PreferredChannelConfigurations
+bool PingPongDelayAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+{
+  #if JucePlugin_IsMidiEffect
+    ignoreUnused (layouts);
+    return true;
+  #else
+    // This is the place where you check if the layout is supported.
+    // In this template code we only support mono or stereo.
+    if (layouts.getMainOutputChannelSet() != AudioChannelSet::mono()
+     && layouts.getMainOutputChannelSet() != AudioChannelSet::stereo())
+        return false;
+
+    // This checks if the input layout matches the output layout
+   #if ! JucePlugin_IsSynth
+    if (layouts.getMainOutputChannelSet() != layouts.getMainInputChannelSet())
+        return false;
+   #endif
+
+    return true;
+  #endif
+}
+#endif
+
+void PingPongDelayAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer& /*midiMessages*/)
+{
+    ScopedNoDenormals noDenormals;
+
+    const float *inBuffers[2] = { buffer.getReadPointer(0), buffer.getReadPointer(1) };
+    float* outBuffers[2] = { buffer.getWritePointer(0), buffer.getWritePointer(1) };
+
+    delay.render(buffer.getNumSamples(), inBuffers, outBuffers);
+}
+
+bool PingPongDelayAudioProcessor::hasEditor() const
+{
+    return true; // (change this to false if you choose to not supply an editor)
+}
+
+AudioProcessorEditor* PingPongDelayAudioProcessor::createEditor()
+{
+    return new PingPongDelayAudioProcessorEditor (*this);
+}
+
+void PingPongDelayAudioProcessor::getStateInformation (MemoryBlock& destData)
+{
+    // You should use this method to store your parameters in the memory block.
+    // You could do that either as raw data, or use the XML or ValueTree classes
+    // as intermediaries to make it easy to save and load complex data.
+    destData.setSize(1);    // make VstHost happy
+}
+
+void PingPongDelayAudioProcessor::setStateInformation (const void* /*data*/, int /*sizeInBytes*/)
+{
+    // You should use this method to restore your parameters from this memory block,
+    // whose contents will have been created by the getStateInformation() call.
+}
+
+AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+{
+    return new PingPongDelayAudioProcessor();
+}

--- a/Developer/AKStereoDelay/Source/PluginProcessor.cpp
+++ b/Developer/AKStereoDelay/Source/PluginProcessor.cpp
@@ -1,17 +1,11 @@
 #include "PluginProcessor.h"
 #include "PluginEditor.h"
 
-PingPongDelayAudioProcessor::PingPongDelayAudioProcessor()
-#ifndef JucePlugin_PreferredChannelConfigurations
+AKStereoDelayProcessor::AKStereoDelayProcessor()
     : AudioProcessor(BusesProperties()
-#if ! JucePlugin_IsMidiEffect
-#if ! JucePlugin_IsSynth
         .withInput("Input", AudioChannelSet::stereo(), true)
-#endif
         .withOutput("Output", AudioChannelSet::stereo(), true)
-#endif
     )
-#endif
     , paramTree(*this, nullptr, "PARAMETERS", {
             std::make_unique<AudioParameterBool>("pingpong", "Ping-Pong", false),
             std::make_unique<AudioParameterFloat>("delaySec", "DelaySec", 0.0f, 2.0f, 0.5f),
@@ -25,11 +19,11 @@ PingPongDelayAudioProcessor::PingPongDelayAudioProcessor()
     paramTree.addParameterListener("fxLevel", this);
 }
 
-PingPongDelayAudioProcessor::~PingPongDelayAudioProcessor()
+AKStereoDelayProcessor::~AKStereoDelayProcessor()
 {
 }
 
-void PingPongDelayAudioProcessor::parameterChanged(const String& parameterID, float newValue)
+void AKStereoDelayProcessor::parameterChanged(const String& parameterID, float newValue)
 {
     if (parameterID == "pingpong")
     {
@@ -49,12 +43,12 @@ void PingPongDelayAudioProcessor::parameterChanged(const String& parameterID, fl
     }
 }
 
-const String PingPongDelayAudioProcessor::getName() const
+const String AKStereoDelayProcessor::getName() const
 {
     return JucePlugin_Name;
 }
 
-bool PingPongDelayAudioProcessor::acceptsMidi() const
+bool AKStereoDelayProcessor::acceptsMidi() const
 {
    #if JucePlugin_WantsMidiInput
     return true;
@@ -63,7 +57,7 @@ bool PingPongDelayAudioProcessor::acceptsMidi() const
    #endif
 }
 
-bool PingPongDelayAudioProcessor::producesMidi() const
+bool AKStereoDelayProcessor::producesMidi() const
 {
    #if JucePlugin_ProducesMidiOutput
     return true;
@@ -72,7 +66,7 @@ bool PingPongDelayAudioProcessor::producesMidi() const
    #endif
 }
 
-bool PingPongDelayAudioProcessor::isMidiEffect() const
+bool AKStereoDelayProcessor::isMidiEffect() const
 {
    #if JucePlugin_IsMidiEffect
     return true;
@@ -81,43 +75,41 @@ bool PingPongDelayAudioProcessor::isMidiEffect() const
    #endif
 }
 
-double PingPongDelayAudioProcessor::getTailLengthSeconds() const
+double AKStereoDelayProcessor::getTailLengthSeconds() const
 {
     return 0.0;
 }
 
-int PingPongDelayAudioProcessor::getNumPrograms()
+int AKStereoDelayProcessor::getNumPrograms()
 {
     return 1;   // NB: some hosts don't cope very well if you tell them there are 0 programs,
                 // so this should be at least 1, even if you're not really implementing programs.
 }
 
-int PingPongDelayAudioProcessor::getCurrentProgram()
+int AKStereoDelayProcessor::getCurrentProgram()
 {
     return 0;
 }
 
-void PingPongDelayAudioProcessor::setCurrentProgram (int /*index*/)
+void AKStereoDelayProcessor::setCurrentProgram (int /*index*/)
 {
 }
 
-const String PingPongDelayAudioProcessor::getProgramName (int /*index*/)
+const String AKStereoDelayProcessor::getProgramName (int /*index*/)
 {
     return {};
 }
 
-void PingPongDelayAudioProcessor::changeProgramName (int /*index*/, const String& /*newName*/)
+void AKStereoDelayProcessor::changeProgramName (int /*index*/, const String& /*newName*/)
 {
 }
 
-void PingPongDelayAudioProcessor::prepareToPlay (double sampleRate, int /*samplesPerBlock*/)
+void AKStereoDelayProcessor::prepareToPlay (double sampleRate, int /*samplesPerBlock*/)
 {
     bool pingPong = *paramTree.getRawParameterValue("pingpong") > 0.5f;
     float delayTimeSeconds = *paramTree.getRawParameterValue("delaySec");
     float feedbackFraction = *paramTree.getRawParameterValue("feedback");
     float effectLevelFraction = *paramTree.getRawParameterValue("fxLevel");
-
-    DBG("prepareToPlay: pingPong is " + String(pingPong ? "TRUE" : "FALSE"));
 
     delay.init(sampleRate, 2000.0);
     delay.setPingPongMode(pingPong);
@@ -126,13 +118,13 @@ void PingPongDelayAudioProcessor::prepareToPlay (double sampleRate, int /*sample
     delay.setEffectLevel(effectLevelFraction);
 }
 
-void PingPongDelayAudioProcessor::releaseResources()
+void AKStereoDelayProcessor::releaseResources()
 {
     delay.deinit();
 }
 
 #ifndef JucePlugin_PreferredChannelConfigurations
-bool PingPongDelayAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+bool AKStereoDelayProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
   #if JucePlugin_IsMidiEffect
     ignoreUnused (layouts);
@@ -155,27 +147,29 @@ bool PingPongDelayAudioProcessor::isBusesLayoutSupported (const BusesLayout& lay
 }
 #endif
 
-void PingPongDelayAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer& /*midiMessages*/)
+void AKStereoDelayProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer& /*midiMessages*/)
 {
     ScopedNoDenormals noDenormals;
 
     const float *inBuffers[2] = { buffer.getReadPointer(0), buffer.getReadPointer(1) };
     float* outBuffers[2] = { buffer.getWritePointer(0), buffer.getWritePointer(1) };
 
+    
+
     delay.render(buffer.getNumSamples(), inBuffers, outBuffers);
 }
 
-bool PingPongDelayAudioProcessor::hasEditor() const
+bool AKStereoDelayProcessor::hasEditor() const
 {
     return true; // (change this to false if you choose to not supply an editor)
 }
 
-AudioProcessorEditor* PingPongDelayAudioProcessor::createEditor()
+AudioProcessorEditor* AKStereoDelayProcessor::createEditor()
 {
-    return new PingPongDelayAudioProcessorEditor (*this);
+    return new AKStereoDelayProcessorEditor (*this);
 }
 
-void PingPongDelayAudioProcessor::getStateInformation (MemoryBlock& destData)
+void AKStereoDelayProcessor::getStateInformation (MemoryBlock& destData)
 {
     // You should use this method to store your parameters in the memory block.
     // You could do that either as raw data, or use the XML or ValueTree classes
@@ -183,7 +177,7 @@ void PingPongDelayAudioProcessor::getStateInformation (MemoryBlock& destData)
     destData.setSize(1);    // make VstHost happy
 }
 
-void PingPongDelayAudioProcessor::setStateInformation (const void* /*data*/, int /*sizeInBytes*/)
+void AKStereoDelayProcessor::setStateInformation (const void* /*data*/, int /*sizeInBytes*/)
 {
     // You should use this method to restore your parameters from this memory block,
     // whose contents will have been created by the getStateInformation() call.
@@ -191,5 +185,5 @@ void PingPongDelayAudioProcessor::setStateInformation (const void* /*data*/, int
 
 AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
-    return new PingPongDelayAudioProcessor();
+    return new AKStereoDelayProcessor();
 }

--- a/Developer/AKStereoDelay/Source/PluginProcessor.h
+++ b/Developer/AKStereoDelay/Source/PluginProcessor.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "JuceHeader.h"
+#include "AKStereoDelay.hpp"
+
+class PingPongDelayAudioProcessor : public AudioProcessor,
+                                    public AudioProcessorValueTreeState::Listener
+{
+public:
+    PingPongDelayAudioProcessor();
+    ~PingPongDelayAudioProcessor();
+
+    void parameterChanged(const String &parameterID, float newValue) override;
+
+    void prepareToPlay (double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+   #ifndef JucePlugin_PreferredChannelConfigurations
+    bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
+   #endif
+
+    void processBlock (AudioBuffer<float>&, MidiBuffer&) override;
+
+    AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override;
+
+    const String getName() const override;
+
+    bool acceptsMidi() const override;
+    bool producesMidi() const override;
+    bool isMidiEffect() const override;
+    double getTailLengthSeconds() const override;
+
+    int getNumPrograms() override;
+    int getCurrentProgram() override;
+    void setCurrentProgram (int index) override;
+    const String getProgramName (int index) override;
+    void changeProgramName (int index, const String& newName) override;
+
+    void getStateInformation (MemoryBlock& destData) override;
+    void setStateInformation (const void* data, int sizeInBytes) override;
+
+    AudioProcessorValueTreeState paramTree;
+
+private:
+    AudioKitCore::AKStereoDelay delay;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PingPongDelayAudioProcessor)
+};

--- a/Developer/AKStereoDelay/Source/PluginProcessor.h
+++ b/Developer/AKStereoDelay/Source/PluginProcessor.h
@@ -2,12 +2,12 @@
 #include "JuceHeader.h"
 #include "AKStereoDelay.hpp"
 
-class PingPongDelayAudioProcessor : public AudioProcessor,
-                                    public AudioProcessorValueTreeState::Listener
+class AKStereoDelayProcessor :  public AudioProcessor,
+                                public AudioProcessorValueTreeState::Listener
 {
 public:
-    PingPongDelayAudioProcessor();
-    ~PingPongDelayAudioProcessor();
+    AKStereoDelayProcessor();
+    ~AKStereoDelayProcessor();
 
     void parameterChanged(const String &parameterID, float newValue) override;
 
@@ -44,5 +44,5 @@ public:
 private:
     AudioKitCore::AKStereoDelay delay;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PingPongDelayAudioProcessor)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AKStereoDelayProcessor)
 };


### PR DESCRIPTION
This code is not yet integrated into the AudioKit framework. Only one pre-existing file has been altered, and very slightly. Under the Develop folder there is an example of how to use JUCE to create VST and AU plug-ins based on the new code. These are tested and seem to work fine.