### PR TITLE
StopPlayingNotes moved around sequencer

### DIFF
--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerDSPKernel.hpp
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerDSPKernel.hpp
@@ -217,11 +217,15 @@ public:
     }
 
     void clear() {
+        stopPlayingNotes();
+        notes.clear();
+        events.clear();
+    }
+
+    void stopPlayingNotes() {
         while (playingNotes.size() > 0) {
             stopPlayingNote(playingNotes[0], 0, 0);
         }
-        notes.clear();
-        events.clear();
     }
 
     void sendMidiData(UInt8 status, UInt8 data1, UInt8 data2, double offset, double time) {

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerDSPKernel.hpp
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerDSPKernel.hpp
@@ -217,7 +217,6 @@ public:
     }
 
     void clear() {
-        stopPlayingNotes();
         notes.clear();
         events.clear();
     }

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngine.h
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngine.h
@@ -32,5 +32,6 @@ typedef void (^AKCCallback)(void);
 -(void)clear;
 -(void)rewind;
 -(void)seekTo:(double)seekPosition;
+-(void)stopPlayingNotes;
 
 @end

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngine.mm
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngine.mm
@@ -67,6 +67,9 @@
 -(void)clear {
     _kernel.clear();
 }
+-(void)stopPlayingNotes {
+    _kernel.stopPlayingNotes();
+}
 -(void)rewind {
 //    _kernel.rewind();
 }

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerTrack.swift
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerTrack.swift
@@ -132,4 +132,8 @@ open class AKSequencerTrack: AKNode, AKComponent {
     open func clear() {
         internalAU?.clear()
     }
+    
+    open func stopPlayingNotes() {
+        internalAU?.stopPlayingNotes()
+    }
 }


### PR DESCRIPTION
Adds 'stopPlayingNotes' function to sequencer. Moves this behaviour OUT of clear() function - use these functions together if that is the behaviour that you'd like