### PR TITLE
Cleaner AKAudioUnit creation, init, and deinit

### DIFF
--- a/AudioKit/Common/Internals/AKSoundpipeDSPBase.hpp
+++ b/AudioKit/Common/Internals/AKSoundpipeDSPBase.hpp
@@ -29,15 +29,15 @@ protected:
     sp_data *sp = nullptr;
 public:
 
-    void init(int channelCount, double sampleRate) override {
+    virtual void init(int channelCount, double sampleRate) override {
         AKDSPBase::init(channelCount, sampleRate);
         sp_create(&sp);
         sp->sr = sampleRate;
         sp->nchan = channelCount;
     }
 
-    ~AKSoundpipeDSPBase() {
-        // releasing the memory in the destructor only
+    virtual void deinit() override {
+        AKDSPBase::deinit();
         sp_destroy(&sp);
     }
 

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
@@ -27,7 +27,7 @@
  is. I'm not sure the standard way to deal with this.
  */
 
-- (AKDSPRef _Nonnull)initDSPWithSampleRate:(double)sampleRate channelCount:(AVAudioChannelCount)count;
+- (AKDSPRef _Nonnull)createDSP;
 
 /**
  Sets the parameter tree. The important piece here is that setting the parameter tree

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.h
@@ -55,7 +55,6 @@
 // Convolution and Phase-Locked Vocoder
 - (void)setupAudioFileTable:(float *_Nonnull)data size:(UInt32)size;
 - (void)setPartitionLength:(int)partitionLength;
-- (void)initConvolutionEngine;
 
 @property (readonly) BOOL isPlaying;
 @property (readonly) BOOL isSetUp;

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -77,7 +77,7 @@
  This should be overridden. All the base class does is make sure that the pointer to the
  DSP is invalid.
  */
-- (AKDSPRef)initDSPWithSampleRate:(double)sampleRate channelCount:(AVAudioChannelCount)count {
+- (AKDSPRef)createDSP {
     return (_dsp = NULL);
 }
 
@@ -127,12 +127,7 @@
         return nil;
     }
 
-    // Initialize a default format for the busses.
-    AVAudioFormat *arbitraryFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate
-                                                                                    channels:AKSettings.channelCount];
-
-    _dsp = [self initDSPWithSampleRate:arbitraryFormat.sampleRate
-                          channelCount:arbitraryFormat.channelCount];
+    _dsp = [self createDSP];
 
     // Create a default empty parameter tree.
     _parameterTree = [AUParameterTree treeWithChildren:@[]];

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKAudioUnitBase.mm
@@ -69,10 +69,6 @@
     self.kernel->setPartitionLength(partitionLength);
 }
 
