### PR TITLE
AU buffer allocation checks ability to process in place

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -9,7 +9,7 @@
 #ifndef __cplusplus
 
 AUInternalRenderBlock internalRenderBlockDSP(AKDSPRef pDSP);
-void allocateRenderResourcesDSP(AKDSPRef pDSP, AVAudioFormat* format, AVAudioPCMBuffer* inputBuffer, AVAudioPCMBuffer* outputBuffer);
+void allocateRenderResourcesDSP(AKDSPRef pDSP, AVAudioFormat* format, AVAudioPCMBuffer* buffer);
 void deallocateRenderResourcesDSP(AKDSPRef pDSP);
 void resetDSP(AKDSPRef pDSP);
 bool canProcessInPlaceDSP(AKDSPRef pDSP);
@@ -41,8 +41,7 @@ void deleteDSP(AKDSPRef pDSP);
 
 class AKDSPBase {
     
-    const AVAudioPCMBuffer *inputBuffer;
-    const AVAudioPCMBuffer *outputBuffer;
+    const AVAudioPCMBuffer* internalBuffer;
     
     /// Ramp rate for ramped parameters
     float rampDuration;
@@ -73,7 +72,7 @@ public:
     /// Virtual destructor allows child classes to be deleted with only AKDSPBase *pointer
     virtual ~AKDSPBase() {}
     
-    void setBuffers(const AVAudioPCMBuffer* inputBuffer, const AVAudioPCMBuffer* outputBuffer);
+    void setBuffers(const AVAudioPCMBuffer* buffer);
     
     AUInternalRenderBlock internalRenderBlock();
     

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
@@ -17,6 +17,7 @@ struct AKVariableDelayDSP::InternalData {
 AKVariableDelayDSP::AKVariableDelayDSP() : data(new InternalData) {
     parameters[AKVariableDelayParameterTime] = &data->timeRamp;
     parameters[AKVariableDelayParameterFeedback] = &data->feedbackRamp;
+    bCanProcessInPlace = false;
 }
 
 void AKVariableDelayDSP::init(int channelCount, double sampleRate) {

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
@@ -15,6 +15,7 @@ struct AKToneComplementFilterDSP::InternalData {
 
 AKToneComplementFilterDSP::AKToneComplementFilterDSP() : data(new InternalData) {
     parameters[AKToneComplementFilterParameterHalfPowerPoint] = &data->halfPowerPointRamp;
+    bCanProcessInPlace = false;
 }
 
 void AKToneComplementFilterDSP::init(int channelCount, double sampleRate) {

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
@@ -110,8 +110,9 @@ void AKFaderDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferO
                 *tmpout[1] = *tmpout[0];
             } else {
                 if (channelCount == 2 && data->flipStereo) {
+                    float leftSaved = *tmpin[0];
                     *tmpout[0] = *tmpin[1] * data->leftGainRamp.getAndStep();
-                    *tmpout[1] = *tmpin[0] * data->rightGainRamp.getAndStep();
+                    *tmpout[1] = leftSaved * data->rightGainRamp.getAndStep();
                 } else {
                     *tmpout[0] = *tmpin[0] * data->leftGainRamp.getAndStep();
                     *tmpout[1] = *tmpin[1] * data->rightGainRamp.getAndStep();

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.hpp
@@ -25,7 +25,6 @@ public:
 
     AKStereoFieldLimiterDSP() {
         parameters[AKStereoFieldLimiterParameterAmount] = &amountRamp;
-        bCanProcessInPlace = true;
     }
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override {


### PR DESCRIPTION
AUs which can process in place do not need to allocate their own pcm buffer. Instead, they can pull their input directly to the provided output buffer and perform all processing in place, improving performance due to better data locality, as well as saving memory from buffer allocations.

This does require that AUs properly report their ability to process in place (set via a bool in the DSP constructor, defaults to false in AKDSPBase and true in AKSoundpipeDSPBase). An AU that cannot process in place but reports that it can process in place will result in undefined behavior.