### PR TITLE
AKSampler: allow access to AKSampleBuffer objects after loading samples

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
@@ -96,8 +96,9 @@ extension AKSampler {
                                                               endPoint: 0.0)
                     let sampleFileURL = baseURL.appendingPathComponent(sample)
                     if sample.hasSuffix(".wv") {
-                        let buf = loadCompressedSampleFile(from: AKSampleFileDescriptor(sampleDescriptor: sampleDescriptor,
-                                                                                        path: sampleFileURL.path))
+                        let sd = AKSampleFileDescriptor(sampleDescriptor: sampleDescriptor,
+                                                        path: sampleFileURL.path)
+                        let buf = loadCompressedSampleFile(from: sd)
                         sampleBufs.append(buf)
                     } else {
                         if sample.hasSuffix(".aif") || sample.hasSuffix(".wav") {

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
@@ -14,10 +14,12 @@ extension AKSampler {
     /// Load an SFZ at the given location
     ///
     /// Parameters:
-    ///   - path: Path tothe file as a string
+    ///   - path: Path to the file as a string
     ///   - fileName: Name of the SFZ file
     ///
-    open func loadSFZ(path: String, fileName: String) {
+    open func loadSFZ(path: String, fileName: String) -> [AKSampleBuffer]
+    {
+        var sampleBufs = [AKSampleBuffer]()
 
         stopAllVoices()
         unloadAllSamples()
@@ -95,19 +97,22 @@ extension AKSampler {
                                                               endPoint: 0.0)
                     let sampleFileURL = baseURL.appendingPathComponent(sample)
                     if sample.hasSuffix(".wv") {
-                        loadCompressedSampleFile(from: AKSampleFileDescriptor(sampleDescriptor: sampleDescriptor,
-                                                                              path: sampleFileURL.path))
+                        let buf = loadCompressedSampleFile(from: AKSampleFileDescriptor(sampleDescriptor: sampleDescriptor,
+                                                                                        path: sampleFileURL.path))
+                        sampleBufs.append(buf)
                     } else {
                         if sample.hasSuffix(".aif") || sample.hasSuffix(".wav") {
                             let compressedFileURL = baseURL.appendingPathComponent(String(sample.dropLast(4) + ".wv"))
                             let fileMgr = FileManager.default
                             if fileMgr.fileExists(atPath: compressedFileURL.path) {
-                                loadCompressedSampleFile(
+                                let buf = loadCompressedSampleFile(
                                     from: AKSampleFileDescriptor(sampleDescriptor: sampleDescriptor,
                                                                  path: compressedFileURL.path))
+                                sampleBufs.append(buf)
                             } else {
                                 let sampleFile = try AKAudioFile(forReading: sampleFileURL)
-                                loadAKAudioFile(from: sampleDescriptor, file: sampleFile)
+                                let buf = loadAKAudioFile(from: sampleDescriptor, file: sampleFile)
+                                sampleBufs.append(buf)
                             }
                         }
                     }
@@ -119,5 +124,8 @@ extension AKSampler {
 
         buildKeyMap()
         restartVoices()
+
+        return sampleBufs
     }
+
 }

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
@@ -17,8 +17,7 @@ extension AKSampler {
     ///   - path: Path to the file as a string
     ///   - fileName: Name of the SFZ file
     ///
-    open func loadSFZ(path: String, fileName: String) -> [AKSampleBuffer]
-    {
+    open func loadSFZ(path: String, fileName: String) -> [AKSampleBuffer] {
         var sampleBufs = [AKSampleBuffer]()
 
         stopAllVoices()

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
@@ -395,18 +395,19 @@
         self.internalAU?.setParameterImmediately(.filterEnvelopeVelocityScaling, value: filterEnvelopeVelocityScaling)
     }
 
-    @objc open func loadAKAudioFile(from sampleDescriptor: AKSampleDescriptor, file: AKAudioFile) {
+    @objc open func loadAKAudioFile(from sampleDescriptor: AKSampleDescriptor, file: AKAudioFile) -> AKSampleBuffer
+    {
         let sampleRate = Float(file.sampleRate)
         let sampleCount = Int32(file.samplesCount)
         let channelCount = Int32(file.channelCount)
         let flattened = Array(file.floatChannelData!.joined())
         let data = UnsafeMutablePointer<Float>(mutating: flattened)
-        internalAU?.loadSampleData(from: AKSampleDataDescriptor(sampleDescriptor: sampleDescriptor,
+        return internalAU?.loadSampleData(from: AKSampleDataDescriptor(sampleDescriptor: sampleDescriptor,
                                                                 sampleRate: sampleRate,
                                                                 isInterleaved: false,
                                                                 channelCount: channelCount,
                                                                 sampleCount: sampleCount,
-                                                                data: data) )
+                                                                data: data) ) ?? AKSampleBuffer()
     }
 
     @objc open func stopAllVoices() {
@@ -417,12 +418,14 @@
         internalAU?.restartVoices()
     }
 
-    @objc open func loadRawSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) {
-        internalAU?.loadSampleData(from: sampleDataDescriptor)
+    @objc open func loadRawSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) -> AKSampleBuffer
+    {
+        return internalAU?.loadSampleData(from: sampleDataDescriptor) ?? AKSampleBuffer()
     }
 
-    @objc open func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) {
-        internalAU?.loadCompressedSampleFile(from: sampleFileDescriptor)
+    @objc open func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) -> AKSampleBuffer
+    {
+        return internalAU?.loadCompressedSampleFile(from: sampleFileDescriptor) ?? AKSampleBuffer()
     }
 
     @objc open func unloadAllSamples() {

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
@@ -395,8 +395,7 @@
         self.internalAU?.setParameterImmediately(.filterEnvelopeVelocityScaling, value: filterEnvelopeVelocityScaling)
     }
 
-    @objc open func loadAKAudioFile(from sampleDescriptor: AKSampleDescriptor, file: AKAudioFile) -> AKSampleBuffer
-    {
+    @objc open func loadAKAudioFile(from sampleDescriptor: AKSampleDescriptor, file: AKAudioFile) -> AKSampleBuffer {
         let sampleRate = Float(file.sampleRate)
         let sampleCount = Int32(file.samplesCount)
         let channelCount = Int32(file.channelCount)
@@ -418,13 +417,11 @@
         internalAU?.restartVoices()
     }
 
-    @objc open func loadRawSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) -> AKSampleBuffer
-    {
+    @objc open func loadRawSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) -> AKSampleBuffer {
         return internalAU?.loadSampleData(from: sampleDataDescriptor) ?? AKSampleBuffer()
     }
 
-    @objc open func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) -> AKSampleBuffer
-    {
+    @objc open func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) -> AKSampleBuffer {
         return internalAU?.loadCompressedSampleFile(from: sampleFileDescriptor) ?? AKSampleBuffer()
     }
 

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -380,14 +380,12 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         doAKSamplerRestartVoices(dsp)
     }
 
-    public func loadSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) -> AKSampleBuffer?
-    {
+    public func loadSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) -> AKSampleBuffer? {
         var copy = sampleDataDescriptor
         return doAKSamplerLoadData(dsp, &copy)?.pointee
     }
 
-    public func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) -> AKSampleBuffer?
-    {
+    public func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) -> AKSampleBuffer? {
         var copy = sampleFileDescriptor
         return doAKSamplerLoadCompressedFile(dsp, &copy)?.pointee
     }

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -380,14 +380,16 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         doAKSamplerRestartVoices(dsp)
     }
 
-    public func loadSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) {
+    public func loadSampleData(from sampleDataDescriptor: AKSampleDataDescriptor) -> AKSampleBuffer?
+    {
         var copy = sampleDataDescriptor
-        doAKSamplerLoadData(dsp, &copy)
+        return doAKSamplerLoadData(dsp, &copy)?.pointee
     }
 
-    public func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) {
+    public func loadCompressedSampleFile(from sampleFileDescriptor: AKSampleFileDescriptor) -> AKSampleBuffer?
+    {
         var copy = sampleFileDescriptor
-        doAKSamplerLoadCompressedFile(dsp, &copy)
+        return doAKSamplerLoadCompressedFile(dsp, &copy)?.pointee
     }
 
     public func unloadAllSamples() {

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
@@ -46,8 +46,8 @@ typedef NS_ENUM(AUParameterAddress, AKSamplerParameter)
 #include "AKSampler_Typedefs.h"
 
 AKDSPRef createAKSamplerDSP(int channelCount, double sampleRate);
-void doAKSamplerLoadData(AKDSPRef pDSP, AKSampleDataDescriptor *pSDD);
-void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescriptor *pSFD);
+AKSampleBuffer* doAKSamplerLoadData(AKDSPRef pDSP, AKSampleDataDescriptor *pSDD);
+AKSampleBuffer* doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescriptor *pSFD);
 void doAKSamplerUnloadAllSamples(AKDSPRef pDSP);
 void doAKSamplerSetNoteFrequency(AKDSPRef pDSP, int noteNumber, float noteFrequency);
 void doAKSamplerBuildSimpleKeyMap(AKDSPRef pDSP);

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -14,18 +14,18 @@ extern "C" AKDSPRef createAKSamplerDSP(int channelCount, double sampleRate) {
     return new AKSamplerDSP();
 }
 
