### PR TITLE
Add Support for Custom AKTables

### DIFF
--- a/AudioKit/Common/Internals/Table/AKTable.swift
+++ b/AudioKit/Common/Internals/Table/AKTable.swift
@@ -40,6 +40,9 @@
 
     /// Zeros
     case zero
+
+    /// Custom waveform
+    case custom
 }
 
 /// A table of values accessible as a waveform or lookup mechanism
@@ -51,7 +54,7 @@ public class AKTable: NSObject, MutableCollection, Codable {
 
     // MARK: - Properties    /// Values stored in the table
 
-    internal var content = [Element]()
+    public internal(set) var content = [Element]()
 
     /// Phase of the table
     public var phase: Float {
@@ -135,7 +138,17 @@ public class AKTable: NSObject, MutableCollection, Codable {
             self.positiveSquareWave()
         case .zero:
             self.zero()
+        case .custom:
+            assertionFailure("Initializing a custom waveform via this method is unsupported. Please use init(content:phase:count:).")
         }
+    }
+
+    /// Create table from an array of Element
+    @objc public init(_ content: [Element],
+                      phase: Float = 0) {
+        self.type = .custom
+        self.phase = phase
+        self.content = content
     }
 
     /// Create table from audio file


### PR DESCRIPTION
This does two things:

1. It exposes `content` of `AKTable` with a public getter, but still keeps the setter private. When I've been using `AKTable` I've needed to get the contents of the table manually, and mapping the contents via the subscript getter to a new array is extremely expensive, so exposing the getter as a copy seemed like a much faster alternative.

2. It also creates a new initializer and `AKTable` type to support custom waveforms. Previously, I'd have to create an arbitrarily sized sine wave and then map over / replace the contents via the subscript setter, which again was super slow. So now you can just initialize a custom `AKTable` with an array that gets copied in. Creating a custom wavetable via the other initializer throws an assertion as it isn't supported.
