### PR TITLE
Remove bias in triangle-wave generation in Core FunctionTable

### DIFF
--- a/AudioKit/Core/AudioKitCore/Common/FunctionTable.cpp
+++ b/AudioKit/Core/AudioKitCore/Common/FunctionTable.cpp
@@ -43,7 +43,7 @@ namespace AudioKitCore
         else    // you would normally only do this if you plan to low-pass filter the result
         {
             for (int i=0; i < nTableSize; i++)
-                pWaveTable[i] = 2.0f * amplitude * (0.5f - fabsf((float(i)/nTableSize) - 0.5f)) - amplitude;
+                pWaveTable[i] = 2.0f * amplitude * (0.25f - fabsf((float(i)/nTableSize) - 0.5f));
         }
     }
     


### PR DESCRIPTION
My code for generating a triangle-wave was wrong, so there was a negative DC bias.