-extern "C" void doAKSamplerLoadData(AKDSPRef pDSP, AKSampleDataDescriptor *pSDD) {
-    ((AKSamplerDSP*)pDSP)->loadSampleData(*pSDD);
+extern "C" AKSampleBuffer* doAKSamplerLoadData(AKDSPRef pDSP, AKSampleDataDescriptor *pSDD) {
+    return ((AKSamplerDSP*)pDSP)->loadSampleData(*pSDD);
 }
 
-extern "C" void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescriptor *pSFD)
+extern "C" AKSampleBuffer* doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescriptor *pSFD)
 {
     char errMsg[100];
     WavpackContext *wpc = WavpackOpenFileInput(pSFD->path, errMsg, OPEN_2CH_MAX, 0);
     if (wpc == 0)
     {
         printf("Wavpack error loading %s: %s\n", pSFD->path, errMsg);
-        return;
+        return nullptr;
     }
 
     AKSampleDataDescriptor sdd;
@@ -50,8 +50,9 @@ extern "C" void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescrip
     }
     WavpackCloseFile(wpc);
 
-    ((AKSamplerDSP*)pDSP)->loadSampleData(sdd);
+    AKSampleBuffer* pBuf = ((AKSamplerDSP*)pDSP)->loadSampleData(sdd);
     delete[] sdd.data;
