### PR TITLE
Restore oscmorph2d as extension to SP

### DIFF
--- a/AudioKit/Common/Internals/AKSoundpipeDSPBase.hpp
+++ b/AudioKit/Common/Internals/AKSoundpipeDSPBase.hpp
@@ -13,12 +13,14 @@
 #ifndef __cplusplus
 
 #include "soundpipe.h"
+#include "soundpipeextension.h"
 #include "vocwrapper.h"
 
 #else
 
 extern "C" {
 #include "soundpipe.h"
+#include "soundpipeextension.h"
 #include "vocwrapper.h"
 }
 

--- a/AudioKit/Common/Internals/AKSoundpipeKernel.hpp
+++ b/AudioKit/Common/Internals/AKSoundpipeKernel.hpp
@@ -11,6 +11,7 @@
 
 extern "C" {
 #include "soundpipe.h"
+#include "soundpipeextension.h"
 }
 
 #import "AKDSPKernel.hpp"

--- a/AudioKit/Core/SoundpipeExtension/modules/oscmorph2d.c
+++ b/AudioKit/Core/SoundpipeExtension/modules/oscmorph2d.c
@@ -1,0 +1,130 @@
+#include <stdlib.h>
+#include <math.h>
+#include "soundpipeextension.h"
+
+int sp_oscmorph2d_create(sp_oscmorph2d **p)
+{
+    *p = malloc(sizeof(sp_oscmorph2d));
+    return SP_OK;
+}
+
+int sp_oscmorph2d_destroy(sp_oscmorph2d **p)
+{
+    free(*p);
+    return SP_OK;
+}
+
+int sp_oscmorph2d_init(sp_data *sp, sp_oscmorph2d *osc, sp_ftbl **ft, int nft, int nbl, float *fbls, SPFLOAT iphs)
+{
+    int i;
+    osc->freq = 440.0;
+    osc->amp = 0.2;
+    osc->tbl = ft;
+    osc->iphs = fabs(iphs); //iphs: initial phase
+    osc->inc = 0;
+    osc->lphs = ((int32_t)(osc->iphs * SP_FT_MAXLEN)) & SP_FT_PHMASK; //lphs: last phase (this is an incremental value, so it is used to create the current phase)
+    osc->wtpos = 0.0;
+    osc->nft = nft; // number of waveforms 4
+    osc->nbl = nbl; // number of bandlimits 13
+
+    uint32_t prev = (uint32_t)ft[0]->size;
+    for(i = 0; i < nft * nbl; i++) {
+        if(prev != ft[i]->size) {
+            fprintf(stderr, "sp_oscmorph2d: size mismatch\n");
+            return SP_NOT_OK;
+        }
+        prev = (uint32_t)ft[i]->size;
+    }
+
+    osc->fbl = fbls;
+    float fblMin = fbls[0];
+    for(i = 0; i < nbl - 1; i++) {
+        if(fblMin > fbls[i + 1]) {
+            fprintf(stderr, "sp_oscmorph2d: fbl must be in increasing order: %f, %f\n",fblMin,fbls[i + 1]);
+            return SP_NOT_OK;
+        }
+        fblMin = fbls[i];
+    }
+
+    osc->enableBandlimit = 0;
+    osc->bandlimitIndexOverride = -1;
+
+    return SP_OK;
+}
+
+int sp_oscmorph2d_compute(sp_data *sp, sp_oscmorph2d *osc, SPFLOAT *in, SPFLOAT *out)
+{
+    sp_ftbl *ftp1;
+    SPFLOAT amp, cps, fract, v1, v2;
+    SPFLOAT *ft1, *ft2;
+    int32_t phs, lobits, pos;
+    SPFLOAT sicvt = osc->tbl[0]->sicvt; /* sicvt: this stands for Sampling Increment ConVert */
+    const int enableBandlimit = osc->enableBandlimit;
+    int bandlimitIndexOverride = osc->bandlimitIndexOverride;
+
+    int32_t bandlimitIndex = 0;
+    if (enableBandlimit > 0) {
+        if (bandlimitIndexOverride < 0) {
+            /* do not use override */
+            for(int i = 1; i < osc->nbl; i++) {
+                if(osc->freq <= osc->fbl[i]) {
+                    bandlimitIndex = i;
+                    break;
+                }
+            }
+        } else {
+            /* the override is the index */
+            bandlimitIndex = floor(bandlimitIndexOverride);
+            if (bandlimitIndex < 0)
+                bandlimitIndex = 0;
+        }
+    } else {
+        /* hard-code the "non-bandlimited" row of wavetables */
+        bandlimitIndex = 0;
+    }
+
+    /* Use only the fractional part of the position or 1 */
+    if (osc->wtpos > 1.0) {
+        osc->wtpos -= (int)osc->wtpos;
+    }
+    
+    const SPFLOAT findex = (bandlimitIndex * osc->nft) + osc->wtpos * (osc->nft - 1);
+    const int index = floor(findex);
+    const SPFLOAT wtfrac = findex - index;
+
+    lobits = osc->tbl[index]->lobits;
+    amp = osc->amp;
+    cps = osc->freq;
+    phs = osc->lphs;
+    ftp1 = osc->tbl[index];
+    ft1 = osc->tbl[index]->tbl;
+
+    if(index >= (bandlimitIndex * osc->nft) + (osc->nft - 1)) {
+        ft2 = ft1;
+    } else {
+        ft2 = osc->tbl[index + 1]->tbl;
+    }
+    
+    osc->inc = (int32_t)lrintf(cps * sicvt);  
+
+    fract = ((phs) & ftp1->lomask) * ftp1->lodiv;
+
+    pos = phs >> lobits;
+
+    v1 = (1 - wtfrac) * 
+        *(ft1 + pos) + 
+        wtfrac * 
+        *(ft2 + pos);
+    v2 = (1 - wtfrac) * 
+        *(ft1 + ((pos + 1) % ftp1->size))+ 
+        wtfrac * 
+        *(ft2 + ((pos + 1) % ftp1->size));
+
+    *out = (v1 + (v2 - v1) * fract) * amp;
+
+    phs += osc->inc;
+    phs &= SP_FT_PHMASK;
+
+    osc->lphs = phs;
+    return SP_OK;
+}

