### PR TITLE
Add progress for AudioKit.renderToFile and AVAudioEngine.renderToFile

### DIFF
--- a/AudioKit/Common/Internals/AVAudioEngine+Extensions.swift
+++ b/AudioKit/Common/Internals/AVAudioEngine+Extensions.swift
@@ -20,9 +20,15 @@ extension AVAudioEngine {
     ///         - audioFile: An file initialized for writing
     ///         - duration: Duration to render, in seconds
     ///         - prerender: A closure called before rendering starts, use this to start players, set initial parameters, etc...
+    ///         - progress: A closure called while rendering, use this to fetch render progress
     ///
     @available(iOS 11.0, macOS 10.13, tvOS 11.0, *)
-    public func renderToFile(_ audioFile: AVAudioFile, maximumFrameCount: AVAudioFrameCount = 4_096, duration: Double, prerender: (() -> Void)? = nil) throws {
+    public func renderToFile(_ audioFile: AVAudioFile,
+                             maximumFrameCount: AVAudioFrameCount = 4_096,
+                             duration: Double,
+                             prerender: (() -> Void)? = nil,
+                             progress: ((Double) -> Void)? = nil) throws {
+
         guard duration >= 0 else {
             throw NSError(domain: "AVAudioEngine ext", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "Seconds needs to be a positive value"])
@@ -53,6 +59,7 @@ extension AVAudioEngine {
             switch status {
             case .success:
                 try audioFile.write(from: buffer)
+                progress?(min(Double(audioFile.framePosition) / Double(targetSamples), 1.0))
             case .cannotDoInCurrentContext:
                 AKLog("renderToFile cannotDoInCurrentContext")
                 continue

--- a/AudioKit/Common/Internals/AudioKit+SafeConnections.swift
+++ b/AudioKit/Common/Internals/AudioKit+SafeConnections.swift
@@ -112,10 +112,15 @@ extension AudioKit {
     ///         - audioFile: An file initialized for writing
     ///         - duration: Duration to render, in seconds
     ///         - prerender: A closure called before rendering starts, use this to start players, set initial parameters, etc...
+    ///         - progress: A closure called while rendering, use this to fetch render progress
     ///
     @available(iOS 11, macOS 10.13, tvOS 11, *)
-    @objc public static func renderToFile(_ audioFile: AVAudioFile, duration: Double, prerender: (() -> Void)? = nil) throws {
-        try engine.renderToFile(audioFile, duration: duration, prerender: prerender)
+    @objc public static func renderToFile(_ audioFile: AVAudioFile,
+                                          duration: Double,
+                                          prerender: (() -> Void)? = nil,
+                                          progress: ((Double) -> Void)? = nil) throws {
+
+        try engine.renderToFile(audioFile, duration: duration, prerender: prerender, progress: progress)
     }
 
     @available(iOS 11, macOS 10.13, tvOS 11, *)


### PR DESCRIPTION
When export audio as a file, This PR provider a way to know the export progress.
