### PR TITLE
AKPlayer updates for our optimizations.

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -38,6 +38,18 @@
     self.kernel->stop();
 }
 
+- (BOOL)shouldBypassEffect {
+    return self.kernel->isPlaying();
+}
+
+- (void)setShouldBypassEffect:(BOOL)shouldBypassEffect {
+    if (shouldBypassEffect) {
+        self.kernel->stop();
+    } else {
+        self.kernel->start();
+    }
+}
+
 - (void)clear {
     self.kernel->clear();
 }
@@ -61,6 +73,7 @@
 - (void)setWaveformValue:(float)value atIndex:(UInt32)index {
     self.kernel->setWaveformValue(index, value);
 }
+
 - (void)setupAudioFileTable:(float *)data size:(UInt32)size {
     self.kernel->setUpTable(data, size);
 }

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
@@ -183,13 +183,13 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
     /// Function to start, play, or activate the node, all do the same thing
     @objc open func start() {
         self.internalAU?.shouldBypassEffect = false
-        self.internalAU?.start()
+        //self.internalAU?.start() // shouldn't be necessary now
     }
 
     /// Function to stop or bypass the node, both are equivalent
     @objc open func stop() {
         self.internalAU?.shouldBypassEffect = true
-        self.internalAU?.stop()
+        //self.internalAU?.stop() // shouldn't be necessary now
     }
 
     // MARK: - AKAutomatable

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
@@ -182,14 +182,14 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
 
     /// Function to start, play, or activate the node, all do the same thing
     @objc open func start() {
-        internalAU?.shouldBypassEffect = false
-        internalAU?.start()
+        self.internalAU?.shouldBypassEffect = false
+        self.internalAU?.start()
     }
 
     /// Function to stop or bypass the node, both are equivalent
     @objc open func stop() {
-        internalAU?.shouldBypassEffect = true
-        internalAU?.stop()
+        self.internalAU?.shouldBypassEffect = true
+        self.internalAU?.stop()
     }
 
     // MARK: - AKAutomatable

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
@@ -2,7 +2,7 @@
 //  AKFader.swift
 //  AudioKit
 //
-//  Created by Ryan Francesconi, revision history on Github.
+//  Created by Aurelius Prochazka and Ryan Francesconi, revision history on Github.
 //  Copyright © 2019 AudioKit. All rights reserved.
 //
 
@@ -28,7 +28,7 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
     fileprivate var skewParameter: AUParameter?
     fileprivate var offsetParameter: AUParameter?
 
