### PR TITLE
fix crash bug for BeatScratch app

### DIFF
--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
@@ -331,8 +331,10 @@ void AKCoreSampler::play(unsigned noteNumber, unsigned velocity, bool anotherKey
         AudioKitCore::SamplerVoice *pVoice = voicePlayingNote(noteNumber);
         if (pVoice)
         {
+            AudioKitCore::KeyMappedSampleBuffer *pBuf = lookupSample(noteNumber, velocity);
+            if (pBuf == 0) return; // don't crash if someone forgets to build map
             // re-start the note
-            pVoice->restartSameNote(velocity / 127.0f, lookupSample(noteNumber, velocity));
+            pVoice->restartSameNote(velocity / 127.0f, pBuf);
             //printf("Restart note %d as %d\n", noteNumber, pVoice->noteNumber);
             return;
         }

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
@@ -140,6 +140,17 @@ namespace AudioKitCore
         {
             tempGain = masterVolume * tempNoteVolume;
             volumeRamper.reinit(adsrEnvelope.getSample(), sampleCount);
+            // FIXME - is the following 'if' code (Exhibit B) ever executed if previous
+            // 'if (adsrEnvelope.isPreStarting())' (Exhibit A) has already been checked, and is true?
+            if (!adsrEnvelope.isPreStarting()) //FIXME: EXHIBIT B
+            {
+                tempGain = masterVolume * noteVolume;
+                volumeRamper.reinit(adsrEnvelope.getSample(), sampleCount);
+                sampleBuffer = newSampleBuffer;
+                oscillator.increment = (sampleBuffer->sampleRate / samplingRate) * (noteFrequency / sampleBuffer->noteFrequency);
+                oscillator.indexPoint = sampleBuffer->startPoint;
+                oscillator.isLooping = sampleBuffer->isLooping;
+            }
         }
         else
         {

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
@@ -136,13 +136,13 @@ namespace AudioKitCore
     {
         if (adsrEnvelope.isIdle()) return true;
 
-        if (adsrEnvelope.isPreStarting()) //FIXME: EXHIBIT A
+        if (adsrEnvelope.isPreStarting())
         {
             tempGain = masterVolume * tempNoteVolume;
             volumeRamper.reinit(adsrEnvelope.getSample(), sampleCount);
-            // FIXME - is the following 'if' code (Exhibit B) ever executed if previous
-            // 'if (adsrEnvelope.isPreStarting())' (Exhibit A) has already been checked, and is true?
-            if (!adsrEnvelope.isPreStarting()) //FIXME: EXHIBIT B
+            // This can execute as part of the voice-stealing mechanism, and will be executed rarely.
+            // To test, set MAX_POLYPHONY in AKCoreSampler.cpp to something small like 2 or 3.
+            if (!adsrEnvelope.isPreStarting())
             {
                 tempGain = masterVolume * noteVolume;
                 volumeRamper.reinit(adsrEnvelope.getSample(), sampleCount);

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
@@ -140,17 +140,6 @@ namespace AudioKitCore
         {
             tempGain = masterVolume * tempNoteVolume;
             volumeRamper.reinit(adsrEnvelope.getSample(), sampleCount);
-            // FIXME - is the following 'if' code (Exhibit B) ever executed if previous
-            // 'if (adsrEnvelope.isPreStarting())' (Exhibit A) has already been checked, and is true?
-            if (!adsrEnvelope.isPreStarting()) //FIXME: EXHIBIT B
-            {
-                tempGain = masterVolume * noteVolume;
-                volumeRamper.reinit(adsrEnvelope.getSample(), sampleCount);
-                sampleBuffer = newSampleBuffer;
-                oscillator.increment = (sampleBuffer->sampleRate / samplingRate) * (noteFrequency / sampleBuffer->noteFrequency);
-                oscillator.indexPoint = sampleBuffer->startPoint;
-                oscillator.isLooping = sampleBuffer->isLooping;
-            }
         }
         else
         {


### PR DESCRIPTION
New to XCode/Apple dev but hopefully have enough details here to get this in :) To answer the question posed by the comment in the deleted code: yes, it's executed and it crashes my app BeatScratch, downloadable for macOS at beatscratch.io (very soon on TestFlight). (I don't plan on open sourcing this whole app just yet but am happy to paste in parts of the very simple Swift AudioKit implementation here if you think the issue lies elsewhere.)

You can download it now from the site and see it crashes due to this if you fiddle around with a MIDI controller for too long. Audio seems to work fine without this block. The crash specifically seems to be coming from `oscillator.increment = (sampleBuffer->sampleRate / samplingRate) * (noteFrequency / sampleBuffer->noteFrequency);`.

Here's the full dump from my crash (lots of Flutter stuff in here but it should be independent):

```
Stack trace:
Process:               BeatFlutter [74842]
Path:                  /Users/USER/*/BeatFlutter.app/Contents/MacOS/BeatFlutter
Identifier:            io.beatscratch.beatscratchFlutterRedux
Version:               1.0.0 (1)
Code Type:             X86-64 (Native)
Parent Process:        dart [74369]
Responsible:           studio [416]
User ID:               501

Date/Time:             2020-04-27 12:38:20.942 -0400
OS Version:            Mac OS X 10.15.4 (19E287)
Report Version:        12
Bridge OS Version:     3.0 (14Y908)
Anonymous UUID:        AFEEA350-7749-F2ED-9A33-EEC7C3B4913A

Sleep/Wake UUID:       6E564F75-4470-4477-A0E5-5E4D0755B76E

Time Awake Since Boot: 95000 seconds
Time Since Wake:       7300 seconds

System Integrity Protection: enabled

Crashed Thread:        5  com.apple.audio.IOThread.client

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000008
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [74842]

VM Regions Near 0x8:
--> 
    __TEXT                 00000001037dd000-00000001042de000 [ 11.0M] r-x/r-x SM=COW  /Users/USER/*/BeatFlutter.app/Contents/MacOS/BeatFlutter

Thread 0:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff6ef3edfa mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff6ef3f170 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff34eb70b5 __CFRunLoopServiceMachPort + 247
3   com.apple.CoreFoundation      	0x00007fff34eb5b82 __CFRunLoopRun + 1319
4   com.apple.CoreFoundation      	0x00007fff34eb4ffe CFRunLoopRunSpecific + 462
5   com.apple.HIToolbox           	0x00007fff33ae8abd RunCurrentEventLoopInMode + 292
6   com.apple.HIToolbox           	0x00007fff33ae87d5 ReceiveNextEventCommon + 584
7   com.apple.HIToolbox           	0x00007fff33ae8579 _BlockUntilNextEventMatchingListInModeWithFilter + 64
8   com.apple.AppKit              	0x00007fff32133c99 _DPSNextEvent + 883
9   com.apple.AppKit              	0x00007fff321324e0 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1352
10  com.apple.AppKit              	0x00007fff321241ee -[NSApplication run] + 658
11  com.apple.AppKit              	0x00007fff320f5ff6 NSApplicationMain + 777
12  io.beatscratch.beatscratchFlutterRedux	0x00000001037f974d main + 13 (AppDelegate.swift:6)
13  libdyld.dylib                 	0x00007fff6edfdcc9 start + 1

Thread 1:
0   libsystem_kernel.dylib        	0x00007fff6ef3edfa mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff6ef3f170 mach_msg + 60
2   com.apple.audio.midi.CoreMIDI 	0x00007fff35d0d635 XServerMachPort::ReceiveMessage(int&, void*, int&) + 95
3   com.apple.audio.midi.CoreMIDI 	0x00007fff35d2afee MIDIProcess::RunMIDIInThread() + 104
4   com.apple.audio.midi.CoreMIDI 	0x00007fff35d29d5e XThread::RunHelper(void*) + 10
5   com.apple.audio.midi.CoreMIDI 	0x00007fff35d0d331 CAPThread::Entry(CAPThread*) + 77
6   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
7   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 2:: AMCP Logging Spool
0   libsystem_kernel.dylib        	0x00007fff6ef3ee36 semaphore_wait_trap + 10
1   com.apple.audio.caulk         	0x00007fff689d7b16 caulk::mach::semaphore::wait() + 16
2   com.apple.audio.caulk         	0x00007fff689d79b2 caulk::semaphore::timed_wait(double) + 106
3   com.apple.audio.caulk         	0x00007fff689d77c4 caulk::concurrent::details::worker_thread::run() + 30
4   com.apple.audio.caulk         	0x00007fff689d71e4 void* caulk::thread_proxy<std::__1::tuple<caulk::thread::attributes, void (caulk::concurrent::details::worker_thread::*)(), std::__1::tuple<caulk::concurrent::details::worker_thread*> > >(void*) + 45
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 3:
0   libsystem_kernel.dylib        	0x00007fff6ef3ee36 semaphore_wait_trap + 10
1   com.apple.audio.caulk         	0x00007fff689d7b16 caulk::mach::semaphore::wait() + 16
2   com.apple.audio.caulk         	0x00007fff689d79b2 caulk::semaphore::timed_wait(double) + 106
3   com.apple.audio.caulk         	0x00007fff689d77c4 caulk::concurrent::details::worker_thread::run() + 30
4   com.apple.audio.caulk         	0x00007fff689d71e4 void* caulk::thread_proxy<std::__1::tuple<caulk::thread::attributes, void (caulk::concurrent::details::worker_thread::*)(), std::__1::tuple<caulk::concurrent::details::worker_thread*> > >(void*) + 45
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 4:: com.apple.audio.toolbox.AUScheduledParameterRefresher
0   libsystem_kernel.dylib        	0x00007fff6ef3ee36 semaphore_wait_trap + 10
1   com.apple.audio.AudioToolboxCore	0x00007fff49ad6930 WorkThread::entry(void*) + 38
2   libAudioToolboxUtility.dylib  	0x00007fff6b8166c9 CAPThread::Entry(CAPThread*) + 77
3   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
4   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 5 Crashed:: com.apple.audio.IOThread.client
0   io.beatscratch.beatscratchFlutterRedux	0x000000010385763a AudioKitCore::SamplerVoice::prepToGetSamples(int, float, float, float, float, float, float, float, float) + 314
1   io.beatscratch.beatscratchFlutterRedux	0x000000010398dc3f AKCoreSampler::render(unsigned int, unsigned int, float**) + 367
2   io.beatscratch.beatscratchFlutterRedux	0x00000001039b8296 AKSamplerDSP::process(unsigned int, unsigned int) + 694
3   io.beatscratch.beatscratchFlutterRedux	0x000000010398b8a7 AKDSPBase::processWithEvents(AudioTimeStamp const*, unsigned int, AURenderEvent const*) + 119
4   io.beatscratch.beatscratchFlutterRedux	0x000000010396e13b __38-[AKAudioUnitBase processEventsBlock:]_block_invoke + 107
5   io.beatscratch.beatscratchFlutterRedux	0x00000001038b704a __40-[BufferedAudioUnit internalRenderBlock]_block_invoke + 682
6   com.apple.audio.AudioToolboxCore	0x00007fff49af1228 __26-[AUAudioUnit renderBlock]_block_invoke + 166
7   com.apple.audio.AVFAudio      	0x00007fff308faed5 invocation function for block in AUGraphNodeBaseV3::AllocateInputBlock() + 250
8   com.apple.audio.units.Components	0x000000010e30862d 0x10e1e6000 + 1189421
9   com.apple.audio.units.Components	0x000000010e30778b 0x10e1e6000 + 1185675
10  com.apple.audio.units.Components	0x000000010e306d67 0x10e1e6000 + 1183079
11  com.apple.audio.units.Components	0x000000010e304e0f 0x10e1e6000 + 1175055
12  com.apple.audio.units.Components	0x000000010e211c23 0x10e1e6000 + 179235
13  com.apple.audio.units.Components	0x000000010e2bfe3f 0x10e1e6000 + 892479
14  com.apple.audio.AudioToolboxCore	0x00007fff49af1228 __26-[AUAudioUnit renderBlock]_block_invoke + 166
15  com.apple.audio.AVFAudio      	0x00007fff308faed5 invocation function for block in AUGraphNodeBaseV3::AllocateInputBlock() + 250
16  com.apple.audio.units.Components	0x000000010e22bdff 0x10e1e6000 + 286207
17  com.apple.audio.units.Components	0x000000010e1f09b3 0x10e1e6000 + 43443
18  com.apple.audio.AudioToolboxCore	0x00007fff49a32df9 AudioConverterChain::CallInputProc(unsigned int) + 545
19  com.apple.audio.AudioToolboxCore	0x00007fff49a34759 AudioConverterChain::FillBufferFromInputProc(unsigned int*, CABufferList*) + 253
20  com.apple.audio.AudioToolboxCore	0x00007fff49a17c27 BufferedAudioConverter::GetInputBytes(unsigned int, unsigned int&, CABufferList const*&) + 207
21  com.apple.audio.AudioToolboxCore	0x00007fff49b9d92e CBRConverter::RenderOutput(CABufferList*, unsigned int, unsigned int&, AudioStreamPacketDescription*) + 106
22  com.apple.audio.AudioToolboxCore	0x00007fff49a179b1 BufferedAudioConverter::FillBuffer(unsigned int&, AudioBufferList&, AudioStreamPacketDescription*) + 371
23  com.apple.audio.AudioToolboxCore	0x00007fff49a32b84 AudioConverterChain::RenderOutput(CABufferList*, unsigned int, unsigned int&, AudioStreamPacketDescription*) + 106
24  com.apple.audio.AudioToolboxCore	0x00007fff49a179b1 BufferedAudioConverter::FillBuffer(unsigned int&, AudioBufferList&, AudioStreamPacketDescription*) + 371
25  com.apple.audio.AudioToolboxCore	0x00007fff49ac24cf AudioConverterFillComplexBuffer + 866
26  com.apple.audio.units.Components	0x000000010e1efcf9 0x10e1e6000 + 40185
27  com.apple.audio.units.Components	0x000000010e211c23 0x10e1e6000 + 179235
28  com.apple.audio.units.Components	0x000000010e1f2df5 0x10e1e6000 + 52725
29  com.apple.audio.CoreAudio     	0x00007fff3449caaa invocation function for block in HALC_ProxyIOContext::HALC_ProxyIOContext(unsigned int, unsigned int) + 5639
30  com.apple.audio.CoreAudio     	0x00007fff345cfc22 HALB_IOThread::Entry(void*) + 72
31  libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
32  libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 6:: io.flutter.ui
0   libsystem_kernel.dylib        	0x00007fff6ef3edfa mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff6ef3f170 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff34eb70b5 __CFRunLoopServiceMachPort + 247
3   com.apple.CoreFoundation      	0x00007fff34eb5b82 __CFRunLoopRun + 1319
4   com.apple.CoreFoundation      	0x00007fff34eb4ffe CFRunLoopRunSpecific + 462
5   io.flutter.flutter-macos      	0x00000001061f284e fml::MessageLoopDarwin::Run() + 142
6   io.flutter.flutter-macos      	0x00000001061eaf24 fml::MessageLoopImpl::DoRun() + 36
7   io.flutter.flutter-macos      	0x00000001061f1088 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_0> >(void*) + 264
8   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
9   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 7:: io.flutter.io
0   libsystem_kernel.dylib        	0x00007fff6ef3edfa mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff6ef3f170 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff34eb70b5 __CFRunLoopServiceMachPort + 247
3   com.apple.CoreFoundation      	0x00007fff34eb5b82 __CFRunLoopRun + 1319
4   com.apple.CoreFoundation      	0x00007fff34eb4ffe CFRunLoopRunSpecific + 462
5   io.flutter.flutter-macos      	0x00000001061f284e fml::MessageLoopDarwin::Run() + 142
6   io.flutter.flutter-macos      	0x00000001061eaf24 fml::MessageLoopImpl::DoRun() + 36
7   io.flutter.flutter-macos      	0x00000001061f1088 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_0> >(void*) + 264
8   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
9   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 8:: io.flutter.worker.1
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 9:: io.flutter.worker.2
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 10:: io.flutter.worker.3
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 11:: io.flutter.worker.4
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 12:: io.flutter.worker.5
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 13:: io.flutter.worker.6
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 14:: io.flutter.worker.7
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 15:: io.flutter.worker.8
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x00000001061910f4 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 36
3   io.flutter.flutter-macos      	0x00000001061e6193 fml::ConcurrentMessageLoop::WorkerMain() + 163
4   io.flutter.flutter-macos      	0x00000001061e6cfa void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 186
5   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 16:: dart:io EventHandler
0   libsystem_kernel.dylib        	0x00007fff6ef43766 kevent + 10
1   io.flutter.flutter-macos      	0x000000010678d658 dart::bin::EventHandlerImplementation::EventHandlerEntry(unsigned long) + 328
2   io.flutter.flutter-macos      	0x00000001067aff6b dart::bin::ThreadStart(void*) + 59
3   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
4   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 17:: DartWorker
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x0000000106a194c0 dart::Monitor::Wait(long long) + 160
3   io.flutter.flutter-macos      	0x0000000106ab8ac7 dart::BackgroundCompiler::Run() + 695
4   io.flutter.flutter-macos      	0x0000000106aa62d8 dart::ThreadPool::Worker::Loop() + 72
5   io.flutter.flutter-macos      	0x0000000106aa6100 dart::ThreadPool::Worker::Main(unsigned long) + 112
6   io.flutter.flutter-macos      	0x0000000106a189c1 dart::ThreadStart(void*) + 97
7   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
8   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 18:: DartWorker
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002425 _pthread_cond_wait + 698
2   io.flutter.flutter-macos      	0x0000000106a194c0 dart::Monitor::Wait(long long) + 160
3   io.flutter.flutter-macos      	0x0000000106ab8ac7 dart::BackgroundCompiler::Run() + 695
4   io.flutter.flutter-macos      	0x0000000106aa62d8 dart::ThreadPool::Worker::Loop() + 72
5   io.flutter.flutter-macos      	0x0000000106aa6100 dart::ThreadPool::Worker::Main(unsigned long) + 112
6   io.flutter.flutter-macos      	0x0000000106a189c1 dart::ThreadStart(void*) + 97
7   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
8   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 19:: com.apple.NSEventThread
0   libsystem_kernel.dylib        	0x00007fff6ef3edfa mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff6ef3f170 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff34eb70b5 __CFRunLoopServiceMachPort + 247
3   com.apple.CoreFoundation      	0x00007fff34eb5b82 __CFRunLoopRun + 1319
4   com.apple.CoreFoundation      	0x00007fff34eb4ffe CFRunLoopRunSpecific + 462
5   com.apple.AppKit              	0x00007fff322d55b4 _NSEventThread + 132
6   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
7   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 20:: DartWorker
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002457 _pthread_cond_wait + 748
2   io.flutter.flutter-macos      	0x0000000106a195c7 dart::Monitor::WaitMicros(long long) + 135
3   io.flutter.flutter-macos      	0x00000001069845aa dart::MessageHandler::CheckIfIdleLocked(dart::MonitorLocker*) + 202
4   io.flutter.flutter-macos      	0x00000001069843dd dart::MessageHandler::TaskCallback() + 813
5   io.flutter.flutter-macos      	0x0000000106aa62d8 dart::ThreadPool::Worker::Loop() + 72
6   io.flutter.flutter-macos      	0x0000000106aa6100 dart::ThreadPool::Worker::Main(unsigned long) + 112
7   io.flutter.flutter-macos      	0x0000000106a189c1 dart::ThreadStart(void*) + 97
8   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
9   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 21:
0   libsystem_pthread.dylib       	0x00007fff6effdb68 start_wqthread + 0

Thread 22:
0   libsystem_pthread.dylib       	0x00007fff6effdb68 start_wqthread + 0

Thread 23:: DartWorker
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002457 _pthread_cond_wait + 748
2   io.flutter.flutter-macos      	0x0000000106a195c7 dart::Monitor::WaitMicros(long long) + 135
3   io.flutter.flutter-macos      	0x0000000106aa634d dart::ThreadPool::Worker::Loop() + 189
4   io.flutter.flutter-macos      	0x0000000106aa6100 dart::ThreadPool::Worker::Main(unsigned long) + 112
5   io.flutter.flutter-macos      	0x0000000106a189c1 dart::ThreadStart(void*) + 97
6   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
7   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 24:: DartWorker
0   libsystem_kernel.dylib        	0x00007fff6ef41882 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff6f002457 _pthread_cond_wait + 748
2   io.flutter.flutter-macos      	0x0000000106a195c7 dart::Monitor::WaitMicros(long long) + 135
3   io.flutter.flutter-macos      	0x0000000106aa634d dart::ThreadPool::Worker::Loop() + 189
4   io.flutter.flutter-macos      	0x0000000106aa6100 dart::ThreadPool::Worker::Main(unsigned long) + 112
5   io.flutter.flutter-macos      	0x0000000106a189c1 dart::ThreadStart(void*) + 97
6   libsystem_pthread.dylib       	0x00007fff6f002109 _pthread_start + 148
7   libsystem_pthread.dylib       	0x00007fff6effdb8b thread_start + 15

Thread 5 crashed with X86 Thread State (64-bit):
  rax: 0x000000010e190c58  rbx: 0x0000000000000000  rcx: 0x0000000000000000  rdx: 0x00000000001ff000
  rdi: 0x000000010e190e94  rsi: 0x0000000000000010  rbp: 0x000070000c098cc0  rsp: 0x000070000c098c30
   r8: 0x0000000000000002   r9: 0x0000000000000000  r10: 0x00007fcca5711df0  r11: 0xc4e96f753e2500b1
  r12: 0x0000000000000200  r13: 0x000070000c099150  r14: 0x0000000000000000  r15: 0x00007fcca5172c30
  rip: 0x000000010385763a  rfl: 0x0000000000010202  cr2: 0x0000000000000008
  
Logical CPU:     2
Error Code:      0x00000004 (no mapping for user data read)
Trap Number:     14


Binary Images:
       0x1037dd000 -        0x1042ddff7 +io.beatscratch.beatscratchFlutterRedux (1.0.0 - 1) <B0796B1F-822B-3BD1-BAD9-3C355AF6082E> /Users/USER/*/BeatFlutter.app/Contents/MacOS/BeatFlutter
       0x106184000 -        0x107c16fef +io.flutter.flutter-macos (1.0 - 1.0) <44476E4C-DDA5-3C5B-A267-3A39E74128F2> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/FlutterMacOS.framework/Versions/A/FlutterMacOS
       0x10853f000 -        0x10858bff7 +org.cocoapods.GTMSessionFetcher (1.3.1 - 1) <8D95093D-3B8A-3A45-BA22-A6A295A19D70> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/GTMSessionFetcher.framework/Versions/A/GTMSessionFetcher
       0x1085d6000 -        0x1085efff7 +org.cocoapods.GoogleUtilities (6.5.1 - 1) <5F43B6F2-1AC9-3806-923A-04F5A6CB0BDB> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/GoogleUtilities.framework/Versions/A/GoogleUtilities
       0x108618000 -        0x1087e8ff7 +org.cocoapods.SwiftProtobuf (1.8.0 - 1) <4A7FE564-121C-3880-B7FF-5B077F02A0EC> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/SwiftProtobuf.framework/Versions/A/SwiftProtobuf
       0x108afe000 -        0x108b67ffb +org.cocoapods.absl (0.20190808.0 - 1) <859E00DB-F3A3-35A9-9048-5E7C3A72FFF8> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/absl.framework/Versions/A/absl
       0x108c7c000 -        0x108e38ff7 +org.cocoapods.grpc (1.21.0 - 1) <BF78D869-3E76-3F7C-99D6-EE35187519D8> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/grpc.framework/Versions/A/grpc
       0x109130000 -        0x10920cff3 +org.cocoapods.grpcpp (0.0.9 - 1) <5107CAC9-7F2A-308B-A6DC-0B4FCE2007C5> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/grpcpp.framework/Versions/A/grpcpp
       0x10967b000 -        0x109743ff7 +org.cocoapods.leveldb (1.22.0 - 1) <C8214AE7-69E1-362A-AE13-8D8461DB37C9> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/leveldb.framework/Versions/A/leveldb
       0x1098b1000 -        0x1098bbff7 +org.cocoapods.nanopb (0.3.9011 - 1) <1ED89B92-3186-3D89-9502-29060632765E> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/nanopb.framework/Versions/A/nanopb
       0x1098d2000 -        0x109aa7fff +org.cocoapods.openssl-grpc (0.0.3 - 1) <7D4A53A0-F3D8-3E21-AA17-C8F35BCFC55A> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/openssl_grpc.framework/Versions/A/openssl_grpc
       0x109c2d000 -        0x109c31fff +org.cocoapods.url-launcher-macos (0.0.1 - 1) <57F15A4C-A2E3-3F8D-A61C-1FA3D288D3F9> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/url_launcher_macos.framework/Versions/A/url_launcher_macos
       0x109c40000 -        0x109c40fff +io.flutter.flutter.app (1.0 - 1.0) <7308785C-A623-3AA2-A9E8-E8D5BD5019CF> /Users/USER/*/BeatFlutter.app/Contents/Frameworks/App.framework/Versions/A/App
       0x109dae000 -        0x109db1047  libobjc-trampolines.dylib (787.1) <CCA8AC98-12A2-3984-ACD6-1D77DAD6C0AD> /usr/lib/libobjc-trampolines.dylib
       0x10df2e000 -        0x10dff4ff7  com.apple.AMDRadeonX4000GLDriver (3.8.24 - 3.0.8) <C8948AD2-CFF9-31A6-95B9-F2E0A8068EF0> /System/Library/Extensions/AMDRadeonX4000GLDriver.bundle/Contents/MacOS/AMDRadeonX4000GLDriver
       0x10e1e6000 -        0x10e33fff7  com.apple.audio.units.Components (1.14 - 1.14) <81F527EA-7071-38C2-8469-CB411D2804FD> /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio
       0x10e392000 -        0x10e396fff  com.apple.audio.AppleHDAHALPlugIn (283.15 - 283.15) <642685AA-A418-3332-BBA5-4F3562F1127D> /System/Library/Extensions/AppleHDA.kext/Contents/PlugIns/AppleHDAHALPlugIn.bundle/Contents/MacOS/AppleHDAHALPlugIn
       0x1153dd000 -        0x11546eeff  dyld (750.5) <1F893B81-89A5-3502-8510-95B97B9F730D> /usr/lib/dyld
    0x7fff28103000 -     0x7fff28230ff8  com.apple.AMDMTLBronzeDriver (3.8.24 - 3.0.8) <15983EE9-C22E-3979-BDB1-51682FFE9442> /System/Library/Extensions/AMDMTLBronzeDriver.bundle/Contents/MacOS/AMDMTLBronzeDriver
    0x7fff28231000 -     0x7fff28267fff  ATIRadeonX4000SCLib.dylib (3.8.24) <FC75895C-348F-3C26-B82F-6E17FFF0E63C> /System/Library/Extensions/AMDRadeonX4000GLDriver.bundle/Contents/MacOS/ATIRadeonX4000SCLib.dylib
    0x7fff2977c000 -     0x7fff2a134ff3  libSC.dylib (3.8.24) <3A787392-149B-3C17-8257-ECB04A04A1B7> /System/Library/Extensions/AMDShared.bundle/Contents/PlugIns/libSC.dylib
    0x7fff2dc41000 -     0x7fff2ec48fff  com.apple.driver.AppleIntelSKLGraphicsGLDriver (14.5.22 - 14.0.5) <E6CA95A8-3632-378B-AAB9-56A3974597E9> /System/Library/Extensions/AppleIntelSKLGraphicsGLDriver.bundle/Contents/MacOS/AppleIntelSKLGraphicsGLDriver
    0x7fff2ec49000 -     0x7fff2f048ff3  com.apple.driver.AppleIntelSKLGraphicsMTLDriver (14.5.22 - 14.0.5) <8E28B4B5-1CC6-37EC-9C41-A9B1985C1F65> /System/Library/Extensions/AppleIntelSKLGraphicsMTLDriver.bundle/Contents/MacOS/AppleIntelSKLGraphicsMTLDriver
    0x7fff306df000 -     0x7fff308daffb  com.apple.avfoundation (2.0 - 1841.57) <AB376C9E-111C-3F42-B09A-566D50F2E296> /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
    0x7fff308db000 -     0x7fff309a7ffe  com.apple.audio.AVFAudio (1.0 - 415.72) <D912C207-81D1-35AB-8E31-1110F511A685> /System/Library/Frameworks/AVFoundation.framework/Versions/A/Frameworks/AVFAudio.framework/Versions/A/AVFAudio
    0x7fff30ac7000 -     0x7fff30ac7fff  com.apple.Accelerate (1.11 - Accelerate 1.11) <8BE0965F-6A6A-35B0-89D0-F0A75835C2CA> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
    0x7fff30ac8000 -     0x7fff30adefff  libCGInterfaces.dylib (524.2) <9092665A-D5C7-3ED8-A7D5-9216B48F8E3E> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/Libraries/libCGInterfaces.dylib
    0x7fff30adf000 -     0x7fff31135fef  com.apple.vImage (8.1 - 524.2) <DAE0E5C5-BA70-325D-8B4C-6B821F009CBF> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
    0x7fff31136000 -     0x7fff3139dff7  libBLAS.dylib (1303.60.1) <4E980D6B-4B3A-33D6-B52C-AFC7D120D11A> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
    0x7fff3139e000 -     0x7fff31871fef  libBNNS.dylib (144.100.2) <C05F9F9D-4498-37BD-9C1C-2F7B920B401D> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
    0x7fff31872000 -     0x7fff31c0dfff  libLAPACK.dylib (1303.60.1) <F8E9D081-7C60-32EC-A47D-2D30CAD73C5F> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
    0x7fff31c0e000 -     0x7fff31c23fec  libLinearAlgebra.dylib (1303.60.1) <79CB28C5-F811-3EAF-AD8E-7D7D879FE662> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
    0x7fff31c24000 -     0x7fff31c29ff3  libQuadrature.dylib (7) <EB7C9E98-D1E7-314C-90B4-3EB04428CC7C> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
    0x7fff31c2a000 -     0x7fff31c9afff  libSparse.dylib (103) <8C55F5F2-6AE3-393C-B2FF-22B8CFCBD7FC> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
    0x7fff31c9b000 -     0x7fff31cadfef  libSparseBLAS.dylib (1303.60.1) <08F6D629-5DAC-3A99-B261-2B6095DD38B4> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
    0x7fff31cae000 -     0x7fff31e85fd7  libvDSP.dylib (735.100.4) <0744F29B-F822-3571-9B4A-B592146D4E03> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
    0x7fff31e86000 -     0x7fff31f48fef  libvMisc.dylib (735.100.4) <E6C94B52-931B-3858-AF4D-C2EA52ACB7F5> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
    0x7fff31f49000 -     0x7fff31f49fff  com.apple.Accelerate.vecLib (3.11 - vecLib 3.11) <66282197-81EE-316F-978E-EF1471551DEF> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
    0x7fff31f4a000 -     0x7fff31fa9ff0  com.apple.Accounts (113 - 113) <4B85E422-169E-396D-898A-DD1A7715EC6D> /System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
    0x7fff320f3000 -     0x7fff32eb2ff5  com.apple.AppKit (6.9 - 1894.40.150) <FDDF35FF-4007-3F0B-B59C-03CFF3A0A73B> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
    0x7fff32f02000 -     0x7fff32f02fff  com.apple.ApplicationServices (48 - 50) <CABCF23C-55E5-35E1-AAF0-EE5DDE3FDB03> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
    0x7fff32f03000 -     0x7fff32f6efff  com.apple.ApplicationServices.ATS (377 - 493.0.4.1) <6AA4BBCC-43AF-3EBF-8EB5-7916A3B563AA> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
    0x7fff33007000 -     0x7fff33045ff0  libFontRegistry.dylib (274.0.4.2) <FBF6EC26-42C0-334E-B67C-871AD50DB0BC> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
    0x7fff330a0000 -     0x7fff330cffff  com.apple.ATSUI (1.0 - 1) <D8C604E9-D854-3A32-B37B-819197537A63> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATSUI.framework/Versions/A/ATSUI
    0x7fff330d0000 -     0x7fff330d4ffb  com.apple.ColorSyncLegacy (4.13.0 - 1) <2359E2CD-8FCE-32D7-AF76-F4D9A3D9D9F8> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
    0x7fff3316e000 -     0x7fff331c5ffa  com.apple.HIServices (1.22 - 675.1) <B2DEE96F-ED7A-3924-A2E2-44BB7A950BD8> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
    0x7fff331c6000 -     0x7fff331d4fff  com.apple.LangAnalysis (1.7.0 - 1.7.0) <1603F2CC-DC51-3E15-B6B5-0A9F9AB0C045> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
    0x7fff331d5000 -     0x7fff3321affa  com.apple.print.framework.PrintCore (15.4 - 516.2) <525E8A4B-297B-3CAC-8A4A-6C7E211D7A21> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
    0x7fff3321b000 -     0x7fff33225ff7  com.apple.QD (4.0 - 413) <1EAEF5BC-D649-3E42-87BC-43CCEE4D5274> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
    0x7fff33226000 -     0x7fff33233ffc  com.apple.speech.synthesis.framework (9.0.24 - 9.0.24) <C2E5BBFC-2EF0-3FFE-A1CF-960631DC249C> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
    0x7fff33234000 -     0x7fff33315ffa  com.apple.audio.toolbox.AudioToolbox (1.14 - 1.14) <4222CBDF-D637-30DB-BA45-C6E222BABB24> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
    0x7fff33317000 -     0x7fff33317fff  com.apple.audio.units.AudioUnit (1.14 - 1.14) <73D89D5E-05D5-3F64-BE02-2B2ED6AD6C03> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
    0x7fff336aa000 -     0x7fff33a38ffd  com.apple.CFNetwork (1125.2 - 1125.2) <1D4D81F7-FC48-3588-87FC-481E2586E345> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
    0x7fff33ab9000 -     0x7fff33dadff3  com.apple.HIToolbox (2.1.1 - 994.6) <C03A48FC-1A02-320D-9147-F4687A1BBC6F> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
    0x7fff33df8000 -     0x7fff33dfefff  com.apple.speech.recognition.framework (6.0.3 - 6.0.3) <E6BE4EC1-5C53-38BB-AAFD-E7BF7A8975BC> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
    0x7fff33f98000 -     0x7fff33f98fff  com.apple.Cocoa (6.11 - 23) <37E98F4D-1D78-3F22-BDC0-59DC0B9B3A3E> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
    0x7fff33fa6000 -     0x7fff3409cfff  com.apple.ColorSync (4.13.0 - 3394.7) <FC6CFACE-CDD8-3811-BAB6-C9F82AC0A594> /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
    0x7fff3409d000 -     0x7fff3418dff7  com.apple.combine (1.0 - 134.102) <F5EDABC9-4E0D-3D1E-8794-032C38C12786> /System/Library/Frameworks/Combine.framework/Versions/A/Combine
    0x7fff34387000 -     0x7fff34890ffb  com.apple.audio.CoreAudio (5.0 - 5.0) <CF50C6CC-6753-3D64-A76B-21CE211A98E8> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
    0x7fff348e3000 -     0x7fff3491bfff  com.apple.CoreBluetooth (1.0 - 1) <D2943204-C3A0-3C09-A7A9-BF75822678B4> /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
    0x7fff3491c000 -     0x7fff34d06fe8  com.apple.CoreData (120 - 977.3) <9A33F390-687F-3EE2-8293-4E564A164469> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
    0x7fff34d07000 -     0x7fff34e32ffe  com.apple.CoreDisplay (1.0 - 186.5.25) <53F750C6-947A-39AE-984E-41939B858A68> /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
    0x7fff34e33000 -     0x7fff352b2ffb  com.apple.CoreFoundation (6.9 - 1675.129) <9E632A1E-9622-33D6-BCCE-23AC16DAA6B7> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7fff352b4000 -     0x7fff35928fe0  com.apple.CoreGraphics (2.0 - 1355.13) <54528FE3-21A7-3F64-B7AA-F6B95394488D> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
    0x7fff35936000 -     0x7fff35c91ff0  com.apple.CoreImage (15.0.0 - 940.9) <CA78A35D-E15E-3D98-BDEF-9F3D9039DB78> /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
    0x7fff35cfc000 -     0x7fff35d4cff6  com.apple.audio.midi.CoreMIDI (1.10 - 88) <1A30B3DF-94F0-31BE-ADFA-DA58E93D6FBD> /System/Library/Frameworks/CoreMIDI.framework/Versions/A/CoreMIDI
    0x7fff36052000 -     0x7fff3612eff4  com.apple.CoreMedia (1.0 - 2612.58.4.6) <301A075B-022D-3F28-AE2C-7F280CCF1F51> /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
    0x7fff3612f000 -     0x7fff36191ffe  com.apple.CoreMediaIO (1000.0 - 5125.6) <11F1EB21-E366-3AEE-8012-D72DEEAC4D3C> /System/Library/Frameworks/CoreMediaIO.framework/Versions/A/CoreMediaIO
    0x7fff3621b000 -     0x7fff3621bfff  com.apple.CoreServices (1069.22 - 1069.22) <888FE7B9-CE6C-3C7C-BA33-63364462228A> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
    0x7fff3621c000 -     0x7fff362a1fff  com.apple.AE (838.1 - 838.1) <2BAB1B88-C198-3D20-8DA3-056E66510E7A> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
    0x7fff362a2000 -     0x7fff36583ff7  com.apple.CoreServices.CarbonCore (1217 - 1217) <D0FECC17-7E16-308F-98EA-AF311CB77FE6> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
    0x7fff36584000 -     0x7fff365d1ffd  com.apple.DictionaryServices (1.2 - 323.6) <11513ED9-8B4B-39BB-A6B2-AA6AA0A2DF72> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
    0x7fff365d2000 -     0x7fff365daff7  com.apple.CoreServices.FSEvents (1268.100.1 - 1268.100.1) <CE3D8B13-2583-3527-8532-D5DDAAD7D56B> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
    0x7fff365db000 -     0x7fff36814ffc  com.apple.LaunchServices (1069.22 - 1069.22) <E51EE658-608C-3034-9635-4FDF1E241E62> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
    0x7fff36815000 -     0x7fff368adff1  com.apple.Metadata (10.7.0 - 2076.3) <EE42CCA1-FEC2-3F1C-9B62-2E73EFB05FCC> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
    0x7fff368ae000 -     0x7fff368dbfff  com.apple.CoreServices.OSServices (1069.22 - 1069.22) <A0654B4E-3194-3066-911F-FF1FBEE1D2C2> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
    0x7fff368dc000 -     0x7fff36943fff  com.apple.SearchKit (1.4.1 - 1.4.1) <D4F82BC9-FD9B-3E04-B78E-D9E2A73B0BD7> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
    0x7fff36944000 -     0x7fff36968ff5  com.apple.coreservices.SharedFileList (131.4 - 131.4) <AEB4E42C-F5A2-3F63-80B0-4226483AD4F5> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
    0x7fff36bc5000 -     0x7fff36c8cffc  com.apple.CoreTelephony (113 - 7549) <73AB1DBA-D993-3766-B110-323F132FAB58> /System/Library/Frameworks/CoreTelephony.framework/Versions/A/CoreTelephony
    0x7fff36c8d000 -     0x7fff36e44ffc  com.apple.CoreText (643.1.4.4 - 643.1.4.4) <5D4EA236-DC1B-3772-95C5-7F4B6CFEAF84> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
    0x7fff36e45000 -     0x7fff36e89ffb  com.apple.CoreVideo (1.8 - 344.3) <8507ED54-43C3-3E5B-BC74-512FE510BF8D> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
    0x7fff36e8a000 -     0x7fff36f17ffc  com.apple.framework.CoreWLAN (13.0 - 1601.2) <C1C2BBD4-EA97-3CC1-845D-1F1578E68380> /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
    0x7fff371ae000 -     0x7fff371b4fff  com.apple.DiskArbitration (2.7 - 2.7) <D7617B57-B01C-3848-8818-593FB12039E9> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
    0x7fff373a6000 -     0x7fff374d1ffa  com.apple.FileProvider (276 - 276) <B3EB6E66-807E-3F67-951F-88B8484FB8CD> /System/Library/Frameworks/FileProvider.framework/Versions/A/FileProvider
    0x7fff374e9000 -     0x7fff378aeff8  com.apple.Foundation (6.9 - 1675.129) <9A74FA97-7F7B-3929-B381-D9514B1E4754> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
    0x7fff3791b000 -     0x7fff3796bff7  com.apple.GSS (4.0 - 2.0) <16DE732E-4A48-3C8A-BD61-8AF810F3A48C> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
    0x7fff37aa8000 -     0x7fff37bbcff3  com.apple.Bluetooth (7.0.4 - 7.0.4f6) <9003721F-8543-3A21-BF11-2A981614F481> /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
    0x7fff37c22000 -     0x7fff37cc6ff3  com.apple.framework.IOKit (2.0.2 - 1726.100.16) <3D8BA34A-AAF7-3AF2-9B5B-189AC4755404> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
    0x7fff37cc8000 -     0x7fff37cd9ffb  com.apple.IOSurface (269.11 - 269.11) <887CD3FD-1BB8-3BB7-B7F8-6A0BA4B3AEAE> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
    0x7fff37d58000 -     0x7fff37eb4fee  com.apple.ImageIO.framework (3.3.0 - 1976.3.4.4) <EDAA3E6B-6D65-3807-86C2-91736BC0AF88> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
    0x7fff37eb5000 -     0x7fff37eb8fff  libGIF.dylib (1976.3.4.4) <A4627958-EB22-3ADA-92BE-16229F9E9767> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
    0x7fff37eb9000 -     0x7fff37f72fff  libJP2.dylib (1976.3.4.4) <43672561-0E75-3A32-B428-697C6DA13BD8> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
    0x7fff37f73000 -     0x7fff37f96fe3  libJPEG.dylib (1976.3.4.4) <52DC775B-CAB5-32B7-AC86-D9AAF7851BE9> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
    0x7fff38212000 -     0x7fff3822cfef  libPng.dylib (1976.3.4.4) <0B79BE68-50CD-3C99-9CF4-2396CD203EF8> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
    0x7fff3822d000 -     0x7fff3822efff  libRadiance.dylib (1976.3.4.4) <E506A652-A423-3170-8032-0B03FF367FE8> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
    0x7fff3822f000 -     0x7fff38278ffb  libTIFF.dylib (1976.3.4.4) <0419D70A-E156-3B5D-A8B0-33BA29B54A08> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
    0x7fff397da000 -     0x7fff397ecff3  com.apple.Kerberos (3.0 - 1) <DC673FF3-4DC9-3C23-9718-343AB36B2984> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
    0x7fff397ed000 -     0x7fff397edfff  libHeimdalProxy.dylib (77) <A970C7A8-7CCD-3701-A459-078BD5E8FE4E> /System/Library/Frameworks/Kerberos.framework/Versions/A/Libraries/libHeimdalProxy.dylib
    0x7fff39b7f000 -     0x7fff39b89ffb  com.apple.MediaAccessibility (1.0 - 125.1) <B2F72AF8-99DC-3613-B618-C588252EEAC2> /System/Library/Frameworks/MediaAccessibility.framework/Versions/A/MediaAccessibility
    0x7fff39c55000 -     0x7fff3a3a0ffd  com.apple.MediaToolbox (1.0 - 2612.58.4.6) <FEB63B0B-D774-3FEB-B89A-66C2179DAC85> /System/Library/Frameworks/MediaToolbox.framework/Versions/A/MediaToolbox
    0x7fff3a3a2000 -     0x7fff3a46cfff  com.apple.Metal (212.5.15 - 212.5.15) <2CBB178E-434E-31D3-BAE2-ED3EA801D4BC> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
    0x7fff3a489000 -     0x7fff3a4c6ff7  com.apple.MetalPerformanceShaders.MPSCore (1.0 - 1) <5DF84B7A-9DD0-36DB-8686-D669CDA93D59> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSCore.framework/Versions/A/MPSCore
    0x7fff3a4c7000 -     0x7fff3a551fe2  com.apple.MetalPerformanceShaders.MPSImage (1.0 - 1) <CDC36001-66DA-3BBD-A9AA-2470B634B9C9> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSImage.framework/Versions/A/MPSImage
    0x7fff3a552000 -     0x7fff3a577ff4  com.apple.MetalPerformanceShaders.MPSMatrix (1.0 - 1) <1E4FE6EF-6D42-3439-835C-F4F20B05E0F5> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
    0x7fff3a578000 -     0x7fff3a58dffb  com.apple.MetalPerformanceShaders.MPSNDArray (1.0 - 1) <8F8F0C2E-C4EC-3418-A06A-42B8280DDC9D> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNDArray.framework/Versions/A/MPSNDArray
    0x7fff3a58e000 -     0x7fff3a6ecffc  com.apple.MetalPerformanceShaders.MPSNeuralNetwork (1.0 - 1) <6BEFB262-2538-3A12-9E9F-A7CF94D2B68A> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
    0x7fff3a6ed000 -     0x7fff3a73cff4  com.apple.MetalPerformanceShaders.MPSRayIntersector (1.0 - 1) <4D352B8E-97D8-34FA-B2AF-3AB4E3149E2E> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
    0x7fff3a73d000 -     0x7fff3a73eff5  com.apple.MetalPerformanceShaders.MetalPerformanceShaders (1.0 - 1) <07F3B58C-F362-35F2-9A79-F38015A78DDA> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
    0x7fff3b7c5000 -     0x7fff3b7d1ffe  com.apple.NetFS (6.0 - 4.0) <7A96A8FE-17F3-3850-8E81-9DDDC5A48DDB> /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
    0x7fff3b7d2000 -     0x7fff3b929ff3  com.apple.Network (1.0 - 1) <D1C8FDDE-C822-3C40-BB26-18F24CFC8AE2> /System/Library/Frameworks/Network.framework/Versions/A/Network
    0x7fff3e351000 -     0x7fff3e359ff7  libcldcpuengine.dylib (2.14) <BB23A727-5F40-3D27-AD3B-3197A7241F84> /System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
    0x7fff3e35a000 -     0x7fff3e3b2fff  com.apple.opencl (3.5 - 3.5) <3F0E363C-9380-3226-A4D1-67E740079AAD> /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
    0x7fff3e3b3000 -     0x7fff3e3cffff  com.apple.CFOpenDirectory (10.15 - 220.40.1) <58835104-9E7A-32E8-862B-530CE899C9B4> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
    0x7fff3e3d0000 -     0x7fff3e3dbffd  com.apple.OpenDirectory (10.15 - 220.40.1) <D846BA35-59A1-3B78-B1C8-7E0EDE972AD2> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
    0x7fff3ed41000 -     0x7fff3ed43fff  libCVMSPluginSupport.dylib (17.10.22) <65052150-BEFD-38D8-A789-560C2FB1644A> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
    0x7fff3ed44000 -     0x7fff3ed49fff  libCoreFSCache.dylib (176.11) <AEAEE894-BA4B-334F-90E1-7374DFB41979> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
    0x7fff3ed4a000 -     0x7fff3ed4efff  libCoreVMClient.dylib (176.11) <29D2B5C2-CBFF-308A-ADD8-A559B760C494> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
    0x7fff3ed4f000 -     0x7fff3ed57ff7  libGFXShared.dylib (17.10.22) <7FF5455A-3D5D-33D2-9C41-A51ABE53CE66> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
    0x7fff3ed58000 -     0x7fff3ed62fff  libGL.dylib (17.10.22) <08450555-3BC8-3457-8F5E-E2BBE895C0C7> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
    0x7fff3ed63000 -     0x7fff3ed97ff7  libGLImage.dylib (17.10.22) <5182EE22-2914-30E0-A87D-C38F345F695B> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
    0x7fff3ed98000 -     0x7fff3ef2cff7  libGLProgrammability.dylib (17.10.22) <942CCB23-9868-3D76-98CC-3430E45590D2> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
    0x7fff3ef2d000 -     0x7fff3ef69fff  libGLU.dylib (17.10.22) <2FE69FE7-B60D-3D05-824B-CD4958E2C7B8> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
    0x7fff3f9a5000 -     0x7fff3f9b4ff7  com.apple.opengl (17.10.22 - 17.10.22) <4E9C4B23-6D44-3804-AFF8-84C3B060E8F5> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
    0x7fff3f9b5000 -     0x7fff3fb2efff  GLEngine (17.10.22) <803CEBEC-8BA2-3B48-B6E7-23F080B7EE75> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
    0x7fff3fb2f000 -     0x7fff3fb57fff  GLRendererFloat (17.10.22) <EE9FB4C6-8D39-39CC-9A91-7D3EFB16B2DB> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
    0x7fff40972000 -     0x7fff40bf4ff2  com.apple.QuartzCore (1.11 - 840.18) <16502545-A0F3-3367-929B-DD80A6440226> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
    0x7fff41775000 -     0x7fff41abeff1  com.apple.security (7.0 - 59306.101.1) <430E04FE-F068-3476-9CA2-72CB5F040D1F> /System/Library/Frameworks/Security.framework/Versions/A/Security
    0x7fff41abf000 -     0x7fff41b47ffb  com.apple.securityfoundation (6.0 - 55236.60.1) <BC15B825-955D-33CF-B416-A64D69A1D008> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
    0x7fff41b76000 -     0x7fff41b7aff8  com.apple.xpc.ServiceManagement (1.0 - 1) <C66FC9CF-224B-348C-94A5-ABAC579F5C0A> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
    0x7fff42825000 -     0x7fff42893ff7  com.apple.SystemConfiguration (1.19 - 1.19) <71AC15DE-7018-3D2B-B599-F2972F0288AE> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
    0x7fff42b12000 -     0x7fff42e95ff4  com.apple.VideoToolbox (1.0 - 2612.58.4.6) <C488A935-B94F-3F80-88E7-D2743FB1E460> /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
    0x7fff467f0000 -     0x7fff468b5ff7  com.apple.APFS (1412.101.1 - 1412.101.1) <2F5A48FB-9788-3A24-87FE-C1B7DDBC8A07> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
    0x7fff479c2000 -     0x7fff479c3ff1  com.apple.AggregateDictionary (1.0 - 1) <FE9B8728-9C37-367E-91A6-2D1321D485A0> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
    0x7fff47f5d000 -     0x7fff47f7aff4  com.apple.AppContainer (4.0 - 448.100.6) <FBA274DA-2172-31C8-9759-AFB227E0E7E7> /System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
    0x7fff47f9c000 -     0x7fff47fb2ff3  com.apple.AppSSOCore (1.0 - 1) <547C0367-6E49-3894-8A4F-04392DD24451> /System/Library/PrivateFrameworks/AppSSOCore.framework/Versions/A/AppSSOCore
    0x7fff47fcf000 -     0x7fff47fddff7  com.apple.AppSandbox (4.0 - 448.100.6) <B38CE066-5303-3FBF-B0D3-A0D3889E2005> /System/Library/PrivateFrameworks/AppSandbox.framework/Versions/A/AppSandbox
    0x7fff483c7000 -     0x7fff4842cff7  com.apple.AppSupport (1.0.0 - 29) <6F8049D2-B017-3DD3-986E-519E2BE07F03> /System/Library/PrivateFrameworks/AppSupport.framework/Versions/A/AppSupport
    0x7fff48458000 -     0x7fff4847cffb  com.apple.framework.Apple80211 (13.0 - 1602.3) <7D1A08A0-27B0-3F53-BFC4-A2A482B055A0> /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
    0x7fff4873a000 -     0x7fff48749fd7  com.apple.AppleFSCompression (119.100.1 - 1.0) <E1B024EB-DAB1-30A1-A43D-01D9E9357F2B> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
    0x7fff48848000 -     0x7fff48853ff7  com.apple.AppleIDAuthSupport (1.0 - 1) <BE6A7C6D-060E-38E9-A010-61975ECE5E43> /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
    0x7fff48895000 -     0x7fff488ddff7  com.apple.AppleJPEG (1.0 - 1) <C163D80A-6818-3C36-B9A9-7CC8777FE593> /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
    0x7fff48ccb000 -     0x7fff48cedfff  com.apple.applesauce (1.0 - 16.25) <A6C6D37B-9AA5-3137-A02E-F61798A908B0> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
    0x7fff48dac000 -     0x7fff48dafffb  com.apple.AppleSystemInfo (3.1.5 - 3.1.5) <52444963-7A5E-36C8-BAAA-FFF8A0D14612> /System/Library/PrivateFrameworks/AppleSystemInfo.framework/Versions/A/AppleSystemInfo
    0x7fff48db0000 -     0x7fff48e00ff7  com.apple.AppleVAFramework (6.1.2 - 6.1.2) <A46D4D00-6251-302B-9A4A-3A930855BC1F> /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
    0x7fff48e49000 -     0x7fff48e58ff9  com.apple.AssertionServices (1.0 - 223.100.31) <2DA45CD2-C755-397C-977C-F4C6435A1272> /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
    0x7fff4939a000 -     0x7fff49795ff8  com.apple.audio.AudioResourceArbitration (1.0 - 1) <B7E163FF-F028-32A5-9AD3-DB7022E99DE7> /System/Library/PrivateFrameworks/AudioResourceArbitration.framework/Versions/A/AudioResourceArbitration
    0x7fff498d4000 -     0x7fff49925ff9  com.apple.audio.AudioSession (1.0 - 17) <133B2FAF-097E-35FF-ACFD-D2D4078C7553> /System/Library/PrivateFrameworks/AudioSession.framework/Versions/A/AudioSession
    0x7fff49926000 -     0x7fff49953ff7  libSessionUtility.dylib (17) <99E016BE-6238-3535-BAD5-D02FEFE9165C> /System/Library/PrivateFrameworks/AudioSession.framework/libSessionUtility.dylib
    0x7fff499eb000 -     0x7fff49c2bff0  com.apple.audio.AudioToolboxCore (1.0 - 1104.80) <EE6A2BD9-843C-3CC3-AEFC-6D7855DBB331> /System/Library/PrivateFrameworks/AudioToolboxCore.framework/Versions/A/AudioToolboxCore
    0x7fff49c2f000 -     0x7fff49d4bff3  com.apple.AuthKit (1.0 - 1) <0A3A05D4-0795-35B8-8729-4BF252D52E60> /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
    0x7fff49f08000 -     0x7fff49f11ff7  com.apple.coreservices.BackgroundTaskManagement (1.0 - 104) <2088BC70-5329-3390-A851-C4ECF654047C> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
    0x7fff49f12000 -     0x7fff49fb3ff5  com.apple.backup.framework (1.11.4 - 1298.4.19) <1F848C06-11E3-3D85-8358-7E37AD2BE9D7> /System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
    0x7fff49fb4000 -     0x7fff4a040ff6  com.apple.BaseBoard (466.3 - 466.3) <1EFE4339-9393-3B15-8DC9-2BE9B03F3062> /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
    0x7fff4a142000 -     0x7fff4a17eff7  com.apple.bom (14.0 - 219.2) <4B7C18B2-1E51-376E-9D6A-CE3F58D2AE53> /System/Library/PrivateFrameworks/Bom.framework/Versions/A/Bom
    0x7fff4acfa000 -     0x7fff4ad49fff  com.apple.ChunkingLibrary (307 - 307) <4A5C3E8E-1E95-3363-8A78-CCD55770F064> /System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
    0x7fff4bbae000 -     0x7fff4bbb9ff5  com.apple.CommerceCore (1.0 - 709.6.5) <98C154AE-2EE0-3E36-9662-F85EF62534AB> /System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Frameworks/CommerceCore.framework/Versions/A/CommerceCore
    0x7fff4bbba000 -     0x7fff4bbcaffb  com.apple.CommonAuth (4.0 - 2.0) <E09BBBBE-ECDD-3442-8D4E-27A12F5E2347> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
    0x7fff4bbde000 -     0x7fff4bbf5fff  com.apple.commonutilities (8.0 - 900) <1E6CE910-4B06-3704-A47D-06337A6F0992> /System/Library/PrivateFrameworks/CommonUtilities.framework/Versions/A/CommonUtilities
    0x7fff4c2fb000 -     0x7fff4c6d0fc8  com.apple.CoreAUC (283.0.0 - 283.0.0) <5BF7FDC2-E106-3E73-B950-2A0DDE2CA11F> /System/Library/PrivateFrameworks/CoreAUC.framework/Versions/A/CoreAUC
    0x7fff4c6d1000 -     0x7fff4c6feff7  com.apple.CoreAVCHD (6.1.0 - 6100.4.1) <4BD22FB9-F5F7-35E5-AAD6-CF92706C9816> /System/Library/PrivateFrameworks/CoreAVCHD.framework/Versions/A/CoreAVCHD
    0x7fff4c721000 -     0x7fff4c740ffc  com.apple.analyticsd (1.0 - 1) <F33987F5-A14A-3A55-8D26-FDE9A57B9269> /System/Library/PrivateFrameworks/CoreAnalytics.framework/Versions/A/CoreAnalytics
    0x7fff4ccc7000 -     0x7fff4ccd7ff3  com.apple.CoreEmoji (1.0 - 107) <AC83B860-61BD-384E-81BF-CA3CBE655968> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
    0x7fff4d317000 -     0x7fff4d381ff0  com.apple.CoreNLP (1.0 - 213) <687A4C31-A307-3255-83BE-9B123971FF62> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
    0x7fff4d7af000 -     0x7fff4d7b7ff8  com.apple.CorePhoneNumbers (1.0 - 1) <17E6A3B0-A181-3295-8B19-E139EDF12E4B> /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
    0x7fff4e1a4000 -     0x7fff4e1c7fff  com.apple.CoreSVG (1.0 - 129) <53213F48-F888-3EBE-AE30-E9303E9B712C> /System/Library/PrivateFrameworks/CoreSVG.framework/Versions/A/CoreSVG
    0x7fff4e1c8000 -     0x7fff4e1fbfff  com.apple.CoreServicesInternal (446.7 - 446.7) <4C4834E0-EA46-36DE-BA11-16B8826DD754> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
    0x7fff4e1fc000 -     0x7fff4e22affd  com.apple.CSStore (1069.22 - 1069.22) <39E431F9-3584-34DF-A64D-C5895AA72068> /System/Library/PrivateFrameworks/CoreServicesStore.framework/Versions/A/CoreServicesStore
    0x7fff4e74e000 -     0x7fff4e7e4ff7  com.apple.CoreSymbolication (11.4 - 64535.33.1) <DCA00787-D285-3944-AAFA-CAF78775B8D3> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
    0x7fff4e87c000 -     0x7fff4e9a8ff6  com.apple.coreui (2.1 - 609.4) <55EACF17-86EA-3F6E-A2CF-AF2F08C5F295> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
    0x7fff4e9a9000 -     0x7fff4eb5fff5  com.apple.CoreUtils (6.2 - 620.34) <172FC306-619F-3451-9BCA-F0B0D0B58EFD> /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
    0x7fff4ec99000 -     0x7fff4ecacff1  com.apple.CrashReporterSupport (10.13 - 15016) <8AB4A416-A174-386B-8A96-5F16EAA3FCDE> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
    0x7fff4ed65000 -     0x7fff4ed77ff8  com.apple.framework.DFRFoundation (1.0 - 252.40.1) <852E7EE8-EC39-3CFF-9605-9F971F7BCED5> /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
    0x7fff4ed78000 -     0x7fff4ed7dfff  com.apple.DSExternalDisplay (3.1 - 380) <61597AB3-7E66-339D-A709-50D4F9B3D8E9> /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
    0x7fff4ee07000 -     0x7fff4ee81ff0  com.apple.datadetectorscore (8.0 - 659) <F7BA8B28-FD51-34A7-A423-63878638D00E> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
    0x7fff4eecd000 -     0x7fff4ef0aff8  com.apple.DebugSymbols (194 - 194) <0406F803-6865-370E-9D32-01EF177B5E7A> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
    0x7fff4ef0b000 -     0x7fff4f092ff2  com.apple.desktopservices (1.14.4 - 1281.4.19) <82777143-A900-33D0-BCFA-2511C89C9EAD> /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
    0x7fff50a2b000 -     0x7fff50e46ff1  com.apple.vision.FaceCore (4.3.0 - 4.3.0) <E081D201-B82C-3AE3-8B58-1E909CE053B3> /System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
    0x7fff514d7000 -     0x7fff5160effc  libFontParser.dylib (277.2.4.2) <B59E080A-9FC3-3511-9024-E6D5461E60D1> /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
    0x7fff5160f000 -     0x7fff51643fff  libTrueTypeScaler.dylib (277.2.4.2) <3A485687-23E8-3C53-83B0-1AA9625DCD37> /System/Library/PrivateFrameworks/FontServices.framework/libTrueTypeScaler.dylib
    0x7fff516a8000 -     0x7fff516b8ff6  libhvf.dylib (1.0 - $[CURRENT_PROJECT_VERSION]) <5A0F87CA-81C0-3444-B958-AAC7BD4319BC> /System/Library/PrivateFrameworks/FontServices.framework/libhvf.dylib
    0x7fff54b99000 -     0x7fff54b9afff  libmetal_timestamp.dylib (902.14.9) <E675DA7E-A99D-3351-94D1-3485CD86808B> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/3902/Libraries/libmetal_timestamp.dylib
    0x7fff5623e000 -     0x7fff56249ff7  libGPUSupportMercury.dylib (17.10.22) <FE3E328E-F2AC-3FE3-BE4C-31592ABB168B> /System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
    0x7fff5624a000 -     0x7fff56250fff  com.apple.GPUWrangler (5.1.16 - 5.1.16) <F91AD6D6-8242-348C-8296-AF1DD8DBA2EF> /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
    0x7fff5656f000 -     0x7fff56595ff1  com.apple.GenerationalStorage (2.0 - 314) <54182052-9E17-3A2A-8943-8915E6D319CE> /System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
    0x7fff576c4000 -     0x7fff576d2ffb  com.apple.GraphVisualizer (1.0 - 100.1) <7289AEE6-C577-3D89-A99E-98551218EB7D> /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
    0x7fff57872000 -     0x7fff57930ff4  com.apple.Heimdal (4.0 - 2.0) <C4838DCE-48FB-3828-9FB2-097BA2848C99> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
    0x7fff59aa7000 -     0x7fff59ab0ffe  com.apple.IOAccelMemoryInfo (1.0 - 1) <8626B839-52BD-3BE1-BD83-B5C72D7B586D> /System/Library/PrivateFrameworks/IOAccelMemoryInfo.framework/Versions/A/IOAccelMemoryInfo
    0x7fff59ab1000 -     0x7fff59ab9ff5  com.apple.IOAccelerator (438.4.5 - 438.4.5) <4B2F1D11-C36B-3C48-9934-8A973348A966> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
    0x7fff59ac6000 -     0x7fff59adcfff  com.apple.IOPresentment (1.0 - 37) <2FE66352-4CF9-3F79-944D-053E2AD451D6> /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
    0x7fff59e64000 -     0x7fff59eafff1  com.apple.IconServices (438.3 - 438.3) <2431AD46-37B8-367F-A1DC-119C781B1453> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
    0x7fff5a06d000 -     0x7fff5a074ffa  com.apple.InternationalSupport (1.0 - 45.2) <296B6979-342E-35B8-A58B-B0797DFBA789> /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
    0x7fff5a301000 -     0x7fff5a320ffd  com.apple.security.KeychainCircle.KeychainCircle (1.0 - 1) <D0F59C6D-F069-3F0D-81C2-CBFC2E6B7101> /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
    0x7fff5a455000 -     0x7fff5a523ffd  com.apple.LanguageModeling (1.0 - 215.1) <3FAF1700-F7D4-3F92-88AA-A3920702B8BB> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
    0x7fff5a524000 -     0x7fff5a56cfff  com.apple.Lexicon-framework (1.0 - 72) <212D02CE-11BC-3C7F-BDFD-DF1A0C4017EE> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
    0x7fff5a573000 -     0x7fff5a578ff3  com.apple.LinguisticData (1.0 - 353.18) <BA3869B7-9C39-32DA-A4BA-12F1BC4B04CF> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
    0x7fff5ae10000 -     0x7fff5ae13fff  com.apple.Mangrove (1.0 - 25) <9490A0D4-5EF9-3FDA-B048-A71BE3A17096> /System/Library/PrivateFrameworks/Mangrove.framework/Versions/A/Mangrove
    0x7fff5b07c000 -     0x7fff5b106ff8  com.apple.MediaExperience (1.0 - 1) <F86763CC-6791-390E-8BCF-512B04C931BA> /System/Library/PrivateFrameworks/MediaExperience.framework/Versions/A/MediaExperience
    0x7fff5b8df000 -     0x7fff5b92bfff  com.apple.spotlight.metadata.utilities (1.0 - 2076.3) <EF8AC054-B15F-375F-AACB-018DC73CD16E> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
    0x7fff5b92c000 -     0x7fff5b9fdffa  com.apple.gpusw.MetalTools (1.0 - 1) <BA343D96-58EA-374A-818C-E42968101EA8> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
    0x7fff5bc30000 -     0x7fff5bc4efff  com.apple.MobileKeyBag (2.0 - 1.0) <0837C5C4-A860-387C-8F31-9A4627A3132F> /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
    0x7fff5beb1000 -     0x7fff5bee1ff7  com.apple.MultitouchSupport.framework (3440.1 - 3440.1) <0AA68A0D-23F6-3628-A93F-8F8018B84920> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
    0x7fff5c3e0000 -     0x7fff5c3eafff  com.apple.NetAuth (6.2 - 6.2) <D324C7CC-E614-35F6-8619-DECBE90ECAEB> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
    0x7fff5cdf5000 -     0x7fff5ce40ffb  com.apple.OTSVG (1.0 - 643.1.4.4) <DCCAD72C-ED3E-3FB9-80C8-4DB36362C28A> /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
    0x7fff5e048000 -     0x7fff5e053ff2  com.apple.PerformanceAnalysis (1.243.2 - 243.2) <FFE831BE-C133-38BE-A6B4-BEEB9FD6BF37> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
    0x7fff5e054000 -     0x7fff5e07cffb  com.apple.persistentconnection (1.0 - 1.0) <F16D4768-61F2-3298-8E37-0EAF612A55C0> /System/Library/PrivateFrameworks/PersistentConnection.framework/Versions/A/PersistentConnection
    0x7fff60a3a000 -     0x7fff60a53ffb  com.apple.ProtocolBuffer (1 - 274.24.9.16.3) <05BE7640-A9FD-3963-8199-E60DE3C37A7E> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
    0x7fff60eb2000 -     0x7fff60edbff1  com.apple.RemoteViewServices (2.0 - 148) <680F9F89-C44B-3AB3-B9EA-155B41B7295A> /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
    0x7fff61040000 -     0x7fff6107bff0  com.apple.RunningBoardServices (1.0 - 223.100.31) <28C26D68-F1F5-3ADC-832B-AF63336F35FB> /System/Library/PrivateFrameworks/RunningBoardServices.framework/Versions/A/RunningBoardServices
    0x7fff62958000 -     0x7fff6295bff5  com.apple.SecCodeWrapper (4.0 - 448.100.6) <87710569-BCB4-37C1-B56D-F0EB89863A78> /System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
    0x7fff62ace000 -     0x7fff62bf5ff1  com.apple.Sharing (1526.14 - 1526.14) <8D0C1BC4-5133-399B-9EFC-74CAEF4FA389> /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
    0x7fff64008000 -     0x7fff642fefff  com.apple.SkyLight (1.600.0 - 450.9) <C6AF6A79-C673-3B9E-95E0-993F43AE7EED> /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
    0x7fff64b4b000 -     0x7fff64b59ffb  com.apple.SpeechRecognitionCore (6.0.91 - 6.0.91) <4678A6DB-D56E-393F-90BD-5AF4F3664440> /System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
    0x7fff6538b000 -     0x7fff65394ff7  com.apple.SymptomDiagnosticReporter (1.0 - 1238.100.26) <A2197A8A-796E-321C-8EBB-075AED9995B0> /System/Library/PrivateFrameworks/SymptomDiagnosticReporter.framework/Versions/A/SymptomDiagnosticReporter
    0x7fff6564a000 -     0x7fff6565aff3  com.apple.TCC (1.0 - 1) <AEE98D6E-03FD-3C80-90AC-5B45B4AE7A2E> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
    0x7fff65b7d000 -     0x7fff65c43ff0  com.apple.TextureIO (3.10.9 - 3.10.9) <362C5815-6A2B-3CA8-B577-C5D4978EF981> /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
    0x7fff65e04000 -     0x7fff6605cff0  com.apple.UIFoundation (1.0 - 661.2) <27837A1C-A833-3F99-B8D8-84A583EEA523> /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
    0x7fff66ccf000 -     0x7fff66cefffc  com.apple.UserManagement (1.0 - 1) <6F223C62-641C-3F7E-BE20-B0C9F19709C7> /System/Library/PrivateFrameworks/UserManagement.framework/Versions/A/UserManagement
    0x7fff67a9b000 -     0x7fff67b85ff8  com.apple.ViewBridge (464.1 - 464.1) <E1DB0984-8B31-36E4-9854-A3345F67BED3> /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
    0x7fff67d2b000 -     0x7fff67d2cfff  com.apple.WatchdogClient.framework (1.0 - 67.101.1) <1D6C2858-0A09-380E-8718-14131D9A0FE1> /System/Library/PrivateFrameworks/WatchdogClient.framework/Versions/A/WatchdogClient
    0x7fff68958000 -     0x7fff6895bffa  com.apple.dt.XCTTargetBootstrap (1.0 - 16091) <B40E4B60-2DB5-30ED-A210-3ED708862162> /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
    0x7fff689d5000 -     0x7fff689e3ff5  com.apple.audio.caulk (1.0 - 32.3) <DFE1EBB6-9A42-3227-8601-5CFCB1F665CD> /System/Library/PrivateFrameworks/caulk.framework/Versions/A/caulk
    0x7fff68d25000 -     0x7fff68d27ff3  com.apple.loginsupport (1.0 - 1) <B84ABC31-431B-3F99-BABE-44ED0A7DB3C0> /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
    0x7fff68d28000 -     0x7fff68d3bffd  com.apple.login (3.0 - 3.0) <8FAC178E-0C61-3E48-844A-CB4446CC7BC6> /System/Library/PrivateFrameworks/login.framework/Versions/A/login
    0x7fff68d6d000 -     0x7fff68d79ffd  com.apple.perfdata (1.0 - 51.100.6) <F7D0F01D-CD05-3FA8-A475-E71D89250740> /System/Library/PrivateFrameworks/perfdata.framework/Versions/A/perfdata
    0x7fff6b7f9000 -     0x7fff6b805ff9  libAudioStatistics.dylib (1104.80) <9ED11599-1BB1-34B2-A4A2-CD69989DE9EA> /usr/lib/libAudioStatistics.dylib
    0x7fff6b806000 -     0x7fff6b839ffa  libAudioToolboxUtility.dylib (1104.80) <C34C8FCE-54DE-3884-8074-057B06807D22> /usr/lib/libAudioToolboxUtility.dylib
    0x7fff6b840000 -     0x7fff6b874fff  libCRFSuite.dylib (48) <E52BECF7-1819-3998-ACC4-8D1A332CE4EB> /usr/lib/libCRFSuite.dylib
    0x7fff6b877000 -     0x7fff6b881fff  libChineseTokenizer.dylib (34) <EE842A48-3D30-34B0-B9D2-F045DE582650> /usr/lib/libChineseTokenizer.dylib
    0x7fff6b90d000 -     0x7fff6b90fff7  libDiagnosticMessagesClient.dylib (112) <BE749883-9400-334A-8FBF-F3321CF205F5> /usr/lib/libDiagnosticMessagesClient.dylib
    0x7fff6b955000 -     0x7fff6bb0cffb  libFosl_dynamic.dylib (100.4) <68038226-8CAA-36B5-B5D6-510F900B318D> /usr/lib/libFosl_dynamic.dylib
    0x7fff6bb33000 -     0x7fff6bb39ff3  libIOReport.dylib (54) <FA47D01E-E02C-3178-9C10-DF4E7F6351B0> /usr/lib/libIOReport.dylib
    0x7fff6bc1b000 -     0x7fff6bc22fff  libMatch.1.dylib (36) <815A4553-4763-369F-A77C-62663A586D60> /usr/lib/libMatch.1.dylib
    0x7fff6bc51000 -     0x7fff6bc71fff  libMobileGestalt.dylib (826.100.27) <4B771C86-0CB7-3B06-8F41-5A40DDF66D72> /usr/lib/libMobileGestalt.dylib
    0x7fff6bcf1000 -     0x7fff6bdceff7  libSMC.dylib (20) <8EDBE07C-A4C7-356C-9D80-524FA08BB465> /usr/lib/libSMC.dylib
    0x7fff6bde3000 -     0x7fff6bde4fff  libSystem.B.dylib (1281.100.1) <DB8310F1-272D-3533-A840-3B390AF55C26> /usr/lib/libSystem.B.dylib
    0x7fff6bde5000 -     0x7fff6be70ff7  libTelephonyUtilDynamic.dylib (5017.1) <78480078-F0A7-343F-A088-857C7CA607F3> /usr/lib/libTelephonyUtilDynamic.dylib
    0x7fff6be71000 -     0x7fff6be72fff  libThaiTokenizer.dylib (3) <DC582222-7C1F-3C27-8C3A-BAF696A2197D> /usr/lib/libThaiTokenizer.dylib
    0x7fff6be8a000 -     0x7fff6bea0fff  libapple_nghttp2.dylib (1.39.2) <268F4E3E-95DC-35FB-82DC-5B0D1855A676> /usr/lib/libapple_nghttp2.dylib
    0x7fff6bed5000 -     0x7fff6bf47ff7  libarchive.2.dylib (72.100.1) <65E0870E-02AB-365D-84F9-5800B5BB69FC> /usr/lib/libarchive.2.dylib
    0x7fff6bf48000 -     0x7fff6bfe1fe5  libate.dylib (3.0.1) <4477640F-CC1B-3825-B877-69508F367E3D> /usr/lib/libate.dylib
    0x7fff6bfe5000 -     0x7fff6bfe5ff3  libauto.dylib (187) <FD0E5750-7004-36A7-B9C2-D6B6B4EF559B> /usr/lib/libauto.dylib
    0x7fff6bfe6000 -     0x7fff6c0aaffe  libboringssl.dylib (283.101.1) <E5D07E64-1439-3B53-A6F2-49269F974925> /usr/lib/libboringssl.dylib
    0x7fff6c0ab000 -     0x7fff6c0bbffb  libbsm.0.dylib (60.100.1) <B0373A39-DBC6-3A84-879B-BA46E30D04BF> /usr/lib/libbsm.0.dylib
    0x7fff6c0bc000 -     0x7fff6c0c8fff  libbz2.1.0.dylib (44) <FFCD4427-AF87-36D2-8097-8870FDC75A1B> /usr/lib/libbz2.1.0.dylib
    0x7fff6c0c9000 -     0x7fff6c11bfff  libc++.1.dylib (902.1) <08199809-33CA-321E-9B9D-FD5B2BC64580> /usr/lib/libc++.1.dylib
    0x7fff6c11c000 -     0x7fff6c131ffb  libc++abi.dylib (902) <1C880020-396D-3F91-BE27-5A09A9239F68> /usr/lib/libc++abi.dylib
    0x7fff6c132000 -     0x7fff6c132fff  libcharset.1.dylib (59) <4E63BA25-04A3-329A-923D-251155C03F30> /usr/lib/libcharset.1.dylib
    0x7fff6c133000 -     0x7fff6c144fff  libcmph.dylib (8) <D4C5E0A8-92D9-33D5-9F83-6F4742FFBE29> /usr/lib/libcmph.dylib
    0x7fff6c145000 -     0x7fff6c15cfd7  libcompression.dylib (87) <7F258A06-E01D-32D2-9CD2-6B2931DA5DA7> /usr/lib/libcompression.dylib
    0x7fff6c436000 -     0x7fff6c44cff7  libcoretls.dylib (167) <EFC237BB-78F7-33C6-BFF9-53860062DD99> /usr/lib/libcoretls.dylib
    0x7fff6c44d000 -     0x7fff6c44efff  libcoretls_cfhelpers.dylib (167) <2E542A2B-7730-33EE-9B3B-154B08608AA6> /usr/lib/libcoretls_cfhelpers.dylib
    0x7fff6ca0b000 -     0x7fff6ca6aff7  libcups.2.dylib (483.6) <F446DEF0-66C0-31AD-88E1-919B05F06C90> /usr/lib/libcups.2.dylib
    0x7fff6cb76000 -     0x7fff6cb76fff  libenergytrace.dylib (21) <FFB9FB70-8DBD-3025-BC92-51F02481A489> /usr/lib/libenergytrace.dylib
    0x7fff6cb77000 -     0x7fff6cb8ffff  libexpat.1.dylib (19.60.2) <1ED53818-578C-3D17-8761-68792CCAD685> /usr/lib/libexpat.1.dylib
    0x7fff6cb9d000 -     0x7fff6cb9ffff  libfakelink.dylib (149.1) <B04F9A05-7E52-3382-9186-F603BE4BFBB2> /usr/lib/libfakelink.dylib
    0x7fff6cbae000 -     0x7fff6cbb3fff  libgermantok.dylib (24) <8091F952-B592-38E3-982B-7DEA0A44E211> /usr/lib/libgermantok.dylib
    0x7fff6cbb4000 -     0x7fff6cbbdff7  libheimdal-asn1.dylib (564.100.1) <2D639331-43CF-331F-98F4-CDF41990A468> /usr/lib/libheimdal-asn1.dylib
    0x7fff6cbbe000 -     0x7fff6ccaefff  libiconv.2.dylib (59) <9458704B-A702-37CB-9707-66ABBB5DB71E> /usr/lib/libiconv.2.dylib
    0x7fff6ccaf000 -     0x7fff6cf06fff  libicucore.A.dylib (64260.0.1) <DCC4A4EE-32FD-350F-84D8-E857F2F29855> /usr/lib/libicucore.A.dylib
    0x7fff6cf20000 -     0x7fff6cf21fff  liblangid.dylib (133) <E9595222-602B-38F0-8572-0F1872A00527> /usr/lib/liblangid.dylib
    0x7fff6cf22000 -     0x7fff6cf3aff3  liblzma.5.dylib (16) <0AA1EB11-A433-327E-B8DB-7395CFF06554> /usr/lib/liblzma.5.dylib
    0x7fff6cf52000 -     0x7fff6cff9ff7  libmecab.dylib (883.10) <13136C11-8763-37BA-AEB2-676092798DAA> /usr/lib/libmecab.dylib
    0x7fff6cffa000 -     0x7fff6d25cfe1  libmecabra.dylib (883.10) <6AC22857-F528-35CE-94A9-D70F6F766C15> /usr/lib/libmecabra.dylib
    0x7fff6d5c9000 -     0x7fff6d5f8fff  libncurses.5.4.dylib (57) <6BD6F430-C8B3-39D8-87B5-2C16E6578FD5> /usr/lib/libncurses.5.4.dylib
    0x7fff6d728000 -     0x7fff6dba3ff5  libnetwork.dylib (1880.100.30) <9519B6F8-44E2-3F53-B995-1527C5333240> /usr/lib/libnetwork.dylib
    0x7fff6dc43000 -     0x7fff6dc76fde  libobjc.A.dylib (787.1) <20AC082F-2DB7-3974-A2D4-8C5E01787584> /usr/lib/libobjc.A.dylib
    0x7fff6dc89000 -     0x7fff6dc8dfff  libpam.2.dylib (25.100.1) <D5CEC1AD-A2EC-362C-B71A-22FD521917F1> /usr/lib/libpam.2.dylib
    0x7fff6dc90000 -     0x7fff6dcc6ff7  libpcap.A.dylib (89.100.1) <171BAAB0-A5C8-32C5-878E-83D46073BF8C> /usr/lib/libpcap.A.dylib
    0x7fff6dd06000 -     0x7fff6dd14ff9  libperfcheck.dylib (37.100.2) <FAD84AEF-7F3A-3330-A193-FF367DA48CC6> /usr/lib/libperfcheck.dylib
    0x7fff6dd4a000 -     0x7fff6dd62fff  libresolv.9.dylib (67.40.1) <92A522F9-95E2-35EE-A8AD-FC8DEE6B2C1F> /usr/lib/libresolv.9.dylib
    0x7fff6dd64000 -     0x7fff6dda8ff7  libsandbox.1.dylib (1217.101.2) <5E362637-203E-3170-B988-1C470A6B0642> /usr/lib/libsandbox.1.dylib
    0x7fff6ddbc000 -     0x7fff6ddbdff7  libspindump.dylib (281.3) <16F53AD2-1839-37BF-A2F5-92253FE4AF1A> /usr/lib/libspindump.dylib
    0x7fff6ddbe000 -     0x7fff6dfa8ff7  libsqlite3.dylib (308.4) <BBC375B7-AF20-3D2C-8826-78D3BDC8A004> /usr/lib/libsqlite3.dylib
    0x7fff6e19e000 -     0x7fff6e1f8ff8  libusrtcp.dylib (1880.100.30) <EA950C6F-2EE4-324E-81D7-A0B02B372165> /usr/lib/libusrtcp.dylib
    0x7fff6e1f9000 -     0x7fff6e1fcffb  libutil.dylib (57) <07ED7CF0-1744-3386-B8B2-0DDBD446999E> /usr/lib/libutil.dylib
    0x7fff6e1fd000 -     0x7fff6e20aff7  libxar.1.dylib (425.2) <625F24E1-1A0F-3301-9F99-F0F3DADE0287> /usr/lib/libxar.1.dylib
    0x7fff6e210000 -     0x7fff6e2f2ff7  libxml2.2.dylib (33.3) <24147A90-E3EB-3926-BFB0-5F0FC9F706E2> /usr/lib/libxml2.2.dylib
    0x7fff6e2f6000 -     0x7fff6e31efff  libxslt.1.dylib (16.9) <8C8648B1-F2CA-38EA-A409-D6F19715C6E6> /usr/lib/libxslt.1.dylib
    0x7fff6e31f000 -     0x7fff6e331ff3  libz.1.dylib (76) <6A449C6A-DF88-36C1-8F2D-DB9A808263B5> /usr/lib/libz.1.dylib
    0x7fff6e427000 -     0x7fff6e7dc437  libswiftCore.dylib (5.2 - 1103.8.25.8) <1BB781ED-EB29-3BF0-960B-DA4672FFF9F9> /usr/lib/swift/libswiftCore.dylib
    0x7fff6e7f2000 -     0x7fff6e7f4fff  libswiftCoreFoundation.dylib (??? - ???) <6866BE6D-5F58-3BD2-85C1-6DD2C15B5B51> /usr/lib/swift/libswiftCoreFoundation.dylib
    0x7fff6e7f5000 -     0x7fff6e802fff  libswiftCoreGraphics.dylib (??? - ???) <0C4DD665-27B1-3B52-8987-8FEE2EBA5E53> /usr/lib/swift/libswiftCoreGraphics.dylib
    0x7fff6e861000 -     0x7fff6e867fff  libswiftDarwin.dylib (??? - ???) <6593ACCA-D578-3BFF-B339-5798C4AC384E> /usr/lib/swift/libswiftDarwin.dylib
    0x7fff6e868000 -     0x7fff6e87fcdf  libswiftDispatch.dylib (??? - ???) <C4A4B8DC-B3D7-3815-80ED-99D46017438E> /usr/lib/swift/libswiftDispatch.dylib
    0x7fff6e880000 -     0x7fff6ea05277  libswiftFoundation.dylib (??? - ???) <C4E89ED3-976F-3924-A24F-661DDE4A7CA6> /usr/lib/swift/libswiftFoundation.dylib
    0x7fff6ea14000 -     0x7fff6ea16ff3  libswiftIOKit.dylib (??? - ???) <2A458B23-A3D3-3868-AAE0-E33316AB9C57> /usr/lib/swift/libswiftIOKit.dylib
    0x7fff6eaaf000 -     0x7fff6eab2fe7  libswiftObjectiveC.dylib (??? - ???) <091A84D0-7C63-3CE7-92FB-84A435C0D944> /usr/lib/swift/libswiftObjectiveC.dylib
    0x7fff6ebb3000 -     0x7fff6ebb5fff  libswiftXPC.dylib (??? - ???) <69F04529-774D-3811-9D41-85ADB4964E2F> /usr/lib/swift/libswiftXPC.dylib
    0x7fff6ebb6000 -     0x7fff6ebbcfe7  libswiftos.dylib (??? - ???) <E5998747-1D1A-339A-BC86-A93DF83F3BD4> /usr/lib/swift/libswiftos.dylib
    0x7fff6ebdf000 -     0x7fff6ebe4ff3  libcache.dylib (83) <5F90FFCE-403B-3724-991D-BA32401D99C5> /usr/lib/system/libcache.dylib
    0x7fff6ebe5000 -     0x7fff6ebf0fff  libcommonCrypto.dylib (60165) <C7A5E3F7-1E5A-3785-875A-B6647082B614> /usr/lib/system/libcommonCrypto.dylib
    0x7fff6ebf1000 -     0x7fff6ebf8fff  libcompiler_rt.dylib (101.2) <A517E149-2D25-3C04-BCEF-F69149C85B18> /usr/lib/system/libcompiler_rt.dylib
    0x7fff6ebf9000 -     0x7fff6ec02ff7  libcopyfile.dylib (166.40.1) <1A5270B5-0D97-35DA-9296-4F4A428BC6A2> /usr/lib/system/libcopyfile.dylib
    0x7fff6ec03000 -     0x7fff6ec95fe3  libcorecrypto.dylib (866.100.30) <FCDEC0D1-8C30-3989-BDD1-996BBC715C29> /usr/lib/system/libcorecrypto.dylib
    0x7fff6eda2000 -     0x7fff6ede2ff0  libdispatch.dylib (1173.100.2) <EB592997-B11C-3AB3-85B1-F725F3D0B412> /usr/lib/system/libdispatch.dylib
    0x7fff6ede3000 -     0x7fff6ee19fff  libdyld.dylib (750.5) <D2A07EF5-A64B-3692-BE13-89DAA2EC5E80> /usr/lib/system/libdyld.dylib
    0x7fff6ee1a000 -     0x7fff6ee1affb  libkeymgr.dylib (30) <CC5A2B43-770B-3C6C-BA10-AA3A6B4A142D> /usr/lib/system/libkeymgr.dylib
    0x7fff6ee1b000 -     0x7fff6ee27ff3  libkxld.dylib (6153.101.6) <77282DCB-83D6-3199-874E-9A4A0FD7D4F3> /usr/lib/system/libkxld.dylib
    0x7fff6ee28000 -     0x7fff6ee28ff7  liblaunch.dylib (1738.100.39) <A7FF7357-600F-3014-8C28-A4F367717E8D> /usr/lib/system/liblaunch.dylib
    0x7fff6ee29000 -     0x7fff6ee2eff7  libmacho.dylib (959.0.1) <D8FED478-25A2-3844-AE4B-A5C9F9827615> /usr/lib/system/libmacho.dylib
    0x7fff6ee2f000 -     0x7fff6ee31ff3  libquarantine.dylib (110.40.3) <51E0304F-AB11-3BF7-99DC-BB916CC9088B> /usr/lib/system/libquarantine.dylib
    0x7fff6ee32000 -     0x7fff6ee33ff7  libremovefile.dylib (48) <078F29AB-26BA-3493-BCAA-E1E75A187521> /usr/lib/system/libremovefile.dylib
    0x7fff6ee34000 -     0x7fff6ee4bff3  libsystem_asl.dylib (377.60.2) <0F1BAC19-2AE0-3F8E-9B90-AACF819B2BF7> /usr/lib/system/libsystem_asl.dylib
    0x7fff6ee4c000 -     0x7fff6ee4cff7  libsystem_blocks.dylib (74) <32224AFF-C06F-3279-B753-097194EDEF49> /usr/lib/system/libsystem_blocks.dylib
    0x7fff6ee4d000 -     0x7fff6eed4fff  libsystem_c.dylib (1353.100.2) <4F5EED22-4D46-3F04-8C64-C492CDAD70EB> /usr/lib/system/libsystem_c.dylib
    0x7fff6eed5000 -     0x7fff6eed8ffb  libsystem_configuration.dylib (1061.101.1) <2A2C778D-07EB-35C7-A954-8BF8FD74BD75> /usr/lib/system/libsystem_configuration.dylib
    0x7fff6eed9000 -     0x7fff6eedcfff  libsystem_coreservices.dylib (114) <FDA41CC4-170A-3D93-85BD-838A563B03C4> /usr/lib/system/libsystem_coreservices.dylib
    0x7fff6eedd000 -     0x7fff6eee5fff  libsystem_darwin.dylib (1353.100.2) <B567B86D-8818-38A4-A861-03EB83B55867> /usr/lib/system/libsystem_darwin.dylib
    0x7fff6eee6000 -     0x7fff6eeedfff  libsystem_dnssd.dylib (1096.100.3) <7C690DF5-E119-33FB-85CD-9EFC67A36E40> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff6eeee000 -     0x7fff6eeefffb  libsystem_featureflags.dylib (17) <415D83EF-084C-3485-B757-53001870EA94> /usr/lib/system/libsystem_featureflags.dylib
    0x7fff6eef0000 -     0x7fff6ef3dff7  libsystem_info.dylib (538) <17049D3F-C798-3651-B391-1551FC699D3E> /usr/lib/system/libsystem_info.dylib
    0x7fff6ef3e000 -     0x7fff6ef6aff7  libsystem_kernel.dylib (6153.101.6) <E76440E1-D1E8-3D9A-8B47-D01F554FF1C4> /usr/lib/system/libsystem_kernel.dylib
    0x7fff6ef6b000 -     0x7fff6efb2fff  libsystem_m.dylib (3178) <74741FA8-5C29-3241-9046-4FC91C6A6D4A> /usr/lib/system/libsystem_m.dylib
    0x7fff6efb3000 -     0x7fff6efdafff  libsystem_malloc.dylib (283.100.5) <97833239-2F83-3AEB-A426-0593997C8A54> /usr/lib/system/libsystem_malloc.dylib
    0x7fff6efdb000 -     0x7fff6efe8ffb  libsystem_networkextension.dylib (1095.100.29) <C9E988B2-6A18-35C0-9577-63201E9D6018> /usr/lib/system/libsystem_networkextension.dylib
    0x7fff6efe9000 -     0x7fff6eff2ff7  libsystem_notify.dylib (241.100.2) <E405F84B-BD4F-3874-9755-CB3EC86E18D5> /usr/lib/system/libsystem_notify.dylib
    0x7fff6eff3000 -     0x7fff6effbfef  libsystem_platform.dylib (220.100.1) <6EF12F34-C33F-36BF-9A9A-2A35EA19EFE0> /usr/lib/system/libsystem_platform.dylib
    0x7fff6effc000 -     0x7fff6f006fff  libsystem_pthread.dylib (416.100.3) <A8514582-E000-3854-911A-0A73D2C79600> /usr/lib/system/libsystem_pthread.dylib
    0x7fff6f007000 -     0x7fff6f00bff3  libsystem_sandbox.dylib (1217.101.2) <E9D78CDE-FB67-32E7-BABC-9EFC23AA0DC6> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff6f00c000 -     0x7fff6f00efff  libsystem_secinit.dylib (62.100.2) <AAC639E5-7103-3366-A602-8FC6944E2C13> /usr/lib/system/libsystem_secinit.dylib
    0x7fff6f00f000 -     0x7fff6f016ffb  libsystem_symptoms.dylib (1238.100.26) <487B92DE-45F9-39F9-A478-89BBD478157D> /usr/lib/system/libsystem_symptoms.dylib
    0x7fff6f017000 -     0x7fff6f02dff2  libsystem_trace.dylib (1147.100.8) <BB90B1FD-8C09-3DF4-BD8B-9E4AEADFEA2B> /usr/lib/system/libsystem_trace.dylib
    0x7fff6f02f000 -     0x7fff6f034ff7  libunwind.dylib (35.4) <CC87C836-BE9D-334E-A0E6-0297D52E9D73> /usr/lib/system/libunwind.dylib
    0x7fff6f035000 -     0x7fff6f06affe  libxpc.dylib (1738.100.39) <32B0E31E-9DA3-328B-A962-BC9591B93537> /usr/lib/system/libxpc.dylib

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 616
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 11997410
    thread_create: 0
    thread_set_state: 0

VM Region Summary:
ReadOnly portion of Libraries: Total=717.7M resident=0K(0%) swapped_out_or_unallocated=717.7M(100%)
Writable regions: Total=710.0M written=0K(0%) resident=0K(0%) swapped_out=0K(0%) unallocated=710.0M(100%)
 
                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Accelerate framework               128K        1 
Activity Tracing                   256K        1 
CG backing stores                 1320K        2 
CG image                            72K        5 
CoreAnimation                       88K        8 
CoreGraphics                         8K        1 
CoreImage                           24K        2 
CoreServices                        80K        1 
CoreUI image data                  784K        7 
Dispatch continuations            16.0M        1 
Foundation                           4K        1 
Kernel Alloc Once                    8K        1 
MALLOC                           361.2M      340 
MALLOC guard page                   32K        7 
Memory Tag 242                      12K        1 
OpenGL GLSL                        256K        3 
SQLite page cache                   64K        1 
STACK GUARD                       56.1M       25 
Stack                             23.2M       25 
VM_ALLOCATE                      304.1M      640 
VM_ALLOCATE (reserved)            3092K        1         reserved VM address space (unallocated)
__DATA                            46.1M      339 
__DATA_CONST                       384K       15 
__FONT_DATA                          4K        1 
__GLSLBUILTINS                    5176K        1 
__LINKEDIT                       441.2M       21 
__OBJC_RO                         32.2M        1 
__OBJC_RW                         1892K        2 
__TEXT                           276.5M      324 
__UNICODE                          564K        1 
mapped file                       84.9M       32 
shared memory                      648K       17 
===========                     =======  ======= 
TOTAL                              1.6G     1828 
TOTAL, minus reserved VM space     1.6G     1828 

Model: MacBookPro13,3, BootROM 265.0.0.0.0, 4 processors, Quad-Core Intel Core i7, 2.7 GHz, 16 GB, SMC 2.38f10
Graphics: kHW_IntelHDGraphics530Item, Intel HD Graphics 530, spdisplays_builtin
Graphics: kHW_AMDRadeonPro455Item, AMD Radeon Pro 455, spdisplays_pcie_device, 2 GB
Memory Module: BANK 0/DIMM0, 8 GB, LPDDR3, 2133 MHz, 0x80CE, 0x4B3445424533303445422D45474347202020
Memory Module: BANK 1/DIMM0, 8 GB, LPDDR3, 2133 MHz, 0x80CE, 0x4B3445424533303445422D45474347202020
AirPort: spairport_wireless_card_type_airport_extreme (0x14E4, 0x15A), Broadcom BCM43xx 1.0 (7.77.111.1 AirPortDriverBrcmNIC-1600.4)
Bluetooth: Version 7.0.4f6, 3 services, 27 devices, 1 incoming serial ports
Network Service: Wi-Fi, AirPort, en0
USB Device: USB 3.0 Bus
USB Device: nanoKEY2
USB Device: Apple T1 Controller
USB Device: LPK25
Thunderbolt Bus: MacBook Pro, Apple Inc., 41.2
Thunderbolt Bus: MacBook Pro, Apple Inc., 41.2
```

Here's where XCode showed the illegal access happening:

![image](https://user-images.githubusercontent.com/127916/80400032-37b8a900-8888-11ea-96e7-a6f3026f4650.png)
