### PR TITLE
Allow paths with whitespaces for samples in SFZ loader

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler+SFZ.swift
@@ -73,7 +73,7 @@ extension AKSampler {
                         } else if part.hasPrefix("loop_end") {
                             loopEndPoint = Float32(part.components(separatedBy: "=")[1])!
                         } else if part.hasPrefix("sample") {
-                            sample = part.components(separatedBy: "sample=")[1]
+                            sample = trimmed.components(separatedBy: "sample=")[1]
                         }
                     }
 


### PR DESCRIPTION
The following SFZ line example (1):

`<region> loop_mode=loop_continuous loop_start=3510 loop_end=3984 sample=samples/Mizmar A-Sha3bi-1.wav `

Was incorrectly interpreted as:

`<region> loop_mode=loop_continuous loop_start=3510 loop_end=3984 sample=samples/Mizmar
`

This patch allows referencing samples with whitespaces in their paths (like 1).