--- a/AudioKit/Core/SoundpipeExtension/soundpipeextension.h
+++ b/AudioKit/Core/SoundpipeExtension/soundpipeextension.h
@@ -1,0 +1,25 @@
+#ifndef SOUNDPIPEEXTENSION_H
+#define SOUNDPIPEEXTENSION_H
+#include "soundpipe.h"
+
+// Extension of Soundpipe library specific to AK
+
+typedef struct {
+    SPFLOAT freq, amp, iphs;
+    int32_t lphs;
+    sp_ftbl **tbl;
+    int inc;
+    SPFLOAT wtpos;
+    int nft; // number of waveforms
+    int nbl; // number of bandlimited tables per waveform
+    float *fbl; // array of frequencies per bandlimited waveform
+    int enableBandlimit; // if 0 use index 0, if 1 select index based on freq
+    int bandlimitIndexOverride; // temporary
+} sp_oscmorph2d;
+
+int sp_oscmorph2d_create(sp_oscmorph2d **p);
+int sp_oscmorph2d_destroy(sp_oscmorph2d **p);
+int sp_oscmorph2d_init(sp_data *sp, sp_oscmorph2d *osc, sp_ftbl **ft, int nft, int nbl, float *fbls, SPFLOAT iphs);
+int sp_oscmorph2d_compute(sp_data *sp, sp_oscmorph2d *p, SPFLOAT *in, SPFLOAT *out);
+
+#endif

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		55E4F5221F57CB540088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5201F57CB540088018A /* AKSamplerMetronome.m */; };
 		55F29C091E90654C00A2151F /* AKScheduledAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F29C081E90654C00A2151F /* AKScheduledAction.swift */; };
 		6520FFC21D361B030052410C /* resonantFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6520FFC11D361B030052410C /* resonantFilter.swift */; };
+		69E269462320234B00861150 /* soundpipeextension.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E269452320234B00861150 /* soundpipeextension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69E26949232023BE00861150 /* oscmorph2d.c in Sources */ = {isa = PBXBuildFile; fileRef = 69E26948232023BE00861150 /* oscmorph2d.c */; };
 		898DED261C6944430026FCC3 /* AKVariSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898DED251C6944430026FCC3 /* AKVariSpeed.swift */; };
 		8D0E46581D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0E46561D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift */; };
 		8D0E46591D3827970000CCF8 /* AKAudioFile+Peripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0E46571D3827970000CCF8 /* AKAudioFile+Peripherals.swift */; };