-- (void)initConvolutionEngine {
-    self.kernel->initConvolutionEngine();
-}
-
 /**
  This should be overridden. All the base class does is make sure that the pointer to the
  DSP is invalid.

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.hpp
@@ -36,7 +36,9 @@ protected:
     AUEventSampleTime now = 0;
 
 public:
-
+    
+    AKDSPBase();
+    
     /// Virtual destructor allows child classes to be deleted with only AKDSPBase *pointer
     virtual ~AKDSPBase() {}
 
@@ -82,8 +84,6 @@ public:
     virtual void setUpTable(float *table, UInt32 size) {}
 
     virtual void setPartitionLength(int partLength) {}
-
-    virtual void initConvolutionEngine() {}
 
     virtual bool isLooping()
     {

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKDSPBase.mm
@@ -8,6 +8,12 @@
 
 #import "AKDSPBase.hpp"
 
+AKDSPBase::AKDSPBase()
+: sampleRate(44100) // best guess
+, channelCount(2)   // best guess
+{
+}
+
 void AKDSPBase::processWithEvents(AudioTimeStamp const *timestamp, AUAudioFrameCount frameCount,
                                   AURenderEvent const *events)
 {

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.h
@@ -33,7 +33,6 @@
 // Convolution and Phase-Locked Vocoder
 - (void)setupAudioFileTable:(float *)data size:(UInt32)size;
 - (void)setPartitionLength:(int)partitionLength;
-- (void)initConvolutionEngine;
 
 // Sequencing Tools
 - (bool)isLooping;

--- a/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AK4/AKGeneratorAudioUnitBase.mm
@@ -37,9 +37,6 @@
 - (void)setPartitionLength:(int)partitionLength {
     ((AKDSPBase *)self.dsp)->setPartitionLength(partitionLength);
 }
-- (void)initConvolutionEngine {
-    ((AKDSPBase *)self.dsp)->initConvolutionEngine();
-}
 - (bool)isLooping {
     return ((AKDSPBase *)self.dsp)->isLooping();
 }

--- a/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayAudioUnit.swift
@@ -38,9 +38,8 @@ public class AKStereoDelayAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createStereoDelayDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createStereoDelayDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKStereoDelayParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createStereoDelayDSP(int channelCount, double sampleRate);
+AKDSPRef createStereoDelayDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayDSP.mm
@@ -10,9 +10,8 @@
 #include "StereoDelay.hpp"
 #include "DSPKernel.hpp" // for clamp()
 
-extern "C" AKDSPRef createStereoDelayDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createStereoDelayDSP() {
     AKStereoDelayDSP *dsp = new AKStereoDelayDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKVariableDelayAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createVariableDelayDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createVariableDelayDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKVariableDelayParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createVariableDelayDSP(int channelCount, double sampleRate);
+AKDSPRef createVariableDelayDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
@@ -9,9 +9,8 @@
 #include "AKVariableDelayDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createVariableDelayDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createVariableDelayDSP() {
     AKVariableDelayDSP *dsp = new AKVariableDelayDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -71,6 +70,7 @@ void AKVariableDelayDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKVariableDelayDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_vdelay_destroy(&data->vdelay0);
     sp_vdelay_destroy(&data->vdelay1);
 }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKBitCrusherAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createBitCrusherDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createBitCrusherDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKBitCrusherParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createBitCrusherDSP(int channelCount, double sampleRate);
+AKDSPRef createBitCrusherDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
@@ -9,9 +9,8 @@
 #include "AKBitCrusherDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createBitCrusherDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createBitCrusherDSP() {
     AKBitCrusherDSP *dsp = new AKBitCrusherDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -71,6 +70,7 @@ void AKBitCrusherDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKBitCrusherDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_bitcrush_destroy(&data->bitcrush0);
     sp_bitcrush_destroy(&data->bitcrush1);
 }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKClipperAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createClipperDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createClipperDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKClipperParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createClipperDSP(int channelCount, double sampleRate);
+AKDSPRef createClipperDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
@@ -9,9 +9,8 @@
 #include "AKClipperDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createClipperDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createClipperDSP() {
     AKClipperDSP *dsp = new AKClipperDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -60,6 +59,7 @@ void AKClipperDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKClipperDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_clip_destroy(&data->clip0);
     sp_clip_destroy(&data->clip1);
 }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionAudioUnit.swift
@@ -38,9 +38,8 @@ public class AKTanhDistortionAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createTanhDistortionDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createTanhDistortionDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKTanhDistortionParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createTanhDistortionDSP(int channelCount, double sampleRate);
+AKDSPRef createTanhDistortionDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
@@ -9,9 +9,8 @@
 #include "AKTanhDistortionDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createTanhDistortionDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createTanhDistortionDSP() {
     AKTanhDistortionDSP *dsp = new AKTanhDistortionDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -93,6 +92,7 @@ void AKTanhDistortionDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKTanhDistortionDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_dist_destroy(&data->dist0);
     sp_dist_destroy(&data->dist1);
 }

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
@@ -42,9 +42,8 @@ public class AKDynamicRangeCompressorAudioUnit: AKAudioUnitBase {
         get { parameter(withAddress: AKDynamicRangeCompressorParameter.compressionAmount.rawValue) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createDynamicRangeCompressorDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createDynamicRangeCompressorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.hpp
@@ -21,7 +21,7 @@ typedef NS_ENUM(AUParameterAddress, AKDynamicRangeCompressorParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createDynamicRangeCompressorDSP(int channelCount, double sampleRate);
+AKDSPRef createDynamicRangeCompressorDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
@@ -9,9 +9,8 @@
 #include "AKDynamicRangeCompressorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createDynamicRangeCompressorDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createDynamicRangeCompressorDSP() {
     AKDynamicRangeCompressorDSP *dsp = new AKDynamicRangeCompressorDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -97,6 +96,7 @@ void AKDynamicRangeCompressorDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKDynamicRangeCompressorDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_compressor_destroy(&data->compressor0);
     sp_compressor_destroy(&data->compressor1);
 }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelope.mm
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelope.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createAmplitudeEnvelopeDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createAmplitudeEnvelopeDSP() {
     AKAmplitudeEnvelopeDSP *dsp = new AKAmplitudeEnvelopeDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeAudioUnit.swift
@@ -38,9 +38,8 @@ public class AKAmplitudeEnvelopeAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createAmplitudeEnvelopeDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createAmplitudeEnvelopeDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeDSP.hpp
@@ -22,7 +22,7 @@ typedef NS_ENUM(AUParameterAddress, AKAmplitudeEnvelopeParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createAmplitudeEnvelopeDSP(int channelCount, double sampleRate);
+AKDSPRef createAmplitudeEnvelopeDSP(void);
 
 #else
 
@@ -111,6 +111,7 @@ public:
     }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_adsr_destroy(&_adsr);
     }
 

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremolo.mm
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremolo.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createTremoloDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createTremoloDSP() {
     AKTremoloDSP *dsp = new AKTremoloDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKTremoloAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createTremoloDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createTremoloDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKTremoloParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createTremoloDSP(int channelCount, double sampleRate);
+AKDSPRef createTremoloDSP(void);
 
 #else
 
@@ -92,6 +92,7 @@ public:
     }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_osc_destroy(&trem);
     }
 

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.hpp
@@ -25,12 +25,13 @@ AKDSPRef createTremoloDSP(void);
 #else
 
 #import "AKSoundpipeDSPBase.hpp"
+#import <vector>
 
 class AKTremoloDSP : public AKSoundpipeDSPBase {
 
     sp_osc *trem;
     sp_ftbl *tbl;
-    UInt32 tbl_size = 4096;
+    std::vector<float> wavetable;
 
 private:
     AKLinearParameterRamp frequencyRamp;
@@ -76,6 +77,8 @@ public:
 
     void init(int channelCount, double sampleRate) override {
         AKSoundpipeDSPBase::init(channelCount, sampleRate);
+        sp_ftbl_create(sp, &tbl, wavetable.size());
+        std::copy(wavetable.cbegin(), wavetable.cend(), tbl->tbl);
         sp_osc_create(&trem);
         sp_osc_init(sp, trem, tbl, 0);
         trem->freq = 10.0;
@@ -83,17 +86,17 @@ public:
     }
 
     void setupWaveform(uint32_t size) override {
-        tbl_size = size;
-        sp_ftbl_create(sp, &tbl, tbl_size);
+        wavetable.resize(size);
     }
 
     void setWaveformValue(uint32_t index, float value) override {
-        tbl->tbl[index] = value;
+        wavetable[index] = value;
     }
 
     void deinit() override {
         AKSoundpipeDSPBase::deinit();
         sp_osc_destroy(&trem);
+        sp_ftbl_destroy(&tbl);
     }
 
     void process(uint32_t frameCount, uint32_t bufferOffset) override {

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKBandPassButterworthFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createBandPassButterworthFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createBandPassButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKBandPassButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createBandPassButterworthFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createBandPassButterworthFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKBandPassButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createBandPassButterworthFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createBandPassButterworthFilterDSP() {
     AKBandPassButterworthFilterDSP *dsp = new AKBandPassButterworthFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKBandRejectButterworthFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createBandRejectButterworthFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createBandRejectButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKBandRejectButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createBandRejectButterworthFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createBandRejectButterworthFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKBandRejectButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createBandRejectButterworthFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createBandRejectButterworthFilterDSP() {
     AKBandRejectButterworthFilterDSP *dsp = new AKBandRejectButterworthFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -71,6 +70,7 @@ void AKBandRejectButterworthFilterDSP::init(int channelCount, double sampleRate)
 }
 
 void AKBandRejectButterworthFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_butbr_destroy(&data->butbr0);
     sp_butbr_destroy(&data->butbr1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockAudioUnit.swift
@@ -10,9 +10,8 @@ import AVFoundation
 
 public class AKDCBlockAudioUnit: AKAudioUnitBase {
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createDCBlockDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createDCBlockDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.hpp
@@ -12,7 +12,7 @@
 
 #ifndef __cplusplus
 
-AKDSPRef createDCBlockDSP(int channelCount, double sampleRate);
+AKDSPRef createDCBlockDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
@@ -8,9 +8,8 @@
 
 #include "AKDCBlockDSP.hpp"
 
-extern "C" AKDSPRef createDCBlockDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createDCBlockDSP() {
     AKDCBlockDSP *dsp = new AKDCBlockDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -30,6 +29,7 @@ void AKDCBlockDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKDCBlockDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_dcblock_destroy(&data->dcblock0);
     sp_dcblock_destroy(&data->dcblock1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKEqualizerFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createEqualizerFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKEqualizerFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createEqualizerFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createEqualizerFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createEqualizerFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createEqualizerFilterDSP() {
     AKEqualizerFilterDSP *dsp = new AKEqualizerFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -82,6 +81,7 @@ void AKEqualizerFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKEqualizerFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_eqfil_destroy(&data->eqfil0);
     sp_eqfil_destroy(&data->eqfil1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKFormantFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createFormantFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createFormantFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKFormantFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createFormantFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createFormantFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKFormantFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createFormantFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createFormantFilterDSP() {
     AKFormantFilterDSP *dsp = new AKFormantFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -82,6 +81,7 @@ void AKFormantFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKFormantFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_fofilt_destroy(&data->fofilt0);
     sp_fofilt_destroy(&data->fofilt1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKHighPassButterworthFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createHighPassButterworthFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createHighPassButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKHighPassButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createHighPassButterworthFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createHighPassButterworthFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKHighPassButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createHighPassButterworthFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createHighPassButterworthFilterDSP() {
     AKHighPassButterworthFilterDSP *dsp = new AKHighPassButterworthFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -60,6 +59,7 @@ void AKHighPassButterworthFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKHighPassButterworthFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_buthp_destroy(&data->buthp0);
     sp_buthp_destroy(&data->buthp1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKHighShelfParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createHighShelfParametricEqualizerFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createHighShelfParametricEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKHighShelfParametricEqualizerFilterParamete
 
 #ifndef __cplusplus
 
-AKDSPRef createHighShelfParametricEqualizerFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createHighShelfParametricEqualizerFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKHighShelfParametricEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createHighShelfParametricEqualizerFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createHighShelfParametricEqualizerFilterDSP() {
     AKHighShelfParametricEqualizerFilterDSP *dsp = new AKHighShelfParametricEqualizerFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -84,6 +83,7 @@ void AKHighShelfParametricEqualizerFilterDSP::init(int channelCount, double samp
 }
 
 void AKHighShelfParametricEqualizerFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_pareq_destroy(&data->pareq0);
     sp_pareq_destroy(&data->pareq1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKKorgLowPassFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createKorgLowPassFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createKorgLowPassFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKKorgLowPassFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createKorgLowPassFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createKorgLowPassFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKKorgLowPassFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createKorgLowPassFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createKorgLowPassFilterDSP() {
     AKKorgLowPassFilterDSP *dsp = new AKKorgLowPassFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -82,6 +81,7 @@ void AKKorgLowPassFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKKorgLowPassFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_wpkorg35_destroy(&data->wpkorg350);
     sp_wpkorg35_destroy(&data->wpkorg351);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKLowPassButterworthFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createLowPassButterworthFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createLowPassButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKLowPassButterworthFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createLowPassButterworthFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createLowPassButterworthFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKLowPassButterworthFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createLowPassButterworthFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createLowPassButterworthFilterDSP() {
     AKLowPassButterworthFilterDSP *dsp = new AKLowPassButterworthFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -60,6 +59,7 @@ void AKLowPassButterworthFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKLowPassButterworthFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_butlp_destroy(&data->butlp0);
     sp_butlp_destroy(&data->butlp1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKLowShelfParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createLowShelfParametricEqualizerFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createLowShelfParametricEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKLowShelfParametricEqualizerFilterParameter
 
 #ifndef __cplusplus
 
-AKDSPRef createLowShelfParametricEqualizerFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createLowShelfParametricEqualizerFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKLowShelfParametricEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createLowShelfParametricEqualizerFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createLowShelfParametricEqualizerFilterDSP() {
     AKLowShelfParametricEqualizerFilterDSP *dsp = new AKLowShelfParametricEqualizerFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -84,6 +83,7 @@ void AKLowShelfParametricEqualizerFilterDSP::init(int channelCount, double sampl
 }
 
 void AKLowShelfParametricEqualizerFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_pareq_destroy(&data->pareq0);
     sp_pareq_destroy(&data->pareq1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKModalResonanceFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createModalResonanceFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createModalResonanceFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKModalResonanceFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createModalResonanceFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createModalResonanceFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKModalResonanceFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createModalResonanceFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createModalResonanceFilterDSP() {
     AKModalResonanceFilterDSP *dsp = new AKModalResonanceFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -71,6 +70,7 @@ void AKModalResonanceFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKModalResonanceFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_mode_destroy(&data->mode0);
     sp_mode_destroy(&data->mode1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKMoogLadderAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createMoogLadderDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createMoogLadderDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKMoogLadderParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createMoogLadderDSP(int channelCount, double sampleRate);
+AKDSPRef createMoogLadderDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
@@ -9,9 +9,8 @@
 #include "AKMoogLadderDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createMoogLadderDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createMoogLadderDSP() {
     AKMoogLadderDSP *dsp = new AKMoogLadderDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -71,6 +70,7 @@ void AKMoogLadderDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKMoogLadderDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_moogladder_destroy(&data->moogladder0);
     sp_moogladder_destroy(&data->moogladder1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKPeakingParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPeakingParametricEqualizerFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPeakingParametricEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKPeakingParametricEqualizerFilterParameter)
 
 #ifndef __cplusplus
 
-AKDSPRef createPeakingParametricEqualizerFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createPeakingParametricEqualizerFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKPeakingParametricEqualizerFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createPeakingParametricEqualizerFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPeakingParametricEqualizerFilterDSP() {
     AKPeakingParametricEqualizerFilterDSP *dsp = new AKPeakingParametricEqualizerFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -84,6 +83,7 @@ void AKPeakingParametricEqualizerFilterDSP::init(int channelCount, double sample
 }
 
 void AKPeakingParametricEqualizerFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_pareq_destroy(&data->pareq0);
     sp_pareq_destroy(&data->pareq1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKResonantFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createResonantFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createResonantFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKResonantFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createResonantFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createResonantFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKResonantFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createResonantFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createResonantFilterDSP() {
     AKResonantFilterDSP *dsp = new AKResonantFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -71,6 +70,7 @@ void AKResonantFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKResonantFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_reson_destroy(&data->reson0);
     sp_reson_destroy(&data->reson1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterAudioUnit.swift
@@ -38,9 +38,8 @@ public class AKRolandTB303FilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createRolandTB303FilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createRolandTB303FilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKRolandTB303FilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createRolandTB303FilterDSP(int channelCount, double sampleRate);
+AKDSPRef createRolandTB303FilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKRolandTB303FilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createRolandTB303FilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createRolandTB303FilterDSP() {
     AKRolandTB303FilterDSP *dsp = new AKRolandTB303FilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -93,6 +92,7 @@ void AKRolandTB303FilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKRolandTB303FilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_tbvcf_destroy(&data->tbvcf0);
     sp_tbvcf_destroy(&data->tbvcf1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKStringResonatorAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createStringResonatorDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createStringResonatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKStringResonatorParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createStringResonatorDSP(int channelCount, double sampleRate);
+AKDSPRef createStringResonatorDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
@@ -9,9 +9,8 @@
 #include "AKStringResonatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createStringResonatorDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createStringResonatorDSP() {
     AKStringResonatorDSP *dsp = new AKStringResonatorDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -71,6 +70,7 @@ void AKStringResonatorDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKStringResonatorDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_streson_destroy(&data->streson0);
     sp_streson_destroy(&data->streson1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKThreePoleLowpassFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createThreePoleLowpassFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createThreePoleLowpassFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKThreePoleLowpassFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createThreePoleLowpassFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createThreePoleLowpassFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKThreePoleLowpassFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createThreePoleLowpassFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createThreePoleLowpassFilterDSP() {
     AKThreePoleLowpassFilterDSP *dsp = new AKThreePoleLowpassFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -82,6 +81,7 @@ void AKThreePoleLowpassFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKThreePoleLowpassFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_lpf18_destroy(&data->lpf180);
     sp_lpf18_destroy(&data->lpf181);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKToneComplementFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createToneComplementFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createToneComplementFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKToneComplementFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createToneComplementFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createToneComplementFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKToneComplementFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createToneComplementFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createToneComplementFilterDSP() {
     AKToneComplementFilterDSP *dsp = new AKToneComplementFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -60,6 +59,7 @@ void AKToneComplementFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKToneComplementFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_atone_destroy(&data->atone0);
     sp_atone_destroy(&data->atone1);
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKToneFilterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createToneFilterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createToneFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKToneFilterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createToneFilterDSP(int channelCount, double sampleRate);
+AKDSPRef createToneFilterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKToneFilterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createToneFilterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createToneFilterDSP() {
     AKToneFilterDSP *dsp = new AKToneFilterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -60,6 +59,7 @@ void AKToneFilterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKToneFilterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_tone_destroy(&data->tone0);
     sp_tone_destroy(&data->tone1);
 }

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKAutoWahAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createAutoWahDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createAutoWahDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKAutoWahParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createAutoWahDSP(int channelCount, double sampleRate);
+AKDSPRef createAutoWahDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
@@ -9,9 +9,8 @@
 #include "AKAutoWahDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createAutoWahDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createAutoWahDSP() {
     AKAutoWahDSP *dsp = new AKAutoWahDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -82,6 +81,7 @@ void AKAutoWahDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKAutoWahDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_autowah_destroy(&data->autowah0);
     sp_autowah_destroy(&data->autowah1);
 }

--- a/AudioKit/Common/Nodes/Effects/Modulation/Chorus/AKChorusAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Chorus/AKChorusAudioUnit.swift
@@ -38,9 +38,8 @@ public class AKChorusAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createChorusDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createChorusDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.hpp
@@ -51,8 +51,8 @@ extern const float kAKFlanger_MaxDryWetMix;
 
 #ifndef __cplusplus
 
-AKDSPRef createChorusDSP(int channelCount, double sampleRate);
-AKDSPRef createFlangerDSP(int channelCount, double sampleRate);
+AKDSPRef createChorusDSP(void);
+AKDSPRef createFlangerDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
@@ -13,12 +13,12 @@
 
 #include "AKModulatedDelayDSP.hpp"
 
-extern "C" AKDSPRef createChorusDSP(int channelCount, double sampleRate)
+extern "C" AKDSPRef createChorusDSP()
 {
     return new AKModulatedDelayDSP(kChorus);
 }
 
-extern "C" AKDSPRef createFlangerDSP(int channelCount, double sampleRate)
+extern "C" AKDSPRef createFlangerDSP()
 {
     return new AKModulatedDelayDSP(kFlanger);
 }
@@ -83,6 +83,7 @@ void AKModulatedDelayDSP::init(int channels, double sampleRate)
 
 void AKModulatedDelayDSP::deinit()
 {
+    AKDSPBase::deinit();
     AKModulatedDelay::deinit();
 }
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Flanger/AKFlangerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Flanger/AKFlangerAudioUnit.swift
@@ -38,9 +38,8 @@ public class AKFlangerAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createFlangerDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createFlangerDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserAudioUnit.swift
@@ -58,9 +58,8 @@ public class AKPhaserAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPhaserDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPhaserDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.hpp
@@ -25,7 +25,7 @@ typedef NS_ENUM(AUParameterAddress, AKPhaserParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPhaserDSP(int channelCount, double sampleRate);
+AKDSPRef createPhaserDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
@@ -9,9 +9,8 @@
 #include "AKPhaserDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createPhaserDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPhaserDSP() {
     AKPhaserDSP *dsp = new AKPhaserDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -136,6 +135,7 @@ void AKPhaserDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKPhaserDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_phaser_destroy(&data->phaser);
 }
 

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKPitchShifterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPitchShifterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPitchShifterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKPitchShifterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPitchShifterDSP(int channelCount, double sampleRate);
+AKDSPRef createPitchShifterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
@@ -9,9 +9,8 @@
 #include "AKPitchShifterDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createPitchShifterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPitchShifterDSP() {
     AKPitchShifterDSP *dsp = new AKPitchShifterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -82,6 +81,7 @@ void AKPitchShifterDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKPitchShifterDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_pshift_destroy(&data->pshift0);
     sp_pshift_destroy(&data->pshift1);
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbAudioUnit.swift
@@ -22,9 +22,8 @@ public class AKChowningReverbAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createChowningReverbDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createChowningReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.hpp
@@ -16,7 +16,7 @@ typedef NS_ENUM(AUParameterAddress, AKChowningReverbParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createChowningReverbDSP(int channelCount, double sampleRate);
+AKDSPRef createChowningReverbDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
@@ -9,9 +9,8 @@
 #include "AKChowningReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createChowningReverbDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createChowningReverbDSP() {
     AKChowningReverbDSP *dsp = new AKChowningReverbDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -31,6 +30,7 @@ void AKChowningReverbDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKChowningReverbDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_jcrev_destroy(&data->jcrev0);
     sp_jcrev_destroy(&data->jcrev1);
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverb.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverb.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createCombFilterReverbDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createCombFilterReverbDSP() {
     AKCombFilterReverbDSP *dsp = new AKCombFilterReverbDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKCombFilterReverbAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createCombFilterReverbDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createCombFilterReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKCombFilterReverbParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createCombFilterReverbDSP(int channelCount, double sampleRate);
+AKDSPRef createCombFilterReverbDSP(void);
 
 #else
 
@@ -78,6 +78,7 @@ public:
     }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_comb_destroy(&comb0);
         sp_comb_destroy(&comb1);
     }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolution.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolution.swift
@@ -56,7 +56,6 @@ open class AKConvolution: AKNode, AKToggleable, AKComponent, AKInput {
             input?.connect(to: strongSelf)
             strongSelf.internalAU?.setPartitionLength(Int32(partitionLength))
             strongSelf.readAudioFile()
-            strongSelf.internalAU?.initConvolutionEngine()
             strongSelf.internalAU?.start()
         }
     }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.swift
@@ -22,9 +22,8 @@ public class AKConvolutionAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createConvolutionDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createConvolutionDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.hpp
@@ -36,7 +36,6 @@ public:
 
     void setUpTable(float *table, UInt32 size) override;
     void setPartitionLength(int partLength) override;
-    void initConvolutionEngine() override;
 
     void deinit() override;
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.hpp
@@ -16,7 +16,7 @@ typedef NS_ENUM(AUParameterAddress, AKConvolutionParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createConvolutionDSP(int channelCount, double sampleRate);
+AKDSPRef createConvolutionDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.mm
@@ -9,9 +9,8 @@
 #include "AKConvolutionDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createConvolutionDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createConvolutionDSP() {
     AKConvolutionDSP *dsp = new AKConvolutionDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -50,6 +49,7 @@ void AKConvolutionDSP::initConvolutionEngine() {
 }
 
 void AKConvolutionDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_conv_destroy(&data->conv0);
     sp_conv_destroy(&data->conv1);
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.mm
@@ -8,6 +8,7 @@
 
 #include "AKConvolutionDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
+#include <vector>
 
 extern "C" AKDSPRef createConvolutionDSP() {
     AKConvolutionDSP *dsp = new AKConvolutionDSP();
@@ -19,7 +20,7 @@ struct AKConvolutionDSP::InternalData {
     sp_conv *conv1;
 
     sp_ftbl *ftbl;
-    UInt32 ftbl_size = 4096;
+    std::vector<float> wavetable;
 
     int partitionLength = 2048;
 };
@@ -28,6 +29,12 @@ AKConvolutionDSP::AKConvolutionDSP() : data(new InternalData) {}
 
 void AKConvolutionDSP::init(int channelCount, double sampleRate) {
     AKSoundpipeDSPBase::init(channelCount, sampleRate);
+    sp_ftbl_create(sp, &data->ftbl, data->wavetable.size());
+    std::copy(data->wavetable.cbegin(), data->wavetable.cend(), data->ftbl->tbl);
+    sp_conv_create(&data->conv0);
+    sp_conv_create(&data->conv1);
+    sp_conv_init(sp, data->conv0, data->ftbl, (float)data->partitionLength);
+    sp_conv_init(sp, data->conv1, data->ftbl, (float)data->partitionLength);
 }
 
 void AKConvolutionDSP::setPartitionLength(int partLength) {
@@ -35,23 +42,14 @@ void AKConvolutionDSP::setPartitionLength(int partLength) {
 }
 
 void AKConvolutionDSP::setUpTable(float *table, UInt32 size) {
-    data->ftbl_size = size;
-    sp_ftbl_create(sp, &data->ftbl, data->ftbl_size);
-    data->ftbl->tbl = table;
-}
-
-
-void AKConvolutionDSP::initConvolutionEngine() {
-    sp_conv_create(&data->conv0);
-    sp_conv_create(&data->conv1);
-    sp_conv_init(sp, data->conv0, data->ftbl, (float)data->partitionLength);
-    sp_conv_init(sp, data->conv1, data->ftbl, (float)data->partitionLength);
+    data->wavetable = std::vector<float>(table, table + size);
 }
 
 void AKConvolutionDSP::deinit() {
     AKSoundpipeDSPBase::deinit();
     sp_conv_destroy(&data->conv0);
     sp_conv_destroy(&data->conv1);
+    sp_ftbl_destroy(&data->ftbl);
 }
 
 void AKConvolutionDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKCostelloReverbAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createCostelloReverbDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createCostelloReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.hpp
@@ -18,7 +18,7 @@ typedef NS_ENUM(AUParameterAddress, AKCostelloReverbParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createCostelloReverbDSP(int channelCount, double sampleRate);
+AKDSPRef createCostelloReverbDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.mm
@@ -9,9 +9,8 @@
 #include "AKCostelloReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createCostelloReverbDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createCostelloReverbDSP() {
     AKCostelloReverbDSP *dsp = new AKCostelloReverbDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -66,6 +65,7 @@ void AKCostelloReverbDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKCostelloReverbDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_revsc_destroy(&data->revsc);
 }
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKFlatFrequencyResponseReverbAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createFlatFrequencyResponseReverbDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createFlatFrequencyResponseReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKFlatFrequencyResponseReverbParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createFlatFrequencyResponseReverbDSP(int channelCount, double sampleRate);
+AKDSPRef createFlatFrequencyResponseReverbDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
@@ -9,9 +9,8 @@
 #include "AKFlatFrequencyResponseReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createFlatFrequencyResponseReverbDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createFlatFrequencyResponseReverbDSP() {
     AKFlatFrequencyResponseReverbDSP *dsp = new AKFlatFrequencyResponseReverbDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -67,6 +66,7 @@ void AKFlatFrequencyResponseReverbDSP::init(int channelCount, double sampleRate)
 }
 
 void AKFlatFrequencyResponseReverbDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_allpass_destroy(&data->allpass0);
     sp_allpass_destroy(&data->allpass1);
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbAudioUnit.swift
@@ -62,9 +62,8 @@ public class AKZitaReverbAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createZitaReverbDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createZitaReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.hpp
@@ -26,7 +26,7 @@ typedef NS_ENUM(AUParameterAddress, AKZitaReverbParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createZitaReverbDSP(int channelCount, double sampleRate);
+AKDSPRef createZitaReverbDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
@@ -9,9 +9,8 @@
 #include "AKZitaReverbDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createZitaReverbDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createZitaReverbDSP() {
     AKZitaReverbDSP *dsp = new AKZitaReverbDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -146,6 +145,7 @@ void AKZitaReverbDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKZitaReverbDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_zitarev_destroy(&data->zitarev);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKBrownianNoiseAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createBrownianNoiseDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createBrownianNoiseDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKBrownianNoiseParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createBrownianNoiseDSP(int channelCount, double sampleRate);
+AKDSPRef createBrownianNoiseDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.mm
@@ -9,9 +9,8 @@
 #include "AKBrownianNoiseDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createBrownianNoiseDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createBrownianNoiseDSP() {
     AKBrownianNoiseDSP *dsp = new AKBrownianNoiseDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -55,6 +54,7 @@ void AKBrownianNoiseDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKBrownianNoiseDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_brown_destroy(&data->brown);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKPinkNoiseAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPinkNoiseDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPinkNoiseDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKPinkNoiseParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPinkNoiseDSP(int channelCount, double sampleRate);
+AKDSPRef createPinkNoiseDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
@@ -9,9 +9,8 @@
 #include "AKPinkNoiseDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createPinkNoiseDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPinkNoiseDSP() {
     AKPinkNoiseDSP *dsp = new AKPinkNoiseDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -56,6 +55,7 @@ void AKPinkNoiseDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKPinkNoiseDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_pinknoise_destroy(&data->pinknoise);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKWhiteNoiseAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createWhiteNoiseDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createWhiteNoiseDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.hpp
@@ -17,7 +17,7 @@ typedef NS_ENUM(AUParameterAddress, AKWhiteNoiseParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createWhiteNoiseDSP(int channelCount, double sampleRate);
+AKDSPRef createWhiteNoiseDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
@@ -9,9 +9,8 @@
 #include "AKWhiteNoiseDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createWhiteNoiseDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createWhiteNoiseDSP() {
     AKWhiteNoiseDSP *dsp = new AKWhiteNoiseDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -56,6 +55,7 @@ void AKWhiteNoiseDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKWhiteNoiseDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_noise_destroy(&data->noise);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorAudioUnit.swift
@@ -42,9 +42,8 @@ public class AKFMOscillatorAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createFMOscillatorDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createFMOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.hpp
@@ -21,7 +21,7 @@ typedef NS_ENUM(AUParameterAddress, AKFMOscillatorParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createFMOscillatorDSP(int channelCount, double sampleRate);
+AKDSPRef createFMOscillatorDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.mm
@@ -9,9 +9,8 @@
 #include "AKFMOscillatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createFMOscillatorDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createFMOscillatorDSP() {
     AKFMOscillatorDSP *dsp = new AKFMOscillatorDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -99,6 +98,7 @@ void AKFMOscillatorDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKFMOscillatorDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_fosc_destroy(&data->fosc);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorAudioUnit.swift
@@ -42,9 +42,8 @@ public class AKMorphingOscillatorAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createMorphingOscillatorDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createMorphingOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.hpp
@@ -21,7 +21,7 @@ typedef NS_ENUM(AUParameterAddress, AKMorphingOscillatorParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createMorphingOscillatorDSP(int channelCount, double sampleRate);
+AKDSPRef createMorphingOscillatorDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
@@ -9,9 +9,8 @@
 #include "AKMorphingOscillatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createMorphingOscillatorDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createMorphingOscillatorDSP() {
     AKMorphingOscillatorDSP *dsp = new AKMorphingOscillatorDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -93,6 +92,7 @@ void AKMorphingOscillatorDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKMorphingOscillatorDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_oscmorph_destroy(&data->oscmorph);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorAudioUnit.swift
@@ -38,9 +38,8 @@ public class AKOscillatorAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createOscillatorDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKOscillatorParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createOscillatorDSP(int channelCount, double sampleRate);
+AKDSPRef createOscillatorDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -9,9 +9,8 @@
 #include "AKOscillatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createOscillatorDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createOscillatorDSP() {
     AKOscillatorDSP *dsp = new AKOscillatorDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -87,6 +86,7 @@ void AKOscillatorDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKOscillatorDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_osc_destroy(&data->osc);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -8,6 +8,7 @@
 
 #include "AKOscillatorDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
+#include <vector>
 
 extern "C" AKDSPRef createOscillatorDSP() {
     AKOscillatorDSP *dsp = new AKOscillatorDSP();
@@ -17,7 +18,7 @@ extern "C" AKDSPRef createOscillatorDSP() {
 struct AKOscillatorDSP::InternalData {
     sp_osc *osc;
     sp_ftbl *ftbl;
-    UInt32 ftbl_size = 4096;
+    std::vector<float> waveform;
     AKLinearParameterRamp frequencyRamp;
     AKLinearParameterRamp amplitudeRamp;
     AKLinearParameterRamp detuningOffsetRamp;
@@ -79,6 +80,10 @@ float AKOscillatorDSP::getParameter(uint64_t address) {
 void AKOscillatorDSP::init(int channelCount, double sampleRate) {
     AKSoundpipeDSPBase::init(channelCount, sampleRate);
     isStarted = false;
+    
+    sp_ftbl_create(sp, &data->ftbl, data->waveform.size());
+    std::copy(data->waveform.cbegin(), data->waveform.cend(), data->ftbl->tbl);
+    
     sp_osc_create(&data->osc);
     sp_osc_init(sp, data->osc, data->ftbl, 0);
     data->osc->freq = defaultFrequency;
@@ -88,15 +93,15 @@ void AKOscillatorDSP::init(int channelCount, double sampleRate) {
 void AKOscillatorDSP::deinit() {
     AKSoundpipeDSPBase::deinit();
     sp_osc_destroy(&data->osc);
+    sp_ftbl_destroy(&data->ftbl);
 }
 
 void AKOscillatorDSP::setupWaveform(uint32_t size) {
-    data->ftbl_size = size;
-    sp_ftbl_create(sp, &data->ftbl, data->ftbl_size);
+    data->waveform.resize(size);
 }
 
 void AKOscillatorDSP::setWaveformValue(uint32_t index, float value) {
-    data->ftbl->tbl[index] = value;
+    data->waveform[index] = value;
 }
 
 void AKOscillatorDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorAudioUnit.swift
@@ -42,9 +42,8 @@ public class AKPWMOscillatorAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPWMOscillatorDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPWMOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKPWMOscillatorParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPWMOscillatorDSP(int channelCount, double sampleRate);
+AKDSPRef createPWMOscillatorDSP(void);
 
 #else
 
@@ -114,6 +114,7 @@ public:
    }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_blsquare_destroy(&blsquare);
     }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createPWMOscillatorDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPWMOscillatorDSP() {
     AKPWMOscillatorDSP *dsp = new AKPWMOscillatorDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorAudioUnit.swift
@@ -42,9 +42,8 @@ public class AKPhaseDistortionOscillatorAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPhaseDistortionOscillatorDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPhaseDistortionOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKPhaseDistortionOscillatorParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPhaseDistortionOscillatorDSP(int channelCount, double sampleRate);
+AKDSPRef createPhaseDistortionOscillatorDSP(void);
 
 #else
 
@@ -123,7 +123,10 @@ public:
    }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_pdhalf_destroy(&pdhalf);
+        sp_tabread_destroy(&tabread);
+        sp_phasor_destroy(&phasor);
     }
 
     void setupWaveform(uint32_t size) override {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createPhaseDistortionOscillatorDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPhaseDistortionOscillatorDSP() {
     AKPhaseDistortionOscillatorDSP *dsp = new AKPhaseDistortionOscillatorDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetAudioUnit.swift
@@ -29,9 +29,8 @@ public class AKClarinetAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createClarinetDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createClarinetDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKClarinetParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createClarinetDSP(int channelCount, double sampleRate);
+AKDSPRef createClarinetDSP(void);
 
 #else
 
@@ -47,7 +47,7 @@ public:
 
     void triggerFrequencyAmplitude(AUValue freq, AUValue amp) override;
 
-    void destroy();
+    void deinit() override;
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
 };

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Clarinet/AKClarinetDSP.mm
@@ -12,9 +12,8 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createClarinetDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createClarinetDSP() {
     AKClarinetDSP *dsp = new AKClarinetDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -89,7 +88,8 @@ void AKClarinetDSP::triggerFrequencyAmplitude(AUValue freq, AUValue amp)  {
     trigger();
 }
 
-void AKClarinetDSP::destroy() {
+void AKClarinetDSP::deinit() {
+    AKDSPBase::deinit();
     delete data->clarinet;
 }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripAudioUnit.swift
@@ -50,9 +50,8 @@ public class AKDripAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createDripDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createDripDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKDripParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createDripDSP(int channelCount, double sampleRate);
+AKDSPRef createDripDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.mm
@@ -9,9 +9,8 @@
 #include "AKDripDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createDripDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createDripDSP() {
     AKDripDSP *dsp = new AKDripDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -116,6 +115,7 @@ void AKDripDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKDripDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_drip_destroy(&data->drip);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteAudioUnit.swift
@@ -29,9 +29,8 @@ public class AKFluteAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createFluteDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createFluteDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKFluteParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createFluteDSP(int channelCount, double sampleRate);
+AKDSPRef createFluteDSP(void);
 
 #else
 
@@ -47,7 +47,7 @@ public:
 
     void triggerFrequencyAmplitude(AUValue freq, AUValue amp) override;
 
-    void destroy();
+    void deinit() override;
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
 };

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Flute/AKFluteDSP.mm
@@ -12,9 +12,8 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createFluteDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createFluteDSP() {
     AKFluteDSP *dsp = new AKFluteDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -88,7 +87,8 @@ void AKFluteDSP::triggerFrequencyAmplitude(AUValue freq, AUValue amp)  {
     trigger();
 }
 
-void AKFluteDSP::destroy() {
+void AKFluteDSP::deinit() {
+    AKDSPBase::deinit();
     delete data->flute;
 }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarAudioUnit.swift
@@ -50,9 +50,8 @@ public class AKMetalBarAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createMetalBarDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createMetalBarDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKMetalBarParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createMetalBarDSP(int channelCount, double sampleRate);
+AKDSPRef createMetalBarDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.mm
@@ -9,9 +9,8 @@
 #include "AKMetalBarDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createMetalBarDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createMetalBarDSP() {
     AKMetalBarDSP *dsp = new AKMetalBarDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -116,6 +115,7 @@ void AKMetalBarDSP::init(int channelCount, double sampleRate) {
 }
 
 void AKMetalBarDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_bar_destroy(&data->bar);
 }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringAudioUnit.swift
@@ -30,9 +30,8 @@ public class AKPluckedStringAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPluckedStringDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPluckedStringDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKPluckedStringParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPluckedStringDSP(int channelCount, double sampleRate);
+AKDSPRef createPluckedStringDSP(void);
 
 #else
 
@@ -81,6 +81,7 @@ public:
     }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_pluck_destroy(&pluck);
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createPluckedStringDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPluckedStringDSP() {
     AKPluckedStringDSP *dsp = new AKPluckedStringDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Rhodes Piano/AKRhodesPianoAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Rhodes Piano/AKRhodesPianoAudioUnit.swift
@@ -29,9 +29,8 @@ public class AKRhodesPianoAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createRhodesPianoDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createRhodesPianoDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Rhodes Piano/AKRhodesPianoDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Rhodes Piano/AKRhodesPianoDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKRhodesPianoParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createRhodesPianoDSP(int channelCount, double sampleRate);
+AKDSPRef createRhodesPianoDSP(void);
 
 #else
 
@@ -47,7 +47,7 @@ public:
 
     void triggerFrequencyAmplitude(AUValue freq, AUValue amp) override;
 
-    void destroy();
+    void deinit() override;
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
 };

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Rhodes Piano/AKRhodesPianoDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Rhodes Piano/AKRhodesPianoDSP.mm
@@ -14,9 +14,8 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createRhodesPianoDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createRhodesPianoDSP() {
     AKRhodesPianoDSP *dsp = new AKRhodesPianoDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -108,7 +107,8 @@ void AKRhodesPianoDSP::triggerFrequencyAmplitude(AUValue freq, AUValue amp)  {
     trigger();
 }
 
-void AKRhodesPianoDSP::destroy() {
+void AKRhodesPianoDSP::deinit() {
+    AKDSPBase::deinit();
     delete data->rhodesPiano;
 }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Shaker/AKShakerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Shaker/AKShakerAudioUnit.swift
@@ -23,9 +23,8 @@ public class AKShakerAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.amplitude, value: amplitude) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createShakerDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createShakerDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Shaker/AKShakerDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Shaker/AKShakerDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKShakerParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createShakerDSP(int channelCount, double sampleRate);
+AKDSPRef createShakerDSP(void);
 
 #else
 
@@ -46,7 +46,7 @@ public:
 
     void triggerTypeAmplitude(AUValue freq, AUValue amp) override;
 
-    void destroy();
+    void deinit() override;
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Shaker/AKShakerDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Shaker/AKShakerDSP.mm
@@ -12,9 +12,8 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createShakerDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createShakerDSP() {
     AKShakerDSP *dsp = new AKShakerDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -75,7 +74,8 @@ void AKShakerDSP::triggerTypeAmplitude(AUValue type, AUValue amp)  {
     trigger();
 }
 
-void AKShakerDSP::destroy() {
+void AKShakerDSP::deinit() {
+    AKDSPBase::deinit();
     delete data->shaker;
 }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Tubular Bells/AKTubularBellsAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Tubular Bells/AKTubularBellsAudioUnit.swift
@@ -29,9 +29,8 @@ public class AKTubularBellsAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createTubularBellsDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createTubularBellsDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Tubular Bells/AKTubularBellsDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Tubular Bells/AKTubularBellsDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKTubularBellsParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createTubularBellsDSP(int channelCount, double sampleRate);
+AKDSPRef createTubularBellsDSP(void);
 
 #else
 
@@ -47,7 +47,7 @@ public:
 
     void triggerFrequencyAmplitude(AUValue freq, AUValue amp) override;
 
-    void destroy();
+    void deinit() override;
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
 };

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Tubular Bells/AKTubularBellsDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Tubular Bells/AKTubularBellsDSP.mm
@@ -14,9 +14,8 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createTubularBellsDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createTubularBellsDSP() {
     AKTubularBellsDSP *dsp = new AKTubularBellsDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -108,7 +107,8 @@ void AKTubularBellsDSP::triggerFrequencyAmplitude(AUValue freq, AUValue amp)  {
     trigger();
 }
 
-void AKTubularBellsDSP::destroy() {
+void AKTubularBellsDSP::deinit() {
+    AKDSPBase::deinit();
     delete data->tubularBells;
 }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTract.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTract.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createVocalTractDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createVocalTractDSP() {
     AKVocalTractDSP *dsp = new AKVocalTractDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractAudioUnit.swift
@@ -42,9 +42,8 @@ public class AKVocalTractAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createVocalTractDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createVocalTractDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.hpp
@@ -23,7 +23,7 @@ typedef NS_ENUM(AUParameterAddress, AKVocalTractParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createVocalTractDSP(int channelCount, double sampleRate);
+AKDSPRef createVocalTractDSP(void);
 
 #else
 
@@ -116,6 +116,7 @@ public:
     }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_vocwrapper_destroy(&vocwrapper);
     }
 

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynthAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynthAudioUnit.swift
@@ -78,9 +78,8 @@ public class AKSynthAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.filterReleaseDuration, value: filterReleaseDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createAKSynthDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createAKSynthDSP()
     }
 
     override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynthDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynthDSP.hpp
@@ -38,7 +38,7 @@ typedef NS_ENUM(AUParameterAddress, AKSynthParameter)
 
 #ifndef __cplusplus
 
-AKDSPRef createAKSynthDSP(int channelCount, double sampleRate);
+AKDSPRef createAKSynthDSP(void);
 void doAKSynthPlayNote(AKDSPRef pDSP, UInt8 noteNumber, UInt8 velocity, float noteFrequency);
 void doAKSynthStopNote(AKDSPRef pDSP, UInt8 noteNumber, bool immediate);
 void doAKSynthSustainPedal(AKDSPRef pDSP, bool pedalDown);

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynthDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Synth/AKSynthDSP.mm
@@ -9,7 +9,7 @@
 #import "AKSynthDSP.hpp"
 #include <math.h>
 
-extern "C" void *createAKSynthDSP(int channelCount, double sampleRate) {
+extern "C" void *createAKSynthDSP() {
     return new AKSynthDSP();
 }
 
@@ -46,6 +46,7 @@ void AKSynthDSP::init(int channelCount, double sampleRate)
 
 void AKSynthDSP::deinit()
 {
+    AKDSPBase::deinit();
     AKCoreSynth::deinit();
 }
 

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerAudioUnit.swift
@@ -29,9 +29,8 @@ public class AKAutoPannerAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createAutoPannerDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createAutoPannerDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM(AUParameterAddress, AKAutoPannerParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createAutoPannerDSP(int channelCount, double sampleRate);
+AKDSPRef createAutoPannerDSP(void);
 
 #else
 
@@ -96,6 +96,7 @@ public:
     }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_osc_destroy(&trem);
         sp_panst_destroy(&panst);
     }

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createAutoPannerDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createAutoPannerDSP() {
     AKAutoPannerDSP *dsp = new AKAutoPannerDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderAudioUnit.swift
@@ -31,11 +31,8 @@ public class AKFaderAudioUnit: AKAudioUnitBase {
 
     public override var canProcessInPlace: Bool { return true }
 
-    public override func initDSP(
-        withSampleRate sampleRate: Double,
-        channelCount count: AVAudioChannelCount
-    ) -> AKDSPRef {
-        return createFaderDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createFaderDSP()
     }
 
     public override init(

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.hpp
@@ -21,7 +21,7 @@ typedef NS_ENUM (AUParameterAddress, AKFaderParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createFaderDSP(int channelCount, double sampleRate);
+AKDSPRef createFaderDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
@@ -9,10 +9,9 @@
 #include "AKFaderDSP.hpp"
 #import "ParameterRamper.hpp"
 
-extern "C" AKDSPRef createFaderDSP(int channelCount, double sampleRate)
+extern "C" AKDSPRef createFaderDSP()
 {
     AKFaderDSP *dsp = new AKFaderDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKBoosterAudioUnit: AKAudioUnitBase {
         }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createBoosterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createBoosterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.hpp
@@ -20,7 +20,7 @@ typedef NS_ENUM (AUParameterAddress, AKBoosterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createBoosterDSP(int channelCount, double sampleRate);
+AKDSPRef createBoosterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.mm
@@ -8,10 +8,9 @@
 
 #include "AKBoosterDSP.hpp"
 
-extern "C" AKDSPRef createBoosterDSP(int channelCount, double sampleRate)
+extern "C" AKDSPRef createBoosterDSP()
 {
     AKBoosterDSP *dsp = new AKBoosterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKPannerAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPannerDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPannerDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKPannerParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPannerDSP(int channelCount, double sampleRate);
+AKDSPRef createPannerDSP(void);
 
 #else
 
@@ -70,6 +70,7 @@ public:
     }
 
     void deinit() override {
+        AKSoundpipeDSPBase::deinit();
         sp_panst_destroy(&panst);
     }
 

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.mm
@@ -10,8 +10,7 @@
 
 // "Constructor" function for interop with Swift
 
-extern "C" AKDSPRef createPannerDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPannerDSP() {
     AKPannerDSP *dsp = new AKPannerDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterAudioUnit.swift
@@ -26,9 +26,8 @@ public class AKStereoFieldLimiterAudioUnit: AKAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createStereoFieldLimiterDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createStereoFieldLimiterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKStereoFieldLimiterParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createStereoFieldLimiterDSP(int channelCount, double sampleRate);
+AKDSPRef createStereoFieldLimiterDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.mm
@@ -12,9 +12,8 @@
 // In this case a destructor is not needed, since the DSP object doesn't do any of
 // its own heap based allocation.
 
-extern "C" AKDSPRef createStereoFieldLimiterDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createStereoFieldLimiterDSP() {
     AKStereoFieldLimiterDSP *dsp = new AKStereoFieldLimiterDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 

--- a/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderAudioUnit.swift
@@ -34,9 +34,8 @@ public class AKPhaseLockedVocoderAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.rampDuration, value: rampDuration) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createPhaseLockedVocoderDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createPhaseLockedVocoderDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderDSP.hpp
@@ -19,7 +19,7 @@ typedef NS_ENUM(AUParameterAddress, AKPhaseLockedVocoderParameter) {
 
 #ifndef __cplusplus
 
-AKDSPRef createPhaseLockedVocoderDSP(int channelCount, double sampleRate);
+AKDSPRef createPhaseLockedVocoderDSP(void);
 
 #else
 

--- a/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderDSP.mm
@@ -9,9 +9,8 @@
 #include "AKPhaseLockedVocoderDSP.hpp"
 #import "AKLinearParameterRamp.hpp"
 
-extern "C" AKDSPRef createPhaseLockedVocoderDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createPhaseLockedVocoderDSP() {
     AKPhaseLockedVocoderDSP *dsp = new AKPhaseLockedVocoderDSP();
-    dsp->init(channelCount, sampleRate);
     return dsp;
 }
 
@@ -83,6 +82,7 @@ void AKPhaseLockedVocoderDSP::setUpTable(float *table, UInt32 size) {
 }
 
 void AKPhaseLockedVocoderDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
     sp_ftbl_destroy(&data->ftbl);
     sp_mincer_destroy(&data->mincer);
 }

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -126,9 +126,8 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.filterEnvelopeVelocityScaling, value: filterEnvelopeVelocityScaling) }
     }
 
-    public override func initDSP(withSampleRate sampleRate: Double,
-                                 channelCount count: AVAudioChannelCount) -> AKDSPRef {
-        return createAKSamplerDSP(Int32(count), sampleRate)
+    public override func createDSP() -> AKDSPRef {
+        return createAKSamplerDSP()
     }
 
     override init(componentDescription: AudioComponentDescription,

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
@@ -50,7 +50,7 @@ typedef NS_ENUM(AUParameterAddress, AKSamplerParameter)
 
 #include "AKSampler_Typedefs.h"
 
-AKDSPRef createAKSamplerDSP(int channelCount, double sampleRate);
+AKDSPRef createAKSamplerDSP(void);
 void doAKSamplerLoadData(AKDSPRef pDSP, AKSampleDataDescriptor *pSDD);
 void doAKSamplerLoadCompressedFile(AKDSPRef pDSP, AKSampleFileDescriptor *pSFD);
 void doAKSamplerUnloadAllSamples(AKDSPRef pDSP);

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -10,7 +10,7 @@
 #include "wavpack.h"
 #include <math.h>
 
-extern "C" AKDSPRef createAKSamplerDSP(int channelCount, double sampleRate) {
+extern "C" AKDSPRef createAKSamplerDSP() {
     return new AKSamplerDSP();
 }
 
@@ -122,6 +122,7 @@ void AKSamplerDSP::init(int channelCount, double sampleRate)
 
 void AKSamplerDSP::deinit()
 {
+    AKDSPBase::deinit();
     AKCoreSampler::deinit();
 }
 

--- a/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
+++ b/AudioKit/macOS/AudioKit For macOS.xcodeproj/project.pbxproj
@@ -1131,7 +1131,6 @@
 		EA03BFD0201DD87C00E8BE2C /* AKMandolinDSPKernel.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA03BFCF201DD87B00E8BE2C /* AKMandolinDSPKernel.mm */; };
 		EA03BFEA202070A000E8BE2C /* AKRhinoGuitarProcessorDSPKernel.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA03BFE9202070A000E8BE2C /* AKRhinoGuitarProcessorDSPKernel.mm */; };
 		EA03C02C2024606300E8BE2C /* ParameterRamper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EA03C02B2024606200E8BE2C /* ParameterRamper.cpp */; };
