### PR TITLE
Bugfix: MIDI input not working with AKAudioUnitInstrument

### DIFF
--- a/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitInstrument.swift
+++ b/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitInstrument.swift
@@ -31,7 +31,7 @@ open class AKAudioUnitInstrument: AKMIDIInstrument {
     ///   - velocity: MIDI velocity to play the note at
     ///   - channel: MIDI channel to play the note on
     ///
-    open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity = 64, channel: MIDIChannel = 0) {
+    override open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity = 64, channel: MIDIChannel = 0) {
         guard let midiInstrument = midiInstrument else {
             AKLog("no midiInstrument exists")
             return
@@ -58,21 +58,37 @@ open class AKAudioUnitInstrument: AKMIDIInstrument {
     }
 
     open override func receivedMIDIController(_ controller: MIDIByte, value: MIDIByte, channel: MIDIChannel) {
-        midiInstrument?.sendController(controller, withValue: value, onChannel: channel)
+        guard let midiInstrument = midiInstrument else {
+            AKLog("no midiInstrument exists")
+            return
+        }
+        midiInstrument.sendController(controller, withValue: value, onChannel: channel)
     }
 
     open override func receivedMIDIAftertouch(noteNumber: MIDINoteNumber,
                                            pressure: MIDIByte,
                                            channel: MIDIChannel) {
-        midiInstrument?.sendPressure(forKey: noteNumber, withValue: pressure, onChannel: channel)
+        guard let midiInstrument = midiInstrument else {
+            AKLog("no midiInstrument exists")
+            return
+        }
+        midiInstrument.sendPressure(forKey: noteNumber, withValue: pressure, onChannel: channel)
     }
 
     open override func receivedMIDIAfterTouch(_ pressure: MIDIByte, channel: MIDIChannel) {
-        midiInstrument?.sendPressure(pressure, onChannel: channel)
+        guard let midiInstrument = midiInstrument else {
+            AKLog("no midiInstrument exists")
+            return
+        }
+        midiInstrument.sendPressure(pressure, onChannel: channel)
     }
 
     open override func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord, channel: MIDIChannel) {
-        midiInstrument?.sendPitchBend(pitchWheelValue, onChannel: channel)
+        guard let midiInstrument = midiInstrument else {
+            AKLog("no midiInstrument exists")
+            return
+        }
+        midiInstrument.sendPitchBend(pitchWheelValue, onChannel: channel)
     }
 
 }