@@ -1304,6 +1306,8 @@
 		55E4F5201F57CB540088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSamplerMetronome.m; sourceTree = "<group>"; };
 		55F29C081E90654C00A2151F /* AKScheduledAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKScheduledAction.swift; sourceTree = "<group>"; };
 		6520FFC11D361B030052410C /* resonantFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = resonantFilter.swift; sourceTree = "<group>"; };
+		69E269452320234B00861150 /* soundpipeextension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = soundpipeextension.h; sourceTree = "<group>"; };
+		69E26948232023BE00861150 /* oscmorph2d.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = oscmorph2d.c; sourceTree = "<group>"; };
 		701E04851F1B7CB500A7A2D8 /* AKRotaryKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKRotaryKnob.swift; sourceTree = "<group>"; };
 		898DED251C6944430026FCC3 /* AKVariSpeed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKVariSpeed.swift; sourceTree = "<group>"; };
 		8D0E46561D3827970000CCF8 /* AKAudioFile+ProcessingAsynchronously.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKAudioFile+ProcessingAsynchronously.swift"; sourceTree = "<group>"; };
@@ -2699,6 +2703,23 @@
 				55B95B2C1FEDBFA800C76AF5 /* AKInterop.h */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		69E269442320234B00861150 /* SoundpipeExtension */ = {
+			isa = PBXGroup;
+			children = (
+				69E26947232023BE00861150 /* modules */,
+				69E269452320234B00861150 /* soundpipeextension.h */,
+			);
+			path = SoundpipeExtension;
+			sourceTree = "<group>";
+		};
+		69E26947232023BE00861150 /* modules */ = {
+			isa = PBXGroup;
+			children = (
+				69E26948232023BE00861150 /* oscmorph2d.c */,
+			);
+			path = modules;
 			sourceTree = "<group>";
 		};
 		B1468E1820D023460030BA66 /* Player */ = {
@@ -4235,6 +4256,7 @@
 				C49B138B204A06B7009C7C8E /* README.md */,
 				3404A78120507B1500A2C9E4 /* AudioKitCore */,
 				C49B1149204A06B6009C7C8E /* Soundpipe */,
+				69E269442320234B00861150 /* SoundpipeExtension */,
 				C49B11E2204A06B6009C7C8E /* Devoloop */,
 				C49B120C204A06B6009C7C8E /* Sporth */,
 				C49B12A7204A06B6009C7C8E /* STK */,
@@ -5541,6 +5563,7 @@
 				34BB674A205AC238000E5450 /* wavpack_local.h in Headers */,
 				C433230A1FE05F0200330AEC /* TPCircularBuffer+Unit.h in Headers */,
 				C49B1584204A06B8009C7C8E /* Socket.h in Headers */,
+				69E269462320234B00861150 /* soundpipeextension.h in Headers */,
 				C49B139D204A06B7009C7C8E /* kiss_fftr.h in Headers */,
 				C44EA2562018704D0072399F /* AKPhaserDSP.hpp in Headers */,
 				C49B139B204A06B7009C7C8E /* kiss_fft.h in Headers */,
@@ -5870,6 +5893,7 @@
 				34BB6743205AC238000E5450 /* unpack_dsd.c in Sources */,
 				C4077AE92008733A00E5923C /* AKBandRejectButterworthFilterAudioUnit.swift in Sources */,
 				FEB3AB2F22DFE06B0080A5CB /* AKMusicTrack+Events.swift in Sources */,
+				69E26949232023BE00861150 /* oscmorph2d.c in Sources */,
 				C539CCC821F823B10096AF95 /* AKMIDIClockListener.swift in Sources */,
 				C40831CD202848FD00F7153D /* AKLowShelfParametricEqualizerFilterDSP.mm in Sources */,
 				C49B13FE204A06B7009C7C8E /* port.c in Sources */,

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		55B95B331FEDC34F00C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B321FEDC34700C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5291F57DAC30088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F5271F57DAC30088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F52A1F57DAC30088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5281F57DAC30088018A /* AKSamplerMetronome.m */; };
+		69E2694E232025E700861150 /* soundpipeextension.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E2694B232025E700861150 /* soundpipeextension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69E2694F232025E700861150 /* oscmorph2d.c in Sources */ = {isa = PBXBuildFile; fileRef = 69E2694D232025E700861150 /* oscmorph2d.c */; };
 		A8E996F41EB9212600116ADA /* AKTuningTable+Brun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E996F31EB9212600116ADA /* AKTuningTable+Brun.swift */; };
 		B10CC6AE201C0A5300B0B9B9 /* AKExponentialParameterRamp.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B10CC6AD201C0A5200B0B9B9 /* AKExponentialParameterRamp.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1468E1D20D025E40030BA66 /* AKDynamicPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1468E1C20D025E40030BA66 /* AKDynamicPlayer.swift */; };
