### PR TITLE
Leak fix for AKTimelineTap

### DIFF
--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.m
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.m
@@ -208,11 +208,7 @@
 
 - (void)dealloc {
     NSLog(@"* { AKParameterAutomation.dealloc }");
-
     [self stopAutomation];
-
-    // make sure that the tap's block is nil:
-    [tap detach];
     tap = nil;
     auAudioUnit = nil;
     avAudioUnit = nil;

--- a/AudioKit/Common/Taps/Timeline Tap/AKTimelineTap.m
+++ b/AudioKit/Common/Taps/Timeline Tap/AKTimelineTap.m
@@ -42,13 +42,14 @@
 
 - (AKRenderNotifyBlock)renderNotify {
     AKTimeline *timeline = &_timeline;
+    AudioUnitRenderActionFlags *actionFlags = &self->actionFlags;
 
     return ^(AudioUnitRenderActionFlags *ioActionFlags,
              const AudioTimeStamp *inTimeStamp,
              UInt32 inBusNumber,
              UInt32 inNumberFrames,
              AudioBufferList *ioData) {
-               if ((*ioActionFlags & actionFlags)) {
+               if ((*ioActionFlags & *actionFlags)) {
                    AKTimelineRender(timeline, inTimeStamp, inNumberFrames, ioData);
                }
     };
@@ -73,15 +74,6 @@
         return nil;
     }
     return [self initWithAudioUnit:avAudioUnit.audioUnit timelineBlock:block];
-}
-
-- (void)detach {
-    self->_block = nil;
-    self->renderTap = nil;
-}
-
-- (void)dealloc {
-    NSLog(@"* { AKTimelineTap.dealloc }");
 }
 
 static void TimingCallback(void            *refCon,


### PR DESCRIPTION
Correct fix included for leak in the timeline tap. Render flags was being kept around. Able to remove the detach now and ARC picks it up.