### PR TITLE
Small refactor in AKAudioUnitManagerDelegate

### DIFF
--- a/Examples/iOS/AudioUnitManager/AudioUnitManager/ViewController.swift
+++ b/Examples/iOS/AudioUnitManager/AudioUnitManager/ViewController.swift
@@ -249,21 +249,20 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: AKAudioUnitManagerDelegate {
-    func handleEffectRemoved(at auIndex: Int) {
-        // Do nothing (for now?)
-    }
+    func handleAudioUnitManagerNotification(_ notification: AKAudioUnitManager.Notification,
+                                            audioUnitManager: AKAudioUnitManager) {
+        guard let auManager = auManager, audioUnitManager == auManager else { return }
 
-    func handleAudioUnitNotification(type: AKAudioUnitManager.Notification, object: Any?) {
-        guard let auManager = auManager else { return }
-
-        if type == AKAudioUnitManager.Notification.changed {
+        switch notification {
+        case .changed:
             updateEffectsUI(audioUnits: auManager.availableEffects)
             updateInstrumentsUI(audioUnits: auManager.availableInstruments)
+        default:
+            break
         }
     }
 
-    /// this is where you can request the UI of the Audio Unit
-    func handleEffectAdded(at auIndex: Int) {
+    func audioUnitManager(_ audioUnitManager: AKAudioUnitManager, didAddEffectAtIndex index: Int) {
         guard let player = player else { return }
         guard let auManager = auManager else { return }
 
@@ -272,9 +271,13 @@ extension ViewController: AKAudioUnitManagerDelegate {
             player.play()
         }
 
-        if let au = auManager.effectsChain[auIndex] {
-            showAudioUnit(au)
+        if let audioUnit = auManager.effectsChain[index] {
+            showAudioUnit(audioUnit)
         }
+    }
+
+    func audioUnitManager(_ audioUnitManager: AKAudioUnitManager, didRemoveEffectAtIndex index: Int) {
+
     }
 }
 

--- a/Examples/macOS/AudioUnitManager/AudioUnitManager/AudioUnitManager+Effects.swift
+++ b/Examples/macOS/AudioUnitManager/AudioUnitManager/AudioUnitManager+Effects.swift
@@ -314,18 +314,23 @@ extension AudioUnitManager {
 }
 
 extension AudioUnitManager: AKAudioUnitManagerDelegate {
-    func handleAudioUnitNotification(type: AKAudioUnitManager.Notification, object: Any?) {
-        if type == .changed {
+
+    func handleAudioUnitManagerNotification(_ notification: AKAudioUnitManager.Notification,
+                                            audioUnitManager: AKAudioUnitManager) {
+        switch notification {
+        case .changed:
             updateEffectsUI(audioUnits: internalManager.availableEffects)
+        default:
+            break
         }
     }
 
-    func handleEffectAdded(at auIndex: Int) {
-        showEffect(at: auIndex, state: true)
+    func audioUnitManager(_ audioUnitManager: AKAudioUnitManager, didAddEffectAtIndex index: Int) {
+        showEffect(at: index, state: true)
         reconnect()
     }
 
-    func handleEffectRemoved(at auIndex: Int) {
+    func audioUnitManager(_ audioUnitManager: AKAudioUnitManager, didRemoveEffectAtIndex index: Int) {
         reconnect()
     }
 }


### PR DESCRIPTION
- Passes the `AKAudioUnitManager` itself in the delegate methods, making it easier to use multiple instances of `AKAudioUnitManager`
- Adds specific types for notifications

I needed this change for a project I'm working on, so I thought it could be helpful for others. 
Of course this breaks compatibility with clients that are already using the `AKAudioManager`. 