### PR TITLE
Remove automatic rewind in diskstreamer

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Disk Streamer/AKDiskStreamerDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Disk Streamer/AKDiskStreamerDSPKernel.hpp
@@ -45,7 +45,6 @@ public:
         started = false;
         useTempStartPoint = false;
         useTempEndPoint = false;
-        rewind();
     }
 
     void rewind() {


### PR DESCRIPTION
Removes automatic rewind call in stop function of akdiskstreamer
Rewind can be done at higher level - stop function merely does what it 'says on the tin'