### PR TITLE
Basics playground typo fix

### DIFF
--- a/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Mixing Nodes.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/AudioKitPlaygrounds/Playgrounds/Basics.playground/Pages/Mixing Nodes.xcplaygroundpage/Contents.swift
@@ -98,7 +98,7 @@ class LiveView: AKLiveViewController {
             lead.pan = sliderValue
         })
 
-        addView(AKSlider(property: "Overall Voilume", value: booster.gain, range: 0 ... 2) { sliderValue in
+        addView(AKSlider(property: "Overall Volume", value: booster.gain, range: 0 ... 2) { sliderValue in
             booster.gain = sliderValue
         })
     }


### PR DESCRIPTION
While going through the basics playground I found a typo and this simply addresses that.