--- a/AudioKit/Common/MIDI/AKMIDINode.swift
+++ b/AudioKit/Common/MIDI/AKMIDINode.swift
@@ -65,11 +65,12 @@ open class AKMIDINode: AKNode, AKMIDIListener {
     // Send MIDI data to the audio unit
     func handleMIDI(data1: MIDIByte, data2: MIDIByte, data3: MIDIByte) {
         let status = AKMIDIStatus(byte: data1)
+        let channel = status?.channel
         let noteNumber = MIDINoteNumber(data2)
         let velocity = MIDIVelocity(data3)
 
         if status?.type == .noteOn && velocity > 0 {
-            internalNode.play(noteNumber: noteNumber, velocity: velocity)
+            internalNode.play(noteNumber: noteNumber, velocity: velocity, channel: channel ?? 0)
         } else if status?.type == .noteOn && velocity == 0 {
             internalNode.stop(noteNumber: noteNumber)
         } else if status?.type == .noteOff {
@@ -88,7 +89,7 @@ open class AKMIDINode: AKNode, AKMIDIListener {
                                  velocity: MIDIVelocity,
                                  channel: MIDIChannel) {
         if velocity > 0 {
-            internalNode.play(noteNumber: noteNumber, velocity: velocity)
+            internalNode.play(noteNumber: noteNumber, velocity: velocity, channel: channel)
         } else {
             internalNode.stop(noteNumber: noteNumber)
         }

--- a/AudioKit/Common/MIDI/Packets/MIDIPacket+Extensions.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacket+Extensions.swift
@@ -22,7 +22,7 @@ extension MIDIPacket {
     }
 
     var isSystemCommand: Bool {
-        return data.0 & 0x80 > 0
+        return data.0 >= 0xf0
     }
 
     var systemCommand: AKMIDISystemCommand? {

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -88,7 +88,7 @@ public protocol AKPolyphonic {
     ///   - noteNumber: MIDI Note Number
     ///   - velocity:   MIDI Velocity
     ///   - frequency:  Play this frequency
-    func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double)
+    func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double, channel: MIDIChannel)
 
     /// Play a sound corresponding to a MIDI note
     ///
@@ -96,7 +96,7 @@ public protocol AKPolyphonic {
     ///   - noteNumber: MIDI Note Number
     ///   - velocity:   MIDI Velocity
     ///
-    func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity)
+    func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel)
 
     /// Stop a sound corresponding to a MIDI note
     ///
@@ -119,8 +119,12 @@ public protocol AKPolyphonic {
     ///   - velocity:   MIDI Velocity
     ///   - frequency:  Play this frequency
     ///
-    @objc open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
-        AKLog("Playing note: \(noteNumber), velocity: \(velocity), frequency: \(frequency), override in subclass")
+    @objc open func play(noteNumber: MIDINoteNumber,
+                         velocity: MIDIVelocity,
+                         frequency: Double,
+                         channel: MIDIChannel = 0) {
+        AKLog("Playing note: \(noteNumber), velocity: \(velocity), frequency: \(frequency), channel: \(channel), " +
+            "override in subclass")
     }
 
     /// Play a sound corresponding to a MIDI note
@@ -129,13 +133,13 @@ public protocol AKPolyphonic {
     ///   - noteNumber: MIDI Note Number
     ///   - velocity:   MIDI Velocity
     ///
-    @objc open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity) {
+    @objc open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel = 0) {
 
         // MARK: Microtonal pitch lookup
         // default implementation is 12 ET
         let frequency = AKPolyphonicNode.tuningTable.frequency(forNoteNumber: noteNumber)
         //        AKLog("Playing note: \(noteNumber), velocity: \(velocity), using tuning table frequency: \(frequency)")
-        self.play(noteNumber: noteNumber, velocity: velocity, frequency: frequency)
+        self.play(noteNumber: noteNumber, velocity: velocity, frequency: frequency, channel: channel)
     }
 
     /// Stop a sound corresponding to a MIDI note

--- a/AudioKit/Common/Nodes/Callback Instrument/AKCallbackInstrument.swift
+++ b/AudioKit/Common/Nodes/Callback Instrument/AKCallbackInstrument.swift
@@ -47,7 +47,7 @@ open class AKCallbackInstrument: AKPolyphonicNode, AKComponent {
         }
     }
 
-    override open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity) {
+    override open func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel) {
         internalAU?.startNote(noteNumber, velocity: velocity)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drum Synths/AKDrumSynths.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drum Synths/AKDrumSynths.swift
@@ -33,7 +33,7 @@ open class AKSynthKick: AKMIDIInstrument {
     }
 
     /// Function to start, play, or activate the node, all do the same thing
-    @objc open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity) {
+    @objc open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel = 0) {
         filter.cutoffFrequency = (Double(velocity) / 127.0 * 366.0) + 300.0
         filter.resonance = 1.0 - Double(velocity) / 127.0
         generator.trigger()
@@ -86,7 +86,7 @@ open class AKSynthSnare: AKMIDIInstrument {
     }
 
     /// Function to start, play, or activate the node, all do the same thing
-    @objc open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity) {
+    @objc open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel) {
         cutoff = (Double(velocity) / 127.0 * 1_600.0) + 300.0
         generator.trigger()
     }

--- a/AudioKit/Common/Nodes/Generators/Polysynths/FM Oscillator Bank/AKFMOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/FM Oscillator Bank/AKFMOscillatorBank.swift
@@ -297,7 +297,10 @@ open class AKFMOscillatorBank: AKPolyphonicNode, AKComponent {
     // MARK: - AKPolyphonic
 
     // Function to start, play, or activate the node at frequency
-    open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    open override func play(noteNumber: MIDINoteNumber,
+                            velocity: MIDIVelocity,
+                            frequency: Double,
+                            channel: MIDIChannel = 0) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
 

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Morphing Oscillator Bank/AKMorphingOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Morphing Oscillator Bank/AKMorphingOscillatorBank.swift
@@ -265,7 +265,10 @@ open class AKMorphingOscillatorBank: AKPolyphonicNode, AKComponent {
     // MARK: - AKPolyphonic
 
     // Function to start, play, or activate the node at frequency
-    open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    open override func play(noteNumber: MIDINoteNumber,
+                            velocity: MIDIVelocity,
+                            frequency: Double,
+                            channel: MIDIChannel = 0) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
 

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Oscillator Bank/AKOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Oscillator Bank/AKOscillatorBank.swift
@@ -239,7 +239,10 @@ open class AKOscillatorBank: AKPolyphonicNode, AKComponent {
     // MARK: - AKPolyphonic
 
     // Function to start, play, or activate the node at frequency
-    open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    open override func play(noteNumber: MIDINoteNumber,
+                            velocity: MIDIVelocity,
+                            frequency: Double,
+                            channel: MIDIChannel = 0) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
 

--- a/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBank.swift
@@ -232,7 +232,10 @@ open class AKPWMOscillatorBank: AKPolyphonicNode, AKComponent {
     // MARK: - AKPolyphonic
 
     // Function to start, play, or activate the node at frequency
-    open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    open override func play(noteNumber: MIDINoteNumber,
+                            velocity: MIDIVelocity,
+                            frequency: Double,
+                            channel: MIDIChannel = 0) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
 

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Phase Distortion Oscillator Bank/AKPhaseDistortionOscillatorBank.swift
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Phase Distortion Oscillator Bank/AKPhaseDistortionOscillatorBank.swift
@@ -248,7 +248,10 @@ open class AKPhaseDistortionOscillatorBank: AKPolyphonicNode, AKComponent {
     // MARK: - AKPolyphonic
 
     // Function to start, play, or activate the node at frequency
-    open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    open override func play(noteNumber: MIDINoteNumber,
+                            velocity: MIDIVelocity,
+                            frequency: Double,
+                            channel: MIDIChannel = 0) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
     /// Function to stop or bypass the node, both are equivalent

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynth.swift
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynth.swift
@@ -317,7 +317,10 @@
         self.internalAU?.setParameterImmediately(.filterReleaseDuration, value: filterReleaseDuration)
     }
 
-    @objc open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    @objc open override func play(noteNumber: MIDINoteNumber,
+                                  velocity: MIDIVelocity,
+                                  frequency: Double,
+                                  channel: MIDIChannel = 0) {
         internalAU?.playNote(noteNumber: noteNumber, velocity: velocity, noteFrequency: Float(frequency))
     }
 

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
@@ -472,7 +472,10 @@
         internalAU?.setLoop(thruRelease: thruRelease)
     }
 
-    @objc open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    @objc open override func play(noteNumber: MIDINoteNumber,
+                                  velocity: MIDIVelocity,
+                                  frequency: Double,
+                                  channel: MIDIChannel = 0) {
         internalAU?.playNote(noteNumber: noteNumber, velocity: velocity, noteFrequency: Float(frequency))
     }
 


### PR DESCRIPTION
Hi, I wanted to use the `AKSequencer` with a `AKAudioUnitInstrument`, so I checked the sequencer example, but it wasn't working.

I found these 2 problems:

1. from my understanding, MIDI system command are the ones starting with status byte `f0` and above. But the check at [MIDIPacket+Extensions.swift:15](https://github.com/AudioKit/AudioKit/compare/develop...oettam:bugfix/midi-au-instrument?expand=1#diff-ba2f52e5a7b5247169428fcbbd455441R25) would identify all the packets as system command
1. the MIDI packets coming from an endpoint (set via the `midiIn` property of the `AKMIDIInstrument`) didn't reach the `AKAudioUnitIntrument`