### PR TITLE
Core FunctionTable: one bug fix, one enhancement

### DIFF
--- a/AudioKit/Core/AudioKitCore/Common/FunctionTable.cpp
+++ b/AudioKit/Core/AudioKitCore/Common/FunctionTable.cpp
@@ -65,6 +65,19 @@ namespace AudioKitCore
             pWaveTable[i] = (float)(amplitude * sin(double(i)/nTableSize * 2.0 * M_PI));
     }
 
+    // A variation of sinusoid() which adds a tiny bit of 2nd harmonic, producing a tone closer to
+    // that of a Hammond organ tonewheel generator.
+    void AudioKitCore::FunctionTable::hammond(float amplitude)
+    {
+        // in case user forgot, init table to default size
+        if (pWaveTable == 0) init();
+
+        for (int i = 0; i < nTableSize; i++)
+            pWaveTable[i] = (float)(amplitude *
+                (sin(double(i) / nTableSize * 2.0 * M_PI) + 0.015f * sin(double(i) / nTableSize * 4.0 * M_PI))
+                );
+    }
+
     void FunctionTable::square(float amplitude, float dutyCycle)
     {
         // in case user forgot, init table to default size

--- a/AudioKit/Core/AudioKitCore/Common/FunctionTable.hpp
+++ b/AudioKit/Core/AudioKitCore/Common/FunctionTable.hpp
@@ -38,6 +38,7 @@ namespace AudioKitCore
         void triangle(float amplitude=1.0f);
         void sawtooth(float amplitude=1.0f);
         void sinusoid(float amplitude=1.0f);
+        void hammond(float amplitude=1.0f);
         void square(float amplitude=1.0f, float dutyCycle=0.5f);
         
         inline float interp_cyclic(float phase)

--- a/AudioKit/Core/AudioKitCore/Common/FunctionTable.hpp
+++ b/AudioKit/Core/AudioKitCore/Common/FunctionTable.hpp
@@ -65,7 +65,7 @@ namespace AudioKitCore
             if (phase < 0) return pWaveTable[0];
             if (phase >= 1.0) return pWaveTable[nTableSize-1];
             
-            float readIndex = phase * nTableSize;
+            float readIndex = phase * (nTableSize - 1);
             int ri = int(readIndex);
             float f = readIndex - ri;
             int rj = ri + 1; if (rj >= nTableSize) rj = nTableSize - 1;


### PR DESCRIPTION
AudioKitCore::FunctionTable::interp_bounded had a subtle error, because I made the code too similar to interp_cyclic, not realizing that the cases are quite different.

I also added a new "hammond" init function to create a sinusoid with a slight amount of 2nd harmonic, following an example I found in another MIT-licensed project (https://github.com/grib00/beta3).

Both these changes are required for my latest updates to AudioKit/ExtendingCore.