### PR TITLE
Made AKMicrohpone init a failable initilizer

### DIFF
--- a/Developer/iOS/iOSDevelopment/iOSDevelopment/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Developer/iOS/iOSDevelopment/iOSDevelopment/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {


### PR DESCRIPTION
1. Made `init` for AKMicrophone a failable initializer.
2. Made `setAVSessionSampleRate(sampleRate: Double)` a throwing function

`init` will fail under the following conditions:
- `format` returns nil
- `setAVSessionSampleRate` throws an error

I think the 2nd `setAVSessionSampleRate(sampleRate: Double)` throwing, thus failing the entire init for AKMicrophone might be a little heavy handed, but in any case that there is samplerate mismatch, we should never hard crash our apps, as alot of users (maybe just me 😜 ) seem to have this crash.

Happy to revise in anyway, thanks so much team!