### PR TITLE
Kill the Tanker! Kill it with fire!

### DIFF
--- a/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.cpp
+++ b/AudioKit/Core/AudioKitCore/ModulatedDelay/AdjustableDelayLine.cpp
@@ -50,6 +50,7 @@ namespace AudioKitCore
         if (fReadWriteGap > capacity) fReadWriteGap = (float)capacity;
         readIndex = writeIndex - fReadWriteGap;
         while (readIndex < 0.0f) readIndex += capacity;
+        while (readIndex >= capacity) readIndex -= capacity;
     }
     
     float AdjustableDelayLine::push(float sample)


### PR DESCRIPTION
Problem was a rare case where the ModulatedDelay could try to access a memory location one past the end of the array.