### PR TITLE
AKPlayer: fallback processingFormat

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -198,8 +198,14 @@ public class AKPlayer: AKAbstractPlayer {
 
     @objc public var processingFormat: AVAudioFormat? {
         guard let audioFile = audioFile else { return nil }
-        return AVAudioFormat(standardFormatWithSampleRate: audioFile.fileFormat.sampleRate,
+        let format = AVAudioFormat(standardFormatWithSampleRate: audioFile.fileFormat.sampleRate,
                              channels: audioFile.fileFormat.channelCount)
+        if format == nil {
+            // fallback
+            return audioFile.processingFormat
+        }
+
+        return format
     }
 
     // MARK: - Public Options


### PR DESCRIPTION
AVAudioFormat will fail for pretty much any channel
count that is >2 when no channel layout is given.
It's better to fallback to non-standard format from
audio file.

I tested it with 6 channels file from there: https://www2.iis.fraunhofer.de/AAC/ChID-BLITS-EBU-Narration.mp4

It failed even with simplest playback like:
```swift
file = try! AKAudioFile(readFileName: "test.mp4")
player = AKPlayer(audioFile: file)
player.buffering = .always
AudioKit.output = player
try! AudioKit.start()
player.play()
```

Because `processingFormat` was returning null it couldn't connect nodes and was infinitely calling these lines:
https://github.com/AudioKit/AudioKit/blob/b28526ad8c103947676ab9cb8a2f0c7d6cd671a4/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer%2BPlayback.swift#L167-L169

What is purpose of that helper method anyway? Why cannot we just use format that was read from file?