### PR TITLE
Loop completion handler

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -263,6 +263,7 @@ extension AKPlayer {
             startTime = loop.start
             endTime = loop.end
             play()
+            loopCompletionHandler?()
             return
         }
         if pauseTime != nil {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -183,6 +183,10 @@ public class AKPlayer: AKNode {
     /// stop() is called while playing or when looping from a buffer.
     @objc public var completionHandler: AKCallback?
 
+    /// Completion handler to be called when Audio has looped. The handler won't be called if
+    /// stop() is called while playing.
+    @objc public var loopCompletionHandler: AKCallback?
+
     /// Used with buffering players
     @objc public var buffer: AVAudioPCMBuffer?
 


### PR DESCRIPTION
Adds a completion handler specific to looping. A use-case is a speed trainer that increments the tempo on every loop.