### PR TITLE
Fix for currentTime starting from zero when resuming from pause https…

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -71,7 +71,9 @@ extension AKPlayer {
 
         // restore that startTime as it might be a selection
         startTime = previousStartTime
-        pauseTime = nil
+        // restore the pauseTime cleared by play and preserve it by setting _isPaused to false manually
+        pauseTime = time
+        _isPaused = false
     }
 
     /// Stop playback and cancel any pending scheduled playback or completion events

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -176,6 +176,8 @@ public class AKPlayer: AKNode {
     internal var _rate: Double {
         return 1.0
     }
+    
+    internal var _isPaused = false
 
     // MARK: - Public Properties
 
@@ -303,12 +305,20 @@ public class AKPlayer: AKNode {
     /// - Returns: Current time of the player in seconds while playing.
     @objc public var currentTime: Double {
         let currentDuration = (endTime - startTime == 0) ? duration : (endTime - startTime)
-        let current = startTime + playerTime.truncatingRemainder(dividingBy: currentDuration)
-
+        var normalisedPauseTime = 0.0
+        if let pauseTime = pauseTime, pauseTime > startTime {
+            normalisedPauseTime = pauseTime - startTime
+        }
+        let current = startTime + normalisedPauseTime + playerTime.truncatingRemainder(dividingBy: currentDuration)
+        
         return current
     }
-
-    public var pauseTime: Double?
+    
+    public var pauseTime: Double? {
+        didSet {
+            _isPaused = pauseTime != nil
+        }
+    }
 
     @objc public var processingFormat: AVAudioFormat? {
         guard let audioFile = audioFile else { return nil }
@@ -333,7 +343,7 @@ public class AKPlayer: AKNode {
     @objc public var isLooping: Bool = false
 
     @objc public var isPaused: Bool {
-        return pauseTime != nil
+        return _isPaused
     }
 
     /// Reversing the audio will set the player to buffering
@@ -497,6 +507,8 @@ public class AKPlayer: AKNode {
             return
         }
         initFader(at: audioTime, hostTime: hostTime)
+        
+        pauseTime = nil
     }
 
     // MARK: - Deinit


### PR DESCRIPTION
pauseTime and isPaused live different lives now so pauseTime can be used to give correct currentTime value after pausing. This makes it possible to keep the fix for https://github.com/AudioKit/AudioKit/issues/1675 (startTime is not changed when resuming from pause) while also fixing https://github.com/AudioKit/AudioKit/issues/1730 (currentTime starting from zero when resuming from pause)

The preserved pauseTime is additionally always cleared when the main play() is called so stuff such as seeking to different time don't mess stuff up. 