### PR TITLE
Add CaseIterable Conformance to AKTable

### DIFF
--- a/AudioKit/Common/Internals/Table/AKTable.swift
+++ b/AudioKit/Common/Internals/Table/AKTable.swift
@@ -7,7 +7,7 @@
 //
 
 /// Supported default table types
-@objc public enum AKTableType: Int, Codable {
+@objc public enum AKTableType: Int, Codable, CaseIterable {
     /// Standard sine waveform
     case sine
 


### PR DESCRIPTION
This conforms `AKTable` to `CaseIterable` to allow use of Swift's `.allCases`

It makes things like iterating over all pre-defined waveforms easier ¯\_(ツ)_/¯ 