+    return pBuf;
 }
 
 extern "C" void doAKSamplerUnloadAllSamples(AKDSPRef pDSP)

--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
@@ -106,7 +106,7 @@ void AKCoreSampler::deinit()
         data->keyMap[i].clear();
 }
 
-void AKCoreSampler::loadSampleData(AKSampleDataDescriptor& sdd)
+AKSampleBuffer* AKCoreSampler::loadSampleData(AKSampleDataDescriptor& sdd)
 {
     AudioKitCore::KeyMappedSampleBuffer *pBuf = new AudioKitCore::KeyMappedSampleBuffer();
     pBuf->minimumNoteNumber = sdd.sampleDescriptor.minimumNoteNumber;
@@ -142,6 +142,8 @@ void AKCoreSampler::loadSampleData(AKSampleDataDescriptor& sdd)
         if (sdd.sampleDescriptor.loopEndPoint > 1.0f) pBuf->loopEndPoint = sdd.sampleDescriptor.loopEndPoint;
         else pBuf->loopEndPoint = pBuf->endPoint * sdd.sampleDescriptor.loopEndPoint;
     }
+
+    return pBuf;
 }
 
 AudioKitCore::KeyMappedSampleBuffer *AKCoreSampler::lookupSample(unsigned noteNumber, unsigned velocity)

--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
@@ -41,7 +41,7 @@ public:
     void restartVoices();
     
     /// call to load samples
-    void loadSampleData(AKSampleDataDescriptor& sdd);
+    AKSampleBuffer* loadSampleData(AKSampleDataDescriptor& sdd);
     
     // after loading samples, call one of these to build the key map
     

--- a/AudioKit/Core/AudioKitCore/Sampler/AKSampler_Typedefs.h
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKSampler_Typedefs.h
@@ -42,3 +42,16 @@ typedef struct
     const char *path;
     
 } AKSampleFileDescriptor;
+
+typedef struct
+{
+    float *samples;
+    float sampleRate;
+    int channelCount;
+    int sampleCount;
+    float startPoint, endPoint;
+    bool isLooping;
+    float loopStartPoint, loopEndPoint;
+    float noteFrequency;
+
+} AKSampleBuffer;

--- a/AudioKit/Core/AudioKitCore/Sampler/SampleBuffer.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SampleBuffer.cpp
@@ -12,15 +12,15 @@ namespace AudioKitCore
 {
 
     SampleBuffer::SampleBuffer()
-    : samples(0)
-    , channelCount(0)
-    , sampleCount(0)
-    , startPoint(0.0f)
-    , endPoint(0.0f)
-    , isLooping(false)
-    , loopStartPoint(0.0f)
-    , loopEndPoint(0.0f)
     {
+        samples = 0;
+        channelCount = 0;
+        sampleCount = 0;
+        startPoint = 0.0f;
+        endPoint = 0.0f;
+        isLooping = false;
+        loopStartPoint = 0.0f;
+        loopEndPoint = 0.0f;
     }
     
     SampleBuffer::~SampleBuffer()

--- a/AudioKit/Core/AudioKitCore/Sampler/SampleBuffer.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SampleBuffer.hpp
@@ -7,23 +7,16 @@
 //
 
 #pragma once
+#include "AKSampler_Typedefs.h"
+
 namespace AudioKitCore
 {
 
     // SampleBuffer represents an array of sample data, which can be addressed with a real-valued
     // "index" via linear interpolation.
     
-    struct SampleBuffer
-    {
-        float *samples;
-        float sampleRate;
-        int channelCount;
-        int sampleCount;
-        float startPoint, endPoint;
-        bool isLooping;
-        float loopStartPoint, loopEndPoint;
-        float noteFrequency;
-        
+    struct SampleBuffer : public AKSampleBuffer
+    {        
         SampleBuffer();
         ~SampleBuffer();
         


### PR DESCRIPTION
AKSampler data-loading methods return a pointer to an AKSampleBuffer object, through which parameters like sample-start, -end, loop-start, loop-end etc. can be manipulated after loading the sample.