### PR TITLE
AKWaveTable uses passed MIDI Note Velocity

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Wave Table/AKWaveTableDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Wave Table/AKWaveTableDSPKernel.hpp
@@ -330,6 +330,7 @@ public:
                 uint8_t note = midiEvent.data[1];
                 uint8_t veloc = midiEvent.data[2];
                 if (note > 127 || veloc > 127) break;
+                setVolume(float(veloc) / 127.0f);
                 start();
                 break;
             }


### PR DESCRIPTION
Per #2043, changes the `AKWaveTable` engine to use the passed MIDI Note velocity information.

Tested with `AKSequencerTrack` using an `AKWaveTable` as the `targetNode`