### PR TITLE
Per-voice vibrato for AKSampler

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSampler.swift
@@ -21,6 +21,8 @@
     fileprivate var pitchBendParameter: AUParameter?
     fileprivate var vibratoDepthParameter: AUParameter?
     fileprivate var vibratoFrequencyParameter: AUParameter?
+    fileprivate var voiceVibratoDepthParameter: AUParameter?
+    fileprivate var voiceVibratoFrequencyParameter: AUParameter?
     fileprivate var filterCutoffParameter: AUParameter?
     fileprivate var filterStrengthParameter: AUParameter?
     fileprivate var filterResonanceParameter: AUParameter?
@@ -109,6 +111,34 @@
             }
 
             internalAU?.vibratoFrequency = newValue
+        }
+    }
+
+    /// Voice Vibrato amount (semitones) - each voice behaves indpendently
+    @objc open dynamic var voiceVibratoDepth: Double = 1.0 {
+        willSet {
+            guard voiceVibratoDepth != newValue else { return }
+
+            if internalAU?.isSetUp == true {
+                voiceVibratoDepthParameter?.value = AUValue(newValue)
+                return
+            }
+
+            internalAU?.voiceVibratoDepth = newValue
+        }
+    }
+
+    /// Vibrato speed (hz)
+    @objc open dynamic var voiceVibratoFrequency: Double = 5.0 {
+        willSet {
+            guard voiceVibratoFrequency != newValue else { return }
+
+            if internalAU?.isSetUp == true {
+                voiceVibratoFrequencyParameter?.value = AUValue(newValue)
+                return
+            }
+
+            internalAU?.voiceVibratoFrequency = newValue
         }
     }
 
@@ -329,6 +359,8 @@
     ///   - pitchBend: semitones, signed
     ///   - vibratoDepth: semitones, typically less than 1.0
     ///   - vibratoFrequency: hertz
+    ///   - voiceVibratoDepth: semitones, typically less than 1.0
+    ///   - voiceVibratoFrequency: hertz
     ///   - filterCutoff: relative to sample playback pitch, 1.0 = fundamental, 2.0 = 2nd harmonic etc
     ///   - filterStrength: same units as filterCutoff; amount filter EG adds to filterCutoff
     ///   - filterResonance: dB, -20.0 - 20.0
@@ -358,6 +390,8 @@
         pitchBend: Double = 0.0,
         vibratoDepth: Double = 0.0,
         vibratoFrequency: Double = 5.0,
+        voiceVibratoDepth: Double = 0.0,
+        voiceVibratoFrequency: Double = 5.0,
         filterCutoff: Double = 4.0,
         filterStrength: Double = 20.0,
         filterResonance: Double = 0.0,
@@ -386,6 +420,8 @@
         self.pitchBend = pitchBend
         self.vibratoDepth = vibratoDepth
         self.vibratoFrequency = vibratoFrequency
+        self.voiceVibratoDepth = voiceVibratoDepth
+        self.voiceVibratoFrequency = voiceVibratoFrequency
         self.filterCutoff = filterCutoff
         self.filterStrength = filterStrength
         self.filterResonance = filterResonance
@@ -433,6 +469,8 @@
         self.pitchBendParameter = tree["pitchBend"]
         self.vibratoDepthParameter = tree["vibratoDepth"]
         self.vibratoFrequencyParameter = tree["vibratoFrequency"]
+        self.voiceVibratoDepthParameter = tree["voiceVibratoDepth"]
+        self.voiceVibratoFrequencyParameter = tree["voiceVibratoFrequency"]
         self.filterCutoffParameter = tree["filterCutoff"]
         self.filterStrengthParameter = tree["filterStrength"]
         self.filterResonanceParameter = tree["filterResonance"]
@@ -461,6 +499,8 @@
         self.internalAU?.setParameterImmediately(.pitchBend, value: pitchBend)
         self.internalAU?.setParameterImmediately(.vibratoDepth, value: vibratoDepth)
         self.internalAU?.setParameterImmediately(.vibratoFrequency, value: vibratoFrequency)
+        self.internalAU?.setParameterImmediately(.voiceVibratoDepth, value: voiceVibratoDepth)
+        self.internalAU?.setParameterImmediately(.voiceVibratoFrequency, value: voiceVibratoFrequency)
         self.internalAU?.setParameterImmediately(.filterCutoff, value: filterCutoff)
         self.internalAU?.setParameterImmediately(.filterStrength, value: filterStrength)
         self.internalAU?.setParameterImmediately(.filterResonance, value: filterResonance)

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerAudioUnit.swift
@@ -34,6 +34,14 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         didSet { setParameter(.vibratoFrequency, value: vibratoFrequency) }
     }
 
