### PR TITLE
AKNodeRecorder crash fix.

### DIFF
--- a/AudioKit/Common/Internals/AKNodeRecorder.swift
+++ b/AudioKit/Common/Internals/AKNodeRecorder.swift
@@ -11,10 +11,7 @@ open class AKNodeRecorder: NSObject {
     // MARK: - Properties
 
     // The node we record from
-    fileprivate var node: AKNode?
-
-    // The file to record to
-    fileprivate var internalAudioFile: AKAudioFile
+    public private(set) var node: AKNode?
 
     /// True if we are recording.
     @objc public private(set) dynamic var isRecording = false
@@ -27,9 +24,6 @@ open class AKNodeRecorder: NSObject {
         return internalAudioFile.duration
     }
 
-    /// The bus to install the recording tap on. Default is 0.
-    open var bus: Int = 0
-
     /// If non-nil, attempts to apply this as the format of the specified output bus. This should
     /// only be done when attaching to an output bus which is not connected to another node; an
     /// error will result otherwise.
@@ -39,8 +33,14 @@ open class AKNodeRecorder: NSObject {
     /// Default is nil.
     open var recordFormat: AVAudioFormat?
 
+    // The file to record to
+    private var internalAudioFile: AKAudioFile
+
+    /// The bus to install the recording tap on. Default is 0.
+    private var bus: Int = 0
+
     /// Used for fixing recordings being truncated
-    fileprivate var recordBufferDuration: Double = 16_384 / AKSettings.sampleRate
+    private var recordBufferDuration: Double = 16_384 / AKSettings.sampleRate
 
     /// return the AKAudioFile for reading
     open var audioFile: AKAudioFile? {
@@ -48,8 +48,7 @@ open class AKNodeRecorder: NSObject {
             return try AKAudioFile(forReading: internalAudioFile.url)
 
         } catch let error as NSError {
-            AKLog("Cannot create internal audio file for reading")
-            AKLog("Error: \(error.localizedDescription)")
+            AKLog("Error, Cannot create internal audio file for reading: \(error.localizedDescription)")
             return nil
         }
     }
@@ -66,15 +65,14 @@ open class AKNodeRecorder: NSObject {
     ///   - file: Audio file to record to
     ///
     public init(node: AKNode? = AudioKit.output,
-                file: AKAudioFile? = nil) throws {
-        // AVAudioSession buffer setup
-
+                file: AKAudioFile? = nil,
+                bus: Int = 0) throws {
         guard let existingFile = file else {
             // We create a record file in temp directory
             do {
                 internalAudioFile = try AKAudioFile()
             } catch let error as NSError {
-                AKLog("AKNodeRecorder Error: Cannot create an empty audio file")
+                AKLog("Error: Cannot create an empty audio file")
                 throw error
             }
             self.node = node
@@ -86,10 +84,11 @@ open class AKNodeRecorder: NSObject {
             internalAudioFile = try AKAudioFile(forWriting: existingFile.url,
                                                 settings: existingFile.fileFormat.settings)
         } catch let error as NSError {
-            AKLog("AKNodeRecorder Error: cannot write to \(existingFile.fileNamePlusExtension)")
+            AKLog("Error: cannot write to \(existingFile.fileNamePlusExtension)")
             throw error
         }
 
+        self.bus = bus
         self.node = node
     }
 
@@ -98,12 +97,12 @@ open class AKNodeRecorder: NSObject {
     /// Start recording
     @objc open func record() throws {
         if isRecording == true {
-            AKLog("AKNodeRecorder Warning: already recording")
+            AKLog("Warning: already recording")
             return
         }
 
         guard let node = node else {
-            AKLog("AKNodeRecorder Error: input node is nil")
+            AKLog("Error: input node is nil")
             return
         }
 
@@ -111,7 +110,7 @@ open class AKNodeRecorder: NSObject {
         isRecording = true
 
         // Note: if you install a tap on a bus that already has a tap it will crash your application.
-        AKLog("AKNodeRecorder: recording using format", internalAudioFile.processingFormat.debugDescription)
+        AKLog("Recording using format", internalAudioFile.processingFormat.debugDescription)
 
         // note, format should be nil as per the documentation for installTap:
         // "If non-nil, attempts to apply this as the format of the specified output bus. This should
@@ -142,7 +141,7 @@ open class AKNodeRecorder: NSObject {
     /// Stop recording
     @objc open func stop() {
         if isRecording == false {
-            AKLog("AKNodeRecorder Warning: Cannot stop recording, already stopped")
+            AKLog("Warning: Cannot stop recording, already stopped")
             return
         }
 
@@ -153,7 +152,7 @@ open class AKNodeRecorder: NSObject {
             let delay = UInt32(recordBufferDuration * 1_000_000)
             usleep(delay)
         }
-        node?.avAudioUnitOrNode.removeTap(onBus: 0)
+        node?.avAudioUnitOrNode.removeTap(onBus: bus)
     }
 
     /// Reset the AKAudioFile to clear previous recordings
@@ -179,7 +178,7 @@ open class AKNodeRecorder: NSObject {
         // Creates a blank new file
         do {
             internalAudioFile = try AKAudioFile(forWriting: url, settings: settings)
-            AKLog("AKNodeRecorder: file has been cleared")
+            AKLog("File has been cleared")
         } catch let error as NSError {
             AKLog("Error: Can't record to", internalAudioFile.fileNamePlusExtension)
             throw error


### PR DESCRIPTION
fix for format crash. see notes in commit.

*** Terminating app due to uncaught exception 'com.apple.coreaudio.avfaudio', reason: '[[busArray objectAtIndexedSubscript:(NSUInteger)element] setFormat:format error:&nsErr]: returned false, error Error Domain=NSOSStatusErrorDomain Code=-10868 "(null)"'
terminating with uncaught exception of type NSException
abort() called