### PR TITLE
Improve documentation comments.

### DIFF
--- a/AudioKit/Common/User Interface/AKNodeOutputPlot.swift
+++ b/AudioKit/Common/User Interface/AKNodeOutputPlot.swift
@@ -13,6 +13,8 @@ extension Notification.Name {
 }
 
 /// Plot the output from any node in an signal processing graph
+///
+/// By default this plots the output of AudioKit.output
 @IBDesignable
 open class AKNodeOutputPlot: EZAudioPlot {
 
@@ -71,6 +73,8 @@ open class AKNodeOutputPlot: EZAudioPlot {
     internal var bufferSize: UInt32 = 1_024
 
     /// The node whose output to graph
+    ///
+    /// Defaults to AudioKit.output
     @objc open var node: AKNode? {
         willSet {
             pause()


### PR DESCRIPTION
Specify the behavior in a comment since it was confusing to me as a new user. (Note: in general I would avoid having defaults like this, to make the behavior explicit)