### PR TITLE
AKPlayer creating loop artifacts in official playground, AKAudioPlayer fixes it

### DIFF
--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Balancing Nodes.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Balancing Nodes.xcplaygroundpage/Contents.swift
@@ -12,8 +12,8 @@ import AudioKitUI
 
 //: This section prepares the players
 let file = try AKAudioFile(readFileName: "drumloop.wav")
-var source = AKPlayer(audioFile: file)
-source.isLooping = true
+var source = try AKAudioPlayer(file: file)
+source.looping = true
 
 let highPassFiltering = AKHighPassFilter(source, cutoffFrequency: 900)
 let lowPassFiltering = AKLowPassFilter(highPassFiltering, cutoffFrequency: 300)

--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Dry Wet Mixer.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Dry Wet Mixer.xcplaygroundpage/Contents.swift
@@ -13,8 +13,8 @@ import AudioKitPlaygrounds
 import AudioKit
 //: This section prepares the players
 let file = try AKAudioFile(readFileName: "drumloop.wav")
-var drums = AKPlayer(audioFile: file)
-drums.isLooping = true
+var drums = try AKAudioPlayer(file: file)
+drums.looping = true
 
 //: Build an effects chain:
 


### PR DESCRIPTION
Hey folks! Noob here! Just started learning AudioKit. For some reason, one of the playgrounds was giving me loop artifacts. I compared the code with the previous Playground and noticed the difference of using `AKPlayer` and `AKAudioPlayer`. Switching to the leather fixes it.

Maybe it is just API differences or some bug, I'll let you guys that know better dig into it. But while you investigate, maybe replace it by the one that works?