-    /// Amplification Factor
+    /// Amplification Factor, from 0 ... 2
     @objc open dynamic var gain: Double = 1 {
         willSet {
             // ensure that the parameters aren't nil,

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderAudioUnit.swift
@@ -2,7 +2,7 @@
 //  AKFaderAudioUnit.swift
 //  AudioKit
 //
-//  Created by Ryan Francesconi, revision history on Github.
+//  Created by Aurelius Prochazka and Ryan Francesconi, revision history on Github.
 //  Copyright © 2019 AudioKit. All rights reserved.
 //
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.hpp
@@ -2,7 +2,7 @@
 //  AKFaderDSP.hpp
 //  AudioKit
 //
-//  Created by Ryan Francesconi, revision history on Github.
+//  Created by Aurelius Prochazka and Ryan Francesconi, revision history on Github.
 //  Copyright © 2019 AudioKit. All rights reserved.
 //
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
@@ -73,11 +73,13 @@ float AKFaderDSP::getParameter(AUParameterAddress address)
     return 0;
 }
 
-void AKFaderDSP::start() {
+void AKFaderDSP::start()
+{
     isStarted = true;
 }
 
-void AKFaderDSP::stop() {
+void AKFaderDSP::stop()
+{
     isStarted = false;
 }
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
@@ -2,7 +2,7 @@
 //  AKFaderDSP.mm
 //  AudioKit
 //
-//  Created by Ryan Francesconi, revision history on Github.
+//  Created by Aurelius Prochazka and Ryan Francesconi, revision history on Github.
 //  Copyright © 2019 AudioKit. All rights reserved.
 //
 

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
@@ -7,7 +7,7 @@
 //
 
 /// Psuedo abstract base class for players that wish to use AKFader based automation.
-open class AKAbstractPlayer: AKNode {
+open class AKAbstractPlayer: AKDynamicNode {
     /// Since AVAudioEngineManualRenderingMode is only available in 10.13, iOS 11+, this enum duplicates it
     public enum RenderingMode {
         case realtime, offline
@@ -123,7 +123,7 @@ open class AKAbstractPlayer: AKNode {
     /// Holds characteristics about the loop options.
     public var loop = Loop()
 
-    /// The underlying gain booster which controls fades as well. Created on demand.
+    /// The underlying gain booster and main output which controls fades as well.
     @objc public var faderNode: AKFader?
 
     @available(*, deprecated, renamed: "fadeOutAndStop(with:)")

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
@@ -7,7 +7,7 @@
 //
 
 /// Psuedo abstract base class for players that wish to use AKFader based automation.
-open class AKAbstractPlayer: AKDynamicNode {
+open class AKAbstractPlayer: AKNode {
     /// Since AVAudioEngineManualRenderingMode is only available in 10.13, iOS 11+, this enum duplicates it
     public enum RenderingMode {
         case realtime, offline
@@ -129,8 +129,8 @@ open class AKAbstractPlayer: AKDynamicNode {
     @available(*, deprecated, renamed: "fadeOutAndStop(with:)")
     @objc public var stopEnvelopeTime: Double = 0 {
         didSet {
-            if faderNode == nil {
-                createFader()
+            if stopEnvelopeTime > 0 {
+                startFader()
             }
         }
     }
@@ -142,10 +142,10 @@ open class AKAbstractPlayer: AKDynamicNode {
         }
 
         set {
-            if newValue != 1, faderNode == nil {
-                createFader()
-            } else if newValue == 1, faderNode != nil, !isPlaying {
-                removeFader()
+            if newValue != 1 {
+                startFader()
+            } else if newValue == 1 {
+                bypassFader()
             }
             // this is the value that the fader will fade to
             fade.maximumGain = newValue
@@ -312,30 +312,17 @@ open class AKAbstractPlayer: AKDynamicNode {
         return AUAudioFrameCount(value * sampleRate)
     }
 
-    public func createFader() {
-        // only do this once when needed
-        guard faderNode == nil else {
-            faderNode?.gain = fade.inTime > 0 ? Fade.minimumGain : gain
-            return
+    // Enables the internal fader from the signal chain if it is bypassed
+    public func startFader() {
+        if faderNode?.isBypassed == true {
+            faderNode?.start()
         }
-
-        faderNode = AKFader()
-        faderNode?.gain = fade.inTime > 0 ? Fade.minimumGain : gain
-        initialize()
     }
 
-    // Removes the internal fader from the signal chain
-    public func removeFader() {
-        guard faderNode != nil else { return }
-        let wasPlaying = isPlaying
-        stop()
-        faderNode?.disconnectOutput()
-        faderNode?.detach()
-        faderNode = nil
-
-        initialize()
-        if wasPlaying {
-            play()
+    // Bypasses the internal fader from the signal chain
+    public func bypassFader() {
+        if faderNode?.isBypassed == false {
+            faderNode?.bypass()
         }
     }
 
@@ -361,4 +348,12 @@ open class AKAbstractPlayer: AKDynamicNode {
         faderNode?.detach()
         faderNode = nil
     }
+}
+
+extension AKAbstractPlayer {
+    @available(*, unavailable, renamed: "startFader")
+    public func createFader() {}
+
+    @available(*, unavailable, renamed: "bypassFader")
+    public func removeFader() {}
 }

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
@@ -89,31 +89,31 @@ public class AKDynamicPlayer: AKPlayer {
             return
         }
 
-        /*
-        // has pitch and fader
-        if let timePitchNode = timePitchNode, let faderNode = super.faderNode {
-            AudioKit.connect(playerNode, to: timePitchNode.avAudioNode, format: processingFormat)
-            AudioKit.connect(timePitchNode.avAudioNode, to: faderNode.avAudioUnitOrNode, format: processingFormat)
-            AudioKit.connect(faderNode.avAudioUnitOrNode, to: mixer, format: processingFormat)
-            timePitchNode.bypass() // bypass timePitch by default to save CPU
+        var connectionFormat = processingFormat
+        var playerOutput: AVAudioNode = playerNode
 
-            // just has pitch
-        } else if let timePitchNode = timePitchNode, super.faderNode == nil {
-            AudioKit.connect(playerNode, to: timePitchNode.avAudioNode, format: processingFormat)
-            AudioKit.connect(timePitchNode.avAudioNode, to: mixer, format: processingFormat)
+        // if there is a mixer that was creating, insert it in line
+        // this is used only for dynamic sample rate conversion to
+        // AKSettings.audioFormat if needed
+        if let mixerNode = mixerNode {
+            AudioKit.connect(playerNode, to: mixerNode, format: processingFormat)
+            connectionFormat = AKSettings.audioFormat
+            playerOutput = mixerNode
+        }
+
+        if let faderNode = faderNode, let timePitchNode = timePitchNode {
+            // AKLog("👉 Player → Time Pitch → Fader")
+            AudioKit.connect(playerOutput, to: timePitchNode.avAudioNode, format: connectionFormat)
+            AudioKit.connect(timePitchNode.avAudioUnitOrNode, to: faderNode.avAudioUnitOrNode, format: connectionFormat)
             timePitchNode.bypass()
 
-            // just has fader
         } else if let faderNode = super.faderNode {
-            // if the timePitchNode isn't created connect the player directly to the faderNode
-            AudioKit.connect(playerNode, to: faderNode.avAudioUnitOrNode, format: processingFormat)
-            AudioKit.connect(faderNode.avAudioUnitOrNode, to: mixer, format: processingFormat)
-
-            // doesn't have pitch or fader
-        } else {
-            AudioKit.connect(playerNode, to: mixer, format: processingFormat)
+            // AKLog("👉 Player → Fader")
+            AudioKit.connect(playerOutput, to: faderNode.avAudioUnitOrNode, format: connectionFormat)
         }
-    */
+
+        // start this bypassed
+        super.faderNode?.bypass()
     }
 
     public func createTimePitch() {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
@@ -80,7 +80,6 @@ public class AKDynamicPlayer: AKPlayer {
                 timePitchNode.disconnectOutput()
             }
         }
-
         super.initialize(restartIfPlaying: restartIfPlaying)
     }
 
@@ -90,6 +89,8 @@ public class AKDynamicPlayer: AKPlayer {
             return
         }
 
+        /*
+        // has pitch and fader
         if let timePitchNode = timePitchNode, let faderNode = super.faderNode {
             AudioKit.connect(playerNode, to: timePitchNode.avAudioNode, format: processingFormat)
             AudioKit.connect(timePitchNode.avAudioNode, to: faderNode.avAudioUnitOrNode, format: processingFormat)
@@ -97,22 +98,26 @@ public class AKDynamicPlayer: AKPlayer {
             timePitchNode.bypass() // bypass timePitch by default to save CPU
             // AKLog(audioFile?.url.lastPathComponent ?? "URL is nil", processingFormat, "Connecting timePitch and fader")
 
+            // just has pitch
         } else if let timePitchNode = timePitchNode, super.faderNode == nil {
             AudioKit.connect(playerNode, to: timePitchNode.avAudioNode, format: processingFormat)
             AudioKit.connect(timePitchNode.avAudioNode, to: mixer, format: processingFormat)
             timePitchNode.bypass()
             // AKLog(audioFile?.url.lastPathComponent ?? "URL is nil", processingFormat, "Connecting timePitch")
 
+            // just has fader
         } else if let faderNode = super.faderNode {
             // if the timePitchNode isn't created connect the player directly to the faderNode
             AudioKit.connect(playerNode, to: faderNode.avAudioUnitOrNode, format: processingFormat)
             AudioKit.connect(faderNode.avAudioUnitOrNode, to: mixer, format: processingFormat)
             // AKLog(audioFile?.url.lastPathComponent ?? "URL is nil", processingFormat, "Connecting fader")
 
+            // doesn't have pitch or fader
         } else {
             AudioKit.connect(playerNode, to: mixer, format: processingFormat)
             // AKLog(audioFile?.url.lastPathComponent ?? "URL is nil", processingFormat, "Connecting player to mixer")
         }
+    */
     }
 
     public func createTimePitch() {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -99,7 +99,7 @@ extension AKPlayer {
         }
 
         // creates if necessary only
-        createFader()
+        startFader()
 
         // Provides a convenience for a quick fade out when a user presses stop.
         // Only do this if it's realtime playback, as Timers aren't running
@@ -236,7 +236,6 @@ extension AKPlayer {
 
     @available(iOS 11, macOS 10.13, tvOS 11, *)
     @objc internal func handleCallbackComplete(completionType: AVAudioPlayerNodeCompletionCallbackType) {
-
         // only forward the completion if is actually done playing without user intervention.
 
         // it seems to be unstable having any outbound calls from this callback not be sent to main?

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -3240,17 +3240,17 @@
 		C45664EB1D448D7E00D26565 /* Nodes */ = {
 			isa = PBXGroup;
 			children = (
-				C44EA2882018749A0072399F /* README.md */,
-				C45664EC1D448D7E00D26565 /* AKNode.swift */,
 				552FBD441F3F731200C02C08 /* AKConnection.swift */,
+				C45664EC1D448D7E00D26565 /* AKNode.swift */,
 				C45664ED1D448D7E00D26565 /* Analysis */,
 				FE4BDB2121925906007E3DA3 /* Callback Instrument */,
 				C45664F81D448D7E00D26565 /* Effects */,
 				C45665C71D448D7E00D26565 /* Generators */,
 				C45666291D448D7E00D26565 /* Input */,
 				C456662B1D448D7E00D26565 /* Mixing */,
-				C456663F1D448D7E00D26565 /* Playback */,
 				552CD48C1F3BBA1B005762E9 /* Offline */,
+				C456663F1D448D7E00D26565 /* Playback */,
+				C44EA2882018749A0072399F /* README.md */,
 			);
 			name = Nodes;
 			path = ../Common/Nodes;


### PR DESCRIPTION
AKPlayer has been altered to remove AVAudioMixerNode as its main output in favor of AKFader. This will reduce node counts and remove a sample rate conversion / cpu drain. AKFader is bypassed by default.

I also added the shouldBypassEffect to the base class. Let me know if that looks right to you - I think it's correct now.