### PR TITLE
add abillity to monitor amount that AKDynamicRangeCompressor is working

### DIFF
--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressor.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressor.swift
@@ -109,6 +109,10 @@ open class AKDynamicRangeCompressor: AKNode, AKToggleable, AKComponent, AKInput 
         return internalAU?.isPlaying ?? false
     }
 
+    @objc open dynamic var compressionAmount: Float {
+        return internalAU?.compressionAmount ?? 0
+    }
+
     // MARK: - Initialization
 
     /// Initialize this compressor node

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
@@ -38,6 +38,10 @@ public class AKDynamicRangeCompressorAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
+    var compressionAmount: Float {
+        get { parameter(withAddress: AKDynamicRangeCompressorParameter.compressionAmount.rawValue) }
+    }
+
     public override func initDSP(withSampleRate sampleRate: Double,
                                  channelCount count: AVAudioChannelCount) -> AKDSPRef {
         return createDynamicRangeCompressorDSP(Int32(count), sampleRate)

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.hpp
@@ -15,7 +15,8 @@ typedef NS_ENUM(AUParameterAddress, AKDynamicRangeCompressorParameter) {
     AKDynamicRangeCompressorParameterThreshold,
     AKDynamicRangeCompressorParameterAttackDuration,
     AKDynamicRangeCompressorParameterReleaseDuration,
-    AKDynamicRangeCompressorParameterRampDuration
+    AKDynamicRangeCompressorParameterRampDuration,
+    AKDynamicRangeCompressorParameterCompressionAmount
 };
 
 #ifndef __cplusplus
@@ -30,7 +31,7 @@ class AKDynamicRangeCompressorDSP : public AKSoundpipeDSPBase {
 private:
     struct InternalData;
     std::unique_ptr<InternalData> data;
- 
+
 public:
     AKDynamicRangeCompressorDSP();
 
@@ -55,7 +56,7 @@ public:
 
     // Uses the ParameterAddress as a key
     float getParameter(AUParameterAddress address) override;
-    
+
     void init(int channelCount, double sampleRate) override;
 
     void deinit() override;


### PR DESCRIPTION
Hi, 
I've been working on an audiokit based project that includes AKDynamicRangeCompressor as a last-chance limiter.  I want to be able to see how much the compressor is working and feed that back to the user.  here's a patch that does this.

Questions:

- is averaging the amount of compression performed correct?  would RMS be better?  max amount of compression per buffer?
- would you prefer to output this value in DBs or as a float-point?

thanks,
osheroff
