### PR TITLE
Improvements to AKMIDI port selection and sysex message handling

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
@@ -49,9 +49,14 @@ extension AKMIDI {
     /// - Parameter forUid: unique id for a input
     /// - Returns: name of input or "Unknown"
     public func inputName(for inputUid: MIDIUniqueID) -> String {
-        let name : String = zip(inputNames, inputUIDs).first { (arg: (String, MIDIUniqueID)) -> Bool in let (_, uid) = arg; return inputUid == uid }.map { (arg) -> String in
-            let (name, _) = arg
-            return name
+        let name : String = zip(inputNames, inputUIDs).first {
+                (arg: (String, MIDIUniqueID)) -> Bool in
+                let (_, uid) = arg;
+                return inputUid == uid
+            }.map {
+                (arg) -> String in
+                let (name, _) = arg
+                return name
             } ?? "Uknown"
         return name
     }
@@ -94,7 +99,7 @@ extension AKMIDI {
     /// - Returns: unique identifier for the port
     public func uidForInputAtIndex(_ inputIndex: Int = 0) -> MIDIUniqueID {
         let endpoint: MIDIEndpointRef = MIDISources()[inputIndex]
-        let uid = GetMIDIObjectIntegerProperty(ref: endpoint, property: kMIDIPropertyUniqueID)
+        let uid = getMIDIObjectIntegerProperty(ref: endpoint, property: kMIDIPropertyUniqueID)
         return uid
     }
 

--- a/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
@@ -16,10 +16,6 @@
 //      * Simplicty to close all ports
 //      * Ports must be identifies using MIDIUniqueIDs because ports can share the same name across devices and clients
 //
-// Possible Improvements:
-//      * Support hidden uuid generation so the caller can worry about less
-//      *
-//
 
 internal struct MIDISources: Collection {
     typealias Index = Int

--- a/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
@@ -49,12 +49,10 @@ extension AKMIDI {
     /// - Parameter forUid: unique id for a input
     /// - Returns: name of input or "Unknown"
     public func inputName(for inputUid: MIDIUniqueID) -> String {
-        let name : String = zip(inputNames, inputUIDs).first {
-                (arg: (String, MIDIUniqueID)) -> Bool in
-                let (_, uid) = arg;
+        let name : String = zip(inputNames, inputUIDs).first { (arg: (String, MIDIUniqueID)) -> Bool in
+                let (_, uid) = arg
                 return inputUid == uid
-            }.map {
-                (arg) -> String in
+            }.map { (arg) -> String in
                 let (name, _) = arg
                 return name
             } ?? "Uknown"

--- a/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
@@ -43,6 +43,12 @@ extension AKMIDI {
         listeners.append(listener)
     }
 
+    public func removeListener(_ listener: AKMIDIListener) {
+        listeners.removeAll { (item) -> Bool in
+            return item == listener
+        }
+    }
+
     /// Remove all listeners
     public func clearListeners() {
         listeners.removeAll()
@@ -51,6 +57,12 @@ extension AKMIDI {
     /// Add a transformer to the transformers list
     public func addTransformer(_ transformer: AKMIDITransformer) {
         transformers.append(transformer)
+    }
+
+    public func removeTransformer(_ transformer: AKMIDITransformer) {
+        transformers.removeAll { (item) -> Bool in
+            return item == transformer
+        }
     }
 
     /// Remove all transformers

--- a/AudioKit/Common/MIDI/AKMIDI+Sending.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Sending.swift
@@ -62,18 +62,18 @@ internal struct MIDIDestinations: Collection {
 extension Collection where Iterator.Element == MIDIEndpointRef {
     var names: [String] {
         return map {
-            GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyName)
+            getMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyName)
         }
     }
 
     var uniqueIds: [MIDIUniqueID] {
         return map {
-            GetMIDIObjectIntegerProperty(ref: $0, property: kMIDIPropertyUniqueID)
+            getMIDIObjectIntegerProperty(ref: $0, property: kMIDIPropertyUniqueID)
         }
     }
 }
 
-internal func GetMIDIObjectStringProperty(ref: MIDIObjectRef, property: CFString) -> String {
+internal func getMIDIObjectStringProperty(ref: MIDIObjectRef, property: CFString) -> String {
     var string: Unmanaged<CFString>?
     MIDIObjectGetStringProperty(ref, property, &string)
     if let returnString = string?.takeRetainedValue() {
@@ -83,7 +83,7 @@ internal func GetMIDIObjectStringProperty(ref: MIDIObjectRef, property: CFString
     }
 }
 
-internal func GetMIDIObjectIntegerProperty(ref: MIDIObjectRef, property: CFString) -> Int32 {
+internal func getMIDIObjectIntegerProperty(ref: MIDIObjectRef, property: CFString) -> Int32 {
     var result: Int32 = 0
     MIDIObjectGetIntegerProperty(ref, property, &result)
     return result
@@ -106,9 +106,14 @@ extension AKMIDI {
     /// - Parameter forUid: unique id for a destination
     /// - Returns: name of destination or "Unknown"
     public func destinationName(for destUid: MIDIUniqueID) -> String {
-        let name : String = zip(destinationNames, destinationUIDs).first { (arg: (String, MIDIUniqueID)) -> Bool in let (_, uid) = arg; return destUid == uid }.map { (arg) -> String in
-            let (name, _) = arg
-            return name
+        let name : String = zip(destinationNames, destinationUIDs).first {
+                (arg: (String, MIDIUniqueID)) -> Bool in
+                let (_, uid) = arg;
+                return destUid == uid
+            }.map {
+                (arg) -> String in
+                let (name, _) = arg
+                return name
             } ?? "Uknown"
         return name
     }
@@ -119,7 +124,7 @@ extension AKMIDI {
     /// - Returns: unique identifier for the port
     public func uidForDestinationAtIndex(_ outputIndex: Int = 0) -> MIDIUniqueID {
         let endpoint: MIDIEndpointRef = MIDIDestinations()[outputIndex]
-        let uid = GetMIDIObjectIntegerProperty(ref: endpoint, property: kMIDIPropertyUniqueID)
+        let uid = getMIDIObjectIntegerProperty(ref: endpoint, property: kMIDIPropertyUniqueID)
         return uid
     }
 
@@ -146,7 +151,7 @@ extension AKMIDI {
 
         // close any previous output port and dispose of it
         if outputPort != 0 {
-            let uid = GetMIDIObjectIntegerProperty(ref: outputPort, property: kMIDIPropertyUniqueID)
+            let uid = getMIDIObjectIntegerProperty(ref: outputPort, property: kMIDIPropertyUniqueID)
             closeOutput(uid)
             outputPort = 0
         }
@@ -162,8 +167,12 @@ extension AKMIDI {
             }
         } else {
             // To get only [the FIRST] endpoint with name provided in output (conditional mapping)
-            _ = zip(destinationUIDs, destinations).first { (arg: (MIDIUniqueID, MIDIDestinations.Element)) -> Bool in let (uid, _) = arg; return outputUid == uid }.map {
-                endpoints[$0] = $1
+            _ = zip(destinationUIDs, destinations).first {
+                    (arg: (MIDIUniqueID, MIDIDestinations.Element)) -> Bool in
+                    let (uid, _) = arg;
+                    return outputUid == uid
+                }.map {
+                    endpoints[$0] = $1
             }
         }
     }

--- a/AudioKit/Common/MIDI/AKMIDI+Sending.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Sending.swift
@@ -106,12 +106,10 @@ extension AKMIDI {
     /// - Parameter forUid: unique id for a destination
     /// - Returns: name of destination or "Unknown"
     public func destinationName(for destUid: MIDIUniqueID) -> String {
-        let name : String = zip(destinationNames, destinationUIDs).first {
-                (arg: (String, MIDIUniqueID)) -> Bool in
-                let (_, uid) = arg;
+        let name : String = zip(destinationNames, destinationUIDs).first { (arg: (String, MIDIUniqueID)) -> Bool in
+                let (_, uid) = arg
                 return destUid == uid
-            }.map {
-                (arg) -> String in
+            }.map { (arg) -> String in
                 let (name, _) = arg
                 return name
             } ?? "Uknown"
@@ -138,7 +136,7 @@ extension AKMIDI {
 
     /// Open a MIDI Output Port by name
     ///
-    /// Destination name (string) can be empty for some hardware device;
+    /// Destination name (string) can be empty for some hardware device
     /// So optional string is better for checking and targeting the device.
     ///
     /// - parameter outputName: String containing the name of the MIDI Input
@@ -167,9 +165,8 @@ extension AKMIDI {
             }
         } else {
             // To get only [the FIRST] endpoint with name provided in output (conditional mapping)
-            _ = zip(destinationUIDs, destinations).first {
-                    (arg: (MIDIUniqueID, MIDIDestinations.Element)) -> Bool in
-                    let (uid, _) = arg;
+            _ = zip(destinationUIDs, destinations).first { (arg: (MIDIUniqueID, MIDIDestinations.Element)) -> Bool in
+                    let (uid, _) = arg
                     return outputUid == uid
                 }.map {
                     endpoints[$0] = $1

--- a/AudioKit/Common/MIDI/AKMIDI+VirtualPorts.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+VirtualPorts.swift
@@ -1,0 +1,105 @@
+//
+//  AKMIDI+VirtualPorts.swift
+//  AudioKit
+//
+//  Created by Kurt Arnlund on 1/15/19.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import CoreMIDI
+
+extension AKMIDI {
+
+    // MARK: - Virtual MIDI
+    //
+    // Virtual MIDI Goals
+    //      * Simplicty in creating a virtual input and virtual output ports together
+    //      * Simplicty in disposing of virtual ports together
+    //      * Ability to create a single virtual input, or single virtual output
+    //
+    // Possible Improvements:
+    //      * Support a greater numbers of virtual ports
+    //      * Support hidden uuid generation so the caller can worry about less
+    //
+
+    /// Create set of virtual input and output MIDI ports
+    open func createVirtualPorts(_ uniqueID: Int32 = 2_000_000, name: String? = nil) {
+        AKLog("Creating virtual input and output ports")
+        destroyVirtualPorts()
+        createVirtualInputPort(name: name)
+        createVirtualOutputPort(name: name)
+    }
+
+    /// Create a virtual MIDI input port
+    open func createVirtualInputPort(_ uniqueID: Int32 = 2_000_000, name: String? = nil) {
+        destroyVirtualInputPort()
+        let virtualPortname = name ?? String(clientName)
+
+        let result = MIDIDestinationCreateWithBlock(
+            client,
+            virtualPortname as CFString,
+            &virtualInput) { packetList, _ in
+                for packet in packetList.pointee {
+                    // a Core MIDI packet may contain multiple MIDI events
+                    for event in packet {
+                        self.handleMIDIMessage(event)
+                    }
+                }
+        }
+
+        if result == noErr {
+            MIDIObjectSetIntegerProperty(virtualInput, kMIDIPropertyUniqueID, uniqueID)
+        } else {
+            AKLog("Error Creating Virtual Input Port: \(virtualPortname) -- \(virtualInput)")
+            CheckError(result)
+        }
+    }
+
+    /// Create a virtual MIDI output port
+    open func createVirtualOutputPort(_ uniqueID: Int32 = 2_000_001, name: String? = nil) {
+        destroyVirtualOutputPort()
+        let virtualPortname = name ?? String(clientName)
+
+        let result = MIDISourceCreate(client, virtualPortname as CFString, &virtualOutput)
+        if result == noErr {
+            MIDIObjectSetIntegerProperty(virtualInput, kMIDIPropertyUniqueID, uniqueID)
+        } else {
+            AKLog("Error Creating Virtual Output Port: \(virtualPortname) -- \(virtualOutput)")
+            CheckError(result)
+        }
+    }
+
+    /// Discard all virtual ports
+    open func destroyVirtualPorts() {
+        destroyVirtualInputPort()
+        destroyVirtualOutputPort()
+    }
+
+    /// Closes the virtual input port, if created one already.
+    ///
+    /// - Returns: Returns true if virtual input closed.
+    ///
+    @discardableResult open func destroyVirtualInputPort() -> Bool {
+        if virtualInput != 0 {
+            if MIDIEndpointDispose(virtualInput) == noErr {
+                virtualInput = 0
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Closes the virtual output port, if created one already.
+    ///
+    /// - Returns: Returns true if virtual output closed.
+    ///
+    @discardableResult open func destroyVirtualOutputPort() -> Bool {
+        if virtualOutput != 0 {
+            if MIDIEndpointDispose(virtualOutput) == noErr {
+                virtualOutput = 0
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/AudioKit/Common/MIDI/AKMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI.swift
@@ -27,14 +27,14 @@ open class AKMIDI {
     /// MIDI Client Reference
     open var client = MIDIClientRef()
 
+    /// MIDI Client Name
+    internal let clientName: CFString = "MIDI Client" as CFString
+
     /// Array of MIDI In ports
-    internal var inputPorts: [String: MIDIPortRef] = [:]
+    internal var inputPorts = [MIDIUniqueID: MIDIPortRef]()
 
     /// Virtual MIDI Input destination
     open var virtualInput = MIDIPortRef()
-
-    /// MIDI Client Name
-    private let clientName: CFString = "MIDI Client" as CFString
 
     /// MIDI In Port Name
     internal let inputPortName: CFString = "MIDI In Port" as CFString
@@ -45,11 +45,11 @@ open class AKMIDI {
     /// Virtual MIDI output
     open var virtualOutput = MIDIPortRef()
 
-    /// Array of MIDI Endpoints
-    open var endpoints = [String: MIDIEndpointRef]()
-
     /// MIDI Out Port Name
     internal var outputPortName: CFString = "MIDI Out Port" as CFString
+
+    /// Array of MIDI Endpoints
+    open var endpoints = [MIDIUniqueID: MIDIEndpointRef]()
 
     /// Array of all listeners
     internal var listeners = [AKMIDIListener]()
@@ -83,88 +83,7 @@ open class AKMIDI {
         }
     }
 
-    // MARK: - Virtual MIDI
-
-    /// Create set of virtual input and output MIDI ports
-    open func createVirtualPorts(_ uniqueID: Int32 = 2_000_000, name: String? = nil) {
-        AKLog("Creating virtual input and output ports")
-        destroyVirtualPorts()
-        createVirtualInputPort(uniqueID, name: name)
-        createVirtualOutputPort(uniqueID, name: name)
-    }
-
-    /// Create a virtual MIDI input port
-    open func createVirtualInputPort(_ uniqueID: Int32 = 2_000_000, name: String? = nil) {
-        destroyVirtualInputPort()
-        let virtualPortname = name ?? String(clientName)
-
-        let result = MIDIDestinationCreateWithBlock(
-            client,
-            virtualPortname as CFString,
-            &virtualInput) { packetList, _ in
-                for packet in packetList.pointee {
-                    // a Core MIDI packet may contain multiple MIDI events
-                    for event in packet {
-                        self.handleMIDIMessage(event)
-                    }
-                }
-        }
-
-        if result == noErr {
-            MIDIObjectSetIntegerProperty(virtualInput, kMIDIPropertyUniqueID, uniqueID)
-        } else {
-            AKLog("Error Creating Virtual Input Port: \(virtualPortname) -- \(virtualInput)")
-            CheckError(result)
-        }
-    }
-
-    /// Create a virtual MIDI output port
-    open func createVirtualOutputPort(_ uniqueID: Int32 = 2_000_000, name: String? = nil) {
-        destroyVirtualOutputPort()
-        let virtualPortname = name ?? String(clientName)
-
-        let result = MIDISourceCreate(client, virtualPortname as CFString, &virtualOutput)
-        if result == noErr {
-            MIDIObjectSetIntegerProperty(virtualInput, kMIDIPropertyUniqueID, uniqueID + 1)
-        } else {
-            AKLog("Error Creating Virtual Output Port: \(virtualPortname) -- \(virtualOutput)")
-            CheckError(result)
-        }
-    }
-
-    /// Discard all virtual ports
-    open func destroyVirtualPorts() {
-        destroyVirtualInputPort()
-        destroyVirtualOutputPort()
-    }
-
-    /// Closes the virtual input port, if created one already.
-    ///
-    /// - Returns: Returns true if virtual input closed.
-    ///
-    @discardableResult open func destroyVirtualInputPort() -> Bool {
-        if virtualInput != 0 {
-            if MIDIEndpointDispose(virtualInput) == noErr {
-                virtualInput = 0
-                return true
-            }
-        }
-        return false
-    }
-
-    /// Closes the virtual output port, if created one already.
-    ///
-    /// - Returns: Returns true if virtual output closed.
-    ///
-    @discardableResult open func destroyVirtualOutputPort() -> Bool {
-        if virtualOutput != 0 {
-            if MIDIEndpointDispose(virtualOutput) == noErr {
-                virtualOutput = 0
-                return true
-            }
-        }
-        return false
-    }
+    // MARK: - SYSEX
 
     internal var isReceivingSysex: Bool = false
     func startReceivingSysex(with midiBytes: [MIDIByte]) {
@@ -176,3 +95,4 @@ open class AKMIDI {
     }
     var incomingSysex = [MIDIByte]()
 }
+

--- a/AudioKit/Common/MIDI/AKMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI.swift
@@ -95,4 +95,3 @@ open class AKMIDI {
     }
     var incomingSysex = [MIDIByte]()
 }
-

--- a/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
@@ -31,12 +31,12 @@ public struct EndpointInfo {
 extension Collection where Iterator.Element == MIDIEndpointRef {
     var endpointInfos: [EndpointInfo] {
 
-        let name = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyName) }
-        let displayName = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDisplayName) }
-        let manufacturer = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyManufacturer) }
-        let model = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyModel) }
-        let image = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyImage) }
-        let driverOwner = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDriverOwner) }
+        let name = map { getMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyName) }
+        let displayName = map { getMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDisplayName) }
+        let manufacturer = map { getMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyManufacturer) }
+        let model = map { getMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyModel) }
+        let image = map { getMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyImage) }
+        let driverOwner = map { getMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDriverOwner) }
 
         var ei = [EndpointInfo]()
         for i in 0 ..< displayName.count {

--- a/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
@@ -33,8 +33,8 @@ extension Collection where Iterator.Element == MIDIEndpointRef {
 
         let name = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyName) }
         let displayName = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDisplayName) }
-        let manufacturer = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyModel) }
-        let model = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyManufacturer) }
+        let manufacturer = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyManufacturer) }
+        let model = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyModel) }
         let image = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyImage) }
         let driverOwner = map { GetMIDIObjectStringProperty(ref: $0, property: kMIDIPropertyDriverOwner) }
 

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -319,17 +319,18 @@ public struct AKMIDIEvent {
 
     static func decode(packet: MIDIPacket) -> [MIDIByte]? {
         var outBytes = [MIDIByte]()
-        var computedLength = 0
+        var tupleIndex : UInt16 = 0
+        let byteCount = packet.length
         let mirrorData = Mirror(reflecting: packet.data)
-        for (_, value) in mirrorData.children {
-            if computedLength < 256 {
-                computedLength += 1
+        for (_, value) in mirrorData.children { // [tupleIndex, outBytes] in
+            if tupleIndex < 256 {
+                tupleIndex += 1
             }
-            guard let byte = value as? MIDIByte else {
-                AKLog("unable to create sysex midi byte")
-                return nil
+            if let byte = value as? MIDIByte {
+                if (tupleIndex <= byteCount) {
+                    outBytes.append(byte)
+                }
             }
-            outBytes.append(byte)
         }
         return outBytes
     }

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -319,7 +319,7 @@ public struct AKMIDIEvent {
 
     static func decode(packet: MIDIPacket) -> [MIDIByte]? {
         var outBytes = [MIDIByte]()
-        var tupleIndex : UInt16 = 0
+        var tupleIndex: UInt16 = 0
         let byteCount = packet.length
         let mirrorData = Mirror(reflecting: packet.data)
         for (_, value) in mirrorData.children { // [tupleIndex, outBytes] in
@@ -327,7 +327,7 @@ public struct AKMIDIEvent {
                 tupleIndex += 1
             }
             if let byte = value as? MIDIByte {
-                if (tupleIndex <= byteCount) {
+                if tupleIndex <= byteCount {
                     outBytes.append(byte)
                 }
             }

--- a/AudioKit/Common/MIDI/AKMIDIListener.swift
+++ b/AudioKit/Common/MIDI/AKMIDIListener.swift
@@ -189,4 +189,11 @@ public extension AKMIDIListener {
         AKLog("MIDI Setup Has Changed.")
     }
 
+    func isEqualTo(_ listener : AKMIDIListener) -> Bool {
+        return self == listener
+    }
+}
+
+func ==(lhs: AKMIDIListener, rhs: AKMIDIListener) -> Bool {
+    return lhs.isEqualTo(rhs)
 }

--- a/AudioKit/Common/MIDI/AKMIDIListener.swift
+++ b/AudioKit/Common/MIDI/AKMIDIListener.swift
@@ -194,6 +194,6 @@ public extension AKMIDIListener {
     }
 }
 
-func ==(lhs: AKMIDIListener, rhs: AKMIDIListener) -> Bool {
+func == (lhs: AKMIDIListener, rhs: AKMIDIListener) -> Bool {
     return lhs.isEqualTo(rhs)
 }

--- a/AudioKit/Common/MIDI/AKMIDITransformer.swift
+++ b/AudioKit/Common/MIDI/AKMIDITransformer.swift
@@ -16,4 +16,12 @@ public extension AKMIDITransformer {
         AKLog("MIDI Transformer called")
         return eventList
     }
+
+    func isEqualTo(_ transformer : AKMIDITransformer) -> Bool {
+        return self == transformer
+    }
+}
+
+func ==(lhs: AKMIDITransformer, rhs: AKMIDITransformer) -> Bool {
+    return lhs.isEqualTo(rhs)
 }

--- a/AudioKit/Common/MIDI/AKMIDITransformer.swift
+++ b/AudioKit/Common/MIDI/AKMIDITransformer.swift
@@ -17,11 +17,11 @@ public extension AKMIDITransformer {
         return eventList
     }
 
-    func isEqualTo(_ transformer : AKMIDITransformer) -> Bool {
+    func isEqualTo(_ transformer: AKMIDITransformer) -> Bool {
         return self == transformer
     }
 }
 
-func ==(lhs: AKMIDITransformer, rhs: AKMIDITransformer) -> Bool {
+func == (lhs: AKMIDITransformer, rhs: AKMIDITransformer) -> Bool {
     return lhs.isEqualTo(rhs)
 }

--- a/AudioKit/Common/MIDI/Packets/MIDIPacket+SequenceType.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacket+SequenceType.swift
@@ -32,10 +32,7 @@ extension MIDIPacket: Sequence {
             func pop() -> MIDIByte {
                 assert((index < self.length) || (index <= self.length && self.data.0 != AKMIDISystemCommand.sysex.byte))
                 index += 1
-                guard let byte = generator.next() as? MIDIByte else {
-                    return 0 // Is this right?
-                }
-                return byte
+                return generator.next() as! MIDIByte
             }
             let status = pop()
             if AudioKit.midi.isReceivingSysex {

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -1088,6 +1088,7 @@
 		C4EDF5F81F5B871300A45815 /* AKLiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EDFAA61F5B81370029A371 /* AKLiveViewController.swift */; };
 		C4F17CB22005F71600AFDE31 /* AKChowningReverbAudioUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F17CB12005F71500AFDE31 /* AKChowningReverbAudioUnit.swift */; };
 		C4FE68871EC2AD74000B09B2 /* AKMIDIEndpointInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FE68861EC2AD74000B09B2 /* AKMIDIEndpointInfo.swift */; };
+		C51D172421EE4D47008EB51F /* AKMIDI+VirtualPorts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51D172321EE4D47008EB51F /* AKMIDI+VirtualPorts.swift */; };
 		EA03BFCC201DD3CE00E8BE2C /* AKDSPBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA03BFCB201DD3CE00E8BE2C /* AKDSPBase.mm */; };
 		EA03BFD0201DD87C00E8BE2C /* AKMandolinDSPKernel.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA03BFCF201DD87B00E8BE2C /* AKMandolinDSPKernel.mm */; };
 		EA03BFEA202070A000E8BE2C /* AKRhinoGuitarProcessorDSPKernel.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA03BFE9202070A000E8BE2C /* AKRhinoGuitarProcessorDSPKernel.mm */; };
@@ -2336,6 +2337,7 @@
 		C4EDFAA61F5B81370029A371 /* AKLiveViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKLiveViewController.swift; sourceTree = "<group>"; };
 		C4F17CB12005F71500AFDE31 /* AKChowningReverbAudioUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKChowningReverbAudioUnit.swift; sourceTree = "<group>"; };
 		C4FE68861EC2AD74000B09B2 /* AKMIDIEndpointInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKMIDIEndpointInfo.swift; sourceTree = "<group>"; };
+		C51D172321EE4D47008EB51F /* AKMIDI+VirtualPorts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AKMIDI+VirtualPorts.swift"; sourceTree = "<group>"; };
 		EA03BFCB201DD3CE00E8BE2C /* AKDSPBase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKDSPBase.mm; sourceTree = "<group>"; };
 		EA03BFCF201DD87B00E8BE2C /* AKMandolinDSPKernel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKMandolinDSPKernel.mm; sourceTree = "<group>"; };
 		EA03BFE9202070A000E8BE2C /* AKRhinoGuitarProcessorDSPKernel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKRhinoGuitarProcessorDSPKernel.mm; sourceTree = "<group>"; };
@@ -2967,6 +2969,7 @@
 				FE081EE021E916F100653575 /* MIDIFile */,
 				FEF991AA21E9114A00F8CAD3 /* MIDI+Extensions.swift */,
 				C45664D91D448D7E00D26565 /* AKMIDI.swift */,
+				C51D172321EE4D47008EB51F /* AKMIDI+VirtualPorts.swift */,
 				C468DC3221AC21A200678959 /* AKMIDI+Receiving.swift */,
 				C468DC3321AC21A200678959 /* AKMIDI+Sending.swift */,
 				C4FE68861EC2AD74000B09B2 /* AKMIDIEndpointInfo.swift */,
@@ -5867,6 +5870,7 @@
 				C456669F1D448D7E00D26565 /* AKAudioFile+ConvenienceInitializers.swift in Sources */,
 				C49B1913204A0AD1009C7C8E /* allpass.c in Sources */,
 				C49B1808204A0AD0009C7C8E /* md5.c in Sources */,
+				C51D172421EE4D47008EB51F /* AKMIDI+VirtualPorts.swift in Sources */,
 				C45231041DCDC21900A4F0DC /* increment.swift in Sources */,
 				34BB66C0205ABBC0000E5450 /* open_legacy.c in Sources */,
 				C49B18B9204A0AD1009C7C8E /* RageProcessor.cpp in Sources */,

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/xcshareddata/xcschemes/AudioKit-macOS.xcscheme
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/xcshareddata/xcschemes/AudioKit-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/GeneralSysexCommunicationsManger.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/GeneralSysexCommunicationsManger.swift
@@ -2,13 +2,18 @@
 //  GeneralSysexCommunicationsManger.swift
 //  
 //  Created by Kurt Arnlund on 1/12/19.
-//  Copyright © 2019 iatapps. All rights reserved.
+//  Copyright © 2019 AudioKit. All rights reserved.
 //
 //
 
 import Foundation
 import AudioKit
 
+/// A class that performs an action block, then starts a timer that
+/// catches timeout conditions where a response is not received.
+/// Since the external caller is responsible for what constitues succes,
+/// they are expected to call succeed() which will prevent timeout from
+/// happening.
 open class SuccessOrTimeoutMgr : NSObject {
     private var onSuccess : (() -> Void)?
     private var onTimeout : (() -> Void)?
@@ -38,6 +43,8 @@ open class SuccessOrTimeoutMgr : NSObject {
     }
 }
 
+/// A class responsible for sending sysex messages and informing a caller of
+/// reception of a sysex response, or a timeout error condition.
 open class GeneralSysexCommunicationsManger : AKMIDIListener {
     static let ReceivedSysex = Notification.Name(rawValue: "ReceivedSysexNotification")
     static let SysexTimedOut = Notification.Name(rawValue: "SysexTimedOutNotification")
@@ -45,6 +52,8 @@ open class GeneralSysexCommunicationsManger : AKMIDIListener {
     let midi = AudioKit.midi
     let K5000 = K5000_messages()
 
+    /// Defaults to 44 seconds, which is just a bit longer than it takes
+    /// the largest K5000 sysex messages to be received.
     let timeoutInterval = TimeInterval(44)
     let messageTimeout: SuccessOrTimeoutMgr
 
@@ -56,6 +65,8 @@ open class GeneralSysexCommunicationsManger : AKMIDIListener {
         }
         midi.addListener(self)
     }
+
+    // MARK: - Request
 
     public func requestAndWaitForResponse() {
         messageTimeout.performWithTimeout( {
@@ -76,6 +87,8 @@ open class GeneralSysexCommunicationsManger : AKMIDIListener {
             midi.sendMessage(sysexMessage)
         })
     }
+
+    // MARK: - AKMIDIListener
 
     public func receivedMIDISystemCommand(_ data: [MIDIByte]) {
         guard data[0] == AKMIDISystemCommand.sysex.rawValue else {

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/GeneralSysexCommunicationsManger.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/GeneralSysexCommunicationsManger.swift
@@ -1,0 +1,88 @@
+//
+//  GeneralSysexCommunicationsManger.swift
+//  
+//  Created by Kurt Arnlund on 1/12/19.
+//  Copyright © 2019 iatapps. All rights reserved.
+//
+//
+
+import Foundation
+import AudioKit
+
+open class SuccessOrTimeoutMgr : NSObject {
+    private var onSuccess : (() -> Void)?
+    private var onTimeout : (() -> Void)?
+    let timeoutInterval : TimeInterval
+
+    init(timeoutInterval t: TimeInterval, success: @escaping () -> Void, timeout: @escaping () -> Void) {
+        timeoutInterval = t
+        onSuccess = success
+        onTimeout = timeout
+        super.init()
+    }
+
+    open func performWithTimeout(_ block: () -> Void) {
+        self.perform(#selector(messageTimeout), with: nil, afterDelay: timeoutInterval)
+        block()
+    }
+
+    public func succeed() {
+        print("success")
+        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(messageTimeout), object: nil)
+        self.onSuccess?()
+    }
+
+    @objc func messageTimeout() {
+        print("timed out")
+        self.onTimeout?()
+    }
+}
+
+open class GeneralSysexCommunicationsManger : AKMIDIListener {
+    static let ReceivedSysex = Notification.Name(rawValue: "ReceivedSysexNotification")
+    static let SysexTimedOut = Notification.Name(rawValue: "SysexTimedOutNotification")
+
+    let midi = AudioKit.midi
+    let K5000 = K5000_messages()
+
+    let timeoutInterval = TimeInterval(44)
+    let messageTimeout: SuccessOrTimeoutMgr
+
+    init() {
+        messageTimeout = SuccessOrTimeoutMgr(timeoutInterval: timeoutInterval, success: {
+        NotificationCenter.default.post(name: GeneralSysexCommunicationsManger.ReceivedSysex, object: nil)
+        }) {
+            NotificationCenter.default.post(name: GeneralSysexCommunicationsManger.SysexTimedOut, object: nil)
+        }
+        midi.addListener(self)
+    }
+
+    public func requestAndWaitForResponse() {
+        messageTimeout.performWithTimeout( {
+            // Very fast requests
+            let sysexMessage = K5000.one_single_ADD_A(channel: .channel_0, patch: 0)
+//            let sysexMessage = K5000.one_combination_C(channel: .channel_0, combi: 0)
+//            let sysexMessage = K5000.one_single_ADD_D(channel: .channel_0, patch: 0)
+//            let sysexMessage = K5000.one_single_ADD_E(channel: .channel_0, patch: 0)
+//            let sysexMessage = K5000.one_single_ADD_F(channel: .channel_0, patch: 0)
+
+            // Very slow requests
+//            let sysexMessage = K5000.block_single_ADD_A(channel: .channel_0)
+//            let sysexMessage = K5000.block_combination_C(channel: .channel_0)
+//            let sysexMessage = K5000.block_single_ADD_D(channel: .channel_0)
+//            let sysexMessage = K5000.block_single_ADD_E(channel: .channel_0)
+//            let sysexMessage = K5000.block_single_ADD_F(channel: .channel_0)
+
+            midi.sendMessage(sysexMessage)
+        })
+    }
+
+    public func receivedMIDISystemCommand(_ data: [MIDIByte]) {
+        guard data[0] == AKMIDISystemCommand.sysex.rawValue else {
+            return
+        }
+        print("Received MIDI data: \(data)")
+        messageTimeout.succeed()
+    }
+
+}

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/GeneralSysexCommunicationsManger.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/GeneralSysexCommunicationsManger.swift
@@ -14,13 +14,13 @@ import AudioKit
 /// Since the external caller is responsible for what constitues succes,
 /// they are expected to call succeed() which will prevent timeout from
 /// happening.
-open class SuccessOrTimeoutMgr : NSObject {
-    private var onSuccess : (() -> Void)?
-    private var onTimeout : (() -> Void)?
-    let timeoutInterval : TimeInterval
+open class SuccessOrTimeoutMgr: NSObject {
+    private var onSuccess: (() -> Void)?
+    private var onTimeout: (() -> Void)?
+    let timeoutInterval: TimeInterval
 
-    init(timeoutInterval t: TimeInterval, success: @escaping () -> Void, timeout: @escaping () -> Void) {
-        timeoutInterval = t
+    init(timeoutInterval time: TimeInterval, success: @escaping () -> Void, timeout: @escaping () -> Void) {
+        timeoutInterval = time
         onSuccess = success
         onTimeout = timeout
         super.init()
@@ -45,12 +45,12 @@ open class SuccessOrTimeoutMgr : NSObject {
 
 /// A class responsible for sending sysex messages and informing a caller of
 /// reception of a sysex response, or a timeout error condition.
-open class GeneralSysexCommunicationsManger : AKMIDIListener {
+open class GeneralSysexCommunicationsManger: AKMIDIListener {
     static let ReceivedSysex = Notification.Name(rawValue: "ReceivedSysexNotification")
     static let SysexTimedOut = Notification.Name(rawValue: "SysexTimedOutNotification")
 
     let midi = AudioKit.midi
-    let K5000 = K5000_messages()
+    let synthK5000 = K5000messages()
 
     /// Defaults to 44 seconds, which is just a bit longer than it takes
     /// the largest K5000 sysex messages to be received.
@@ -60,7 +60,7 @@ open class GeneralSysexCommunicationsManger : AKMIDIListener {
     init() {
         messageTimeout = SuccessOrTimeoutMgr(timeoutInterval: timeoutInterval, success: {
         NotificationCenter.default.post(name: GeneralSysexCommunicationsManger.ReceivedSysex, object: nil)
-        }) {
+        }) timeout: {
             NotificationCenter.default.post(name: GeneralSysexCommunicationsManger.SysexTimedOut, object: nil)
         }
         midi.addListener(self)
@@ -71,18 +71,18 @@ open class GeneralSysexCommunicationsManger : AKMIDIListener {
     public func requestAndWaitForResponse() {
         messageTimeout.performWithTimeout( {
             // Very fast requests
-            let sysexMessage = K5000.one_single_ADD_A(channel: .channel_0, patch: 0)
-//            let sysexMessage = K5000.one_combination_C(channel: .channel_0, combi: 0)
-//            let sysexMessage = K5000.one_single_ADD_D(channel: .channel_0, patch: 0)
-//            let sysexMessage = K5000.one_single_ADD_E(channel: .channel_0, patch: 0)
-//            let sysexMessage = K5000.one_single_ADD_F(channel: .channel_0, patch: 0)
+            let sysexMessage = synthK5000.oneSingleAreaA(channel: .channel0, patch: 0)
+//            let sysexMessage = synthK5000.oneCombinationAreaC(channel: .channel0, combi: 0)
+//            let sysexMessage = synthK5000.oneSingleAreaD(channel: .channel0, patch: 0)
+//            let sysexMessage = synthK5000.oneSingleAreaE(channel: .channel0, patch: 0)
+//            let sysexMessage = synthK5000.oneSingleAreaF(channel: .channel0, patch: 0)
 
             // Very slow requests
-//            let sysexMessage = K5000.block_single_ADD_A(channel: .channel_0)
-//            let sysexMessage = K5000.block_combination_C(channel: .channel_0)
-//            let sysexMessage = K5000.block_single_ADD_D(channel: .channel_0)
-//            let sysexMessage = K5000.block_single_ADD_E(channel: .channel_0)
-//            let sysexMessage = K5000.block_single_ADD_F(channel: .channel_0)
+//            let sysexMessage = synthK5000.blockSingleAreaA(channel: .channel0)
+//            let sysexMessage = synthK5000.blockCombinationAreaC(channel: .channel0)
+//            let sysexMessage = synthK5000.blockSingleAreaD(channel: .channel0)
+//            let sysexMessage = synthK5000.blockSingleAreaE(channel: .channel0)
+//            let sysexMessage = synthK5000.blockSingleAreaF(channel: .channel0)
 
             midi.sendMessage(sysexMessage)
         })

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
@@ -1,0 +1,447 @@
+//
+//  K5000SysexMessages.swift
+//
+//  Created by Kurt Arnlund on 1/12/19.
+//  Copyright © 2019 iatapps. All rights reserved.
+//
+
+import Foundation
+import AudioKit
+
+/// K5000 manufacturer and machine bytes
+enum kawai_K5000 : MIDIByte {
+    case manufacturer_id = 0x40
+    case machine         = 0x0A
+}
+
+/// K5000 sysex messages all have a midi channel byte
+enum K5000_sysex_channel : MIDIByte {
+    case channel_0 = 0x00
+    case channel_1 = 0x01
+    case channel_2 = 0x02
+    case channel_3 = 0x03
+    case channel_4 = 0x04
+    case channel_5 = 0x05
+    case channel_6 = 0x06
+    case channel_7 = 0x07
+    case channel_8 = 0x08
+    case channel_9 = 0x09
+    case channel_10 = 0x0A
+    case channel_11 = 0x0B
+    case channel_12 = 0x0C
+    case channel_13 = 0x0D
+    case channel_14 = 0x0E
+    case channel_15 = 0x0F
+}
+
+// MARK: - Usefull runs of sysex bytes
+let K5000_SYSEX_START : [MIDIByte] = [AKMIDISystemCommand.sysex.rawValue, kawai_K5000.manufacturer_id.rawValue]
+let SYSEX_END : [MIDIByte] = [AKMIDISystemCommand.sysexEnd.rawValue]
+
+/// Request type words used across all devices
+public enum K5000_RequestTypes: MIDIWord {
+    case single         = 0x0000
+    case block          = 0x0100
+}
+
+/// K5000SR requests
+public enum K5000SR_Requests: MIDIWord {
+    case area_a_dump_reqest     = 0x0000
+    case area_c_dump_reqest     = 0x2000
+    case area_d_dump_reqest     = 0x0002
+}
+
+/// K5000SR (with ME1 memory card installed) requests
+public enum K5000_ME1_Requests: MIDIWord {
+    case area_e_dump_reqest     = 0x0003
+    case area_f_dump_reqest     = 0x0004
+}
+
+/// K5000W requests
+public enum K5000W_Requests: MIDIWord {
+    case dump_reqest                = 0x0000
+    case area_b_dump_request_pcm    = 0x0001
+    case dump_request_drum_kit      = 0x1000
+    case dump_request_drum_inst     = 0x1100
+}
+
+// MARK: - Extensions to MIDIWord
+extension MIDIWord {
+    /// Create a MIDIWord for a command and command version
+    ///
+    /// - Parameters:
+    ///   - command: Command Byte Value
+    ///   - version: Command Byte Version Value
+    init(command:MIDIByte, version: MIDIByte) {
+        self = MIDIWord((command << 8) | version)
+    }
+
+    /// Create a MIDIWord from a byte by taking the
+    /// upper nibble and lower nibble of a byte,
+    /// and separating each into a byte in the word
+    ///
+    /// - Parameter ioBitmap: Full 8bits of ioMapping for one output
+    init(ioBitmap: UInt8) {
+        let high = (ioBitmap & 0xF0) >> 4
+        let low = ioBitmap & 0x0F
+        self = UInt16(high << 8) | UInt16(low)
+    }
+
+    /// Most significant byte in a MIDIWord
+    var msb: MIDIByte {
+        return MIDIByte(self >> 8)
+    }
+
+    /// Lease significant byte in a MIDIWord
+    var lsb: MIDIByte {
+        return MIDIByte(self & 0x00FF)
+    }
+}
+
+// MARK: - Extension related to the i/o message filter bits
+extension MIDIByte {
+    /// Internal function to convert a boolean to a 0x01 or 0x00 value
+    ///
+    /// - Parameter b: true(1) or false(0)
+    /// - Returns: 1 or 0
+    private static func boolToByte(_ b:Bool) -> Int8 {
+        return (b ? 0x01 : 0x00)
+    }
+
+    /// Internal function to convert a single bit position to a boolean respresting whether the bit was 1(true) or 0(false)
+    ///
+    /// - Parameter pos: Bit position to test
+    /// - Returns: true if bit position contains 1 or false if bit position contains 0
+    private func bitToBool(_ pos:Int8) -> Bool {
+        return (self & (1 << pos)) > 0
+    }
+
+    /// Constructor of a MIDIByte represting a bit field
+    ///
+    /// - Parameters:
+    ///   - bit7:
+    ///   - bit6:
+    ///   - bit5:
+    ///   - bit4:
+    ///   - bit3:
+    ///   - bit2:
+    ///   - bit1:
+    init(bit7:Bool, bit6:Bool, bit5:Bool, bit4:Bool, bit3:Bool, bit2:Bool, bit1:Bool)  {
+        let nibbleH = UInt8((bit7 ? 1<<6 : 0) |
+            (bit6 ? 1<<5 : 0) |
+            (bit5 ? 1<<4 : 0))
+        let nibbleL = UInt8((bit4 ? 1<<3 : 0) |
+            (bit3 ? 1<<2 : 0) |
+            (bit2 ? 1<<1 : 0) |
+            (bit1 ? 1 : 0))
+        self = nibbleH | nibbleL
+
+    }
+}
+
+/// Sysex Message for the K5000S/R
+class K5000_messages {
+    /// Block Single Dump Request (ADD A1-128)
+    ///
+    /// This request results in 77230 bytes of SYSEX - it take several seconds to get the full result
+    ///
+    /// - Parameter channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func block_single_ADD_A(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.block.rawValue.msb,
+             K5000_RequestTypes.block.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000SR_Requests.area_a_dump_reqest.rawValue.msb,
+             K5000SR_Requests.area_a_dump_reqest.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// One Single Dump Request (ADD A1-128)
+    ///
+    /// This request results in 1242 bytes of SYSEX response
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - patch: (ADD A1-128) 0x00 - 0x7f
+    /// - Returns: [MIDIByte]
+    func one_single_ADD_A(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+        guard patch <= 0x7f else {
+            return []
+        }
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000SR_Requests.area_a_dump_reqest.rawValue.msb,
+             K5000SR_Requests.area_a_dump_reqest.rawValue.lsb,
+             patch] + SYSEX_END
+        return request
+    }
+
+    /// Block Combi Dump Request (Combi C1-64)
+    ///
+    /// This request results in 6600 bytes of SYSEX reponse
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func block_combination_C(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.block.rawValue.msb,
+             K5000_RequestTypes.block.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000SR_Requests.area_c_dump_reqest.rawValue.msb,
+             K5000SR_Requests.area_c_dump_reqest.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// One Combi Dump Request (Combi C1-64)
+    ///
+    /// This request results in 112 bytes of SYSEX reponse
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - combi: (Combi C1-64) 0x00 - 0x3f
+    /// - Returns: [MIDIByte]
+    func one_combination_C(channel: K5000_sysex_channel, combi: UInt8) -> [MIDIByte] {
+        guard combi <= 0x3f else {
+            return []
+        }
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000SR_Requests.area_c_dump_reqest.rawValue.msb,
+             K5000SR_Requests.area_c_dump_reqest.rawValue.lsb,
+             combi] + SYSEX_END
+        return request
+    }
+
+    /// Block Single Dump Request (ADD D1-128)
+    ///
+    /// This request results in 130428 bytes of SYSEX response
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func block_single_ADD_D(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.block.rawValue.msb,
+             K5000_RequestTypes.block.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000SR_Requests.area_d_dump_reqest.rawValue.msb,
+             K5000SR_Requests.area_d_dump_reqest.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// One Single Dump Request (ADD D1-128)
+    ///
+    /// This request results in 1962 bytes of SYSEX response
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - patch: (ADD D1-128) 0x00 - 0x7F
+    /// - Returns: [MIDIByte]
+    func one_single_ADD_D(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+        guard patch <= 0x7f else {
+            return []
+        }
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000SR_Requests.area_d_dump_reqest.rawValue.msb,
+             K5000SR_Requests.area_d_dump_reqest.rawValue.lsb,
+             patch] + SYSEX_END
+        return request
+    }
+
+    /// Block Single Dump Request (ADD E1-128 - ME1 installed)
+    ///
+    /// This request results in 102340 bytes of SYSEX response
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func block_single_ADD_E(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.block.rawValue.msb,
+             K5000_RequestTypes.block.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000_ME1_Requests.area_e_dump_reqest.rawValue.msb,
+             K5000_ME1_Requests.area_e_dump_reqest.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// One Single Dump Request (ADD E1-128 - ME1 installed)
+    ///
+    /// This request results in 2768 bytes of SYSEX response
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - patch: (ADD E1-128) 0x00 - 0x7F
+    /// - Returns: [MIDIByte]
+    func one_single_ADD_E(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+        guard patch <= 0x7f else {
+            return []
+        }
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000_ME1_Requests.area_e_dump_reqest.rawValue.msb,
+             K5000_ME1_Requests.area_e_dump_reqest.rawValue.lsb,
+             patch] + SYSEX_END
+        return request
+    }
+
+    /// Block Single Dump Request (ADD F1-128 - ME1 installed)
+    ///
+    /// This request results in 110634 bytes of SYSEX response
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func block_single_ADD_F(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.block.rawValue.msb,
+             K5000_RequestTypes.block.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000_ME1_Requests.area_f_dump_reqest.rawValue.msb,
+             K5000_ME1_Requests.area_f_dump_reqest.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// One Single Dump Request (ADD F1-128 - ME1 installed)
+    ///
+    /// This request results in 1070 bytes of SYSEX response
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - patch: (ADD F1-128) 0x00 - 0x7F
+    /// - Returns: [MIDIByte]
+    func one_single_ADD_F(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+        guard patch <= 0x7f else {
+            return []
+        }
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000_ME1_Requests.area_f_dump_reqest.rawValue.msb,
+             K5000_ME1_Requests.area_f_dump_reqest.rawValue.lsb,
+             patch] + SYSEX_END
+        return request
+    }
+}
+
+/// Sysex Message for the K5000W
+class K5000W_messages {
+    /// Block Single Dump Request PCM Area (B70-116)
+    ///
+    /// - Parameter channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func block_single_PCM(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.block.rawValue.msb,
+             K5000_RequestTypes.block.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000W_Requests.area_b_dump_request_pcm.rawValue.msb,
+             K5000W_Requests.area_b_dump_request_pcm.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// One Single Dumpe Request PCM Area (B70-116)
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - patch: patch number 0x45 - 0x73
+    /// - Returns: [MIDIByte]
+    func one_single_PCM(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+        guard patch >= 0x45 && patch <= 0x73 else {
+            return []
+        }
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000W_Requests.area_b_dump_request_pcm.rawValue.msb,
+             K5000W_Requests.area_b_dump_request_pcm.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// Drum Kit Request (B117)
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func drum_kit(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000W_Requests.dump_request_drum_kit.rawValue.msb,
+             K5000W_Requests.dump_request_drum_kit.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// Block Drum Instrument Dump Request (Inst U1-32)
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Returns: [MIDIByte]
+    func block_drum_instrument(channel: K5000_sysex_channel) -> [MIDIByte] {
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.block.rawValue.msb,
+             K5000_RequestTypes.block.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000W_Requests.dump_request_drum_inst.rawValue.msb,
+             K5000W_Requests.dump_request_drum_inst.rawValue.lsb,
+             0x00] + SYSEX_END
+        return request
+    }
+
+    /// One Drum Instrument Dump Request (Inst U1-32)
+    ///
+    /// - Parameters:
+    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - instrument: instrument number 0x00 - 0x1F
+    /// - Returns: [MIDIByte]
+    func one_drum_instrument(channel: K5000_sysex_channel, instrument: UInt8) -> [MIDIByte] {
+        guard instrument <= 0x1f else {
+            return []
+        }
+        let request : [MIDIByte] = K5000_SYSEX_START +
+            [channel.rawValue,
+             K5000_RequestTypes.single.rawValue.msb,
+             K5000_RequestTypes.single.rawValue.lsb,
+             kawai_K5000.machine.rawValue,
+             K5000W_Requests.dump_request_drum_inst.rawValue.msb,
+             K5000W_Requests.dump_request_drum_inst.rawValue.lsb,
+             instrument] + SYSEX_END
+        return request
+    }
+}

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
@@ -2,8 +2,10 @@
 //  K5000SysexMessages.swift
 //
 //  Created by Kurt Arnlund on 1/12/19.
-//  Copyright © 2019 iatapps. All rights reserved.
+//  Copyright © 2019 AudioKit. All rights reserved.
 //
+//  A rather complete set of Kawai K5000 Sysex Message Definitions
+//  Used as an example of how to setup Sysex Messages
 
 import Foundation
 import AudioKit

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
@@ -37,8 +37,7 @@ enum K5000sysexChannel: MIDIByte {
 }
 
 // MARK: - Usefull runs of sysex bytes
-let kawaikawaiK5000sysexStart: [MIDIByte] = [AKMIDISystemCommand.sysex.rawValue, kawaiK5000.manufacturerId.rawValue]
-typealias sysexEnd = AKMIDISystemCommand.sysexEnd.rawValue
+let kawaiK5000sysexStart: [MIDIByte] = [AKMIDISystemCommand.sysex.rawValue, kawaiK5000.manufacturerId.rawValue]
 
 /// Request type words used across all devices
 public enum K5000requestTypes: MIDIWord {
@@ -83,7 +82,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000SRdumpRequests.areaA.rawValue.msb,
              K5000SRdumpRequests.areaA.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -106,7 +105,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000SRdumpRequests.areaA.rawValue.msb,
              K5000SRdumpRequests.areaA.rawValue.lsb,
-             patch, sysexEnd]
+             patch, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -125,7 +124,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000SRdumpRequests.areaC.rawValue.msb,
              K5000SRdumpRequests.areaC.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -148,7 +147,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000SRdumpRequests.areaC.rawValue.msb,
              K5000SRdumpRequests.areaC.rawValue.lsb,
-             combi, sysexEnd]
+             combi, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -167,7 +166,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000SRdumpRequests.areaD.rawValue.msb,
              K5000SRdumpRequests.areaD.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -190,7 +189,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000SRdumpRequests.areaD.rawValue.msb,
              K5000SRdumpRequests.areaD.rawValue.lsb,
-             patch, sysexEnd]
+             patch, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -209,7 +208,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000ME1dumpRequests.areaE.rawValue.msb,
              K5000ME1dumpRequests.areaE.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -232,7 +231,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000ME1dumpRequests.areaE.rawValue.msb,
              K5000ME1dumpRequests.areaE.rawValue.lsb,
-             patch, sysexEnd]
+             patch, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -251,7 +250,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000ME1dumpRequests.areaF.rawValue.msb,
              K5000ME1dumpRequests.areaF.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -274,7 +273,7 @@ class K5000messages {
              kawaiK5000.machine.rawValue,
              K5000ME1dumpRequests.areaF.rawValue.msb,
              K5000ME1dumpRequests.areaF.rawValue.lsb,
-             patch, sysexEnd]
+             patch, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 }
@@ -293,7 +292,7 @@ class K5000Wmessages {
              kawaiK5000.machine.rawValue,
              K5000WdumpRequests.areaBpcm.rawValue.msb,
              K5000WdumpRequests.areaBpcm.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -314,7 +313,7 @@ class K5000Wmessages {
              kawaiK5000.machine.rawValue,
              K5000WdumpRequests.areaBpcm.rawValue.msb,
              K5000WdumpRequests.areaBpcm.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -331,7 +330,7 @@ class K5000Wmessages {
              kawaiK5000.machine.rawValue,
              K5000WdumpRequests.drumKit.rawValue.msb,
              K5000WdumpRequests.drumKit.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -348,7 +347,7 @@ class K5000Wmessages {
              kawaiK5000.machine.rawValue,
              K5000WdumpRequests.drumInst.rawValue.msb,
              K5000WdumpRequests.drumInst.rawValue.lsb,
-             0x00, sysexEnd]
+             0x00, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 
@@ -369,7 +368,7 @@ class K5000Wmessages {
              kawaiK5000.machine.rawValue,
              K5000WdumpRequests.drumInst.rawValue.msb,
              K5000WdumpRequests.drumInst.rawValue.lsb,
-             instrument, sysexEnd]
+             instrument, AKMIDISystemCommand.sysexEnd.rawValue]
         return request
     }
 }

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/K5000SysexMessages.swift
@@ -11,153 +11,79 @@ import Foundation
 import AudioKit
 
 /// K5000 manufacturer and machine bytes
-enum kawai_K5000 : MIDIByte {
-    case manufacturer_id = 0x40
+enum kawaiK5000: MIDIByte {
+    case manufacturerId = 0x40
     case machine         = 0x0A
 }
 
 /// K5000 sysex messages all have a midi channel byte
-enum K5000_sysex_channel : MIDIByte {
-    case channel_0 = 0x00
-    case channel_1 = 0x01
-    case channel_2 = 0x02
-    case channel_3 = 0x03
-    case channel_4 = 0x04
-    case channel_5 = 0x05
-    case channel_6 = 0x06
-    case channel_7 = 0x07
-    case channel_8 = 0x08
-    case channel_9 = 0x09
-    case channel_10 = 0x0A
-    case channel_11 = 0x0B
-    case channel_12 = 0x0C
-    case channel_13 = 0x0D
-    case channel_14 = 0x0E
-    case channel_15 = 0x0F
+enum K5000sysexChannel: MIDIByte {
+    case channel0 = 0x00
+    case channel1 = 0x01
+    case channel2 = 0x02
+    case channel3 = 0x03
+    case channel4 = 0x04
+    case channel5 = 0x05
+    case channel6 = 0x06
+    case channel7 = 0x07
+    case channel8 = 0x08
+    case channel9 = 0x09
+    case channel10 = 0x0A
+    case channel11 = 0x0B
+    case channel12 = 0x0C
+    case channel13 = 0x0D
+    case channel14 = 0x0E
+    case channel15 = 0x0F
 }
 
 // MARK: - Usefull runs of sysex bytes
-let K5000_SYSEX_START : [MIDIByte] = [AKMIDISystemCommand.sysex.rawValue, kawai_K5000.manufacturer_id.rawValue]
-let SYSEX_END : [MIDIByte] = [AKMIDISystemCommand.sysexEnd.rawValue]
+let kawaikawaiK5000sysexStart: [MIDIByte] = [AKMIDISystemCommand.sysex.rawValue, kawaiK5000.manufacturerId.rawValue]
+typealias sysexEnd = AKMIDISystemCommand.sysexEnd.rawValue
 
 /// Request type words used across all devices
-public enum K5000_RequestTypes: MIDIWord {
+public enum K5000requestTypes: MIDIWord {
     case single         = 0x0000
     case block          = 0x0100
 }
 
 /// K5000SR requests
-public enum K5000SR_Requests: MIDIWord {
-    case area_a_dump_reqest     = 0x0000
-    case area_c_dump_reqest     = 0x2000
-    case area_d_dump_reqest     = 0x0002
+public enum K5000SRdumpRequests: MIDIWord {
+    case areaA     = 0x0000
+    case areaC     = 0x2000
+    case areaD     = 0x0002
 }
 
 /// K5000SR (with ME1 memory card installed) requests
-public enum K5000_ME1_Requests: MIDIWord {
-    case area_e_dump_reqest     = 0x0003
-    case area_f_dump_reqest     = 0x0004
+public enum K5000ME1dumpRequests: MIDIWord {
+    case areaE     = 0x0003
+    case areaF     = 0x0004
 }
 
 /// K5000W requests
-public enum K5000W_Requests: MIDIWord {
+public enum K5000WdumpRequests: MIDIWord {
     case dump_reqest                = 0x0000
-    case area_b_dump_request_pcm    = 0x0001
-    case dump_request_drum_kit      = 0x1000
-    case dump_request_drum_inst     = 0x1100
-}
-
-// MARK: - Extensions to MIDIWord
-extension MIDIWord {
-    /// Create a MIDIWord for a command and command version
-    ///
-    /// - Parameters:
-    ///   - command: Command Byte Value
-    ///   - version: Command Byte Version Value
-    init(command:MIDIByte, version: MIDIByte) {
-        self = MIDIWord((command << 8) | version)
-    }
-
-    /// Create a MIDIWord from a byte by taking the
-    /// upper nibble and lower nibble of a byte,
-    /// and separating each into a byte in the word
-    ///
-    /// - Parameter ioBitmap: Full 8bits of ioMapping for one output
-    init(ioBitmap: UInt8) {
-        let high = (ioBitmap & 0xF0) >> 4
-        let low = ioBitmap & 0x0F
-        self = UInt16(high << 8) | UInt16(low)
-    }
-
-    /// Most significant byte in a MIDIWord
-    var msb: MIDIByte {
-        return MIDIByte(self >> 8)
-    }
-
-    /// Lease significant byte in a MIDIWord
-    var lsb: MIDIByte {
-        return MIDIByte(self & 0x00FF)
-    }
-}
-
-// MARK: - Extension related to the i/o message filter bits
-extension MIDIByte {
-    /// Internal function to convert a boolean to a 0x01 or 0x00 value
-    ///
-    /// - Parameter b: true(1) or false(0)
-    /// - Returns: 1 or 0
-    private static func boolToByte(_ b:Bool) -> Int8 {
-        return (b ? 0x01 : 0x00)
-    }
-
-    /// Internal function to convert a single bit position to a boolean respresting whether the bit was 1(true) or 0(false)
-    ///
-    /// - Parameter pos: Bit position to test
-    /// - Returns: true if bit position contains 1 or false if bit position contains 0
-    private func bitToBool(_ pos:Int8) -> Bool {
-        return (self & (1 << pos)) > 0
-    }
-
-    /// Constructor of a MIDIByte represting a bit field
-    ///
-    /// - Parameters:
-    ///   - bit7:
-    ///   - bit6:
-    ///   - bit5:
-    ///   - bit4:
-    ///   - bit3:
-    ///   - bit2:
-    ///   - bit1:
-    init(bit7:Bool, bit6:Bool, bit5:Bool, bit4:Bool, bit3:Bool, bit2:Bool, bit1:Bool)  {
-        let nibbleH = UInt8((bit7 ? 1<<6 : 0) |
-            (bit6 ? 1<<5 : 0) |
-            (bit5 ? 1<<4 : 0))
-        let nibbleL = UInt8((bit4 ? 1<<3 : 0) |
-            (bit3 ? 1<<2 : 0) |
-            (bit2 ? 1<<1 : 0) |
-            (bit1 ? 1 : 0))
-        self = nibbleH | nibbleL
-
-    }
+    case areaBpcm    = 0x0001
+    case drumKit      = 0x1000
+    case drumInst     = 0x1100
 }
 
 /// Sysex Message for the K5000S/R
-class K5000_messages {
+class K5000messages {
     /// Block Single Dump Request (ADD A1-128)
     ///
     /// This request results in 77230 bytes of SYSEX - it take several seconds to get the full result
     ///
-    /// - Parameter channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Parameter channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func block_single_ADD_A(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func blockSingleAreaA(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.block.rawValue.msb,
-             K5000_RequestTypes.block.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000SR_Requests.area_a_dump_reqest.rawValue.msb,
-             K5000SR_Requests.area_a_dump_reqest.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.block.rawValue.msb,
+             K5000requestTypes.block.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000SRdumpRequests.areaA.rawValue.msb,
+             K5000SRdumpRequests.areaA.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
@@ -166,21 +92,21 @@ class K5000_messages {
     /// This request results in 1242 bytes of SYSEX response
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     ///   - patch: (ADD A1-128) 0x00 - 0x7f
     /// - Returns: [MIDIByte]
-    func one_single_ADD_A(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+    func oneSingleAreaA(channel: K5000sysexChannel, patch: UInt8) -> [MIDIByte] {
         guard patch <= 0x7f else {
             return []
         }
-        let request : [MIDIByte] = K5000_SYSEX_START +
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000SR_Requests.area_a_dump_reqest.rawValue.msb,
-             K5000SR_Requests.area_a_dump_reqest.rawValue.lsb,
-             patch] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000SRdumpRequests.areaA.rawValue.msb,
+             K5000SRdumpRequests.areaA.rawValue.lsb,
+             patch, sysexEnd]
         return request
     }
 
@@ -189,17 +115,17 @@ class K5000_messages {
     /// This request results in 6600 bytes of SYSEX reponse
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func block_combination_C(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func blockCombinationAreaC(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.block.rawValue.msb,
-             K5000_RequestTypes.block.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000SR_Requests.area_c_dump_reqest.rawValue.msb,
-             K5000SR_Requests.area_c_dump_reqest.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.block.rawValue.msb,
+             K5000requestTypes.block.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000SRdumpRequests.areaC.rawValue.msb,
+             K5000SRdumpRequests.areaC.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
@@ -208,21 +134,21 @@ class K5000_messages {
     /// This request results in 112 bytes of SYSEX reponse
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     ///   - combi: (Combi C1-64) 0x00 - 0x3f
     /// - Returns: [MIDIByte]
-    func one_combination_C(channel: K5000_sysex_channel, combi: UInt8) -> [MIDIByte] {
+    func oneCombinationAreaC(channel: K5000sysexChannel, combi: UInt8) -> [MIDIByte] {
         guard combi <= 0x3f else {
             return []
         }
-        let request : [MIDIByte] = K5000_SYSEX_START +
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000SR_Requests.area_c_dump_reqest.rawValue.msb,
-             K5000SR_Requests.area_c_dump_reqest.rawValue.lsb,
-             combi] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000SRdumpRequests.areaC.rawValue.msb,
+             K5000SRdumpRequests.areaC.rawValue.lsb,
+             combi, sysexEnd]
         return request
     }
 
@@ -231,17 +157,17 @@ class K5000_messages {
     /// This request results in 130428 bytes of SYSEX response
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func block_single_ADD_D(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func blockSingleAreaD(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.block.rawValue.msb,
-             K5000_RequestTypes.block.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000SR_Requests.area_d_dump_reqest.rawValue.msb,
-             K5000SR_Requests.area_d_dump_reqest.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.block.rawValue.msb,
+             K5000requestTypes.block.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000SRdumpRequests.areaD.rawValue.msb,
+             K5000SRdumpRequests.areaD.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
@@ -250,21 +176,21 @@ class K5000_messages {
     /// This request results in 1962 bytes of SYSEX response
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     ///   - patch: (ADD D1-128) 0x00 - 0x7F
     /// - Returns: [MIDIByte]
-    func one_single_ADD_D(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+    func oneSingleAreaD(channel: K5000sysexChannel, patch: UInt8) -> [MIDIByte] {
         guard patch <= 0x7f else {
             return []
         }
-        let request : [MIDIByte] = K5000_SYSEX_START +
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000SR_Requests.area_d_dump_reqest.rawValue.msb,
-             K5000SR_Requests.area_d_dump_reqest.rawValue.lsb,
-             patch] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000SRdumpRequests.areaD.rawValue.msb,
+             K5000SRdumpRequests.areaD.rawValue.lsb,
+             patch, sysexEnd]
         return request
     }
 
@@ -273,17 +199,17 @@ class K5000_messages {
     /// This request results in 102340 bytes of SYSEX response
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func block_single_ADD_E(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func blockSingleAreaE(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.block.rawValue.msb,
-             K5000_RequestTypes.block.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000_ME1_Requests.area_e_dump_reqest.rawValue.msb,
-             K5000_ME1_Requests.area_e_dump_reqest.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.block.rawValue.msb,
+             K5000requestTypes.block.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000ME1dumpRequests.areaE.rawValue.msb,
+             K5000ME1dumpRequests.areaE.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
@@ -292,21 +218,21 @@ class K5000_messages {
     /// This request results in 2768 bytes of SYSEX response
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     ///   - patch: (ADD E1-128) 0x00 - 0x7F
     /// - Returns: [MIDIByte]
-    func one_single_ADD_E(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+    func oneSingleAreaE(channel: K5000sysexChannel, patch: UInt8) -> [MIDIByte] {
         guard patch <= 0x7f else {
             return []
         }
-        let request : [MIDIByte] = K5000_SYSEX_START +
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000_ME1_Requests.area_e_dump_reqest.rawValue.msb,
-             K5000_ME1_Requests.area_e_dump_reqest.rawValue.lsb,
-             patch] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000ME1dumpRequests.areaE.rawValue.msb,
+             K5000ME1dumpRequests.areaE.rawValue.lsb,
+             patch, sysexEnd]
         return request
     }
 
@@ -315,17 +241,17 @@ class K5000_messages {
     /// This request results in 110634 bytes of SYSEX response
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func block_single_ADD_F(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func blockSingleAreaF(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.block.rawValue.msb,
-             K5000_RequestTypes.block.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000_ME1_Requests.area_f_dump_reqest.rawValue.msb,
-             K5000_ME1_Requests.area_f_dump_reqest.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.block.rawValue.msb,
+             K5000requestTypes.block.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000ME1dumpRequests.areaF.rawValue.msb,
+             K5000ME1dumpRequests.areaF.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
@@ -334,116 +260,116 @@ class K5000_messages {
     /// This request results in 1070 bytes of SYSEX response
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     ///   - patch: (ADD F1-128) 0x00 - 0x7F
     /// - Returns: [MIDIByte]
-    func one_single_ADD_F(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+    func oneSingleAreaF(channel: K5000sysexChannel, patch: UInt8) -> [MIDIByte] {
         guard patch <= 0x7f else {
             return []
         }
-        let request : [MIDIByte] = K5000_SYSEX_START +
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000_ME1_Requests.area_f_dump_reqest.rawValue.msb,
-             K5000_ME1_Requests.area_f_dump_reqest.rawValue.lsb,
-             patch] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000ME1dumpRequests.areaF.rawValue.msb,
+             K5000ME1dumpRequests.areaF.rawValue.lsb,
+             patch, sysexEnd]
         return request
     }
 }
 
 /// Sysex Message for the K5000W
-class K5000W_messages {
+class K5000Wmessages {
     /// Block Single Dump Request PCM Area (B70-116)
     ///
-    /// - Parameter channel: K5000_sysex_channel 0x00 - 0x0F
+    /// - Parameter channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func block_single_PCM(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func blockSingleAreaBpcm(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.block.rawValue.msb,
-             K5000_RequestTypes.block.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000W_Requests.area_b_dump_request_pcm.rawValue.msb,
-             K5000W_Requests.area_b_dump_request_pcm.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.block.rawValue.msb,
+             K5000requestTypes.block.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000WdumpRequests.areaBpcm.rawValue.msb,
+             K5000WdumpRequests.areaBpcm.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
     /// One Single Dumpe Request PCM Area (B70-116)
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     ///   - patch: patch number 0x45 - 0x73
     /// - Returns: [MIDIByte]
-    func one_single_PCM(channel: K5000_sysex_channel, patch: UInt8) -> [MIDIByte] {
+    func oneSingleAreaBpcm(channel: K5000sysexChannel, patch: UInt8) -> [MIDIByte] {
         guard patch >= 0x45 && patch <= 0x73 else {
             return []
         }
-        let request : [MIDIByte] = K5000_SYSEX_START +
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000W_Requests.area_b_dump_request_pcm.rawValue.msb,
-             K5000W_Requests.area_b_dump_request_pcm.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000WdumpRequests.areaBpcm.rawValue.msb,
+             K5000WdumpRequests.areaBpcm.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
     /// Drum Kit Request (B117)
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func drum_kit(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func drumKit(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000W_Requests.dump_request_drum_kit.rawValue.msb,
-             K5000W_Requests.dump_request_drum_kit.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000WdumpRequests.drumKit.rawValue.msb,
+             K5000WdumpRequests.drumKit.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
     /// Block Drum Instrument Dump Request (Inst U1-32)
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     /// - Returns: [MIDIByte]
-    func block_drum_instrument(channel: K5000_sysex_channel) -> [MIDIByte] {
-        let request : [MIDIByte] = K5000_SYSEX_START +
+    func blockDrumInstrument(channel: K5000sysexChannel) -> [MIDIByte] {
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.block.rawValue.msb,
-             K5000_RequestTypes.block.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000W_Requests.dump_request_drum_inst.rawValue.msb,
-             K5000W_Requests.dump_request_drum_inst.rawValue.lsb,
-             0x00] + SYSEX_END
+             K5000requestTypes.block.rawValue.msb,
+             K5000requestTypes.block.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000WdumpRequests.drumInst.rawValue.msb,
+             K5000WdumpRequests.drumInst.rawValue.lsb,
+             0x00, sysexEnd]
         return request
     }
 
     /// One Drum Instrument Dump Request (Inst U1-32)
     ///
     /// - Parameters:
-    ///   - channel: K5000_sysex_channel 0x00 - 0x0F
+    ///   - channel: K5000sysexChannel 0x00 - 0x0F
     ///   - instrument: instrument number 0x00 - 0x1F
     /// - Returns: [MIDIByte]
-    func one_drum_instrument(channel: K5000_sysex_channel, instrument: UInt8) -> [MIDIByte] {
+    func oneDrumInstrument(channel: K5000sysexChannel, instrument: UInt8) -> [MIDIByte] {
         guard instrument <= 0x1f else {
             return []
         }
-        let request : [MIDIByte] = K5000_SYSEX_START +
+        let request: [MIDIByte] = kawaiK5000sysexStart +
             [channel.rawValue,
-             K5000_RequestTypes.single.rawValue.msb,
-             K5000_RequestTypes.single.rawValue.lsb,
-             kawai_K5000.machine.rawValue,
-             K5000W_Requests.dump_request_drum_inst.rawValue.msb,
-             K5000W_Requests.dump_request_drum_inst.rawValue.lsb,
-             instrument] + SYSEX_END
+             K5000requestTypes.single.rawValue.msb,
+             K5000requestTypes.single.rawValue.lsb,
+             kawaiK5000.machine.rawValue,
+             K5000WdumpRequests.drumInst.rawValue.msb,
+             K5000WdumpRequests.drumInst.rawValue.lsb,
+             instrument, sysexEnd]
         return request
     }
 }

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDI Connection Manager.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDI Connection Manager.swift
@@ -1,0 +1,109 @@
+//
+//  MIDI Connection Manager.swift
+//
+//  Created by Kurt Arnlund on 1/14/19.
+//  Copyright © 2019 iatapps. All rights reserved.
+//
+//  Interactive connection manager for command line testing
+
+import Foundation
+import AudioKit
+
+class MidiConnectionManger : AKMIDIListener {
+    let midi = AudioKit.midi
+
+    var input : MIDIUniqueID = 0
+    var input_index : Int = 0
+    var output : MIDIUniqueID = 0
+    var output_index : Int = 0
+
+    init() {
+        midi.addListener(self)
+    }
+
+    deinit {
+        midi.closeInput(input)
+        midi.closeOutput(output)
+
+        midi.removeListener(self)
+    }
+
+    func receivedMIDISetupChange() {
+        print("MIDI Setup Changed")
+        selectIO()
+    }
+
+    var hasIOConnections: Bool {
+        return input != 0 || output != 0
+    }
+
+    func selectIO() {
+        var confirmed = false
+        while (!confirmed) {
+            selectInput()
+            print("")
+            selectOutput()
+            print("")
+            displayIOSelections()
+            print("Is this ok [Y/n]: ")
+            let userOk = readLine()
+            if userOk?.uppercased() == "Y" {
+                confirmed = true
+            }
+        }
+        midi.openInput(input)
+        midi.openOutput(output)
+    }
+
+    func selectInput() {
+        var userInputAccepted = false
+        while (!userInputAccepted) {
+            var num = 1
+            for input in midi.inputInfos {
+                print("\(num) : \(input.manufacturer) \(input.displayName)")
+                num = num + 1
+            }
+            print("Select input: ")
+            let inputLn = readLine()
+            let inputNum = Int(inputLn ?? "") ?? 0
+            if inputNum > 0 && inputNum <= midi.inputNames.count {
+                let index = inputNum - 1
+                input = midi.inputUIDs[index]
+                input_index = index
+                userInputAccepted = true
+            } else {
+                print("No input selected.")
+            }
+        }
+    }
+
+    private func selectOutput() {
+        var userInputAccepted = false
+        while (!userInputAccepted) {
+            var num = 1
+            for dest in midi.destinationInfos {
+                print("\(num) : \(dest.manufacturer) \(dest.displayName)")
+                num = num + 1
+            }
+            print("Select output: ")
+            let outputLn = readLine()
+            let outputNum = Int(outputLn ?? "") ?? 0
+            if outputNum > 0 && outputNum <= midi.destinationNames.count {
+                let index = outputNum - 1
+                output = midi.destinationUIDs[index]
+                output_index = index
+                userInputAccepted = true
+            } else {
+                print("No output selected.")
+            }
+        }
+    }
+
+    private func displayIOSelections() {
+        let dest = midi.destinationInfos[output_index]
+        let src = midi.inputInfos[input_index]
+
+        print(" Input: \(src.manufacturer) \(src.displayName)")
+        print("Output: \(dest.manufacturer) \(dest.displayName)")
+    }
+}

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDI Connection Manager.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDI Connection Manager.swift
@@ -2,9 +2,9 @@
 //  MIDI Connection Manager.swift
 //
 //  Created by Kurt Arnlund on 1/14/19.
-//  Copyright © 2019 iatapps. All rights reserved.
+//  Copyright © 2019 AudioKit. All rights reserved.
 //
-//  Interactive connection manager for command line testing
+//  Interactive MIDI I/O connection manager for command line testing
 
 import Foundation
 import AudioKit

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDI Connection Manager.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDI Connection Manager.swift
@@ -9,13 +9,13 @@
 import Foundation
 import AudioKit
 
-class MidiConnectionManger : AKMIDIListener {
+class MidiConnectionManger: AKMIDIListener {
     let midi = AudioKit.midi
 
-    var input : MIDIUniqueID = 0
-    var input_index : Int = 0
-    var output : MIDIUniqueID = 0
-    var output_index : Int = 0
+    var input: MIDIUniqueID = 0
+    var inputIndex: Int = 0
+    var output: MIDIUniqueID = 0
+    var outputIndex: Int = 0
 
     init() {
         midi.addListener(self)
@@ -39,7 +39,7 @@ class MidiConnectionManger : AKMIDIListener {
 
     func selectIO() {
         var confirmed = false
-        while (!confirmed) {
+        while confirmed == false {
             selectInput()
             print("")
             selectOutput()
@@ -57,11 +57,11 @@ class MidiConnectionManger : AKMIDIListener {
 
     func selectInput() {
         var userInputAccepted = false
-        while (!userInputAccepted) {
+        while userInputAccepted == false {
             var num = 1
             for input in midi.inputInfos {
                 print("\(num) : \(input.manufacturer) \(input.displayName)")
-                num = num + 1
+                num += 1
             }
             print("Select input: ")
             let inputLn = readLine()
@@ -69,7 +69,7 @@ class MidiConnectionManger : AKMIDIListener {
             if inputNum > 0 && inputNum <= midi.inputNames.count {
                 let index = inputNum - 1
                 input = midi.inputUIDs[index]
-                input_index = index
+                inputIndex = index
                 userInputAccepted = true
             } else {
                 print("No input selected.")
@@ -79,11 +79,11 @@ class MidiConnectionManger : AKMIDIListener {
 
     private func selectOutput() {
         var userInputAccepted = false
-        while (!userInputAccepted) {
+        while userInputAccepted == false {
             var num = 1
             for dest in midi.destinationInfos {
                 print("\(num) : \(dest.manufacturer) \(dest.displayName)")
-                num = num + 1
+                num += 1
             }
             print("Select output: ")
             let outputLn = readLine()
@@ -91,7 +91,7 @@ class MidiConnectionManger : AKMIDIListener {
             if outputNum > 0 && outputNum <= midi.destinationNames.count {
                 let index = outputNum - 1
                 output = midi.destinationUIDs[index]
-                output_index = index
+                outputIndex = index
                 userInputAccepted = true
             } else {
                 print("No output selected.")
@@ -100,8 +100,8 @@ class MidiConnectionManger : AKMIDIListener {
     }
 
     private func displayIOSelections() {
-        let dest = midi.destinationInfos[output_index]
-        let src = midi.inputInfos[input_index]
+        let dest = midi.destinationInfos[outputIndex]
+        let src = midi.inputInfos[inputIndex]
 
         print(" Input: \(src.manufacturer) \(src.displayName)")
         print("Output: \(dest.manufacturer) \(dest.displayName)")

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDIByte+Sysex.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDIByte+Sysex.swift
@@ -1,0 +1,50 @@
+//
+//  MIDIByte+Sysex.swift
+//  MacOSCommandLineDev
+//
+//  Created by Kurt Arnlund on 1/16/19.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import Foundation
+import AudioKit
+
+// MARK: - Extension related to the i/o message filter bits
+extension MIDIByte {
+    /// Internal function to convert a boolean to a 0x01 or 0x00 value
+    ///
+    /// - Parameter b: true(1) or false(0)
+    /// - Returns: 1 or 0
+    private static func boolToByte(_ b: Bool) -> Int8 {
+        return (b ? 0x01 : 0x00)
+    }
+
+    /// Internal function to convert a single bit position to a boolean respresting whether the bit was 1(true) or 0(false)
+    ///
+    /// - Parameter pos: Bit position to test
+    /// - Returns: true if bit position contains 1 or false if bit position contains 0
+    private func bitToBool(_ pos: Int8) -> Bool {
+        return (self & (1 << pos)) > 0
+    }
+
+    /// Constructor of a MIDIByte represting a bit field
+    ///
+    /// - Parameters:
+    ///   - bit7:
+    ///   - bit6:
+    ///   - bit5:
+    ///   - bit4:
+    ///   - bit3:
+    ///   - bit2:
+    ///   - bit1:
+    init(bit7: Bool, bit6: Bool, bit5: Bool, bit4: Bool, bit3: Bool, bit2: Bool, bit1: Bool) {
+        let nibbleH = UInt8((bit7 ? 1<<6 : 0) |
+            (bit6 ? 1<<5 : 0) |
+            (bit5 ? 1<<4 : 0))
+        let nibbleL = UInt8((bit4 ? 1<<3 : 0) |
+            (bit3 ? 1<<2 : 0) |
+            (bit2 ? 1<<1 : 0) |
+            (bit1 ? 1 : 0))
+        self = nibbleH | nibbleL
+    }
+}

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDIWord+Sysex.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/MIDIWord+Sysex.swift
@@ -1,0 +1,43 @@
+//
+//  MIDIWord+Sysex.swift
+//  MacOSCommandLineDev
+//
+//  Created by Kurt Arnlund on 1/16/19.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import Foundation
+import AudioKit
+
+// MARK: - Extensions to MIDIWord
+extension MIDIWord {
+    /// Create a MIDIWord for a command and command version
+    ///
+    /// - Parameters:
+    ///   - command: Command Byte Value
+    ///   - version: Command Byte Version Value
+    init(command: MIDIByte, version: MIDIByte) {
+        self = MIDIWord((command << 8) | version)
+    }
+
+    /// Create a MIDIWord from a byte by taking the
+    /// upper nibble and lower nibble of a byte,
+    /// and separating each into a byte in the word
+    ///
+    /// - Parameter ioBitmap: Full 8bits of ioMapping for one output
+    init(ioBitmap: UInt8) {
+        let high = (ioBitmap & 0xF0) >> 4
+        let low = ioBitmap & 0x0F
+        self = UInt16(high << 8) | UInt16(low)
+    }
+
+    /// Most significant byte in a MIDIWord
+    var msb: MIDIByte {
+        return MIDIByte(self >> 8)
+    }
+
+    /// Lease significant byte in a MIDIWord
+    var lsb: MIDIByte {
+        return MIDIByte(self & 0x00FF)
+    }
+}

--- a/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/main.swift
+++ b/Developer/macOS/macOSDevelopment/MacOSCommandLineDev/main.swift
@@ -1,0 +1,39 @@
+//
+//  main.swift
+//  AudiKit Sysex Example/Test
+//
+//  Created by Kurt Arnlund on 1/14/19.
+//  Copyright © 2019 iatapps. All rights reserved.
+//
+
+import Foundation
+
+let midiConnection = MidiConnectionManger()
+midiConnection.selectIO()
+
+print("")
+
+let sysexCom = GeneralSysexCommunicationsManger()
+
+var runUntilNote = true
+let sysex_success = NotificationCenter.default.addObserver(forName: GeneralSysexCommunicationsManger.ReceivedSysex, object: nil, queue: nil) { (note) in
+    runUntilNote = false
+    CFRunLoopStop(RunLoop.current.getCFRunLoop())
+}
+
+let sysex_timeout = NotificationCenter.default.addObserver(forName: GeneralSysexCommunicationsManger.SysexTimedOut, object: nil, queue: nil) { (note) in
+    print("Communications Timeout")
+    runUntilNote = false
+    CFRunLoopStop(RunLoop.current.getCFRunLoop())
+}
+
+print("Sending Sysex Request")
+sysexCom.requestAndWaitForResponse()
+
+while (runUntilNote) {
+    let oneSecondLater = Date(timeIntervalSinceNow: 0.25)
+    RunLoop.current.run(mode: .default, before: oneSecondLater)
+}
+
+NotificationCenter.default.removeObserver(sysex_success)
+NotificationCenter.default.removeObserver(sysex_timeout)

--- a/Developer/macOS/macOSDevelopment/macOSDevelopment.xcodeproj/project.pbxproj
+++ b/Developer/macOS/macOSDevelopment/macOSDevelopment.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		C4BDE7EF1C12FAE600207DA9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BDE7EE1C12FAE600207DA9 /* ViewController.swift */; };
 		C4BDE7F11C12FAE600207DA9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4BDE7F01C12FAE600207DA9 /* Assets.xcassets */; };
 		C4BDE7F41C12FAE600207DA9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C4BDE7F21C12FAE600207DA9 /* Main.storyboard */; };
+		C51D173721EE85D3008EB51F /* MIDI Connection Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51D173321EE85D2008EB51F /* MIDI Connection Manager.swift */; };
+		C51D173821EE85D3008EB51F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51D173421EE85D2008EB51F /* main.swift */; };
+		C51D173A21EE9FF4008EB51F /* AudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4AF139320319D42002E0FD8 /* AudioKit.framework */; };
+		C51D173C21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51D173B21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift */; };
+		C51D173E21EEDE01008EB51F /* K5000SysexMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51D173D21EEDE01008EB51F /* K5000SysexMessages.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +39,18 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		C51D172721EE85A9008EB51F /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		55D897321FDB864D00754292 /* macOSDevelopment-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "macOSDevelopment-Bridging-Header.h"; sourceTree = "<group>"; };
 		C4AF138D20319D41002E0FD8 /* AudioKit For macOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "AudioKit For macOS.xcodeproj"; path = "../../../AudioKit/macOS/AudioKit For macOS.xcodeproj"; sourceTree = "<group>"; };
@@ -46,6 +63,11 @@
 		C4BDE7F01C12FAE600207DA9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C4BDE7F31C12FAE600207DA9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C4BDE7F51C12FAE600207DA9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C51D172921EE85A9008EB51F /* MacOSCommandLineDev */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MacOSCommandLineDev; sourceTree = BUILT_PRODUCTS_DIR; };
+		C51D173321EE85D2008EB51F /* MIDI Connection Manager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MIDI Connection Manager.swift"; sourceTree = "<group>"; };
+		C51D173421EE85D2008EB51F /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = "../../../../../MacOS/Command Line/Unitor Control/Unitor Control/main.swift"; sourceTree = "<group>"; };
+		C51D173B21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralSysexCommunicationsManger.swift; sourceTree = "<group>"; };
+		C51D173D21EEDE01008EB51F /* K5000SysexMessages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = K5000SysexMessages.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +77,14 @@
 			files = (
 				C4AF13A120319E45002E0FD8 /* AudioKit.framework in Frameworks */,
 				C4AF13A220319E45002E0FD8 /* AudioKitUI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C51D172621EE85A9008EB51F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C51D173A21EE9FF4008EB51F /* AudioKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -75,6 +105,7 @@
 			children = (
 				C4AF138D20319D41002E0FD8 /* AudioKit For macOS.xcodeproj */,
 				C4BDE7EB1C12FAE600207DA9 /* macOSDevelopment */,
+				C51D172A21EE85AA008EB51F /* MacOSCommandLineDev */,
 				EA127F541C42123600289567 /* Frameworks */,
 				C4BDE7EA1C12FAE600207DA9 /* Products */,
 			);
@@ -84,6 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				C4BDE7E91C12FAE600207DA9 /* macOSDevelopment.app */,
+				C51D172921EE85A9008EB51F /* MacOSCommandLineDev */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -102,6 +134,17 @@
 				C4AF13A320319EB4002E0FD8 /* sinechirp.wav */,
 			);
 			path = macOSDevelopment;
+			sourceTree = "<group>";
+		};
+		C51D172A21EE85AA008EB51F /* MacOSCommandLineDev */ = {
+			isa = PBXGroup;
+			children = (
+				C51D173421EE85D2008EB51F /* main.swift */,
+				C51D173321EE85D2008EB51F /* MIDI Connection Manager.swift */,
+				C51D173D21EEDE01008EB51F /* K5000SysexMessages.swift */,
+				C51D173B21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift */,
+			);
+			path = MacOSCommandLineDev;
 			sourceTree = "<group>";
 		};
 		EA127F541C42123600289567 /* Frameworks */ = {
@@ -131,19 +174,41 @@
 			productReference = C4BDE7E91C12FAE600207DA9 /* macOSDevelopment.app */;
 			productType = "com.apple.product-type.application";
 		};
+		C51D172821EE85A9008EB51F /* MacOSCommandLineDev */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C51D173121EE85AA008EB51F /* Build configuration list for PBXNativeTarget "MacOSCommandLineDev" */;
+			buildPhases = (
+				C51D172521EE85A9008EB51F /* Sources */,
+				C51D172621EE85A9008EB51F /* Frameworks */,
+				C51D172721EE85A9008EB51F /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MacOSCommandLineDev;
+			productName = MacOSCommandLineDev;
+			productReference = C51D172921EE85A9008EB51F /* MacOSCommandLineDev */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C4BDE7E11C12FAE600207DA9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0910;
-				LastUpgradeCheck = 0900;
+				LastSwiftUpdateCheck = 1010;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = AudioKit;
 				TargetAttributes = {
 					C4BDE7E81C12FAE600207DA9 = {
 						CreatedOnToolsVersion = 7.2;
 						LastSwiftMigration = "";
+						ProvisioningStyle = Automatic;
+					};
+					C51D172821EE85A9008EB51F = {
+						CreatedOnToolsVersion = 10.1;
+						DevelopmentTeam = H8E2LSZV55;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -168,6 +233,7 @@
 			projectRoot = "";
 			targets = (
 				C4BDE7E81C12FAE600207DA9 /* macOSDevelopment */,
+				C51D172821EE85A9008EB51F /* MacOSCommandLineDev */,
 			);
 		};
 /* End PBXProject section */
@@ -213,6 +279,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C51D172521EE85A9008EB51F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C51D173C21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift in Sources */,
+				C51D173721EE85D3008EB51F /* MIDI Connection Manager.swift in Sources */,
+				C51D173821EE85D3008EB51F /* main.swift in Sources */,
+				C51D173E21EEDE01008EB51F /* K5000SysexMessages.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
@@ -239,12 +316,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -292,12 +371,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -369,6 +450,52 @@
 			};
 			name = Release;
 		};
+		C51D172D21EE85AA008EB51F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = H8E2LSZV55;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		C51D172E21EE85AA008EB51F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = H8E2LSZV55;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -386,6 +513,15 @@
 			buildConfigurations = (
 				C4BDE7F91C12FAE600207DA9 /* Debug */,
 				C4BDE7FA1C12FAE600207DA9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C51D173121EE85AA008EB51F /* Build configuration list for PBXNativeTarget "MacOSCommandLineDev" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C51D172D21EE85AA008EB51F /* Debug */,
+				C51D172E21EE85AA008EB51F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Developer/macOS/macOSDevelopment/macOSDevelopment.xcodeproj/project.pbxproj
+++ b/Developer/macOS/macOSDevelopment/macOSDevelopment.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		C51D173A21EE9FF4008EB51F /* AudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4AF139320319D42002E0FD8 /* AudioKit.framework */; };
 		C51D173C21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51D173B21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift */; };
 		C51D173E21EEDE01008EB51F /* K5000SysexMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51D173D21EEDE01008EB51F /* K5000SysexMessages.swift */; };
+		C539CDC621EFAE6D00C45A2C /* MIDIByte+Sysex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C539CDC521EFAE6D00C45A2C /* MIDIByte+Sysex.swift */; };
+		C539CDCA21EFAE9500C45A2C /* MIDIWord+Sysex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C539CDC921EFAE9500C45A2C /* MIDIWord+Sysex.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +70,8 @@
 		C51D173421EE85D2008EB51F /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = "../../../../../MacOS/Command Line/Unitor Control/Unitor Control/main.swift"; sourceTree = "<group>"; };
 		C51D173B21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralSysexCommunicationsManger.swift; sourceTree = "<group>"; };
 		C51D173D21EEDE01008EB51F /* K5000SysexMessages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = K5000SysexMessages.swift; sourceTree = "<group>"; };
+		C539CDC521EFAE6D00C45A2C /* MIDIByte+Sysex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MIDIByte+Sysex.swift"; sourceTree = "<group>"; };
+		C539CDC921EFAE9500C45A2C /* MIDIWord+Sysex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MIDIWord+Sysex.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +147,8 @@
 				C51D173321EE85D2008EB51F /* MIDI Connection Manager.swift */,
 				C51D173D21EEDE01008EB51F /* K5000SysexMessages.swift */,
 				C51D173B21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift */,
+				C539CDC521EFAE6D00C45A2C /* MIDIByte+Sysex.swift */,
+				C539CDC921EFAE9500C45A2C /* MIDIWord+Sysex.swift */,
 			);
 			path = MacOSCommandLineDev;
 			sourceTree = "<group>";
@@ -283,8 +289,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C539CDC621EFAE6D00C45A2C /* MIDIByte+Sysex.swift in Sources */,
 				C51D173C21EEDD75008EB51F /* GeneralSysexCommunicationsManger.swift in Sources */,
 				C51D173721EE85D3008EB51F /* MIDI Connection Manager.swift in Sources */,
+				C539CDCA21EFAE9500C45A2C /* MIDIWord+Sysex.swift in Sources */,
 				C51D173821EE85D3008EB51F /* main.swift in Sources */,
 				C51D173E21EEDE01008EB51F /* K5000SysexMessages.swift in Sources */,
 			);

--- a/Developer/macOS/macOSDevelopment/macOSDevelopment.xcodeproj/xcshareddata/xcschemes/macOSDevelopment.xcscheme
+++ b/Developer/macOS/macOSDevelopment/macOSDevelopment.xcodeproj/xcshareddata/xcschemes/macOSDevelopment.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,7 +29,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C4A007F11FD4CE2F004A91F4"


### PR DESCRIPTION
Port selection now uses MIDIUniqueID instead of a String name, so that ports with the same name can be identified correctly.

Sysex received data is now correct, and does not contain up to 256 0’s after each byte. 

Manufacturer and Model were swapped in the EndpointInfo.

AKMIDI code cleaned up a bit.

Added a command line target to the dev project for testing Sysex or any other features.  Included compete definition of Kawai K5000 sysex dump requests.