+    var voiceVibratoDepth: Double = 1.0 {
+        didSet { setParameter(.voiceVibratoDepth, value: voiceVibratoDepth) }
+    }
+
+    var voiceVibratoFrequency: Double = 5.0 {
+        didSet { setParameter(.voiceVibratoFrequency, value: voiceVibratoFrequency) }
+    }
+
     var filterCutoff: Double = 4.0 {
         didSet { setParameter(.filterCutoff, value: filterCutoff) }
     }
@@ -175,6 +183,26 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         let vibratoFrequencyParameter = AUParameter(
             identifier: "vibratoFrequency",
             name: "Vibrato Speed (hz)",
+            address: parameterAddress,
+            range: 0.0...200.0,
+            unit: .hertz,
+            flags: .default)
+
+        parameterAddress += 1
+
+        let voiceVibratoDepthParameter = AUParameter(
+            identifier: "voiceVibratoDepth",
+            name: "Per-Voice Vibrato amount (semitones)",
+            address: parameterAddress,
+            range: 0.0...24.0,
+            unit: .relativeSemiTones,
+            flags: .default)
+
+        parameterAddress += 1
+
+        let voiceVibratoFrequencyParameter = AUParameter(
+            identifier: "voiceVibratoFrequency",
+            name: "Per-Voice Vibrato Speed (hz)",
             address: parameterAddress,
             range: 0.0...200.0,
             unit: .hertz,
@@ -414,6 +442,8 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
                                                                    pitchBendParameter,
                                                                    vibratoDepthParameter,
                                                                    vibratoFrequencyParameter,
+                                                                   voiceVibratoDepthParameter,
+                                                                   voiceVibratoFrequencyParameter,
                                                                    filterCutoffParameter,
                                                                    filterStrengthParameter,
                                                                    filterResonanceParameter,
@@ -441,6 +471,8 @@ public class AKSamplerAudioUnit: AKGeneratorAudioUnitBase {
         pitchBendParameter.value = 0.0
         vibratoDepthParameter.value = 0.0
         vibratoFrequencyParameter.value = 5.0
+        voiceVibratoDepthParameter.value = 0.0
+        voiceVibratoFrequencyParameter.value = 5.0
         filterCutoffParameter.value = 4.0
         filterStrengthParameter.value = 20.0
         filterResonanceParameter.value = 0.0

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.hpp
@@ -17,6 +17,8 @@ typedef NS_ENUM(AUParameterAddress, AKSamplerParameter)
     AKSamplerParameterPitchBend,
     AKSamplerParameterVibratoDepth,
     AKSamplerParameterVibratoFrequency,
+    AKSamplerParameterVoiceVibratoDepth,
+    AKSamplerParameterVoiceVibratoFrequency,
     AKSamplerParameterFilterCutoff,
     AKSamplerParameterFilterStrength,
     AKSamplerParameterFilterResonance,
@@ -78,6 +80,8 @@ struct AKSamplerDSP : AKDSPBase, AKCoreSampler
     AKLinearParameterRamp pitchBendRamp;
     AKLinearParameterRamp vibratoDepthRamp;
     AKLinearParameterRamp vibratoFrequencyRamp;
+    AKLinearParameterRamp voiceVibratoDepthRamp;
+    AKLinearParameterRamp voiceVibratoFrequencyRamp;
     AKLinearParameterRamp filterCutoffRamp;
     AKLinearParameterRamp filterStrengthRamp;
     AKLinearParameterRamp filterResonanceRamp;

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -108,6 +108,8 @@ AKSamplerDSP::AKSamplerDSP() : AKCoreSampler()
     pitchBendRamp.setTarget(0.0, true);
     vibratoDepthRamp.setTarget(0.0, true);
     vibratoFrequencyRamp.setTarget(5.0, true);
+    voiceVibratoDepthRamp.setTarget(0.0, true);
+    voiceVibratoFrequencyRamp.setTarget(5.0, true);
     filterCutoffRamp.setTarget(4, true);
     filterStrengthRamp.setTarget(20.0f, true);
     filterResonanceRamp.setTarget(1.0, true);
@@ -134,6 +136,8 @@ void AKSamplerDSP::setParameter(AUParameterAddress address, float value, bool im
             pitchBendRamp.setRampDuration(value, sampleRate);
             vibratoDepthRamp.setRampDuration(value, sampleRate);
             vibratoFrequencyRamp.setRampDuration(value, sampleRate);
+            voiceVibratoDepthRamp.setRampDuration(value, sampleRate);
+            voiceVibratoFrequencyRamp.setRampDuration(value, sampleRate);
             filterCutoffRamp.setRampDuration(value, sampleRate);
             filterStrengthRamp.setRampDuration(value, sampleRate);
             filterResonanceRamp.setRampDuration(value, sampleRate);
@@ -152,6 +156,12 @@ void AKSamplerDSP::setParameter(AUParameterAddress address, float value, bool im
             break;
         case AKSamplerParameterVibratoFrequency:
             vibratoFrequencyRamp.setTarget(value, immediate);
+            break;
+        case AKSamplerParameterVoiceVibratoDepth:
+            voiceVibratoDepthRamp.setTarget(value, immediate);
+            break;
+        case AKSamplerParameterVoiceVibratoFrequency:
+            voiceVibratoFrequencyRamp.setTarget(value, immediate);
             break;
         case AKSamplerParameterFilterCutoff:
             filterCutoffRamp.setTarget(value, immediate);
@@ -243,6 +253,10 @@ float AKSamplerDSP::getParameter(AUParameterAddress address)
             return vibratoDepthRamp.getTarget();
         case AKSamplerParameterVibratoFrequency:
             return vibratoFrequencyRamp.getTarget();
+        case AKSamplerParameterVoiceVibratoDepth:
+            return voiceVibratoDepthRamp.getTarget();
+        case AKSamplerParameterVoiceVibratoFrequency:
+            return voiceVibratoFrequencyRamp.getTarget();
         case AKSamplerParameterFilterCutoff:
             return filterCutoffRamp.getTarget();
         case AKSamplerParameterFilterStrength:
@@ -344,6 +358,10 @@ void AKSamplerDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffe
         vibratoDepth = (float)vibratoDepthRamp.getValue();
         vibratoFrequencyRamp.advanceTo(now + frameOffset);
         vibratoFrequency = (float)vibratoFrequencyRamp.getValue();
+        voiceVibratoDepthRamp.advanceTo(now + frameOffset);
+        voiceVibratoDepth = (float)voiceVibratoDepthRamp.getValue();
+        voiceVibratoFrequencyRamp.advanceTo(now + frameOffset);
+        voiceVibratoFrequency = (float)voiceVibratoFrequencyRamp.getValue();
         filterCutoffRamp.advanceTo(now + frameOffset);
         cutoffMultiple = (float)filterCutoffRamp.getValue();
         filterStrengthRamp.advanceTo(now + frameOffset);

--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.cpp
@@ -54,6 +54,8 @@ AKCoreSampler::AKCoreSampler()
 , pitchOffset(0.0f)
 , vibratoDepth(0.0f)
 , vibratoFrequency(5.0f)
+, voiceVibratoDepth(0.0f)
+, voiceVibratoFrequency(5.0f)
 , glideRate(0.0f)   // 0 sec/octave means "no glide"
 , isMonophonic(false)
 , isLegato(false)
@@ -98,7 +100,6 @@ int AKCoreSampler::init(double sampleRate)
     
     for (int i=0; i<MAX_POLYPHONY; i++)
         data->voice[i].init(sampleRate);
-    
     return 0;   // no error
 }
 
@@ -426,7 +427,7 @@ void AKCoreSampler::render(unsigned channelCount, unsigned sampleCount, float *o
             if (stoppingAllVoices ||
                 pVoice->prepToGetSamples(sampleCount, masterVolume, pitchDev, cutoffMul, keyTracking,
                                          cutoffEnvelopeStrength, filterEnvelopeVelocityScaling, linearResonance,
-                                         pitchADSRSemitones) ||
+                                         pitchADSRSemitones, voiceVibratoDepth, voiceVibratoFrequency) ||
                 (pVoice->getSamples(sampleCount, pOutLeft, pOutRight) && allowSampleRunout))
             {
                 stopNote(nn, true);

--- a/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/AKCoreSampler.hpp
@@ -107,7 +107,8 @@ protected:
     bool isFilterEnabled;
     
     // performance parameters
-    float masterVolume, pitchOffset, vibratoDepth, vibratoFrequency, glideRate;
+    float masterVolume, pitchOffset, vibratoDepth, vibratoFrequency,
+    voiceVibratoDepth, voiceVibratoFrequency, glideRate;
     
     // parameters for mono-mode only
     

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
@@ -21,6 +21,8 @@ namespace AudioKitCore
         adsrEnvelope.init();
         filterEnvelope.init();
         pitchEnvelope.init();
+        vibratoLFO.waveTable.sinusoid();
+        vibratoLFO.init(sampleRate/AKCORESAMPLER_CHUNKSIZE, 5.0f);
         volumeRamper.init(0.0f);
         tempGain = 0.0f;
     }
@@ -45,6 +47,8 @@ namespace AudioKitCore
         pitchEnvelope.start();
 
         pitchEnvelopeSemitones = 0.0f;
+
+        voiceLFOSemitones = 0.0f;
 
         glideSemitones = 0.0f;
         if (*glideSecPerOctave != 0.0f && noteFrequency != 0.0 && noteFrequency != frequency)
@@ -74,6 +78,8 @@ namespace AudioKitCore
 
         pitchEnvelopeSemitones = 0.0f;
 
+        voiceLFOSemitones = 0.0f;
+
         noteFrequency = frequency;
         noteNumber = note;
         tempNoteVolume = noteVolume;
@@ -82,6 +88,7 @@ namespace AudioKitCore
         noteVolume = volume;
         filterEnvelope.restart();
         pitchEnvelope.restart();
+        vibratoLFO.phase = 0;
     }
 
     void SamplerVoice::restartNewNoteLegato(unsigned note, float sampleRate, float frequency)
@@ -110,6 +117,7 @@ namespace AudioKitCore
         noteVolume = volume;
         filterEnvelope.restart();
         pitchEnvelope.restart();
+        vibratoLFO.phase = 0;
     }
     
     void SamplerVoice::release(bool loopThruRelease)
@@ -127,12 +135,14 @@ namespace AudioKitCore
         volumeRamper.init(0.0f);
         filterEnvelope.reset();
         pitchEnvelope.reset();
+        vibratoLFO.phase = 0;
     }
 
     bool SamplerVoice::prepToGetSamples(int sampleCount, float masterVolume, float pitchOffset,
                                         float cutoffMultiple, float keyTracking,
                                         float cutoffEnvelopeStrength, float cutoffEnvelopeVelocityScaling,
-                                        float resLinear, float pitchADSRSemitones)
+                                        float resLinear, float pitchADSRSemitones,
+                                        float voiceLFODepthSemitones, float voiceLFOFrequencyHz)
     {
         if (adsrEnvelope.isIdle()) return true;
 
@@ -178,7 +188,10 @@ namespace AudioKitCore
         if (pitchCurveAmount < 0) { pitchCurveAmount = 0; }
         pitchEnvelopeSemitones = pow(pitchEnvelope.getSample(), pitchCurveAmount) * pitchADSRSemitones;
 
-        float pitchOffsetModified = pitchOffset + glideSemitones + pitchEnvelopeSemitones;
+        vibratoLFO.setFrequency(voiceLFOFrequencyHz);
+        voiceLFOSemitones = vibratoLFO.getSample() * voiceLFODepthSemitones;
+
+        float pitchOffsetModified = pitchOffset + glideSemitones + pitchEnvelopeSemitones + voiceLFOSemitones;
         oscillator.setPitchOffsetSemitones(pitchOffsetModified);
 
         // negative value of cutoffMultiple means filters are disabled

--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.hpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.hpp
@@ -12,8 +12,12 @@
 #include "SampleBuffer.hpp"
 #include "SampleOscillator.hpp"
 #include "ADSREnvelope.hpp"
+#include "FunctionTable.hpp"
 #include "ResonantLowPassFilter.hpp"
 #include "LinearRamper.hpp"
+
+// process samples in "chunks" this size
+#define AKCORESAMPLER_CHUNKSIZE 16 // should probably be set elsewhere - currently only use this for setting up lfo
 
 namespace AudioKitCore
 {
@@ -31,6 +35,9 @@ namespace AudioKitCore
         ResonantLowPassFilter leftFilter, rightFilter;
         ADSREnvelope adsrEnvelope, filterEnvelope, pitchEnvelope;
 
+        // per-voice vibrato LFO
+        FunctionTableOscillator vibratoLFO;
+
         /// common glide rate, seconds per octave
         float *glideSecPerOctave;
 
@@ -45,6 +52,9 @@ namespace AudioKitCore
 
         /// amount of semitone change via pitch envelope
         float pitchEnvelopeSemitones;
+
+        /// amount of semitone change via voice lfo
+        float voiceLFOSemitones;
 
         /// fraction 0.0 - 1.0, based on MIDI velocity
         float noteVolume;
@@ -94,7 +104,9 @@ namespace AudioKitCore
                               float cutoffEnvelopeStrength,
                               float cutoffEnvelopeVelocityScaling,
                               float resLinear,
-                              float pitchADSRSemitones);
+                              float pitchADSRSemitones,
+                              float voiceLFOFrequencyHz,
+                              float voiceLFODepthSemitones);
 
         bool getSamples(int sampleCount, float *leftOutput, float *rightOutput);
     };


### PR DESCRIPTION
This adds a new per-voice LFO / vibrato to AKSampler + Voices
This is independent from the global vibrato, which will bend all notes the exact same.
Per-voice vibrato means each new voice restarts the LFO.
Each voice LFO still shares a common frequency and depth setting, just the phase of each vibrato is restarted each time.