-		EA31D1D123C9773D0077BE23 /* AKReverb2.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA31D1D023C9773C0077BE23 /* AKReverb2.swift */; };
 		EAB403D22258A9D400EB0A24 /* ADSREnvelope.hpp in Headers */ = {isa = PBXBuildFile; fileRef = EAB403D02258A9D400EB0A24 /* ADSREnvelope.hpp */; };
 		EAB403D32258A9D500EB0A24 /* EnvelopeGeneratorBase.hpp in Headers */ = {isa = PBXBuildFile; fileRef = EAB403D12258A9D400EB0A24 /* EnvelopeGeneratorBase.hpp */; };
 		EAB403DA2258B49F00EB0A24 /* MikeFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = EAB403D82258B49F00EB0A24 /* MikeFilter.h */; };
@@ -2437,7 +2436,6 @@
 		EA03BFE9202070A000E8BE2C /* AKRhinoGuitarProcessorDSPKernel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AKRhinoGuitarProcessorDSPKernel.mm; sourceTree = "<group>"; };
 		EA03C02B2024606200E8BE2C /* ParameterRamper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParameterRamper.cpp; sourceTree = "<group>"; };
 		EA08A99F214A01AA00115D67 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
-		EA31D1D023C9773C0077BE23 /* AKReverb2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKReverb2.swift; sourceTree = "<group>"; };
 		EAB403D02258A9D400EB0A24 /* ADSREnvelope.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ADSREnvelope.hpp; sourceTree = "<group>"; };
 		EAB403D12258A9D400EB0A24 /* EnvelopeGeneratorBase.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = EnvelopeGeneratorBase.hpp; sourceTree = "<group>"; };
 		EAB403D82258B49F00EB0A24 /* MikeFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MikeFilter.h; sourceTree = "<group>"; };
@@ -7009,6 +7007,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
+				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"NO_LIBSNDFILE=1",
@@ -7040,6 +7039,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
+				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NO_LIBSNDFILE=1",
 					"AUDIOKIT=1",


### PR DESCRIPTION
Nearly all (if not all?) of AudioKit's Soundpipe AUs leaked memory, due to the init() function of AKDSPBase and subclasses being called twice -- once (improperly) from create[AudioUnit]DSP, and once just before beginning processing.

The first was from create[AudioUnit]DSP, which was ultimately called from AKAudioUnitBase  initWithComponentDescription. This function's purpose as Apple intended is not to actually initialize memory and DSP properties of AUs, but to initialize static properties of AUs. The sample rate and other important properties aren't even known at this time. Sample-rate-dependent properties and other memory should be allocated just before processing begins, from allocateRenderResourcesAndReturnError.

Additionally, many DSP classes did not call their superclass deinit() function from within deinit(), causing soundpipe objects created in AKSoundpipeDSPBase to be leaked.

This PR is as much a proposal as a fix, due to one API-breaking change. The following was changed:

1. AKDSPBase::init() is only called once, from allocateRenderResources. It is no longer called at DSP object creation time.

2. All DSP classes now properly call their superclass' deinit() function, and all memory allocated in init() is deallocated in deinit() (not in the object's destructor).

3. initDSPWithSampleRate(sampleRate, channelCount) was renamed to createDSP(void). This is the API-breaking change. It will only affect those who have independent forks of AudioKit with custom AU classes. As part of this PR, I changed all files already part of AudioKit to conform to the new name. I chose to make this change for a few reasons.
    - The name init is misleading, as its purpose is purely to create the DSP object and return a pointer to it. createDSP much more clearly communicates the purpose of the function.
    - The sample rate may not even be known when this function is called. There is no reason to pass a "best guess" sample rate and channel count, as was previously happening, as the exact values will be known and passed to the AU via allocateRenderResources.
    - This API break will cause build failures for those with custom forks of AudioKit with custom AUs, but the fix is a simple function rename. It will also hopefully alert those with custom AUs of a potential memory leak, assuming they have implemented their AUs following how AudioKit has thus far.
    - As this is in the v5-develop branch, it won't break existing v4 projects