### PR TITLE
Add iOS 13 setting setAllowHapticsAndSystemSoundsDuringRecording

### DIFF
--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -80,7 +80,6 @@ open class AKSettings: NSObject {
         didSet {
             if #available(iOS 13.0, *) {
                 do {
-                    print("allow them haptics")
                     try AVAudioSession.sharedInstance().setAllowHapticsAndSystemSoundsDuringRecording(allowHapticsAndSystemSoundsDuringRecording)
                 } catch {
                     print(error)
@@ -268,7 +267,7 @@ extension AKSettings {
             if #available(iOS 13.0, *) {
                 try session.setAllowHapticsAndSystemSoundsDuringRecording(allowHapticsAndSystemSoundsDuringRecording)
             }
-        }  catch {
+        } catch {
             AKLog("Error: Cannot set allowHapticsAndSystemSoundsDuringRecording", error)
         }
 

--- a/AudioKit/Common/Internals/AKSettings.swift
+++ b/AudioKit/Common/Internals/AKSettings.swift
@@ -74,6 +74,22 @@ open class AKSettings: NSObject {
         }
     }
 
+    #if !os(macOS)
+    /// Whether haptics and system sounds are muted while a microhpone is setup or recording is active
+    @objc public static var allowHapticsAndSystemSoundsDuringRecording: Bool = false {
+        didSet {
+            if #available(iOS 13.0, *) {
+                do {
+                    print("allow them haptics")
+                    try AVAudioSession.sharedInstance().setAllowHapticsAndSystemSoundsDuringRecording(allowHapticsAndSystemSoundsDuringRecording)
+                } catch {
+                    print(error)
+                }
+            }
+        }
+    }
+    #endif
+
     /// Number of audio channels: 2 for stereo, 1 for mono
     @objc public static var channelCount: UInt32 = 2
 
@@ -247,6 +263,15 @@ extension AKSettings {
             throw error
         }
 
+        // Core Haptics
+        do {
+            if #available(iOS 13.0, *) {
+                try session.setAllowHapticsAndSystemSoundsDuringRecording(allowHapticsAndSystemSoundsDuringRecording)
+            }
+        }  catch {
+            AKLog("Error: Cannot set allowHapticsAndSystemSoundsDuringRecording", error)
+        }
+
         // Preferred IO Buffer Duration
         do {
             try AKTry {
@@ -320,6 +345,7 @@ extension AKSettings {
             if AKSettings.defaultToSpeaker {
                 options = options.union(.defaultToSpeaker)
             }
+
             #endif
         }
 


### PR DESCRIPTION
📳 iOS 13 added [this wonderful new setting](https://developer.apple.com/documentation/avfoundation/avaudiosession/3240576-setallowhapticsandsystemsoundsdu?language=objc) you can set on `AVAudioSesssion` that allows haptics and system sounds while recording is active. Setting this to true means that your own haptics, incoming notifications, etc will trigger the haptic engine rather than being silenced.

Note: Even if you're not actively recording audio just instantiating an instance of `AKMicrophone` will silence haptics unless you have this setting enabled.