### PR TITLE
Add SwiftUI Drum Pads Example

### DIFF
--- a/Examples/iOS/Drums/Drums.xcodeproj/project.pbxproj
+++ b/Examples/iOS/Drums/Drums.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-all_load",
+					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.Drums;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI.xcodeproj/project.pbxproj
@@ -1,0 +1,373 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		69B7F0C023294D7A00F16443 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7F0BF23294D7A00F16443 /* AppDelegate.swift */; };
+		69B7F0C223294D7A00F16443 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7F0C123294D7A00F16443 /* SceneDelegate.swift */; };
+		69B7F0C423294D7A00F16443 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7F0C323294D7A00F16443 /* ContentView.swift */; };
+		69B7F0C623294D7C00F16443 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 69B7F0C523294D7C00F16443 /* Assets.xcassets */; };
+		69B7F0C923294D7C00F16443 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 69B7F0C823294D7C00F16443 /* Preview Assets.xcassets */; };
+		69B7F0CC23294D7D00F16443 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 69B7F0CA23294D7D00F16443 /* LaunchScreen.storyboard */; };
+		69B7F107232954B800F16443 /* Conductor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7F106232954B800F16443 /* Conductor.swift */; };
+		69B7F10A2329595800F16443 /* Samples in Resources */ = {isa = PBXBuildFile; fileRef = 69B7F1092329595800F16443 /* Samples */; };
+		69BE382F23297AC000090E1D /* AudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69BE382D23297AC000090E1D /* AudioKit.framework */; };
+		69BE383023297AC000090E1D /* AudioKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69BE382E23297AC000090E1D /* AudioKitUI.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		69B7F0BC23294D7A00F16443 /* DrumsSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrumsSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		69B7F0BF23294D7A00F16443 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		69B7F0C123294D7A00F16443 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		69B7F0C323294D7A00F16443 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		69B7F0C523294D7C00F16443 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		69B7F0C823294D7C00F16443 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		69B7F0CB23294D7D00F16443 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		69B7F0CD23294D7D00F16443 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		69B7F106232954B800F16443 /* Conductor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Conductor.swift; sourceTree = "<group>"; };
+		69B7F1092329595800F16443 /* Samples */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Samples; path = ../../../../../Playgrounds/AudioKitPlaygrounds/Playgrounds/Playback.playground/Resources/Samples; sourceTree = "<group>"; };
+		69BE382D23297AC000090E1D /* AudioKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioKit.framework; path = "../../../../../../../Downloads/AudioKit-iOS/AudioKit.framework"; sourceTree = "<group>"; };
+		69BE382E23297AC000090E1D /* AudioKitUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioKitUI.framework; path = "../../../../../../../Downloads/AudioKit-iOS/AudioKitUI.framework"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		69B7F0B923294D7A00F16443 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				69BE383023297AC000090E1D /* AudioKitUI.framework in Frameworks */,
+				69BE382F23297AC000090E1D /* AudioKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		69B7F0B323294D7A00F16443 = {
+			isa = PBXGroup;
+			children = (
+				69B7F0BE23294D7A00F16443 /* DrumsSwiftUI */,
+				69B7F0BD23294D7A00F16443 /* Products */,
+				69B7F1012329549300F16443 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		69B7F0BD23294D7A00F16443 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				69B7F0BC23294D7A00F16443 /* DrumsSwiftUI.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		69B7F0BE23294D7A00F16443 /* DrumsSwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				69B7F1092329595800F16443 /* Samples */,
+				69B7F0BF23294D7A00F16443 /* AppDelegate.swift */,
+				69B7F0C123294D7A00F16443 /* SceneDelegate.swift */,
+				69B7F106232954B800F16443 /* Conductor.swift */,
+				69B7F0C323294D7A00F16443 /* ContentView.swift */,
+				69B7F0C523294D7C00F16443 /* Assets.xcassets */,
+				69B7F0CA23294D7D00F16443 /* LaunchScreen.storyboard */,
+				69B7F0CD23294D7D00F16443 /* Info.plist */,
+				69B7F0C723294D7C00F16443 /* Preview Content */,
+			);
+			path = DrumsSwiftUI;
+			sourceTree = "<group>";
+		};
+		69B7F0C723294D7C00F16443 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				69B7F0C823294D7C00F16443 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		69B7F1012329549300F16443 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				69BE382D23297AC000090E1D /* AudioKit.framework */,
+				69BE382E23297AC000090E1D /* AudioKitUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		69B7F0BB23294D7A00F16443 /* DrumsSwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 69B7F0D023294D7D00F16443 /* Build configuration list for PBXNativeTarget "DrumsSwiftUI" */;
+			buildPhases = (
+				69B7F0B823294D7A00F16443 /* Sources */,
+				69B7F0B923294D7A00F16443 /* Frameworks */,
+				69B7F0BA23294D7A00F16443 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DrumsSwiftUI;
+			productName = DrumsSwiftUI;
+			productReference = 69B7F0BC23294D7A00F16443 /* DrumsSwiftUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		69B7F0B423294D7A00F16443 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1100;
+				ORGANIZATIONNAME = "Matthias Frick";
+				TargetAttributes = {
+					69B7F0BB23294D7A00F16443 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+				};
+			};
+			buildConfigurationList = 69B7F0B723294D7A00F16443 /* Build configuration list for PBXProject "DrumsSwiftUI" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 69B7F0B323294D7A00F16443;
+			productRefGroup = 69B7F0BD23294D7A00F16443 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				69B7F0BB23294D7A00F16443 /* DrumsSwiftUI */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		69B7F0BA23294D7A00F16443 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				69B7F10A2329595800F16443 /* Samples in Resources */,
+				69B7F0CC23294D7D00F16443 /* LaunchScreen.storyboard in Resources */,
+				69B7F0C923294D7C00F16443 /* Preview Assets.xcassets in Resources */,
+				69B7F0C623294D7C00F16443 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		69B7F0B823294D7A00F16443 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				69B7F0C023294D7A00F16443 /* AppDelegate.swift in Sources */,
+				69B7F0C223294D7A00F16443 /* SceneDelegate.swift in Sources */,
+				69B7F0C423294D7A00F16443 /* ContentView.swift in Sources */,
+				69B7F107232954B800F16443 /* Conductor.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		69B7F0CA23294D7D00F16443 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				69B7F0CB23294D7D00F16443 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		69B7F0CE23294D7D00F16443 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		69B7F0CF23294D7D00F16443 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		69B7F0D123294D7D00F16443 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"DrumsSwiftUI/Preview Content\"";
+				DEVELOPMENT_TEAM = 9W69ZP8S5F;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = DrumsSwiftUI/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = "-lc++";
+				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.DrumsSwiftUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		69B7F0D223294D7D00F16443 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"DrumsSwiftUI/Preview Content\"";
+				DEVELOPMENT_TEAM = 9W69ZP8S5F;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = DrumsSwiftUI/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = "-lc++";
+				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.DrumsSwiftUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		69B7F0B723294D7A00F16443 /* Build configuration list for PBXProject "DrumsSwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				69B7F0CE23294D7D00F16443 /* Debug */,
+				69B7F0CF23294D7D00F16443 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		69B7F0D023294D7D00F16443 /* Build configuration list for PBXNativeTarget "DrumsSwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				69B7F0D123294D7D00F16443 /* Debug */,
+				69B7F0D223294D7D00F16443 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 69B7F0B423294D7A00F16443 /* Project object */;
+}

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/AppDelegate.swift
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  DrumsSwiftUI
+//
+//  Created by Matthias Frick on 11/09/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  func application(_ application: UIApplication,
+                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
+
+  // MARK: UISceneSession Lifecycle
+
+  func application(_ application: UIApplication,
+                   configurationForConnecting connectingSceneSession: UISceneSession,
+                   options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after
+    // application:didFinishLaunchingWithOptions.
+    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+  }
+}

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Assets.xcassets/Contents.json
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Conductor.swift
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Conductor.swift
@@ -1,0 +1,70 @@
+//
+//  Conductor.swift
+//  DrumsSwiftUI
+//
+//  Created by Matthias Frick on 11/09/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import AudioKit
+import Combine
+
+struct DrumSample {
+    var fileName: String
+    var midiNote: Int
+    var audioFile: AKAudioFile?
+
+    init(_ sampleFileName: String, note: Int) {
+        fileName = sampleFileName
+        midiNote = note
+        do {
+            audioFile = try AKAudioFile(readFileName: fileName)
+        } catch {
+            AKLog("Could not load: $fileName")
+        }
+    }
+}
+
+class Conductor: ObservableObject {
+    // Mark Published so View updates label on changes
+    @Published private(set) var lastPlayed: String = "None"
+
+    let drumSamplesFiles: [DrumSample] =
+    [
+        DrumSample("Samples/Drums/bass_drum_C1.wav", note: 24),
+        DrumSample("Samples/Drums/closed_hi_hat_F#1.wav", note: 26),
+        DrumSample("Samples/Drums/hi_tom_D2.wav", note: 30),
+        DrumSample("Samples/Drums/lo_tom_F1.wav", note: 34),
+        DrumSample("Samples/Drums/mid_tom_B1.wav", note: 29),
+        DrumSample("Samples/Drums/open_hi_hat_A#1.wav", note: 35),
+        DrumSample("Samples/Drums/snare_D1.wav", note: 24),
+        DrumSample("Samples/Drums/bass_drum_C1.wav", note: 38),
+        DrumSample("Samples/Drums/bass_drum_C1.wav", note: 24)
+    ]
+
+    let drums = AKAppleSampler()
+
+    func playPad(padNumber: Int) {
+        try? drums.play(noteNumber: MIDINoteNumber(drumSamplesFiles[padNumber].midiNote))
+        let fileName = drumSamplesFiles[padNumber].fileName
+        lastPlayed = fileName.components(separatedBy: "/").last!
+    }
+
+    init() {
+        AudioKit.output = drums
+        do {
+            try AudioKit.start()
+        } catch {
+            AKLog("AudioKit did not start!")
+        }
+        do {
+          let files = drumSamplesFiles.map {
+            $0.audioFile!
+          }
+          try drums.loadAudioFiles(files)
+
+        } catch {
+            AKLog("Files Didn't Load")
+        }
+    }
+}

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/ContentView.swift
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/ContentView.swift
@@ -1,0 +1,75 @@
+//
+//  ContentView.swift
+//  DrumsSwiftUI
+//
+//  Created by Matthias Frick on 11/09/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import SwiftUI
+
+struct PadsView: View {
+    @EnvironmentObject var conductor: Conductor
+
+    var body: some View {
+        VStack(spacing: 2) {
+            ForEach((0...2).reversed(), id: \.self) { row in
+                HStack(spacing: 2) {
+                  ForEach((0..<3), id: \.self) { column in
+                      Button(action: {
+                          self.conductor.playPad(padNumber: getPadId(row: row, column: column))
+                      }) {
+                          ZStack {
+                              Rectangle()
+                                .fill(Color.black)
+                                .aspectRatio(contentMode: .fit)
+                              Text(String(getPadId(row: row, column: column))).foregroundColor(.white)
+                          }
+                      }
+                  }
+                }
+            }
+        }
+    }
+}
+
+struct TopView: View {
+    @EnvironmentObject var conductor: Conductor
+
+    var body: some View {
+        VStack {
+            Spacer()
+            Text("AudioKit Drum Pads").font(.system(size: 20)).fontWeight(.bold)
+            Spacer()
+            Text("Last played Sample").fontWeight(.bold)
+            Text(conductor.lastPlayed)
+            Spacer().fixedSize(horizontal: false, vertical: true)
+              .frame(width: 0, height: 40, alignment: .bottom)
+        }
+    }
+}
+
+struct ContentView: View {
+
+    var body: some View {
+        VStack(spacing: 2) {
+          TopView()
+          PadsView()
+          Spacer().fixedSize().frame(minWidth: 0, maxWidth: .infinity,
+                                     minHeight: 0, maxHeight: 5, alignment: .topLeading)
+        }
+    }
+}
+
+private func getPadId(row: Int, column: Int) -> Int {
+    return (row * 3) + column
+}
+
+// Disable Previews because of HoundCI on AudioKit Repo
+// Underscore violation
+
+//struct ContentView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ContentView()
+//    }
+//}

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Info.plist
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/SceneDelegate.swift
+++ b/Examples/iOS/DrumsSwiftUI/DrumsSwiftUI/DrumsSwiftUI/SceneDelegate.swift
@@ -1,0 +1,64 @@
+//
+//  SceneDelegate.swift
+//  DrumsSwiftUI
+//
+//  Created by Matthias Frick on 11/09/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  let conductor = Conductor()
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession,
+             options connectionOptions: UIScene.ConnectionOptions) {
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new
+    // (see `application:configurationForConnectingSceneSession` instead).
+
+    // Create the SwiftUI view that provides the window contents.
+    // Pass in the AudioKit Conductor as Environment Variable
+    let contentView = ContentView().environmentObject(conductor)
+
+    // Use a UIHostingController as window root view controller.
+    if let windowScene = scene as? UIWindowScene {
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = UIHostingController(rootView: contentView)
+        self.window = window
+        window.makeKeyAndVisible()
+    }
+  }
+
+  func sceneDidDisconnect(_ scene: UIScene) {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not neccessarily discarded
+    // (see `application:didDiscardSceneSessions` instead).
+  }
+
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+  }
+
+  func sceneWillResignActive(_ scene: UIScene) {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+  }
+
+  func sceneWillEnterForeground(_ scene: UIScene) {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+  }
+
+  func sceneDidEnterBackground(_ scene: UIScene) {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+  }
+}


### PR DESCRIPTION
Add an Example on how to use Drum Pads with the
AudioKit AUSampler from within SwiftUI.

Obviously required XCode 11 and a more recent AudioKit Version than the one currently available (compiled with XCode 11 / recent Swift version).

![Screenshot 2019-09-11 at 20 59 18](https://user-images.githubusercontent.com/5174440/64726483-0ba60e80-d4d7-11e9-827d-364d41145d61.png)