@@ -1287,6 +1289,8 @@
 		55B95B321FEDC34700C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F5271F57DAC30088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AKSamplerMetronome.h; path = ../AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5281F57DAC30088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AKSamplerMetronome.m; path = ../AKSamplerMetronome.m; sourceTree = "<group>"; };
+		69E2694B232025E700861150 /* soundpipeextension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = soundpipeextension.h; sourceTree = "<group>"; };
+		69E2694D232025E700861150 /* oscmorph2d.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = oscmorph2d.c; sourceTree = "<group>"; };
 		7078DE4C1F260A3600F1DC67 /* AKRotaryKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKRotaryKnob.swift; sourceTree = "<group>"; };
 		A8E996F31EB9212600116ADA /* AKTuningTable+Brun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Brun.swift"; sourceTree = "<group>"; };
 		B10CC6AD201C0A5200B0B9B9 /* AKExponentialParameterRamp.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKExponentialParameterRamp.hpp; sourceTree = "<group>"; };
@@ -2652,6 +2656,23 @@
 				55B95B321FEDC34700C76AF5 /* AKInterop.h */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		69E2694A232025E700861150 /* SoundpipeExtension */ = {
+			isa = PBXGroup;
+			children = (
+				69E2694B232025E700861150 /* soundpipeextension.h */,
+				69E2694C232025E700861150 /* modules */,
+			);
+			path = SoundpipeExtension;
+			sourceTree = "<group>";
+		};
+		69E2694C232025E700861150 /* modules */ = {
+			isa = PBXGroup;
+			children = (
+				69E2694D232025E700861150 /* oscmorph2d.c */,
+			);
+			path = modules;
 			sourceTree = "<group>";
 		};
 		B1468E1720D022FD0030BA66 /* Player */ = {
@@ -4370,6 +4391,7 @@
 				C49B1803204A0AD0009C7C8E /* README.md */,
 				3404A77E205064FD00A2C9E4 /* AudioKitCore */,
 				C49B165B204A0ACF009C7C8E /* Devoloop */,
+				69E2694A232025E700861150 /* SoundpipeExtension */,
 				C49B15C4204A0ACF009C7C8E /* Soundpipe */,
 				C49B1685204A0ACF009C7C8E /* Sporth */,
 				C49B171F204A0ACF009C7C8E /* STK */,
@@ -5351,6 +5373,7 @@
 				C49B18A3204A0AD1009C7C8E /* FFTRealFixLenParam.h in Headers */,
 				EADFC4392151088D003E5191 /* AKCoreSynth.hpp in Headers */,
 				C4B65F83200C518B0074FB93 /* AKClarinetDSP.hpp in Headers */,
+				69E2694E232025E700861150 /* soundpipeextension.h in Headers */,
 				C49B18AA204A0AD1009C7C8E /* FFTRealFixLen.hpp in Headers */,
 				55E4F5291F57DAC30088018A /* AKSamplerMetronome.h in Headers */,
 				C49B1B17204A0C48009C7C8E /* PitShift.h in Headers */,
@@ -5798,6 +5821,7 @@
 				34BB66DC205ABBC0000E5450 /* unpack3.c in Sources */,
 				C49B1852204A0AD0009C7C8E /* base.c in Sources */,
 				C45669BC1D448D7E00D26565 /* AKParameter.swift in Sources */,
+				69E2694F232025E700861150 /* oscmorph2d.c in Sources */,
 				C49B1934204A0AD1009C7C8E /* load.c in Sources */,
 				C49B18E6204A0AD1009C7C8E /* wpkorg35.c in Sources */,
 				C4812B052028556D00D4AFB1 /* AKChowningReverbDSP.mm in Sources */,

--- a/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
+++ b/AudioKit/tvOS/AudioKit For tvOS.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		55B95B351FEDC37600C76AF5 /* AKInterop.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B95B341FEDC37100C76AF5 /* AKInterop.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5321F57DB2D0088018A /* AKSamplerMetronome.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E4F5301F57DB2D0088018A /* AKSamplerMetronome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55E4F5331F57DB2D0088018A /* AKSamplerMetronome.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E4F5311F57DB2D0088018A /* AKSamplerMetronome.m */; };
+		69E269542320262900861150 /* soundpipeextension.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E269512320262900861150 /* soundpipeextension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69E269552320262900861150 /* oscmorph2d.c in Sources */ = {isa = PBXBuildFile; fileRef = 69E269532320262900861150 /* oscmorph2d.c */; };
 		A8E996F61EB921D100116ADA /* AKTuningTable+Brun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E996F51EB921D100116ADA /* AKTuningTable+Brun.swift */; };
 		B12B88A9201C1B65008F196D /* AKExponentialParameterRamp.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B12B88A8201C1B65008F196D /* AKExponentialParameterRamp.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1468E3C20D070450030BA66 /* AKPlayer+Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1468E3620D070430030BA66 /* AKPlayer+Playback.swift */; };
