### PR TITLE
Make attributes of public MIDI Events publicly available

### DIFF
--- a/AudioKit/Common/MIDI/Sequencer/AKMusicTrack+Events.swift
+++ b/AudioKit/Common/MIDI/Sequencer/AKMusicTrack+Events.swift
@@ -122,14 +122,14 @@ extension AKMusicTrack {
 }
 
 public struct AppleMIDIEvent {
-    var time: MusicTimeStamp
-    var type: MusicEventType
-    var data: UnsafeRawPointer?
-    var dataSize: UInt32
+    public var time: MusicTimeStamp
+    public var type: MusicEventType
+    public var data: UnsafeRawPointer?
+    public var dataSize: UInt32
 }
 
 public struct MIDIProgramChangeEvent {
-    var time: MusicTimeStamp
-    var channel: MIDIChannel
-    var number: MIDIByte
+    public var time: MusicTimeStamp
+    public var channel: MIDIChannel
+    public var number: MIDIByte
 }


### PR DESCRIPTION
The attributes of MIDIProgramChangeEvent and AppleMIDIEvent were not available publicly, even though the structs itself are public. This has to do with Swift's public struct mechanisms. The solution is to explicitly declare the attributes public, so I did that.
