### PR TITLE
AKSampler: ensure .wv files are closed after loading

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -48,11 +48,10 @@ extern "C" void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescrip
         for (int i = 0; i < (sdd.sampleCount * sdd.channelCount); i++)
             *pf++ = scale * *pi++;
     }
+    WavpackCloseFile(wpc);
 
     ((AKSamplerDSP*)pDSP)->loadSampleData(sdd);
     delete[] sdd.data;
-
-    WavpackCloseFile(wpc);
 }
 
 extern "C" void doAKSamplerUnloadAllSamples(AKDSPRef pDSP)

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -51,6 +51,8 @@ extern "C" void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescrip
 
     ((AKSamplerDSP*)pDSP)->loadSampleData(sdd);
     delete[] sdd.data;
+
+    WavpackCloseFile(wpc);
 }
 
 extern "C" void doAKSamplerUnloadAllSamples(AKDSPRef pDSP)


### PR DESCRIPTION
This is probably the root of the problems with D1 file loading, especially AUv3 format.