### PR TITLE
Revert "Improvements to open_filename.c to prevent too many open files"

### DIFF
--- a/AudioKit/Core/Wavpack/open_filename.c
+++ b/AudioKit/Core/Wavpack/open_filename.c
@@ -35,7 +35,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 #include "wavpack_local.h"
 
@@ -244,10 +243,7 @@ WavpackContext *WavpackOpenFileInput (const char *infilename, char *error, int f
 #endif
     }
     else if ((wv_id = fopen_func (infilename, file_mode)) == NULL) {
-        if (error != NULL) {
-            printf("INFILE: %s ERR: %s\n", infilename, strerror(errno));
-            sprintf(error, "%s\n", strerror(errno));
-        }
+        if (error) strcpy (error, (flags & OPEN_EDIT_TAGS) ? "can't open file for editing" : "can't open file");
         return NULL;
     }
 
@@ -258,12 +254,11 @@ WavpackContext *WavpackOpenFileInput (const char *infilename, char *error, int f
         strcat (in2filename, "c");
         wvc_id = fopen_func (in2filename, "rb");
         free (in2filename);
-    } else {
-        wvc_id = NULL;
     }
-    WavpackContext *returnValue = WavpackOpenFileInputEx64 (&freader, wv_id, wvc_id, error, flags, norm_offset);
-    fclose(wv_id);
-    return returnValue;
+    else
+        wvc_id = NULL;
+
+    return WavpackOpenFileInputEx64 (&freader, wv_id, wvc_id, error, flags, norm_offset);
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
This reverts commit a1f5a7c11cf56a7d8da6af68778242e5dd61b3d7.

*REPLACE ALL OF THIS TEXT WITH A DESCRIPTION OF YOUR CODE CHANGES*

Ready to send us a pull request? Please make sure your request is based on the [develop](https://github.com/audiokit/AudioKit/tree/develop) branch of the repository as `master` only holds stable releases.