@@ -1156,6 +1158,8 @@
 		55B95B341FEDC37100C76AF5 /* AKInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AKInterop.h; sourceTree = "<group>"; };
 		55E4F5301F57DB2D0088018A /* AKSamplerMetronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AKSamplerMetronome.h; path = Playback/AKSamplerMetronome.h; sourceTree = "<group>"; };
 		55E4F5311F57DB2D0088018A /* AKSamplerMetronome.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AKSamplerMetronome.m; path = Playback/AKSamplerMetronome.m; sourceTree = "<group>"; };
+		69E269512320262900861150 /* soundpipeextension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = soundpipeextension.h; sourceTree = "<group>"; };
+		69E269532320262900861150 /* oscmorph2d.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = oscmorph2d.c; sourceTree = "<group>"; };
 		A8E996F51EB921D100116ADA /* AKTuningTable+Brun.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKTuningTable+Brun.swift"; sourceTree = "<group>"; };
 		B12B88A8201C1B65008F196D /* AKExponentialParameterRamp.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AKExponentialParameterRamp.hpp; sourceTree = "<group>"; };
 		B1468E3620D070430030BA66 /* AKPlayer+Playback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AKPlayer+Playback.swift"; sourceTree = "<group>"; };
@@ -2410,6 +2414,23 @@
 			name = Metronome;
 			sourceTree = "<group>";
 		};
+		69E269502320262900861150 /* SoundpipeExtension */ = {
+			isa = PBXGroup;
+			children = (
+				69E269512320262900861150 /* soundpipeextension.h */,
+				69E269522320262900861150 /* modules */,
+			);
+			path = SoundpipeExtension;
+			sourceTree = "<group>";
+		};
+		69E269522320262900861150 /* modules */ = {
+			isa = PBXGroup;
+			children = (
+				69E269532320262900861150 /* oscmorph2d.c */,
+			);
+			path = modules;
+			sourceTree = "<group>";
+		};
 		B1468E1B20D023E20030BA66 /* Player */ = {
 			isa = PBXGroup;
 			children = (
@@ -3569,6 +3590,7 @@
 				34F5A362205ED22C00290001 /* AudioKitCore */,
 				C49B1C27204A0CF8009C7C8E /* Devoloop */,
 				C49B1DCF204A0CF9009C7C8E /* README.md */,
+				69E269502320262900861150 /* SoundpipeExtension */,
 				C49B1B90204A0CF8009C7C8E /* Soundpipe */,
 				C49B1C51204A0CF8009C7C8E /* Sporth */,
 				C49B1CEB204A0CF9009C7C8E /* STK */,
@@ -4985,6 +5007,7 @@
 				55E4F5321F57DB2D0088018A /* AKSamplerMetronome.h in Headers */,
 				C49B1E5E204A0CFA009C7C8E /* DelayAPF.h in Headers */,
 				C470D06E20174B1C003D1AFA /* AKVocalTractDSP.hpp in Headers */,
+				69E269542320262900861150 /* soundpipeextension.h in Headers */,
 				C49B20BA204A0D57009C7C8E /* FreeVerb.h in Headers */,
 				C49B20F6204A0D57009C7C8E /* InetWvOut.h in Headers */,
 				C49B2109204A0D57009C7C8E /* ADSR.h in Headers */,
@@ -5537,6 +5560,7 @@
 				C49DCD611D2100BF00BF018A /* AKPWMOscillator.swift in Sources */,
 				C470CFDD20174921003D1AFA /* AKModalResonanceFilterAudioUnit.swift in Sources */,
 				555857ED1F6218A000C73F59 /* AKClipPlayer.swift in Sources */,
+				69E269552320262900861150 /* oscmorph2d.c in Sources */,
 				C49B1E25204A0CFA009C7C8E /* padsynth.c in Sources */,
 				C40C42351C40E5C2009D870B /* EZRecorder.m in Sources */,
 				C433232A1FE05FC800330AEC /* AKTimeline.c in Sources */,


### PR DESCRIPTION
Restore oscmorph2d as it has been lost during an update
to Soundpipe. Ensure this does not happen again, by adding
our custom additions to an extension directory.

ping @aure @marcussatellite 


