### PR TITLE
Fix for AKKeyboardView initializer ignoring polyphonic parameter.

### DIFF
--- a/AudioKit/iOS/AudioKit/User Interface/AKKeyboardView.swift
+++ b/AudioKit/iOS/AudioKit/User Interface/AKKeyboardView.swift
@@ -91,7 +91,7 @@ import AudioKit
         oneOctaveSize = CGSize(width: Double(width / octaveCount - width / (octaveCount * octaveCount * 7)),
                                height: Double(height))
         isMultipleTouchEnabled = true
-        setNeedsDisplay()
+        polyphonicMode = polyphonic
     }
 
     /// Initialization within Interface Builder


### PR DESCRIPTION
Fix for #1709.

- Set polyphonicMode property using the polyphonic parameter in the initializer.
- Use the setNeedsDisplay() in the polyphonicMode property observer.
 