### PR TITLE
AudioKit for iOS not compiling with swiftlint 0.39.0 and newer

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,7 +26,9 @@ identifier_name:
     - 1 # warning
 
 force_cast: warning
-empty_count: warning
+empty_count:
+  severity: warning
+  warning: 10
 force_try: warning
 
 cyclomatic_complexity:


### PR DESCRIPTION
With yesterday's release of _swiftlint_ version 0.39.0, _AudioKit for iOS_ is not compiling anymore due to the following error:

`Empty Count Violation: Prefer checking isEmpty over comparing count to zero. (empty_count)`

This error occurs in the `MultitouchGestureRecognizer` and clearly represents a "false positive error" falsely reported by `swiftlint` but still leading to a compile error:

- https://github.com/AudioKit/AudioKit/blob/master/AudioKit/iOS/AudioKit/User%20Interface/MultitouchGestureRecognizer.swift#L56
- https://github.com/AudioKit/AudioKit/blob/master/AudioKit/iOS/AudioKit/User%20Interface/MultitouchGestureRecognizer.swift#L184

While your project's _swiftlint_ configuration sets the severity level of `empty_count` to `warning` (see https://github.com/AudioKit/AudioKit/blob/master/.swiftlint.yml#L29), the `empty_count` configuration has changed since _swiftlint_'s new release (see https://github.com/realm/SwiftLint/commit/ab8cd43e671250cf228b71fc44100ee63646081c#diff-d8da3e1d2fa8d2731595330b5d1c0f1a) which is causing your current configuration to be invalid:

`Invalid configuration for 'empty_count'. Falling back to default.`

Also, the default severity level of `empty_count` has been set to `error`, which is causing the compilation of `AudioKit For iOS.xcodeproj` to fail.

Steps to reproduce:

1. install the current version of swiftlint: `brew install swiftlint`
2. open `AudioKit For iOS.xcodeproj`
3. build the project


Keeping backwards compatibility in mind, the _swiftlint_ configuration for `empty_count` has been updated so that it is compatible with both _swiftlint_ version 0.39.0 and 0.38.x (due to setting both the `warning` and the `severity` configuration option).

You can verify that by compiling with both the newest (`brew upgrade swiftlint`) and an older version of swiftlint, for example by installing version 0.38.2:

`brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/203436f8567a3b6455264a1d896da5b1df1e50e6/Formula/swiftlint.rb`


Thank you for this great project!