### PR TITLE
Generalized parameter automation and other parameter cleanup with AKNodeParameter

### DIFF
--- a/AudioKit/Common/Internals/AKComponent.swift
+++ b/AudioKit/Common/Internals/AKComponent.swift
@@ -20,7 +20,7 @@ extension AUEffect {
 
 /// Helpful in reducing repetitive code in AudioKit
 public protocol AKComponent: AUComponent {
-    associatedtype AKAudioUnitType: AnyObject // eventually AKAudioUnitBase
+    associatedtype AKAudioUnitType: AUAudioUnit // eventually AKAudioUnitBase
     var internalAU: AKAudioUnitType? { get }
     var rampDuration: Double { get set }
 }
@@ -33,7 +33,20 @@ extension AKComponent {
                                      name: "Local \(Self.self)",
                                      version: .max)
     }
-
+    
+    public func instantiateAudioUnit(callback: @escaping (AVAudioUnit) -> Void) {
+        AUAudioUnit.registerSubclass(Self.AKAudioUnitType.self,
+                                     as: Self.ComponentDescription,
+                                     name: "Local \(Self.self)",
+                                     version: .max)
+        
+        AVAudioUnit.instantiate(with: Self.ComponentDescription) { avAudioUnit, _ in
+            guard let au = avAudioUnit else { return }
+            AKManager.engine.attach(au)
+            callback(au)
+        }
+    }
+    
     public var rampDuration: Double {
         get { return (internalAU as? AKAudioUnitBase)?.rampDuration ?? 0.0 }
         set { (internalAU as? AKAudioUnitBase)?.rampDuration = newValue }
@@ -45,43 +58,6 @@ extension AUParameterTree {
     public subscript (key: String) -> AUParameter? {
         return value(forKey: key) as? AUParameter
     }
-
-    public class func createParameter(identifier: String,
-                                      name: String,
-                                      address: AUParameterAddress,
-                                      range: ClosedRange<Double>,
-                                      unit: AudioUnitParameterUnit,
-                                      flags: AudioUnitParameterOptions = []) -> AUParameter {
-        return createParameter(withIdentifier: identifier,
-                               name: name,
-                               address: address,
-                               min: AUValue(range.lowerBound),
-                               max: AUValue(range.upperBound),
-                               unit: unit,
-                               unitName: nil,
-                               flags: flags,
-                               valueStrings: nil,
-                               dependentParameters: nil)
-    }
-//
-//    public class func createParameter(identifier: String,
-//                                      name: String,
-//                                      address: AUParameterAddress,
-//                                      min: AUValue,
-//                                      max: AUValue,
-//                                      unit: AudioUnitParameterUnit,
-//                                      flags: AudioUnitParameterOptions = []) -> AUParameter {
-//        return createParameter(withIdentifier: identifier,
-//                               name: name,
-//                               address: address,
-//                               min: min,
-//                               max: max,
-//                               unit: unit,
-//                               unitName: nil,
-//                               flags: flags,
-//                               valueStrings: nil,
-//                               dependentParameters: nil)
-//    }
 }
 
 /// Adding convenience initializers

--- a/AudioKit/Common/Internals/AudioKitHelpers.swift
+++ b/AudioKit/Common/Internals/AudioKitHelpers.swift
@@ -261,14 +261,14 @@ public extension AUParameter {
     convenience init(identifier: String,
                      name: String,
                      address: AUParameterAddress,
-                     range: ClosedRange<Double>,
+                     range: ClosedRange<AUValue>,
                      unit: AudioUnitParameterUnit,
                      flags: AudioUnitParameterOptions) {
         self.init(identifier: identifier,
                   name: name,
                   address: address,
-                  min: AUValue(range.lowerBound),
-                  max: AUValue(range.upperBound),
+                  min: range.lowerBound,
+                  max: range.upperBound,
                   unit: unit,
                   flags: flags)
     }

--- a/AudioKit/Common/Internals/CoreAudio/AKAudioUnitBase.swift
+++ b/AudioKit/Common/Internals/CoreAudio/AKAudioUnitBase.swift
@@ -70,11 +70,11 @@ open class AKAudioUnitBase: AUAudioUnit {
     public override var parameterTree: AUParameterTree? {
         didSet {
             parameterTree?.implementorValueObserver = { [unowned self] parameter, value in
-                setParameterDSP(self.dsp, parameter.address, value)
+                setParameterValueDSP(self.dsp, parameter.address, value)
             }
 
             parameterTree?.implementorValueProvider = { [unowned self] parameter in
-                return getParameterDSP(self.dsp, parameter.address)
+                return getParameterValueDSP(self.dsp, parameter.address)
             }
 
             parameterTree?.implementorStringFromValueCallback = { parameter, value in
@@ -103,9 +103,6 @@ open class AKAudioUnitBase: AUAudioUnit {
         dsp = createDSP()
         if dsp == nil { throw AKError.InvalidDSPObject }
         
-        // set default ramp duration
-        setRampDurationDSP(dsp, Float(rampDuration))
-        
         // create audio bus connection points
         let format = AKSettings.audioFormat
         for _ in 0..<inputBusCountDSP(dsp) {
@@ -127,7 +124,7 @@ open class AKAudioUnitBase: AUAudioUnit {
     /// Paramater ramp duration (seconds)
     public var rampDuration: Double = AKSettings.rampDuration {
         didSet {
-            setRampDurationDSP(dsp, Float(rampDuration))
+            setParameterRampDurationDSP(dsp, 0, Float(rampDuration))
         }
     }
     

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -54,9 +54,6 @@ class AKDSPBase {
     
     std::vector<const AVAudioPCMBuffer*> internalBuffers;
     
-    /// Ramp rate for ramped parameters
-    float rampDuration;
-    
 protected:
 
     int channelCount;
@@ -72,7 +69,7 @@ protected:
     // current time in samples
     AUEventSampleTime now = 0;
     
-    std::map<AUParameterAddress, class AKParameterRampBase*> parameters;
+    std::map<AUParameterAddress, class ParameterRamper*> parameters;
 
 public:
     
@@ -92,8 +89,6 @@ public:
     
     /// The Render function.
     virtual void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) = 0;
-    
-    void setRampDuration(float duration);
     
     /// Uses the ParameterAddress as a key
     virtual void setParameter(AUParameterAddress address, float value, bool immediate = false);
@@ -144,9 +139,13 @@ public:
         return isInitialized;
     }
 
-    virtual void startRamp(AUParameterAddress address, AUValue value, AUAudioFrameCount duration) {}
-
     virtual void handleMIDIEvent(AUMIDIEvent const& midiEvent) {}
+    
+    void setParameterRampDuration(AUParameterAddress address, float duration);
+    
+    void setParameterRampTaper(AUParameterAddress address, float taper);
+    
+    void setParameterRampSkew(AUParameterAddress address, float skew);
 
 private:
 

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -21,9 +21,12 @@ void allocateRenderResourcesDSP(AKDSPRef pDSP, AVAudioFormat* format);
 void deallocateRenderResourcesDSP(AKDSPRef pDSP);
 void resetDSP(AKDSPRef pDSP);
 
-void setRampDurationDSP(AKDSPRef pDSP, float rampDuration);
-void setParameterDSP(AKDSPRef pDSP, AUParameterAddress address, AUValue value);
-AUValue getParameterDSP(AKDSPRef pDSP, AUParameterAddress address);
+void setParameterValueDSP(AKDSPRef pDSP, AUParameterAddress address, AUValue value);
+AUValue getParameterValueDSP(AKDSPRef pDSP, AUParameterAddress address);
+
+void setParameterRampDurationDSP(AKDSPRef pDSP, AUParameterAddress address, float rampDuration);
+void setParameterRampTaperDSP(AKDSPRef pDSP, AUParameterAddress address, float taper);
+void setParameterRampSkewDSP(AKDSPRef pDSP, AUParameterAddress address, float skew);
 
 void startDSP(AKDSPRef pDSP);
 void stopDSP(AKDSPRef pDSP);
@@ -145,15 +148,15 @@ public:
 
     virtual void handleMIDIEvent(AUMIDIEvent const& midiEvent) {}
 
+private:
+
     /**
      Handles the event list processing and rendering loop. Should be called from AU renderBlock
      From Apple Example code
      */
     void processWithEvents(AudioTimeStamp const *timestamp, AUAudioFrameCount frameCount,
                            AURenderEvent const *events);
-
-private:
-
+    
     void handleOneEvent(AURenderEvent const *event);
     void performAllSimultaneousEvents(AUEventSampleTime now, AURenderEvent const *&event);
 };

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -157,7 +157,10 @@ private:
                            AURenderEvent const *events);
     
     void handleOneEvent(AURenderEvent const *event);
+    
     void performAllSimultaneousEvents(AUEventSampleTime now, AURenderEvent const *&event);
+    
+    void startRamp(const AUParameterEvent& event);
 };
 
 #endif

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
@@ -49,19 +49,29 @@ extern "C" void resetDSP(AKDSPRef pDSP)
     pDSP->reset();
 }
 
-extern "C" void setRampDurationDSP(AKDSPRef pDSP, float rampDuration)
-{
-    pDSP->setRampDuration(rampDuration);
-}
-
-extern "C" void setParameterDSP(AKDSPRef pDSP, AUParameterAddress address, AUValue value)
+extern "C" void setParameterValueDSP(AKDSPRef pDSP, AUParameterAddress address, AUValue value)
 {
     pDSP->setParameter(address, value, false);
 }
 
-extern "C" AUValue getParameterDSP(AKDSPRef pDSP, AUParameterAddress address)
+extern "C" AUValue getParameterValueDSP(AKDSPRef pDSP, AUParameterAddress address)
 {
     return pDSP->getParameter(address);
+}
+
+extern "C" void setParameterRampDurationDSP(AKDSPRef pDSP, AUParameterAddress address, float rampDuration)
+{
+    pDSP->setRampDuration(rampDuration);
+}
+
+extern "C" void setParameterRampTaperDSP(AKDSPRef pDSP, AUParameterAddress address, float taper)
+{
+    
+}
+
+extern "C" void setParameterRampSkewDSP(AKDSPRef pDSP, AUParameterAddress address, float skew)
+{
+    
 }
 
 extern "C" void startDSP(AKDSPRef pDSP)

--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
@@ -130,6 +130,7 @@ void ParameterRamper::dezipperCheck(uint32_t rampDuration)
     int32_t changeCounterSnapshot = data->changeCounter;
     if (data->updateCounter != changeCounterSnapshot) {
         data->updateCounter = changeCounterSnapshot;
+        data->offset = 0; // only use offset for automation
         startRamp(data->uiValue, rampDuration);
     }
 }

--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
@@ -17,6 +17,8 @@
 struct ParameterRamper::InternalData {
     float clampLow, clampHigh;
     float uiValue;
+    float sampleRate;
+    float defaultRampDuration = 0.02;
     float taper = 1;
     float skew = 0;
     uint32_t offset = 0;
@@ -33,10 +35,12 @@ ParameterRamper::ParameterRamper(float value) : data(new InternalData)
     setImmediate(value);
 }
 
-ParameterRamper::~ParameterRamper()
+ParameterRamper::ParameterRamper(const ParameterRamper& other)
+: data(new InternalData(*other.data))
 {
-    delete data;
 }
+
+ParameterRamper::~ParameterRamper() = default;
 
 void ParameterRamper::setImmediate(float value)
 {
@@ -45,18 +49,21 @@ void ParameterRamper::setImmediate(float value)
     data->samplesRemaining = 0;
 }
 
-void ParameterRamper::init()
+/// Call this from AUAudioUnit's allocateRenderResources
+void ParameterRamper::init(float sampleRate)
 {
-    /*
-     Call this from the kernel init.
-     Updates the internal value from the UI value.
-     */
+    data->sampleRate = sampleRate;
     setImmediate(data->uiValue);
 }
 
 void ParameterRamper::reset()
 {
     data->changeCounter = data->updateCounter = 0;
+}
+
+void ParameterRamper::setDefaultRampDuration(float duration)
+{
+    data->defaultRampDuration = duration;
 }
 
 void ParameterRamper::setTaper(float taper)
@@ -110,6 +117,11 @@ void ParameterRamper::setUIValue(float value)
 float ParameterRamper::getUIValue() const
 {
     return data->uiValue;
+}
+
+void ParameterRamper::dezipperCheck()
+{
+    dezipperCheck(data->defaultRampDuration * data->sampleRate);
 }
 
 void ParameterRamper::dezipperCheck(uint32_t rampDuration)

--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.hpp
@@ -9,21 +9,26 @@
 #ifdef __cplusplus
 
 #import <AudioToolbox/AUAudioUnit.h>
+#import <memory>
 
 class ParameterRamper {
 private:
     struct InternalData;
-    struct InternalData *data;
+    std::unique_ptr<struct InternalData> data;
 
 public:
-    ParameterRamper(float value);
+    ParameterRamper(float value = 0.f);
+    ParameterRamper(const ParameterRamper& other);
     ~ParameterRamper();
 
     void setImmediate(float value);
 
-    void init();
+    void init(float sampleRate);
 
     void reset();
+    
+    /// Ramp duration (seconds) to use for UI changes (dezipper checks)
+    void setDefaultRampDuration(float duration);
 
     void setTaper(float taper);
 
@@ -41,6 +46,9 @@ public:
 
     float getUIValue() const;
 
+    /// Dezipper using the default ramp duration
+    void dezipperCheck();
+    
     void dezipperCheck(uint32_t rampDuration);
 
     void startRamp(float newGoal, uint32_t duration);

--- a/AudioKit/Common/Internals/CoreAudio/Bank/AKBankDSPKernel.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/Bank/AKBankDSPKernel.hpp
@@ -104,14 +104,14 @@ public:
     void init(int channelCount, double sampleRate) override {
         AKSoundpipeKernel::init(channelCount, sampleRate);
         
-        attackDurationRamper.init();
-        decayDurationRamper.init();
-        sustainLevelRamper.init();
-        releaseDurationRamper.init();
-        pitchBendRamper.init();
-        vibratoDepthRamper.init();
-        vibratoRateRamper.init();
-        detuningOffsetRamper.init();
+        attackDurationRamper.init(sampleRate);
+        decayDurationRamper.init(sampleRate);
+        sustainLevelRamper.init(sampleRate);
+        releaseDurationRamper.init(sampleRate);
+        pitchBendRamper.init(sampleRate);
+        vibratoDepthRamper.init(sampleRate);
+        vibratoRateRamper.init(sampleRate);
+        detuningOffsetRamper.init(sampleRate);
     }
     
     virtual void reset() {

--- a/AudioKit/Common/Internals/CoreAudio/Filter Synth/AKFilterSynthDSPKernel.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/Filter Synth/AKFilterSynthDSPKernel.hpp
@@ -121,22 +121,22 @@ public:
     void init(int channelCount, double sampleRate) override {
         AKSoundpipeKernel::init(channelCount, sampleRate);
         
-        attackDurationRamper.init();
-        decayDurationRamper.init();
-        sustainLevelRamper.init();
-        releaseDurationRamper.init();
-        pitchBendRamper.init();
-        vibratoDepthRamper.init();
-        vibratoRateRamper.init();
-        filterCutoffFrequencyRamper.init();
-        filterResonanceRamper.init();
-        filterAttackDurationRamper.init();
-        filterDecayDurationRamper.init();
-        filterSustainLevelRamper.init();
-        filterReleaseDurationRamper.init();
-        filterEnvelopeStrengthRamper.init();
-        filterLFODepthRamper.init();
-        filterLFORateRamper.init();
+        attackDurationRamper.init(sampleRate);
+        decayDurationRamper.init(sampleRate);
+        sustainLevelRamper.init(sampleRate);
+        releaseDurationRamper.init(sampleRate);
+        pitchBendRamper.init(sampleRate);
+        vibratoDepthRamper.init(sampleRate);
+        vibratoRateRamper.init(sampleRate);
+        filterCutoffFrequencyRamper.init(sampleRate);
+        filterResonanceRamper.init(sampleRate);
+        filterAttackDurationRamper.init(sampleRate);
+        filterDecayDurationRamper.init(sampleRate);
+        filterSustainLevelRamper.init(sampleRate);
+        filterReleaseDurationRamper.init(sampleRate);
+        filterEnvelopeStrengthRamper.init(sampleRate);
+        filterLFODepthRamper.init(sampleRate);
+        filterLFORateRamper.init(sampleRate);
     }
     
     virtual void reset() {

--- a/AudioKit/Common/Nodes/Analysis/Frequency Tracker/AKFrequencyTracker.swift
+++ b/AudioKit/Common/Nodes/Analysis/Frequency Tracker/AKFrequencyTracker.swift
@@ -3,19 +3,18 @@
 /// This is based on an algorithm originally created by Miller Puckette.
 ///
 open class AKFrequencyTracker: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKFrequencyTrackerAudioUnit
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "ptrk")
-
-    // MARK: - Properties
-
+    
+    public typealias AKAudioUnitType = AKFrequencyTrackerAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open dynamic var isStarted: Bool {
-        return internalAU?.isPlaying ?? false
-    }
-
+    
+    // MARK: - Parameters
+    
     /// Detected Amplitude (Use AKAmplitude tracker if you don't need frequency)
     @objc open dynamic var amplitude: Double {
         return Double(internalAU?.amplitude ?? 0) / Double(AKSettings.channelCount)
@@ -34,38 +33,23 @@ open class AKFrequencyTracker: AKNode, AKToggleable, AKComponent, AKInput {
     /// - parameter hopSize: Hop size.
     /// - parameter peakCount: Number of peaks.
     ///
-    @objc public init(
+    public init(
         _ input: AKNode? = nil,
         hopSize: Int = 4_096,
-        peakCount: Int = 20) {
-
-        _Self.register()
-
+        peakCount: Int = 20
+        ) {
         super.init(avAudioNode: AVAudioNode())
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { [weak self] avAudioUnit in
-            guard let strongSelf = self else {
-                AKLog("Error: self is nil")
-                return
-            }
-            strongSelf.avAudioUnit = avAudioUnit
-            strongSelf.avAudioNode = avAudioUnit
-            strongSelf.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+        
+        instantiateAudioUnit() { avAudioUnit in
+            self.avAudioUnit = avAudioUnit
+            self.avAudioNode = avAudioUnit
+            
+            self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
 
-            input?.connect(to: strongSelf)
+            input?.connect(to: self)
+            
+            self.internalAU?.setPeakCount(UInt32(peakCount))
+            self.internalAU?.setHopSize(UInt32(hopSize))
         }
-        internalAU?.setPeakCount(UInt32(peakCount))
-        internalAU?.setHopSize(UInt32(hopSize))
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayAudioUnit.swift
@@ -4,13 +4,37 @@ import AVFoundation
 
 public class AKStereoDelayAudioUnit: AKAudioUnitBase {
 
-    var time: AUParameter!
+    let time = AUParameter(
+       identifier: "time",
+       name: "Delay time (Seconds)",
+       address: AKStereoDelayParameter.time.rawValue,
+       range: AKStereoDelay.timeRange,
+       unit: .seconds,
+       flags: .default)
 
-    var feedback: AUParameter!
+    let feedback = AUParameter(
+       identifier: "feedback",
+       name: "Feedback (%)",
+       address: AKStereoDelayParameter.feedback.rawValue,
+       range: AKStereoDelay.feedbackRange,
+       unit: .generic,
+       flags: .default)
 
-    var dryWetMix: AUParameter!
+    let dryWetMix = AUParameter(
+       identifier: "dryWetMix",
+       name: "Dry-Wet Mix",
+       address: AKStereoDelayParameter.dryWetMix.rawValue,
+       range: AKStereoDelay.dryWetMixRange,
+       unit: .generic,
+       flags: .default)
 
-    var pingPong: AUParameter!
+    let pingPong = AUParameter(
+       identifier: "pingPong",
+       name: "Ping-Pong Mode",
+       address: AKStereoDelayParameter.pingPong.rawValue,
+       range: 0.0...1.0,
+       unit: .boolean,
+       flags: [.flag_IsReadable, .flag_IsWritable])
 
     public override func createDSP() -> AKDSPRef {
         return createStereoDelayDSP()
@@ -19,40 +43,7 @@ public class AKStereoDelayAudioUnit: AKAudioUnitBase {
     public override init(componentDescription: AudioComponentDescription,
                          options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-        time = AUParameter(
-            identifier: "time",
-            name: "Delay time (Seconds)",
-            address: AKStereoDelayParameter.time.rawValue,
-            range: AKStereoDelay.timeRange,
-            unit: .seconds,
-            flags: .default)
-        feedback = AUParameter(
-            identifier: "feedback",
-            name: "Feedback (%)",
-            address: AKStereoDelayParameter.feedback.rawValue,
-            range: AKStereoDelay.feedbackRange,
-            unit: .generic,
-            flags: .default)
-        dryWetMix = AUParameter(
-            identifier: "dryWetMix",
-            name: "Dry-Wet Mix",
-            address: AKStereoDelayParameter.dryWetMix.rawValue,
-            range: AKStereoDelay.dryWetMixRange,
-            unit: .generic,
-            flags: .default)
-        pingPong = AUParameter(
-            identifier: "pingPong",
-            name: "Ping-Pong Mode",
-            address: AKStereoDelayParameter.pingPong.rawValue,
-            range: 0.0...1.0,
-            unit: .boolean,
-            flags: [.flag_IsReadable, .flag_IsWritable])
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [time, feedback, dryWetMix, pingPong])
-
-        time.value = Float(AKStereoDelay.defaultTime)
-        feedback.value = Float(AKStereoDelay.defaultFeedback)
-        dryWetMix.value = Float(AKStereoDelay.defaultDryWetMix)
-        pingPong.value = 0.0
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKVariableDelayAudioUnit: AKAudioUnitBase {
 
-    private(set) var time: AUParameter!
+    let time = AUParameter(
+        identifier: "time",
+        name: "Delay time (Seconds)",
+        address: AKVariableDelayParameter.time.rawValue,
+        range: AKVariableDelay.timeRange,
+        unit: .seconds,
+        flags: .default)
 
-    private(set) var feedback: AUParameter!
+    let feedback = AUParameter(
+        identifier: "feedback",
+        name: "Feedback (%)",
+        address: AKVariableDelayParameter.feedback.rawValue,
+        range: AKVariableDelay.feedbackRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createVariableDelayDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        time = AUParameter(
-            identifier: "time",
-            name: "Delay time (Seconds)",
-            address: AKVariableDelayParameter.time.rawValue,
-            range: AKVariableDelay.timeRange,
-            unit: .seconds,
-            flags: .default)
-        feedback = AUParameter(
-            identifier: "feedback",
-            name: "Feedback (%)",
-            address: AKVariableDelayParameter.feedback.rawValue,
-            range: AKVariableDelay.feedbackRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [time, feedback])
-
-        time.value = AUValue(AKVariableDelay.defaultTime)
-        feedback.value = AUValue(AKVariableDelay.defaultFeedback)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKBitCrusherAudioUnit: AKAudioUnitBase {
 
-    private(set) var bitDepth: AUParameter!
+    let bitDepth = AUParameter(
+        identifier: "bitDepth",
+        name: "Bit Depth",
+        address: AKBitCrusherParameter.bitDepth.rawValue,
+        range: AKBitCrusher.bitDepthRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var sampleRate: AUParameter!
+    let sampleRate = AUParameter(
+        identifier: "sampleRate",
+        name: "Sample Rate (Hz)",
+        address: AKBitCrusherParameter.sampleRate.rawValue,
+        range: AKBitCrusher.sampleRateRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createBitCrusherDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        bitDepth = AUParameter(
-            identifier: "bitDepth",
-            name: "Bit Depth",
-            address: AKBitCrusherParameter.bitDepth.rawValue,
-            range: AKBitCrusher.bitDepthRange,
-            unit: .generic,
-            flags: .default)
-        sampleRate = AUParameter(
-            identifier: "sampleRate",
-            name: "Sample Rate (Hz)",
-            address: AKBitCrusherParameter.sampleRate.rawValue,
-            range: AKBitCrusher.sampleRateRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [bitDepth, sampleRate])
-
-        bitDepth.value = AUValue(AKBitCrusher.defaultBitDepth)
-        sampleRate.value = AUValue(AKBitCrusher.defaultSampleRate)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKClipperAudioUnit: AKAudioUnitBase {
 
-    private(set) var limit: AUParameter!
+    let limit = AUParameter(
+        identifier: "limit",
+        name: "Threshold",
+        address: AKClipperParameter.limit.rawValue,
+        range: AKClipper.limitRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createClipperDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        limit = AUParameter(
-            identifier: "limit",
-            name: "Threshold",
-            address: AKClipperParameter.limit.rawValue,
-            range: AKClipper.limitRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [limit])
-
-        limit.value = AUValue(AKClipper.defaultLimit)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKClipperDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createClipperDSP() {
     return new AKClipperDSP();
@@ -10,7 +10,7 @@ extern "C" AKDSPRef createClipperDSP() {
 struct AKClipperDSP::InternalData {
     sp_clip *clip0;
     sp_clip *clip1;
-    AKLinearParameterRamp limitRamp;
+    ParameterRamper limitRamp;
 };
 
 AKClipperDSP::AKClipperDSP() : data(new InternalData) {
@@ -43,13 +43,9 @@ void AKClipperDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffe
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->limitRamp.advanceTo(now + frameOffset);
-        }
-
-        data->clip0->lim = data->limitRamp.getValue();
-        data->clip1->lim = data->limitRamp.getValue();
+        float limit = data->limitRamp.getAndStep();
+        data->clip0->lim = limit;
+        data->clip1->lim = limit;
 
         float *tmpin[2];
         float *tmpout[2];

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionAudioUnit.swift
@@ -4,59 +4,46 @@ import AVFoundation
 
 public class AKTanhDistortionAudioUnit: AKAudioUnitBase {
 
-    private(set) var pregain: AUParameter!
+    let pregain = AUParameter(
+        identifier: "pregain",
+        name: "Pregain",
+        address: AKTanhDistortionParameter.pregain.rawValue,
+        range: AKTanhDistortion.pregainRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var postgain: AUParameter!
+    let postgain = AUParameter(
+        identifier: "postgain",
+        name: "Postgain",
+        address: AKTanhDistortionParameter.postgain.rawValue,
+        range: AKTanhDistortion.postgainRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var positiveShapeParameter: AUParameter!
+    let positiveShapeParameter = AUParameter(
+        identifier: "positiveShapeParameter",
+        name: "Positive Shape Parameter",
+        address: AKTanhDistortionParameter.positiveShapeParameter.rawValue,
+        range: AKTanhDistortion.positiveShapeParameterRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var negativeShapeParameter: AUParameter!
+    let negativeShapeParameter = AUParameter(
+        identifier: "negativeShapeParameter",
+        name: "Negative Shape Parameter",
+        address: AKTanhDistortionParameter.negativeShapeParameter.rawValue,
+        range: AKTanhDistortion.negativeShapeParameterRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createTanhDistortionDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        pregain = AUParameter(
-            identifier: "pregain",
-            name: "Pregain",
-            address: AKTanhDistortionParameter.pregain.rawValue,
-            range: AKTanhDistortion.pregainRange,
-            unit: .generic,
-            flags: .default)
-        postgain = AUParameter(
-            identifier: "postgain",
-            name: "Postgain",
-            address: AKTanhDistortionParameter.postgain.rawValue,
-            range: AKTanhDistortion.postgainRange,
-            unit: .generic,
-            flags: .default)
-        positiveShapeParameter = AUParameter(
-            identifier: "positiveShapeParameter",
-            name: "Positive Shape Parameter",
-            address: AKTanhDistortionParameter.positiveShapeParameter.rawValue,
-            range: AKTanhDistortion.positiveShapeParameterRange,
-            unit: .generic,
-            flags: .default)
-        negativeShapeParameter = AUParameter(
-            identifier: "negativeShapeParameter",
-            name: "Negative Shape Parameter",
-            address: AKTanhDistortionParameter.negativeShapeParameter.rawValue,
-            range: AKTanhDistortion.negativeShapeParameterRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [pregain,
-                                                                  postgain,
-                                                                  positiveShapeParameter,
-                                                                  negativeShapeParameter])
-
-        pregain.value = AUValue(AKTanhDistortion.defaultPregain)
-        postgain.value = AUValue(AKTanhDistortion.defaultPostgain)
-        positiveShapeParameter.value = AUValue(AKTanhDistortion.defaultPositiveShapeParameter)
-        negativeShapeParameter.value = AUValue(AKTanhDistortion.defaultNegativeShapeParameter)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [pregain, postgain, positiveShapeParameter, negativeShapeParameter])
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressor.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressor.swift
@@ -2,78 +2,58 @@
 
 /// Dynamic range compressor from Faust
 ///
-open class AKDynamicRangeCompressor: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKDynamicRangeCompressorAudioUnit
+open class AKDynamicRangeCompressor: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "cpsr")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKDynamicRangeCompressorAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Ratio
-    public static let ratioRange: ClosedRange<Double> = 0.01 ... 100.0
+    public static let ratioRange: ClosedRange<AUValue> = 0.01 ... 100.0
 
     /// Lower and upper bounds for Threshold
-    public static let thresholdRange: ClosedRange<Double> = -100.0 ... 0.0
+    public static let thresholdRange: ClosedRange<AUValue> = -100.0 ... 0.0
 
-    /// Lower and upper bounds for Attack Time
-    public static let attackDurationRange: ClosedRange<Double> = 0.0 ... 1.0
+    /// Lower and upper bounds for Attack Duration
+    public static let attackDurationRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
-    /// Lower and upper bounds for Release Time
-    public static let releaseDurationRange: ClosedRange<Double> = 0.0 ... 1.0
+    /// Lower and upper bounds for Release Duration
+    public static let releaseDurationRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
     /// Initial value for Ratio
-    public static let defaultRatio: Double = 1
+    public static let defaultRatio: AUValue = 1
 
     /// Initial value for Threshold
-    public static let defaultThreshold: Double = 0.0
+    public static let defaultThreshold: AUValue = 0.0
 
-    /// Initial value for Attack Time
-    public static let defaultAttackDuration: Double = 0.1
+    /// Initial value for Attack Duration
+    public static let defaultAttackDuration: AUValue = 0.1
 
-    /// Initial value for Release Time
-    public static let defaultReleaseDuration: Double = 0.1
+    /// Initial value for Release Duration
+    public static let defaultReleaseDuration: AUValue = 0.1
 
     /// Ratio to compress with, a value > 1 will compress
-    @objc open var ratio: Double = defaultRatio {
-        willSet {
-            let clampedValue = AKDynamicRangeCompressor.ratioRange.clamp(newValue)
-            guard ratio != clampedValue else { return }
-            internalAU?.ratio.value = AUValue(clampedValue)
-        }
-    }
+    public let ratio = AKNodeParameter(identifier: "ratio")
 
     /// Threshold (in dB) 0 = max
-    @objc open var threshold: Double = defaultThreshold {
-        willSet {
-            let clampedValue = AKDynamicRangeCompressor.thresholdRange.clamp(newValue)
-            guard threshold != clampedValue else { return }
-            internalAU?.threshold.value = AUValue(clampedValue)
-        }
-    }
+    public let threshold = AKNodeParameter(identifier: "threshold")
 
-    /// Attack time
-    @objc open var attackDuration: Double = defaultAttackDuration {
-        willSet {
-            let clampedValue = AKDynamicRangeCompressor.attackDurationRange.clamp(newValue)
-            guard attackDuration != clampedValue else { return }
-            internalAU?.attackTime.value = AUValue(clampedValue)
-        }
-    }
+    /// Attack Duration
+    public let attackDuration = AKNodeParameter(identifier: "attackTime")
 
-    /// Release time
-    @objc open var releaseDuration: Double = defaultReleaseDuration {
-        willSet {
-            let clampedValue = AKDynamicRangeCompressor.releaseDurationRange.clamp(newValue)
-            guard releaseDuration != clampedValue else { return }
-            internalAU?.releaseTime.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    /// Release Duration
+    public let releaseDuration = AKNodeParameter(identifier: "releaseTime")
 
     // MARK: - Initialization
 
@@ -83,41 +63,31 @@ open class AKDynamicRangeCompressor: AKNode, AKToggleable, AKComponent, AKInput 
     ///   - input: Input node to process
     ///   - ratio: Ratio to compress with, a value > 1 will compress
     ///   - threshold: Threshold (in dB) 0 = max
-    ///   - attackTime: Attack time
-    ///   - releaseTime: Release time
+    ///   - attackDuration: Attack Duration
+    ///   - releaseDuration: Release Duration
     ///
     public init(
         _ input: AKNode? = nil,
-        ratio: Double = defaultRatio,
-        threshold: Double = defaultThreshold,
-        attackDuration: Double = defaultAttackDuration,
-        releaseDuration: Double = defaultReleaseDuration
+        ratio: AUValue = defaultRatio,
+        threshold: AUValue = defaultThreshold,
+        attackDuration: AUValue = defaultAttackDuration,
+        releaseDuration: AUValue = defaultReleaseDuration
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.ratio.associate(with: self.internalAU, value: ratio)
+            self.threshold.associate(with: self.internalAU, value: threshold)
+            self.attackDuration.associate(with: self.internalAU, value: attackDuration)
+            self.releaseDuration.associate(with: self.internalAU, value: releaseDuration)
+
             input?.connect(to: self)
-
-            self.ratio = ratio
-            self.threshold = threshold
-            self.attackDuration = attackDuration
-            self.releaseDuration = releaseDuration
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorAudioUnit.swift
@@ -4,56 +4,46 @@ import AVFoundation
 
 public class AKDynamicRangeCompressorAudioUnit: AKAudioUnitBase {
 
-    private(set) var ratio: AUParameter!
+    let ratio = AUParameter(
+        identifier: "ratio",
+        name: "Ratio to compress with, a value > 1 will compress",
+        address: AKDynamicRangeCompressorParameter.ratio.rawValue,
+        range: AKDynamicRangeCompressor.ratioRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var threshold: AUParameter!
+    let threshold = AUParameter(
+        identifier: "threshold",
+        name: "Threshold (in dB) 0 = max",
+        address: AKDynamicRangeCompressorParameter.threshold.rawValue,
+        range: AKDynamicRangeCompressor.thresholdRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var attackTime: AUParameter!
+    let attackTime = AUParameter(
+        identifier: "attackTime",
+        name: "Attack time",
+        address: AKDynamicRangeCompressorParameter.attackTime.rawValue,
+        range: AKDynamicRangeCompressor.attackDurationRange,
+        unit: .seconds,
+        flags: .default)
 
-    private(set) var releaseTime: AUParameter!
+    let releaseTime = AUParameter(
+        identifier: "releaseTime",
+        name: "Release time",
+        address: AKDynamicRangeCompressorParameter.releaseTime.rawValue,
+        range: AKDynamicRangeCompressor.releaseDurationRange,
+        unit: .seconds,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createDynamicRangeCompressorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        ratio = AUParameter(
-            identifier: "ratio",
-            name: "Ratio to compress with, a value > 1 will compress",
-            address: AKDynamicRangeCompressorParameter.ratio.rawValue,
-            range: AKDynamicRangeCompressor.ratioRange,
-            unit: .hertz,
-            flags: .default)
-        threshold = AUParameter(
-            identifier: "threshold",
-            name: "Threshold (in dB) 0 = max",
-            address: AKDynamicRangeCompressorParameter.threshold.rawValue,
-            range: AKDynamicRangeCompressor.thresholdRange,
-            unit: .generic,
-            flags: .default)
-        attackTime = AUParameter(
-            identifier: "attackTime",
-            name: "Attack time",
-            address: AKDynamicRangeCompressorParameter.attackTime.rawValue,
-            range: AKDynamicRangeCompressor.attackDurationRange,
-            unit: .seconds,
-            flags: .default)
-        releaseTime = AUParameter(
-            identifier: "releaseTime",
-            name: "Release time",
-            address: AKDynamicRangeCompressorParameter.releaseTime.rawValue,
-            range: AKDynamicRangeCompressor.releaseDurationRange,
-            unit: .seconds,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [ratio, threshold, attackTime, releaseTime])
-
-        ratio.value = AUValue(AKDynamicRangeCompressor.defaultRatio)
-        threshold.value = AUValue(AKDynamicRangeCompressor.defaultThreshold)
-        attackTime.value = AUValue(AKDynamicRangeCompressor.defaultAttackDuration)
-        releaseTime.value = AUValue(AKDynamicRangeCompressor.defaultReleaseDuration)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelope.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelope.swift
@@ -2,78 +2,58 @@
 
 /// Triggerable classic ADSR envelope
 ///
-open class AKAmplitudeEnvelope: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKAmplitudeEnvelopeAudioUnit
+open class AKAmplitudeEnvelope: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "adsr")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKAmplitudeEnvelopeAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Attack Duration
-    public static let attackDurationRange: ClosedRange<Double> = 0 ... 99
+    public static let attackDurationRange: ClosedRange<AUValue> = 0 ... 99
 
     /// Lower and upper bounds for Decay Duration
-    public static let decayDurationRange: ClosedRange<Double> = 0 ... 99
+    public static let decayDurationRange: ClosedRange<AUValue> = 0 ... 99
 
     /// Lower and upper bounds for Sustain Level
-    public static let sustainLevelRange: ClosedRange<Double> = 0 ... 99
+    public static let sustainLevelRange: ClosedRange<AUValue> = 0 ... 99
 
     /// Lower and upper bounds for Release Duration
-    public static let releaseDurationRange: ClosedRange<Double> = 0 ... 99
+    public static let releaseDurationRange: ClosedRange<AUValue> = 0 ... 99
 
     /// Initial value for Attack Duration
-    public static let defaultAttackDuration: Double = 0.1
+    public static let defaultAttackDuration: AUValue = 0.1
 
     /// Initial value for Decay Duration
-    public static let defaultDecayDuration: Double = 0.1
+    public static let defaultDecayDuration: AUValue = 0.1
 
     /// Initial value for Sustain Level
-    public static let defaultSustainLevel: Double = 1.0
+    public static let defaultSustainLevel: AUValue = 1.0
 
     /// Initial value for Release Duration
-    public static let defaultReleaseDuration: Double = 0.1
+    public static let defaultReleaseDuration: AUValue = 0.1
 
     /// Attack time
-    @objc open var attackDuration: Double = defaultAttackDuration {
-        willSet {
-            let clampedValue = AKAmplitudeEnvelope.attackDurationRange.clamp(newValue)
-            guard attackDuration != clampedValue else { return }
-            internalAU?.attackDuration.value = AUValue(clampedValue)
-        }
-    }
+    public let attackDuration = AKNodeParameter(identifier: "attackDuration")
 
     /// Decay time
-    @objc open var decayDuration: Double = defaultDecayDuration {
-        willSet {
-            let clampedValue = AKAmplitudeEnvelope.decayDurationRange.clamp(newValue)
-            guard decayDuration != clampedValue else { return }
-            internalAU?.decayDuration.value = AUValue(clampedValue)
-        }
-    }
+    public let decayDuration = AKNodeParameter(identifier: "decayDuration")
 
     /// Sustain Level
-    @objc open var sustainLevel: Double = defaultSustainLevel {
-        willSet {
-            let clampedValue = AKAmplitudeEnvelope.sustainLevelRange.clamp(newValue)
-            guard sustainLevel != clampedValue else { return }
-            internalAU?.sustainLevel.value = AUValue(clampedValue)
-        }
-    }
+    public let sustainLevel = AKNodeParameter(identifier: "sustainLevel")
 
     /// Release time
-    @objc open var releaseDuration: Double = defaultReleaseDuration {
-        willSet {
-            let clampedValue = AKAmplitudeEnvelope.releaseDurationRange.clamp(newValue)
-            guard releaseDuration != clampedValue else { return }
-            internalAU?.releaseDuration.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let releaseDuration = AKNodeParameter(identifier: "releaseDuration")
 
     // MARK: - Initialization
 
@@ -88,36 +68,26 @@ open class AKAmplitudeEnvelope: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        attackDuration: Double = defaultAttackDuration,
-        decayDuration: Double = defaultDecayDuration,
-        sustainLevel: Double = defaultSustainLevel,
-        releaseDuration: Double = defaultReleaseDuration
+        attackDuration: AUValue = defaultAttackDuration,
+        decayDuration: AUValue = defaultDecayDuration,
+        sustainLevel: AUValue = defaultSustainLevel,
+        releaseDuration: AUValue = defaultReleaseDuration
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.attackDuration.associate(with: self.internalAU, value: attackDuration)
+            self.decayDuration.associate(with: self.internalAU, value: decayDuration)
+            self.sustainLevel.associate(with: self.internalAU, value: sustainLevel)
+            self.releaseDuration.associate(with: self.internalAU, value: releaseDuration)
+
             input?.connect(to: self)
-
-            self.attackDuration = attackDuration
-            self.decayDuration = decayDuration
-            self.sustainLevel = sustainLevel
-            self.releaseDuration = releaseDuration
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeAudioUnit.swift
@@ -4,59 +4,46 @@ import AVFoundation
 
 public class AKAmplitudeEnvelopeAudioUnit: AKAudioUnitBase {
 
-    private(set) var attackDuration: AUParameter!
+    let attackDuration = AUParameter(
+        identifier: "attackDuration",
+        name: "Attack time",
+        address: AKAmplitudeEnvelopeParameter.attackDuration.rawValue,
+        range: AKAmplitudeEnvelope.attackDurationRange,
+        unit: .seconds,
+        flags: .default)
 
-    private(set) var decayDuration: AUParameter!
+    let decayDuration = AUParameter(
+        identifier: "decayDuration",
+        name: "Decay time",
+        address: AKAmplitudeEnvelopeParameter.decayDuration.rawValue,
+        range: AKAmplitudeEnvelope.decayDurationRange,
+        unit: .seconds,
+        flags: .default)
 
-    private(set) var sustainLevel: AUParameter!
+    let sustainLevel = AUParameter(
+        identifier: "sustainLevel",
+        name: "Sustain Level",
+        address: AKAmplitudeEnvelopeParameter.sustainLevel.rawValue,
+        range: AKAmplitudeEnvelope.sustainLevelRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var releaseDuration: AUParameter!
+    let releaseDuration = AUParameter(
+        identifier: "releaseDuration",
+        name: "Release time",
+        address: AKAmplitudeEnvelopeParameter.releaseDuration.rawValue,
+        range: AKAmplitudeEnvelope.releaseDurationRange,
+        unit: .seconds,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createAmplitudeEnvelopeDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        attackDuration = AUParameter(
-            identifier: "attackDuration",
-            name: "Attack time",
-            address: AKAmplitudeEnvelopeParameter.attackDuration.rawValue,
-            range: AKAmplitudeEnvelope.attackDurationRange,
-            unit: .seconds,
-            flags: .default)
-        decayDuration = AUParameter(
-            identifier: "decayDuration",
-            name: "Decay time",
-            address: AKAmplitudeEnvelopeParameter.decayDuration.rawValue,
-            range: AKAmplitudeEnvelope.decayDurationRange,
-            unit: .seconds,
-            flags: .default)
-        sustainLevel = AUParameter(
-            identifier: "sustainLevel",
-            name: "Sustain Level",
-            address: AKAmplitudeEnvelopeParameter.sustainLevel.rawValue,
-            range: AKAmplitudeEnvelope.sustainLevelRange,
-            unit: .generic,
-            flags: .default)
-        releaseDuration = AUParameter(
-            identifier: "releaseDuration",
-            name: "Release time",
-            address: AKAmplitudeEnvelopeParameter.releaseDuration.rawValue,
-            range: AKAmplitudeEnvelope.releaseDurationRange,
-            unit: .seconds,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [attackDuration,
-                                                                  decayDuration,
-                                                                  sustainLevel,
-                                                                  releaseDuration])
-
-        attackDuration.value = AUValue(AKAmplitudeEnvelope.defaultAttackDuration)
-        decayDuration.value = AUValue(AKAmplitudeEnvelope.defaultDecayDuration)
-        sustainLevel.value = AUValue(AKAmplitudeEnvelope.defaultSustainLevel)
-        releaseDuration.value = AUValue(AKAmplitudeEnvelope.defaultReleaseDuration)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [attackDuration, decayDuration, sustainLevel, releaseDuration])
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremolo.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremolo.swift
@@ -2,48 +2,40 @@
 
 /// Table-lookup tremolo with linear interpolation
 ///
-open class AKTremolo: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKTremoloAudioUnit
+open class AKTremolo: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "trem")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKTremoloAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Frequency
-    public static let frequencyRange: ClosedRange<Double> = 0.0 ... 100.0
+    public static let frequencyRange: ClosedRange<AUValue> = 0.0 ... 100.0
 
     /// Lower and upper bounds for Depth
-    public static let depthRange: ClosedRange<Double> = 0.0 ... 1.0
+    public static let depthRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
     /// Initial value for Frequency
-    public static let defaultFrequency: Double = 10.0
+    public static let defaultFrequency: AUValue = 10.0
 
     /// Initial value for Depth
-    public static let defaultDepth: Double = 1.0
+    public static let defaultDepth: AUValue = 1.0
 
     /// Frequency (Hz)
-    @objc open var frequency: Double = defaultFrequency {
-        willSet {
-            let clampedValue = AKTremolo.frequencyRange.clamp(newValue)
-            guard frequency != clampedValue else { return }
-            internalAU?.frequency.value = AUValue(clampedValue)
-        }
-    }
+    public let frequency = AKNodeParameter(identifier: "frequency")
 
     /// Depth
-    @objc open var depth: Double = defaultDepth {
-        willSet {
-            let clampedValue = AKTremolo.depthRange.clamp(newValue)
-            guard depth != clampedValue else { return }
-            internalAU?.depth.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let depth = AKNodeParameter(identifier: "depth")
 
     // MARK: - Initialization
 
@@ -56,34 +48,25 @@ open class AKTremolo: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        frequency: Double = defaultFrequency,
-        depth: Double = defaultDepth,
+        frequency: AUValue = defaultFrequency,
+        depth: AUValue = defaultDepth,
         waveform: AKTable = AKTable(.positiveSine)
-        ) {
+    ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-            input?.connect(to: self)
-
-            self.frequency = frequency
-            self.depth = depth
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.frequency.associate(with: self.internalAU, value: frequency)
+            self.depth.associate(with: self.internalAU, value: depth)
+            
             self.internalAU?.setWavetable(waveform.content)
+
+            input?.connect(to: self)
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKTremoloAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (Hz)",
+        address: AKTremoloParameter.frequency.rawValue,
+        range: AKTremolo.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var depth: AUParameter!
+    let depth = AUParameter(
+        identifier: "depth",
+        name: "Depth",
+        address: AKTremoloParameter.depth.rawValue,
+        range: AKTremolo.depthRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createTremoloDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (Hz)",
-            address: AKTremoloParameter.frequency.rawValue,
-            range: AKTremolo.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        depth = AUParameter(
-            identifier: "depth",
-            name: "Depth",
-            address: AKTremoloParameter.depth.rawValue,
-            range: AKTremolo.depthRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [frequency, depth])
-
-        frequency.value = AUValue(AKTremolo.defaultFrequency)
-        depth.value = AUValue(AKTremolo.defaultDepth)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilter.swift
@@ -3,48 +3,40 @@
 /// These filters are Butterworth second-order IIR filters. They offer an almost
 /// flat passband and very good precision and stopband attenuation.
 ///
-open class AKBandPassButterworthFilter: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKBandPassButterworthFilterAudioUnit
+open class AKBandPassButterworthFilter: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "btbp")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKBandPassButterworthFilterAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Center Frequency
-    public static let centerFrequencyRange: ClosedRange<Double> = 12.0 ... 20_000.0
+    public static let centerFrequencyRange: ClosedRange<AUValue> = 12.0 ... 20000.0
 
     /// Lower and upper bounds for Bandwidth
-    public static let bandwidthRange: ClosedRange<Double> = 0.0 ... 20_000.0
+    public static let bandwidthRange: ClosedRange<AUValue> = 0.0 ... 20000.0
 
     /// Initial value for Center Frequency
-    public static let defaultCenterFrequency: Double = 2_000.0
+    public static let defaultCenterFrequency: AUValue = 2000.0
 
     /// Initial value for Bandwidth
-    public static let defaultBandwidth: Double = 100.0
+    public static let defaultBandwidth: AUValue = 100.0
 
     /// Center frequency. (in Hertz)
-    @objc open var centerFrequency: Double = defaultCenterFrequency {
-        willSet {
-            let clampedValue = AKBandPassButterworthFilter.centerFrequencyRange.clamp(newValue)
-            guard centerFrequency != clampedValue else { return }
-            internalAU?.centerFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let centerFrequency = AKNodeParameter(identifier: "centerFrequency")
 
     /// Bandwidth. (in Hertz)
-    @objc open var bandwidth: Double = defaultBandwidth {
-        willSet {
-            let clampedValue = AKBandPassButterworthFilter.bandwidthRange.clamp(newValue)
-            guard bandwidth != clampedValue else { return }
-            internalAU?.bandwidth.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let bandwidth = AKNodeParameter(identifier: "bandwidth")
 
     // MARK: - Initialization
 
@@ -57,32 +49,22 @@ open class AKBandPassButterworthFilter: AKNode, AKToggleable, AKComponent, AKInp
     ///
     public init(
         _ input: AKNode? = nil,
-        centerFrequency: Double = defaultCenterFrequency,
-        bandwidth: Double = defaultBandwidth
+        centerFrequency: AUValue = defaultCenterFrequency,
+        bandwidth: AUValue = defaultBandwidth
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.centerFrequency.associate(with: self.internalAU, value: centerFrequency)
+            self.bandwidth.associate(with: self.internalAU, value: bandwidth)
+
             input?.connect(to: self)
-
-            self.centerFrequency = centerFrequency
-            self.bandwidth = bandwidth
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKBandPassButterworthFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var centerFrequency: AUParameter!
+    let centerFrequency = AUParameter(
+        identifier: "centerFrequency",
+        name: "Center Frequency (Hz)",
+        address: AKBandPassButterworthFilterParameter.centerFrequency.rawValue,
+        range: AKBandPassButterworthFilter.centerFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var bandwidth: AUParameter!
+    let bandwidth = AUParameter(
+        identifier: "bandwidth",
+        name: "Bandwidth (Hz)",
+        address: AKBandPassButterworthFilterParameter.bandwidth.rawValue,
+        range: AKBandPassButterworthFilter.bandwidthRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createBandPassButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        centerFrequency = AUParameter(
-            identifier: "centerFrequency",
-            name: "Center Frequency (Hz)",
-            address: AKBandPassButterworthFilterParameter.centerFrequency.rawValue,
-            range: AKBandPassButterworthFilter.centerFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        bandwidth = AUParameter(
-            identifier: "bandwidth",
-            name: "Bandwidth (Hz)",
-            address: AKBandPassButterworthFilterParameter.bandwidth.rawValue,
-            range: AKBandPassButterworthFilter.bandwidthRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [centerFrequency, bandwidth])
-
-        centerFrequency.value = AUValue(AKBandPassButterworthFilter.defaultCenterFrequency)
-        bandwidth.value = AUValue(AKBandPassButterworthFilter.defaultBandwidth)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKBandRejectButterworthFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var centerFrequency: AUParameter!
+    let centerFrequency = AUParameter(
+        identifier: "centerFrequency",
+        name: "Center Frequency (Hz)",
+        address: AKBandRejectButterworthFilterParameter.centerFrequency.rawValue,
+        range: AKBandRejectButterworthFilter.centerFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var bandwidth: AUParameter!
+    let bandwidth = AUParameter(
+        identifier: "bandwidth",
+        name: "Bandwidth (Hz)",
+        address: AKBandRejectButterworthFilterParameter.bandwidth.rawValue,
+        range: AKBandRejectButterworthFilter.bandwidthRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createBandRejectButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        centerFrequency = AUParameter(
-            identifier: "centerFrequency",
-            name: "Center Frequency (Hz)",
-            address: AKBandRejectButterworthFilterParameter.centerFrequency.rawValue,
-            range: AKBandRejectButterworthFilter.centerFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        bandwidth = AUParameter(
-            identifier: "bandwidth",
-            name: "Bandwidth (Hz)",
-            address: AKBandRejectButterworthFilterParameter.bandwidth.rawValue,
-            range: AKBandRejectButterworthFilter.bandwidthRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [centerFrequency, bandwidth])
-
-        centerFrequency.value = AUValue(AKBandRejectButterworthFilter.defaultCenterFrequency)
-        bandwidth.value = AUValue(AKBandRejectButterworthFilter.defaultBandwidth)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlock.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlock.swift
@@ -4,18 +4,18 @@
 /// Based on work by Perry Cook.
 ///
 open class AKDCBlock: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKDCBlockAudioUnit
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "dcbk")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKDCBlockAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
-
+    
+    // MARK: - Parameters
+    
     // MARK: - Initialization
 
     /// Initialize this filter node
@@ -27,26 +27,14 @@ open class AKDCBlock: AKNode, AKToggleable, AKComponent, AKInput {
         _ input: AKNode? = nil
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+
             input?.connect(to: self)
-
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockAudioUnit.swift
@@ -9,10 +9,9 @@ public class AKDCBlockAudioUnit: AKAudioUnitBase {
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [])
-
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKEqualizerFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var centerFrequency: AUParameter!
+    let centerFrequency = AUParameter(
+        identifier: "centerFrequency",
+        name: "Center Frequency (Hz)",
+        address: AKEqualizerFilterParameter.centerFrequency.rawValue,
+        range: AKEqualizerFilter.centerFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var bandwidth: AUParameter!
+    let bandwidth = AUParameter(
+        identifier: "bandwidth",
+        name: "Bandwidth (Hz)",
+        address: AKEqualizerFilterParameter.bandwidth.rawValue,
+        range: AKEqualizerFilter.bandwidthRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var gain: AUParameter!
+    let gain = AUParameter(
+        identifier: "gain",
+        name: "Gain (%)",
+        address: AKEqualizerFilterParameter.gain.rawValue,
+        range: AKEqualizerFilter.gainRange,
+        unit: .percent,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        centerFrequency = AUParameter(
-            identifier: "centerFrequency",
-            name: "Center Frequency (Hz)",
-            address: AKEqualizerFilterParameter.centerFrequency.rawValue,
-            range: AKEqualizerFilter.centerFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        bandwidth = AUParameter(
-            identifier: "bandwidth",
-            name: "Bandwidth (Hz)",
-            address: AKEqualizerFilterParameter.bandwidth.rawValue,
-            range: AKEqualizerFilter.bandwidthRange,
-            unit: .hertz,
-            flags: .default)
-        gain = AUParameter(
-            identifier: "gain",
-            name: "Gain (%)",
-            address: AKEqualizerFilterParameter.gain.rawValue,
-            range: AKEqualizerFilter.gainRange,
-            unit: .percent,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [centerFrequency, bandwidth, gain])
-
-        centerFrequency.value = AUValue(AKEqualizerFilter.defaultCenterFrequency)
-        bandwidth.value = AUValue(AKEqualizerFilter.defaultBandwidth)
-        gain.value = AUValue(AKEqualizerFilter.defaultGain)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilter.swift
@@ -4,63 +4,49 @@
 /// grains. Overlapping will occur when 1/freq < dec, but there is no upper
 /// limit on the number of overlaps.
 ///
-open class AKFormantFilter: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKFormantFilterAudioUnit
+open class AKFormantFilter: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "fofi")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKFormantFilterAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Center Frequency
-    public static let centerFrequencyRange: ClosedRange<Double> = 12.0 ... 20_000.0
+    public static let centerFrequencyRange: ClosedRange<AUValue> = 12.0 ... 20000.0
 
     /// Lower and upper bounds for Attack Duration
-    public static let attackDurationRange: ClosedRange<Double> = 0.0 ... 0.1
+    public static let attackDurationRange: ClosedRange<AUValue> = 0.0 ... 0.1
 
     /// Lower and upper bounds for Decay Duration
-    public static let decayDurationRange: ClosedRange<Double> = 0.0 ... 0.1
+    public static let decayDurationRange: ClosedRange<AUValue> = 0.0 ... 0.1
 
     /// Initial value for Center Frequency
-    public static let defaultCenterFrequency: Double = 1_000
+    public static let defaultCenterFrequency: AUValue = 1000
 
     /// Initial value for Attack Duration
-    public static let defaultAttackDuration: Double = 0.007
+    public static let defaultAttackDuration: AUValue = 0.007
 
     /// Initial value for Decay Duration
-    public static let defaultDecayDuration: Double = 0.04
+    public static let defaultDecayDuration: AUValue = 0.04
 
     /// Center frequency.
-    @objc open var centerFrequency: Double = defaultCenterFrequency {
-        willSet {
-            let clampedValue = AKFormantFilter.centerFrequencyRange.clamp(newValue)
-            guard centerFrequency != clampedValue else { return }
-            internalAU?.centerFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let centerFrequency = AKNodeParameter(identifier: "centerFrequency")
 
     /// Impulse response attack time (in seconds).
-    @objc open var attackDuration: Double = defaultAttackDuration {
-        willSet {
-            let clampedValue = AKFormantFilter.attackDurationRange.clamp(newValue)
-            guard attackDuration != clampedValue else { return }
-            internalAU?.attackDuration.value = AUValue(clampedValue)
-        }
-    }
+    public let attackDuration = AKNodeParameter(identifier: "attackDuration")
 
     /// Impulse reponse decay time (in seconds)
-    @objc open var decayDuration: Double = defaultDecayDuration {
-        willSet {
-            let clampedValue = AKFormantFilter.decayDurationRange.clamp(newValue)
-            guard decayDuration != clampedValue else { return }
-            internalAU?.decayDuration.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let decayDuration = AKNodeParameter(identifier: "decayDuration")
 
     // MARK: - Initialization
 
@@ -74,34 +60,24 @@ open class AKFormantFilter: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        centerFrequency: Double = defaultCenterFrequency,
-        attackDuration: Double = defaultAttackDuration,
-        decayDuration: Double = defaultDecayDuration
+        centerFrequency: AUValue = defaultCenterFrequency,
+        attackDuration: AUValue = defaultAttackDuration,
+        decayDuration: AUValue = defaultDecayDuration
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.centerFrequency.associate(with: self.internalAU, value: centerFrequency)
+            self.attackDuration.associate(with: self.internalAU, value: attackDuration)
+            self.decayDuration.associate(with: self.internalAU, value: decayDuration)
+
             input?.connect(to: self)
-
-            self.centerFrequency = centerFrequency
-            self.attackDuration = attackDuration
-            self.decayDuration = decayDuration
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKFormantFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var centerFrequency: AUParameter!
+    let centerFrequency = AUParameter(
+        identifier: "centerFrequency",
+        name: "Center Frequency (Hz)",
+        address: AKFormantFilterParameter.centerFrequency.rawValue,
+        range: AKFormantFilter.centerFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var attackDuration: AUParameter!
+    let attackDuration = AUParameter(
+        identifier: "attackDuration",
+        name: "Impulse response attack time (Seconds)",
+        address: AKFormantFilterParameter.attackDuration.rawValue,
+        range: AKFormantFilter.attackDurationRange,
+        unit: .seconds,
+        flags: .default)
 
-    private(set) var decayDuration: AUParameter!
+    let decayDuration = AUParameter(
+        identifier: "decayDuration",
+        name: "Impulse reponse decay time (Seconds)",
+        address: AKFormantFilterParameter.decayDuration.rawValue,
+        range: AKFormantFilter.decayDurationRange,
+        unit: .seconds,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createFormantFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        centerFrequency = AUParameter(
-            identifier: "centerFrequency",
-            name: "Center Frequency (Hz)",
-            address: AKFormantFilterParameter.centerFrequency.rawValue,
-            range: AKFormantFilter.centerFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        attackDuration = AUParameter(
-            identifier: "attackDuration",
-            name: "Impulse response attack time (Seconds)",
-            address: AKFormantFilterParameter.attackDuration.rawValue,
-            range: AKFormantFilter.attackDurationRange,
-            unit: .seconds,
-            flags: .default)
-        decayDuration = AUParameter(
-            identifier: "decayDuration",
-            name: "Impulse reponse decay time (Seconds)",
-            address: AKFormantFilterParameter.decayDuration.rawValue,
-            range: AKFormantFilter.decayDurationRange,
-            unit: .seconds,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [centerFrequency, attackDuration, decayDuration])
-
-        centerFrequency.value = AUValue(AKFormantFilter.defaultCenterFrequency)
-        attackDuration.value = AUValue(AKFormantFilter.defaultAttackDuration)
-        decayDuration.value = AUValue(AKFormantFilter.defaultDecayDuration)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKHighPassButterworthFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var cutoffFrequency: AUParameter!
+    let cutoffFrequency = AUParameter(
+        identifier: "cutoffFrequency",
+        name: "Cutoff Frequency (Hz)",
+        address: AKHighPassButterworthFilterParameter.cutoffFrequency.rawValue,
+        range: AKHighPassButterworthFilter.cutoffFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createHighPassButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        cutoffFrequency = AUParameter(
-            identifier: "cutoffFrequency",
-            name: "Cutoff Frequency (Hz)",
-            address: AKHighPassButterworthFilterParameter.cutoffFrequency.rawValue,
-            range: AKHighPassButterworthFilter.cutoffFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [cutoffFrequency])
-
-        cutoffFrequency.value = AUValue(AKHighPassButterworthFilter.defaultCutoffFrequency)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilter.swift
@@ -2,63 +2,49 @@
 
 /// This is an implementation of Zoelzer's parametric equalizer filter.
 ///
-open class AKHighShelfParametricEqualizerFilter: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKHighShelfParametricEqualizerFilterAudioUnit
+open class AKHighShelfParametricEqualizerFilter: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "peq2")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKHighShelfParametricEqualizerFilterAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Center Frequency
-    public static let centerFrequencyRange: ClosedRange<Double> = 12.0 ... 20_000.0
+    public static let centerFrequencyRange: ClosedRange<AUValue> = 12.0 ... 20000.0
 
     /// Lower and upper bounds for Gain
-    public static let gainRange: ClosedRange<Double> = 0.0 ... 10.0
+    public static let gainRange: ClosedRange<AUValue> = 0.0 ... 10.0
 
     /// Lower and upper bounds for Q
-    public static let qRange: ClosedRange<Double> = 0.0 ... 2.0
+    public static let qRange: ClosedRange<AUValue> = 0.0 ... 2.0
 
     /// Initial value for Center Frequency
-    public static let defaultCenterFrequency: Double = 1_000
+    public static let defaultCenterFrequency: AUValue = 1000
 
     /// Initial value for Gain
-    public static let defaultGain: Double = 1.0
+    public static let defaultGain: AUValue = 1.0
 
     /// Initial value for Q
-    public static let defaultQ: Double = 0.707
+    public static let defaultQ: AUValue = 0.707
 
     /// Corner frequency.
-    @objc open var centerFrequency: Double = defaultCenterFrequency {
-        willSet {
-            let clampedValue = AKHighShelfParametricEqualizerFilter.centerFrequencyRange.clamp(newValue)
-            guard centerFrequency != clampedValue else { return }
-            internalAU?.centerFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let centerFrequency = AKNodeParameter(identifier: "centerFrequency")
 
     /// Amount at which the corner frequency value shall be increased or decreased. A value of 1 is a flat response.
-    @objc open var gain: Double = defaultGain {
-        willSet {
-            let clampedValue = AKHighShelfParametricEqualizerFilter.gainRange.clamp(newValue)
-            guard gain != clampedValue else { return }
-            internalAU?.gain.value = AUValue(clampedValue)
-        }
-    }
+    public let gain = AKNodeParameter(identifier: "gain")
 
     /// Q of the filter. sqrt(0.5) is no resonance.
-    @objc open var q: Double = defaultQ {
-        willSet {
-            let clampedValue = AKHighShelfParametricEqualizerFilter.qRange.clamp(newValue)
-            guard q != clampedValue else { return }
-            internalAU?.q.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let q = AKNodeParameter(identifier: "q")
 
     // MARK: - Initialization
 
@@ -72,34 +58,24 @@ open class AKHighShelfParametricEqualizerFilter: AKNode, AKToggleable, AKCompone
     ///
     public init(
         _ input: AKNode? = nil,
-        centerFrequency: Double = defaultCenterFrequency,
-        gain: Double = defaultGain,
-        q: Double = defaultQ
+        centerFrequency: AUValue = defaultCenterFrequency,
+        gain: AUValue = defaultGain,
+        q: AUValue = defaultQ
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.centerFrequency.associate(with: self.internalAU, value: centerFrequency)
+            self.gain.associate(with: self.internalAU, value: gain)
+            self.q.associate(with: self.internalAU, value: q)
+
             input?.connect(to: self)
-
-            self.centerFrequency = centerFrequency
-            self.gain = gain
-            self.q = q
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKHighShelfParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var centerFrequency: AUParameter!
+    let centerFrequency = AUParameter(
+        identifier: "centerFrequency",
+        name: "Corner Frequency (Hz)",
+        address: AKHighShelfParametricEqualizerFilterParameter.centerFrequency.rawValue,
+        range: AKHighShelfParametricEqualizerFilter.centerFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var gain: AUParameter!
+    let gain = AUParameter(
+        identifier: "gain",
+        name: "Gain",
+        address: AKHighShelfParametricEqualizerFilterParameter.gain.rawValue,
+        range: AKHighShelfParametricEqualizerFilter.gainRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var q: AUParameter!
+    let q = AUParameter(
+        identifier: "q",
+        name: "Q",
+        address: AKHighShelfParametricEqualizerFilterParameter.Q.rawValue,
+        range: AKHighShelfParametricEqualizerFilter.qRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createHighShelfParametricEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        centerFrequency = AUParameter(
-            identifier: "centerFrequency",
-            name: "Corner Frequency (Hz)",
-            address: AKHighShelfParametricEqualizerFilterParameter.centerFrequency.rawValue,
-            range: AKHighShelfParametricEqualizerFilter.centerFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        gain = AUParameter(
-            identifier: "gain",
-            name: "Gain",
-            address: AKHighShelfParametricEqualizerFilterParameter.gain.rawValue,
-            range: AKHighShelfParametricEqualizerFilter.gainRange,
-            unit: .generic,
-            flags: .default)
-        q = AUParameter(
-            identifier: "q",
-            name: "Q",
-            address: AKHighShelfParametricEqualizerFilterParameter.Q.rawValue,
-            range: AKHighShelfParametricEqualizerFilter.qRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [centerFrequency, gain, q])
-
-        centerFrequency.value = AUValue(AKHighShelfParametricEqualizerFilter.defaultCenterFrequency)
-        gain.value = AUValue(AKHighShelfParametricEqualizerFilter.defaultGain)
-        q.value = AUValue(AKHighShelfParametricEqualizerFilter.defaultQ)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilter.swift
@@ -2,63 +2,49 @@
 
 /// Analogue model of the Korg 35 Lowpass Filter
 ///
-open class AKKorgLowPassFilter: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKKorgLowPassFilterAudioUnit
+open class AKKorgLowPassFilter: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "klpf")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKKorgLowPassFilterAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Cutoff Frequency
-    public static let cutoffFrequencyRange: ClosedRange<Double> = 0.0 ... 22_050.0
+    public static let cutoffFrequencyRange: ClosedRange<AUValue> = 0.0 ... 22050.0
 
     /// Lower and upper bounds for Resonance
-    public static let resonanceRange: ClosedRange<Double> = 0.0 ... 2.0
+    public static let resonanceRange: ClosedRange<AUValue> = 0.0 ... 2.0
 
     /// Lower and upper bounds for Saturation
-    public static let saturationRange: ClosedRange<Double> = 0.0 ... 10.0
+    public static let saturationRange: ClosedRange<AUValue> = 0.0 ... 10.0
 
     /// Initial value for Cutoff Frequency
-    public static let defaultCutoffFrequency: Double = 1_000.0
+    public static let defaultCutoffFrequency: AUValue = 1000.0
 
     /// Initial value for Resonance
-    public static let defaultResonance: Double = 1.0
+    public static let defaultResonance: AUValue = 1.0
 
     /// Initial value for Saturation
-    public static let defaultSaturation: Double = 0.0
+    public static let defaultSaturation: AUValue = 0.0
 
     /// Filter cutoff
-    @objc open var cutoffFrequency: Double = defaultCutoffFrequency {
-        willSet {
-            let clampedValue = AKKorgLowPassFilter.cutoffFrequencyRange.clamp(newValue)
-            guard cutoffFrequency != clampedValue else { return }
-            internalAU?.cutoffFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let cutoffFrequency = AKNodeParameter(identifier: "cutoffFrequency")
 
     /// Filter resonance (should be between 0-2)
-    @objc open var resonance: Double = defaultResonance {
-        willSet {
-            let clampedValue = AKKorgLowPassFilter.resonanceRange.clamp(newValue)
-            guard resonance != clampedValue else { return }
-            internalAU?.resonance.value = AUValue(clampedValue)
-        }
-    }
+    public let resonance = AKNodeParameter(identifier: "resonance")
 
     /// Filter saturation.
-    @objc open var saturation: Double = defaultSaturation {
-        willSet {
-            let clampedValue = AKKorgLowPassFilter.saturationRange.clamp(newValue)
-            guard saturation != clampedValue else { return }
-            internalAU?.saturation.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let saturation = AKNodeParameter(identifier: "saturation")
 
     // MARK: - Initialization
 
@@ -72,34 +58,24 @@ open class AKKorgLowPassFilter: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        cutoffFrequency: Double = defaultCutoffFrequency,
-        resonance: Double = defaultResonance,
-        saturation: Double = defaultSaturation
+        cutoffFrequency: AUValue = defaultCutoffFrequency,
+        resonance: AUValue = defaultResonance,
+        saturation: AUValue = defaultSaturation
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.cutoffFrequency.associate(with: self.internalAU, value: cutoffFrequency)
+            self.resonance.associate(with: self.internalAU, value: resonance)
+            self.saturation.associate(with: self.internalAU, value: saturation)
+
             input?.connect(to: self)
-
-            self.cutoffFrequency = cutoffFrequency
-            self.resonance = resonance
-            self.saturation = saturation
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKKorgLowPassFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var cutoffFrequency: AUParameter!
+    let cutoffFrequency = AUParameter(
+        identifier: "cutoffFrequency",
+        name: "Filter cutoff",
+        address: AKKorgLowPassFilterParameter.cutoffFrequency.rawValue,
+        range: AKKorgLowPassFilter.cutoffFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var resonance: AUParameter!
+    let resonance = AUParameter(
+        identifier: "resonance",
+        name: "Filter resonance (should be between 0-2)",
+        address: AKKorgLowPassFilterParameter.resonance.rawValue,
+        range: AKKorgLowPassFilter.resonanceRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var saturation: AUParameter!
+    let saturation = AUParameter(
+        identifier: "saturation",
+        name: "Filter saturation.",
+        address: AKKorgLowPassFilterParameter.saturation.rawValue,
+        range: AKKorgLowPassFilter.saturationRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createKorgLowPassFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        cutoffFrequency = AUParameter(
-            identifier: "cutoffFrequency",
-            name: "Filter cutoff",
-            address: AKKorgLowPassFilterParameter.cutoffFrequency.rawValue,
-            range: AKKorgLowPassFilter.cutoffFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        resonance = AUParameter(
-            identifier: "resonance",
-            name: "Filter resonance (should be between 0-2)",
-            address: AKKorgLowPassFilterParameter.resonance.rawValue,
-            range: AKKorgLowPassFilter.resonanceRange,
-            unit: .generic,
-            flags: .default)
-        saturation = AUParameter(
-            identifier: "saturation",
-            name: "Filter saturation.",
-            address: AKKorgLowPassFilterParameter.saturation.rawValue,
-            range: AKKorgLowPassFilter.saturationRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [cutoffFrequency, resonance, saturation])
-
-        cutoffFrequency.value = AUValue(AKKorgLowPassFilter.defaultCutoffFrequency)
-        resonance.value = AUValue(AKKorgLowPassFilter.defaultResonance)
-        saturation.value = AUValue(AKKorgLowPassFilter.defaultSaturation)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilter.swift
@@ -3,33 +3,31 @@
 /// These filters are Butterworth second-order IIR filters. They offer an almost
 /// flat passband and very good precision and stopband attenuation.
 ///
-open class AKLowPassButterworthFilter: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKLowPassButterworthFilterAudioUnit
+open class AKLowPassButterworthFilter: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "btlp")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKLowPassButterworthFilterAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Cutoff Frequency
-    public static let cutoffFrequencyRange: ClosedRange<Double> = 12.0 ... 20_000.0
+    public static let cutoffFrequencyRange: ClosedRange<AUValue> = 12.0 ... 20000.0
 
     /// Initial value for Cutoff Frequency
-    public static let defaultCutoffFrequency: Double = 1_000.0
+    public static let defaultCutoffFrequency: AUValue = 1000.0
 
     /// Cutoff frequency. (in Hertz)
-    @objc open var cutoffFrequency: Double = defaultCutoffFrequency {
-        willSet {
-            let clampedValue = AKLowPassButterworthFilter.cutoffFrequencyRange.clamp(newValue)
-            guard cutoffFrequency != clampedValue else { return }
-            internalAU?.cutoffFrequency.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let cutoffFrequency = AKNodeParameter(identifier: "cutoffFrequency")
 
     // MARK: - Initialization
 
@@ -41,30 +39,20 @@ open class AKLowPassButterworthFilter: AKNode, AKToggleable, AKComponent, AKInpu
     ///
     public init(
         _ input: AKNode? = nil,
-        cutoffFrequency: Double = defaultCutoffFrequency
+        cutoffFrequency: AUValue = defaultCutoffFrequency
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.cutoffFrequency.associate(with: self.internalAU, value: cutoffFrequency)
+
             input?.connect(to: self)
-
-            self.cutoffFrequency = cutoffFrequency
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKLowPassButterworthFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var cutoffFrequency: AUParameter!
+    let cutoffFrequency = AUParameter(
+        identifier: "cutoffFrequency",
+        name: "Cutoff Frequency (Hz)",
+        address: AKLowPassButterworthFilterParameter.cutoffFrequency.rawValue,
+        range: AKLowPassButterworthFilter.cutoffFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createLowPassButterworthFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        cutoffFrequency = AUParameter(
-            identifier: "cutoffFrequency",
-            name: "Cutoff Frequency (Hz)",
-            address: AKLowPassButterworthFilterParameter.cutoffFrequency.rawValue,
-            range: AKLowPassButterworthFilter.cutoffFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [cutoffFrequency])
-
-        cutoffFrequency.value = AUValue(AKLowPassButterworthFilter.defaultCutoffFrequency)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilter.swift
@@ -2,63 +2,49 @@
 
 /// This is an implementation of Zoelzer's parametric equalizer filter.
 ///
-open class AKLowShelfParametricEqualizerFilter: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKLowShelfParametricEqualizerFilterAudioUnit
+open class AKLowShelfParametricEqualizerFilter: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "peq1")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKLowShelfParametricEqualizerFilterAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Corner Frequency
-    public static let cornerFrequencyRange: ClosedRange<Double> = 12.0 ... 20_000.0
+    public static let cornerFrequencyRange: ClosedRange<AUValue> = 12.0 ... 20000.0
 
     /// Lower and upper bounds for Gain
-    public static let gainRange: ClosedRange<Double> = 0.0 ... 10.0
+    public static let gainRange: ClosedRange<AUValue> = 0.0 ... 10.0
 
     /// Lower and upper bounds for Q
-    public static let qRange: ClosedRange<Double> = 0.0 ... 2.0
+    public static let qRange: ClosedRange<AUValue> = 0.0 ... 2.0
 
     /// Initial value for Corner Frequency
-    public static let defaultCornerFrequency: Double = 1_000
+    public static let defaultCornerFrequency: AUValue = 1000
 
     /// Initial value for Gain
-    public static let defaultGain: Double = 1.0
+    public static let defaultGain: AUValue = 1.0
 
     /// Initial value for Q
-    public static let defaultQ: Double = 0.707
+    public static let defaultQ: AUValue = 0.707
 
     /// Corner frequency.
-    @objc open var cornerFrequency: Double = defaultCornerFrequency {
-        willSet {
-            let clampedValue = AKLowShelfParametricEqualizerFilter.cornerFrequencyRange.clamp(newValue)
-            guard cornerFrequency != clampedValue else { return }
-            internalAU?.cornerFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let cornerFrequency = AKNodeParameter(identifier: "cornerFrequency")
 
     /// Amount at which the corner frequency value shall be increased or decreased. A value of 1 is a flat response.
-    @objc open var gain: Double = defaultGain {
-        willSet {
-            let clampedValue = AKLowShelfParametricEqualizerFilter.gainRange.clamp(newValue)
-            guard gain != clampedValue else { return }
-            internalAU?.gain.value = AUValue(clampedValue)
-        }
-    }
+    public let gain = AKNodeParameter(identifier: "gain")
 
     /// Q of the filter. sqrt(0.5) is no resonance.
-    @objc open var q: Double = defaultQ {
-        willSet {
-            let clampedValue = AKLowShelfParametricEqualizerFilter.qRange.clamp(newValue)
-            guard q != clampedValue else { return }
-            internalAU?.q.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let q = AKNodeParameter(identifier: "q")
 
     // MARK: - Initialization
 
@@ -72,34 +58,24 @@ open class AKLowShelfParametricEqualizerFilter: AKNode, AKToggleable, AKComponen
     ///
     public init(
         _ input: AKNode? = nil,
-        cornerFrequency: Double = defaultCornerFrequency,
-        gain: Double = defaultGain,
-        q: Double = defaultQ
+        cornerFrequency: AUValue = defaultCornerFrequency,
+        gain: AUValue = defaultGain,
+        q: AUValue = defaultQ
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.cornerFrequency.associate(with: self.internalAU, value: cornerFrequency)
+            self.gain.associate(with: self.internalAU, value: gain)
+            self.q.associate(with: self.internalAU, value: q)
+
             input?.connect(to: self)
-
-            self.cornerFrequency = cornerFrequency
-            self.gain = gain
-            self.q = q
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKLowShelfParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var cornerFrequency: AUParameter!
+    let cornerFrequency = AUParameter(
+        identifier: "cornerFrequency",
+        name: "Corner Frequency (Hz)",
+        address: AKLowShelfParametricEqualizerFilterParameter.cornerFrequency.rawValue,
+        range: AKLowShelfParametricEqualizerFilter.cornerFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var gain: AUParameter!
+    let gain = AUParameter(
+        identifier: "gain",
+        name: "Gain",
+        address: AKLowShelfParametricEqualizerFilterParameter.gain.rawValue,
+        range: AKLowShelfParametricEqualizerFilter.gainRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var q: AUParameter!
+    let q = AUParameter(
+        identifier: "q",
+        name: "Q",
+        address: AKLowShelfParametricEqualizerFilterParameter.Q.rawValue,
+        range: AKLowShelfParametricEqualizerFilter.qRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createLowShelfParametricEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        cornerFrequency = AUParameter(
-            identifier: "cornerFrequency",
-            name: "Corner Frequency (Hz)",
-            address: AKLowShelfParametricEqualizerFilterParameter.cornerFrequency.rawValue,
-            range: AKLowShelfParametricEqualizerFilter.cornerFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        gain = AUParameter(
-            identifier: "gain",
-            name: "Gain",
-            address: AKLowShelfParametricEqualizerFilterParameter.gain.rawValue,
-            range: AKLowShelfParametricEqualizerFilter.gainRange,
-            unit: .generic,
-            flags: .default)
-        q = AUParameter(
-            identifier: "q",
-            name: "Q",
-            address: AKLowShelfParametricEqualizerFilterParameter.Q.rawValue,
-            range: AKLowShelfParametricEqualizerFilter.qRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [cornerFrequency, gain, q])
-
-        cornerFrequency.value = AUValue(AKLowShelfParametricEqualizerFilter.defaultCornerFrequency)
-        gain.value = AUValue(AKLowShelfParametricEqualizerFilter.defaultGain)
-        q.value = AUValue(AKLowShelfParametricEqualizerFilter.defaultQ)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKModalResonanceFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Resonant Frequency (Hz)",
+        address: AKModalResonanceFilterParameter.frequency.rawValue,
+        range: AKModalResonanceFilter.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var qualityFactor: AUParameter!
+    let qualityFactor = AUParameter(
+        identifier: "qualityFactor",
+        name: "Quality Factor",
+        address: AKModalResonanceFilterParameter.qualityFactor.rawValue,
+        range: AKModalResonanceFilter.qualityFactorRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createModalResonanceFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Resonant Frequency (Hz)",
-            address: AKModalResonanceFilterParameter.frequency.rawValue,
-            range: AKModalResonanceFilter.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        qualityFactor = AUParameter(
-            identifier: "qualityFactor",
-            name: "Quality Factor",
-            address: AKModalResonanceFilterParameter.qualityFactor.rawValue,
-            range: AKModalResonanceFilter.qualityFactorRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [frequency, qualityFactor])
-
-        frequency.value = AUValue(AKModalResonanceFilter.defaultFrequency)
-        qualityFactor.value = AUValue(AKModalResonanceFilter.defaultQualityFactor)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKMoogLadderAudioUnit: AKAudioUnitBase {
 
-    private(set) var cutoffFrequency: AUParameter!
+    let cutoffFrequency = AUParameter(
+        identifier: "cutoffFrequency",
+        name: "Cutoff Frequency (Hz)",
+        address: AKMoogLadderParameter.cutoffFrequency.rawValue,
+        range: AKMoogLadder.cutoffFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var resonance: AUParameter!
+    let resonance = AUParameter(
+        identifier: "resonance",
+        name: "Resonance (%)",
+        address: AKMoogLadderParameter.resonance.rawValue,
+        range: AKMoogLadder.resonanceRange,
+        unit: .percent,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createMoogLadderDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        cutoffFrequency = AUParameter(
-            identifier: "cutoffFrequency",
-            name: "Cutoff Frequency (Hz)",
-            address: AKMoogLadderParameter.cutoffFrequency.rawValue,
-            range: AKMoogLadder.cutoffFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        resonance = AUParameter(
-            identifier: "resonance",
-            name: "Resonance (%)",
-            address: AKMoogLadderParameter.resonance.rawValue,
-            range: AKMoogLadder.resonanceRange,
-            unit: .percent,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [cutoffFrequency, resonance])
-
-        cutoffFrequency.value = AUValue(AKMoogLadder.defaultCutoffFrequency)
-        resonance.value = AUValue(AKMoogLadder.defaultResonance)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderPresets.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderPresets.swift
@@ -5,21 +5,21 @@ public extension AKMoogLadder {
 
     /// Blurry, foggy filter
     func presetFogMoogLadder() {
-        cutoffFrequency = 515.578
-        resonance = 0.206
+        cutoffFrequency.value = 515.578
+        resonance.value = 0.206
     }
 
     /// Dull noise filter
     func presetDullNoiseMoogLadder() {
-        cutoffFrequency = 3_088.157
-        resonance = 0.075
+        cutoffFrequency.value = 3_088.157
+        resonance.value = 0.075
     }
 
     /// Print out current values in case you want to save it as a preset
     func printCurrentValuesAsPreset() {
         AKLog("public func presetSomeNewMoogLadderFilter() {")
-        AKLog("    cutoffFrequency = \(String(format: "%0.3f", cutoffFrequency))")
-        AKLog("    resonance = \(String(format: "%0.3f", resonance))")
+        AKLog("    cutoffFrequency = \(String(format: "%0.3f", cutoffFrequency.value))")
+        AKLog("    resonance = \(String(format: "%0.3f", resonance.value))")
         AKLog("}\n")
     }
 

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKPeakingParametricEqualizerFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var centerFrequency: AUParameter!
+    let centerFrequency = AUParameter(
+        identifier: "centerFrequency",
+        name: "Center Frequency (Hz)",
+        address: AKPeakingParametricEqualizerFilterParameter.centerFrequency.rawValue,
+        range: AKPeakingParametricEqualizerFilter.centerFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var gain: AUParameter!
+    let gain = AUParameter(
+        identifier: "gain",
+        name: "Gain",
+        address: AKPeakingParametricEqualizerFilterParameter.gain.rawValue,
+        range: AKPeakingParametricEqualizerFilter.gainRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var q: AUParameter!
+    let q = AUParameter(
+        identifier: "q",
+        name: "Q",
+        address: AKPeakingParametricEqualizerFilterParameter.Q.rawValue,
+        range: AKPeakingParametricEqualizerFilter.qRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPeakingParametricEqualizerFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        centerFrequency = AUParameter(
-            identifier: "centerFrequency",
-            name: "Center Frequency (Hz)",
-            address: AKPeakingParametricEqualizerFilterParameter.centerFrequency.rawValue,
-            range: AKPeakingParametricEqualizerFilter.centerFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        gain = AUParameter(
-            identifier: "gain",
-            name: "Gain",
-            address: AKPeakingParametricEqualizerFilterParameter.gain.rawValue,
-            range: AKPeakingParametricEqualizerFilter.gainRange,
-            unit: .generic,
-            flags: .default)
-        q = AUParameter(
-            identifier: "q",
-            name: "Q",
-            address: AKPeakingParametricEqualizerFilterParameter.Q.rawValue,
-            range: AKPeakingParametricEqualizerFilter.qRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [centerFrequency, gain, q])
-
-        centerFrequency.value = AUValue(AKPeakingParametricEqualizerFilter.defaultCenterFrequency)
-        gain.value = AUValue(AKPeakingParametricEqualizerFilter.defaultGain)
-        q.value = AUValue(AKPeakingParametricEqualizerFilter.defaultQ)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKPeakingParametricEqualizerFilterDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createPeakingParametricEqualizerFilterDSP() {
     return new AKPeakingParametricEqualizerFilterDSP();
@@ -10,9 +10,9 @@ extern "C" AKDSPRef createPeakingParametricEqualizerFilterDSP() {
 struct AKPeakingParametricEqualizerFilterDSP::InternalData {
     sp_pareq *pareq0;
     sp_pareq *pareq1;
-    AKLinearParameterRamp centerFrequencyRamp;
-    AKLinearParameterRamp gainRamp;
-    AKLinearParameterRamp qRamp;
+    ParameterRamper centerFrequencyRamp;
+    ParameterRamper gainRamp;
+    ParameterRamper qRamp;
 };
 
 AKPeakingParametricEqualizerFilterDSP::AKPeakingParametricEqualizerFilterDSP() : data(new InternalData) {
@@ -27,6 +27,8 @@ void AKPeakingParametricEqualizerFilterDSP::init(int channelCount, double sample
     sp_pareq_init(sp, data->pareq0);
     sp_pareq_create(&data->pareq1);
     sp_pareq_init(sp, data->pareq1);
+    data->pareq0->mode = 0;
+    data->pareq1->mode = 0;
 }
 
 void AKPeakingParametricEqualizerFilterDSP::deinit() {
@@ -40,6 +42,8 @@ void AKPeakingParametricEqualizerFilterDSP::reset() {
     if (!isInitialized) return;
     sp_pareq_init(sp, data->pareq0);
     sp_pareq_init(sp, data->pareq1);
+    data->pareq0->mode = 0;
+    data->pareq1->mode = 0;
 }
 
 void AKPeakingParametricEqualizerFilterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {
@@ -47,19 +51,17 @@ void AKPeakingParametricEqualizerFilterDSP::process(AUAudioFrameCount frameCount
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->centerFrequencyRamp.advanceTo(now + frameOffset);
-            data->gainRamp.advanceTo(now + frameOffset);
-            data->qRamp.advanceTo(now + frameOffset);
-        }
+        float centerFrequency = data->centerFrequencyRamp.getAndStep();
+        data->pareq0->fc = centerFrequency;
+        data->pareq1->fc = centerFrequency;
 
-        data->pareq0->fc = data->centerFrequencyRamp.getValue();
-        data->pareq1->fc = data->centerFrequencyRamp.getValue();
-        data->pareq0->v = data->gainRamp.getValue();
-        data->pareq1->v = data->gainRamp.getValue();
-        data->pareq0->q = data->qRamp.getValue();
-        data->pareq1->q = data->qRamp.getValue();
+        float gain = data->gainRamp.getAndStep();
+        data->pareq0->v = gain;
+        data->pareq1->v = gain;
+
+        float q = data->qRamp.getAndStep();
+        data->pareq0->q = q;
+        data->pareq1->q = q;
 
         float *tmpin[2];
         float *tmpout[2];

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKResonantFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Center frequency of the filter, or frequency position of the peak response.",
+        address: AKResonantFilterParameter.frequency.rawValue,
+        range: AKResonantFilter.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var bandwidth: AUParameter!
+    let bandwidth = AUParameter(
+        identifier: "bandwidth",
+        name: "Bandwidth of the filter.",
+        address: AKResonantFilterParameter.bandwidth.rawValue,
+        range: AKResonantFilter.bandwidthRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createResonantFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Center frequency of the filter, or frequency position of the peak response.",
-            address: AKResonantFilterParameter.frequency.rawValue,
-            range: AKResonantFilter.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        bandwidth = AUParameter(
-            identifier: "bandwidth",
-            name: "Bandwidth of the filter.",
-            address: AKResonantFilterParameter.bandwidth.rawValue,
-            range: AKResonantFilter.bandwidthRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [frequency, bandwidth])
-
-        frequency.value = AUValue(AKResonantFilter.defaultFrequency)
-        bandwidth.value = AUValue(AKResonantFilter.defaultBandwidth)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterAudioUnit.swift
@@ -4,59 +4,46 @@ import AVFoundation
 
 public class AKRolandTB303FilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var cutoffFrequency: AUParameter!
+    let cutoffFrequency = AUParameter(
+        identifier: "cutoffFrequency",
+        name: "Cutoff Frequency (Hz)",
+        address: AKRolandTB303FilterParameter.cutoffFrequency.rawValue,
+        range: AKRolandTB303Filter.cutoffFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var resonance: AUParameter!
+    let resonance = AUParameter(
+        identifier: "resonance",
+        name: "Resonance",
+        address: AKRolandTB303FilterParameter.resonance.rawValue,
+        range: AKRolandTB303Filter.resonanceRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var distortion: AUParameter!
+    let distortion = AUParameter(
+        identifier: "distortion",
+        name: "Distortion",
+        address: AKRolandTB303FilterParameter.distortion.rawValue,
+        range: AKRolandTB303Filter.distortionRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var resonanceAsymmetry: AUParameter!
+    let resonanceAsymmetry = AUParameter(
+        identifier: "resonanceAsymmetry",
+        name: "Resonance Asymmetry",
+        address: AKRolandTB303FilterParameter.resonanceAsymmetry.rawValue,
+        range: AKRolandTB303Filter.resonanceAsymmetryRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createRolandTB303FilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        cutoffFrequency = AUParameter(
-            identifier: "cutoffFrequency",
-            name: "Cutoff Frequency (Hz)",
-            address: AKRolandTB303FilterParameter.cutoffFrequency.rawValue,
-            range: AKRolandTB303Filter.cutoffFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        resonance = AUParameter(
-            identifier: "resonance",
-            name: "Resonance",
-            address: AKRolandTB303FilterParameter.resonance.rawValue,
-            range: AKRolandTB303Filter.resonanceRange,
-            unit: .generic,
-            flags: .default)
-        distortion = AUParameter(
-            identifier: "distortion",
-            name: "Distortion",
-            address: AKRolandTB303FilterParameter.distortion.rawValue,
-            range: AKRolandTB303Filter.distortionRange,
-            unit: .generic,
-            flags: .default)
-        resonanceAsymmetry = AUParameter(
-            identifier: "resonanceAsymmetry",
-            name: "Resonance Asymmetry",
-            address: AKRolandTB303FilterParameter.resonanceAsymmetry.rawValue,
-            range: AKRolandTB303Filter.resonanceAsymmetryRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [cutoffFrequency,
-                                                                  resonance,
-                                                                  distortion,
-                                                                  resonanceAsymmetry])
-
-        cutoffFrequency.value = AUValue(AKRolandTB303Filter.defaultCutoffFrequency)
-        resonance.value = AUValue(AKRolandTB303Filter.defaultResonance)
-        distortion.value = AUValue(AKRolandTB303Filter.defaultDistortion)
-        resonanceAsymmetry.value = AUValue(AKRolandTB303Filter.defaultResonanceAsymmetry)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [cutoffFrequency, resonance, distortion, resonanceAsymmetry])
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonator.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonator.swift
@@ -7,48 +7,40 @@
 /// fundamentalFrequency.  This operation can be used to simulate sympathetic
 /// resonances to an input signal.
 ///
-open class AKStringResonator: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKStringResonatorAudioUnit
+open class AKStringResonator: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "stre")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKStringResonatorAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Fundamental Frequency
-    public static let fundamentalFrequencyRange: ClosedRange<Double> = 12.0 ... 10_000.0
+    public static let fundamentalFrequencyRange: ClosedRange<AUValue> = 12.0 ... 10000.0
 
     /// Lower and upper bounds for Feedback
-    public static let feedbackRange: ClosedRange<Double> = 0.0 ... 1.0
+    public static let feedbackRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
     /// Initial value for Fundamental Frequency
-    public static let defaultFundamentalFrequency: Double = 100
+    public static let defaultFundamentalFrequency: AUValue = 100
 
     /// Initial value for Feedback
-    public static let defaultFeedback: Double = 0.95
+    public static let defaultFeedback: AUValue = 0.95
 
     /// Fundamental frequency of string.
-    @objc open var fundamentalFrequency: Double = defaultFundamentalFrequency {
-        willSet {
-            let clampedValue = AKStringResonator.fundamentalFrequencyRange.clamp(newValue)
-            guard fundamentalFrequency != clampedValue else { return }
-            internalAU?.fundamentalFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let fundamentalFrequency = AKNodeParameter(identifier: "fundamentalFrequency")
 
     /// Feedback amount (value between 0-1). A value close to 1 creates a slower decay and a more pronounced resonance. Small values may leave the input signal unaffected. Depending on the filter frequency, typical values are > .9.
-    @objc open var feedback: Double = defaultFeedback {
-        willSet {
-            let clampedValue = AKStringResonator.feedbackRange.clamp(newValue)
-            guard feedback != clampedValue else { return }
-            internalAU?.feedback.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let feedback = AKNodeParameter(identifier: "feedback")
 
     // MARK: - Initialization
 
@@ -61,32 +53,22 @@ open class AKStringResonator: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        fundamentalFrequency: Double = defaultFundamentalFrequency,
-        feedback: Double = defaultFeedback
+        fundamentalFrequency: AUValue = defaultFundamentalFrequency,
+        feedback: AUValue = defaultFeedback
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.fundamentalFrequency.associate(with: self.internalAU, value: fundamentalFrequency)
+            self.feedback.associate(with: self.internalAU, value: feedback)
+
             input?.connect(to: self)
-
-            self.fundamentalFrequency = fundamentalFrequency
-            self.feedback = feedback
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKStringResonatorAudioUnit: AKAudioUnitBase {
 
-    private(set) var fundamentalFrequency: AUParameter!
+    let fundamentalFrequency = AUParameter(
+        identifier: "fundamentalFrequency",
+        name: "Fundamental Frequency (Hz)",
+        address: AKStringResonatorParameter.fundamentalFrequency.rawValue,
+        range: AKStringResonator.fundamentalFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var feedback: AUParameter!
+    let feedback = AUParameter(
+        identifier: "feedback",
+        name: "Feedback (%)",
+        address: AKStringResonatorParameter.feedback.rawValue,
+        range: AKStringResonator.feedbackRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createStringResonatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        fundamentalFrequency = AUParameter(
-            identifier: "fundamentalFrequency",
-            name: "Fundamental Frequency (Hz)",
-            address: AKStringResonatorParameter.fundamentalFrequency.rawValue,
-            range: AKStringResonator.fundamentalFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        feedback = AUParameter(
-            identifier: "feedback",
-            name: "Feedback (%)",
-            address: AKStringResonatorParameter.feedback.rawValue,
-            range: AKStringResonator.feedbackRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [fundamentalFrequency, feedback])
-
-        fundamentalFrequency.value = AUValue(AKStringResonator.defaultFundamentalFrequency)
-        feedback.value = AUValue(AKStringResonator.defaultFeedback)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKThreePoleLowpassFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var distortion: AUParameter!
+    let distortion = AUParameter(
+        identifier: "distortion",
+        name: "Distortion (%)",
+        address: AKThreePoleLowpassFilterParameter.distortion.rawValue,
+        range: AKThreePoleLowpassFilter.distortionRange,
+        unit: .percent,
+        flags: .default)
 
-    private(set) var cutoffFrequency: AUParameter!
+    let cutoffFrequency = AUParameter(
+        identifier: "cutoffFrequency",
+        name: "Cutoff Frequency (Hz)",
+        address: AKThreePoleLowpassFilterParameter.cutoffFrequency.rawValue,
+        range: AKThreePoleLowpassFilter.cutoffFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var resonance: AUParameter!
+    let resonance = AUParameter(
+        identifier: "resonance",
+        name: "Resonance (%)",
+        address: AKThreePoleLowpassFilterParameter.resonance.rawValue,
+        range: AKThreePoleLowpassFilter.resonanceRange,
+        unit: .percent,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createThreePoleLowpassFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        distortion = AUParameter(
-            identifier: "distortion",
-            name: "Distortion (%)",
-            address: AKThreePoleLowpassFilterParameter.distortion.rawValue,
-            range: AKThreePoleLowpassFilter.distortionRange,
-            unit: .percent,
-            flags: .default)
-        cutoffFrequency = AUParameter(
-            identifier: "cutoffFrequency",
-            name: "Cutoff Frequency (Hz)",
-            address: AKThreePoleLowpassFilterParameter.cutoffFrequency.rawValue,
-            range: AKThreePoleLowpassFilter.cutoffFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        resonance = AUParameter(
-            identifier: "resonance",
-            name: "Resonance (%)",
-            address: AKThreePoleLowpassFilterParameter.resonance.rawValue,
-            range: AKThreePoleLowpassFilter.resonanceRange,
-            unit: .percent,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [distortion, cutoffFrequency, resonance])
-
-        distortion.value = AUValue(AKThreePoleLowpassFilter.defaultDistortion)
-        cutoffFrequency.value = AUValue(AKThreePoleLowpassFilter.defaultCutoffFrequency)
-        resonance.value = AUValue(AKThreePoleLowpassFilter.defaultResonance)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilter.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilter.swift
@@ -2,33 +2,31 @@
 
 /// A complement to the AKLowPassFilter.
 ///
-open class AKToneComplementFilter: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKToneComplementFilterAudioUnit
+open class AKToneComplementFilter: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "aton")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKToneComplementFilterAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Half Power Point
-    public static let halfPowerPointRange: ClosedRange<Double> = 12.0 ... 20_000.0
+    public static let halfPowerPointRange: ClosedRange<AUValue> = 12.0 ... 20000.0
 
     /// Initial value for Half Power Point
-    public static let defaultHalfPowerPoint: Double = 1_000.0
+    public static let defaultHalfPowerPoint: AUValue = 1000.0
 
     /// Half-Power Point in Hertz. Half power is defined as peak power / square root of 2.
-    @objc open var halfPowerPoint: Double = defaultHalfPowerPoint {
-        willSet {
-            let clampedValue = AKToneComplementFilter.halfPowerPointRange.clamp(newValue)
-            guard halfPowerPoint != clampedValue else { return }
-            internalAU?.halfPowerPoint.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let halfPowerPoint = AKNodeParameter(identifier: "halfPowerPoint")
 
     // MARK: - Initialization
 
@@ -40,30 +38,20 @@ open class AKToneComplementFilter: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        halfPowerPoint: Double = defaultHalfPowerPoint
+        halfPowerPoint: AUValue = defaultHalfPowerPoint
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.halfPowerPoint.associate(with: self.internalAU, value: halfPowerPoint)
+
             input?.connect(to: self)
-
-            self.halfPowerPoint = halfPowerPoint
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKToneComplementFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var halfPowerPoint: AUParameter!
+    let halfPowerPoint = AUParameter(
+        identifier: "halfPowerPoint",
+        name: "Half-Power Point (Hz)",
+        address: AKToneComplementFilterParameter.halfPowerPoint.rawValue,
+        range: AKToneComplementFilter.halfPowerPointRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createToneComplementFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        halfPowerPoint = AUParameter(
-            identifier: "halfPowerPoint",
-            name: "Half-Power Point (Hz)",
-            address: AKToneComplementFilterParameter.halfPowerPoint.rawValue,
-            range: AKToneComplementFilter.halfPowerPointRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [halfPowerPoint])
-
-        halfPowerPoint.value = AUValue(AKToneComplementFilter.defaultHalfPowerPoint)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKToneFilterAudioUnit: AKAudioUnitBase {
 
-    private(set) var halfPowerPoint: AUParameter!
+    let halfPowerPoint = AUParameter(
+        identifier: "halfPowerPoint",
+        name: "Half-Power Point (Hz)",
+        address: AKToneFilterParameter.halfPowerPoint.rawValue,
+        range: AKToneFilter.halfPowerPointRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createToneFilterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        halfPowerPoint = AUParameter(
-            identifier: "halfPowerPoint",
-            name: "Half-Power Point (Hz)",
-            address: AKToneFilterParameter.halfPowerPoint.rawValue,
-            range: AKToneFilter.halfPowerPointRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [halfPowerPoint])
-
-        halfPowerPoint.value = AUValue(AKToneFilter.defaultHalfPowerPoint)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKAutoWahAudioUnit: AKAudioUnitBase {
 
-    private(set) var wah: AUParameter!
+    let wah = AUParameter(
+        identifier: "wah",
+        name: "Wah Amount",
+        address: AKAutoWahParameter.wah.rawValue,
+        range: AKAutoWah.wahRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var mix: AUParameter!
+    let mix = AUParameter(
+        identifier: "mix",
+        name: "Dry/Wet Mix",
+        address: AKAutoWahParameter.mix.rawValue,
+        range: AKAutoWah.mixRange,
+        unit: .percent,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Overall level",
+        address: AKAutoWahParameter.amplitude.rawValue,
+        range: AKAutoWah.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createAutoWahDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        wah = AUParameter(
-            identifier: "wah",
-            name: "Wah Amount",
-            address: AKAutoWahParameter.wah.rawValue,
-            range: AKAutoWah.wahRange,
-            unit: .generic,
-            flags: .default)
-        mix = AUParameter(
-            identifier: "mix",
-            name: "Dry/Wet Mix",
-            address: AKAutoWahParameter.mix.rawValue,
-            range: AKAutoWah.mixRange,
-            unit: .percent,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Overall level",
-            address: AKAutoWahParameter.amplitude.rawValue,
-            range: AKAutoWah.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [wah, mix, amplitude])
-
-        wah.value = AUValue(AKAutoWah.defaultWah)
-        mix.value = AUValue(AKAutoWah.defaultMix)
-        amplitude.value = AUValue(AKAutoWah.defaultAmplitude)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/DynaRage Tube Compressor/AKDynaRageCompressorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/DynaRage Tube Compressor/AKDynaRageCompressorAudioUnit.swift
@@ -4,17 +4,53 @@ import AVFoundation
 
 public class AKDynaRageCompressorAudioUnit: AKAudioUnitBase {
 
-    private(set) var ratio: AUParameter!
+    let ratio = AUParameter(
+        identifier: "ratio",
+        name: "Ratio to compress with, a value > 1 will compress",
+        address: AKDynaRageCompressorParameter.ratio.rawValue,
+        range: 1.0 ... 20.0,
+        unit: .generic,
+        flags: .default)
     
-    private(set) var threshold: AUParameter!
+    let threshold = AUParameter(
+        identifier: "threshold",
+        name: "Threshold (in dB) 0 = max",
+        address: AKDynaRageCompressorParameter.threshold.rawValue,
+        range: -100.0 ... 0.0,
+        unit: .decibels,
+        flags: .default)
     
-    private(set) var attack: AUParameter!
+    let attack = AUParameter(
+        identifier: "attackDuration",
+        name: "Attack Duration",
+        address: AKDynaRageCompressorParameter.attack.rawValue,
+        range: 0.1 ... 500.0,
+        unit: .seconds,
+        flags: .default)
     
-    private(set) var release: AUParameter!
+    let release = AUParameter(
+        identifier: "releaseDuration",
+        name: "Release Duration",
+        address: AKDynaRageCompressorParameter.release.rawValue,
+        range: 1.0 ... 20.0,
+        unit: .seconds,
+        flags: .default)
     
-    private(set) var rageAmount: AUParameter!
+    let rageAmount = AUParameter(
+        identifier: "rageAmount",
+        name: "Rage Amount",
+        address: AKDynaRageCompressorParameter.rageAmount.rawValue,
+        range: 0.1 ... 20.0,
+        unit: .generic,
+        flags: .default)
     
-    private(set) var rageEnabled: AUParameter!
+    let rageEnabled = AUParameter(
+        identifier: "rageEnabled",
+        name: "Rage Enabled",
+        address: AKDynaRageCompressorParameter.rageEnabled.rawValue,
+        range: 0.0 ... 1.0,
+        unit: .boolean,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createDynaRageCompressorDSP()
@@ -23,62 +59,7 @@ public class AKDynaRageCompressorAudioUnit: AKAudioUnitBase {
     public override init(componentDescription: AudioComponentDescription,
                          options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        ratio = AUParameter(
-            identifier: "ratio",
-            name: "Ratio to compress with, a value > 1 will compress",
-            address: AKDynaRageCompressorParameter.ratio.rawValue,
-            range: 1.0 ... 20.0,
-            unit: .generic,
-            flags: .default)
-        
-        threshold = AUParameter(
-            identifier: "threshold",
-            name: "Threshold (in dB) 0 = max",
-            address: AKDynaRageCompressorParameter.threshold.rawValue,
-            range: -100.0 ... 0.0,
-            unit: .decibels,
-            flags: .default)
-        
-        attack = AUParameter(
-            identifier: "attackDuration",
-            name: "Attack Duration",
-            address: AKDynaRageCompressorParameter.attack.rawValue,
-            range: 0.1 ... 500.0,
-            unit: .seconds,
-            flags: .default)
-        
-        release = AUParameter(
-            identifier: "releaseDuration",
-            name: "Release Duration",
-            address: AKDynaRageCompressorParameter.release.rawValue,
-            range: 1.0 ... 20.0,
-            unit: .seconds,
-            flags: .default)
-        
-        rageAmount = AUParameter(
-            identifier: "rageAmount",
-            name: "Rage Amount",
-            address: AKDynaRageCompressorParameter.rageAmount.rawValue,
-            range: 0.1 ... 20.0,
-            unit: .generic,
-            flags: .default)
-        
-        rageEnabled = AUParameter(
-            identifier: "rageEnabled",
-            name: "Rage Enabled",
-            address: AKDynaRageCompressorParameter.rageEnabled.rawValue,
-            range: 0.0 ... 1.0,
-            unit: .boolean,
-            flags: .default)
         
         parameterTree = AUParameterTree.createTree(withChildren: [ratio, threshold, attack, release, rageAmount, rageEnabled])
-
-        ratio.value = AUValue(1.0)
-        threshold.value = AUValue(0.0)
-        attack.value = AUValue(0.1)
-        release.value = AUValue(0.1)
-        rageAmount.value = AUValue(0.1)
-        rageEnabled.value = AUValue(1.0)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Rhino/AKRhinoGuitarProcessorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Rhino/AKRhinoGuitarProcessorDSP.mm
@@ -5,7 +5,7 @@
 #include "RageProcessor.h"
 #include "Filter.h"
 #include "Equalisator.h"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 #include <math.h>
 #include <iostream>
 
@@ -27,12 +27,12 @@ struct AKRhinoGuitarProcessorDSP::InternalData {
     MikeFilter *mikeFilterL;
     MikeFilter *mikeFilterR;
 
-    AKLinearParameterRamp preGainRamper;
-    AKLinearParameterRamp postGainRamper;
-    AKLinearParameterRamp lowGainRamper;
-    AKLinearParameterRamp midGainRamper;
-    AKLinearParameterRamp highGainRamper;
-    AKLinearParameterRamp distortionRamper;
+    ParameterRamper preGainRamper;
+    ParameterRamper postGainRamper;
+    ParameterRamper lowGainRamper;
+    ParameterRamper midGainRamper;
+    ParameterRamper highGainRamper;
+    ParameterRamper distortionRamper;
 };
 
 AKRhinoGuitarProcessorDSP::AKRhinoGuitarProcessorDSP() : data(new InternalData) {
@@ -88,22 +88,12 @@ void AKRhinoGuitarProcessorDSP::process(AUAudioFrameCount frameCount, AUAudioFra
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
         
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->preGainRamper.advanceTo(now + frameOffset);
-            data->postGainRamper.advanceTo(now + frameOffset);
-            data->lowGainRamper.advanceTo(now + frameOffset);
-            data->midGainRamper.advanceTo(now + frameOffset);
-            data->highGainRamper.advanceTo(now + frameOffset);
-            data->distortionRamper.advanceTo(now + frameOffset);
-        }
-        
-        float preGain = data->preGainRamper.getValue();
-        float postGain = data->postGainRamper.getValue();
-        float lowGain = data->lowGainRamper.getValue();
-        float midGain = data->midGainRamper.getValue();
-        float highGain = data->highGainRamper.getValue();
-        float distortion = data->distortionRamper.getValue();
+        float preGain = data->preGainRamper.getAndStep();
+        float postGain = data->postGainRamper.getAndStep();
+        float lowGain = data->lowGainRamper.getAndStep();
+        float midGain = data->midGainRamper.getAndStep();
+        float highGain = data->highGainRamper.getAndStep();
+        float distortion = data->distortionRamper.getAndStep();
 
         data->leftEqLo->calc_filter_coeffs(7, 120, sampleRate, 0.75, -2 * -lowGain, false);
         data->rightEqLo->calc_filter_coeffs(7, 120, sampleRate, 0.75, -2 * -lowGain, false);

--- a/AudioKit/Common/Nodes/Effects/Modulation/Chorus/AKChorusAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Chorus/AKChorusAudioUnit.swift
@@ -4,56 +4,46 @@ import AVFoundation
 
 public class AKChorusAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (Hz)",
+        address: AKModulatedDelayParameter.frequency.rawValue,
+        range: AKChorus.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var depth: AUParameter!
+    let depth = AUParameter(
+        identifier: "depth",
+        name: "Depth 0-1",
+        address: AKModulatedDelayParameter.depth.rawValue,
+        range: AKChorus.depthRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var feedback: AUParameter!
+    let feedback = AUParameter(
+        identifier: "feedback",
+        name: "Feedback 0-1",
+        address: AKModulatedDelayParameter.feedback.rawValue,
+        range: AKChorus.feedbackRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var dryWetMix: AUParameter!
+    let dryWetMix = AUParameter(
+        identifier: "dryWetMix",
+        name: "Dry Wet Mix 0-1",
+        address: AKModulatedDelayParameter.dryWetMix.rawValue,
+        range: AKChorus.dryWetMixRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createChorusDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (Hz)",
-            address: AKModulatedDelayParameter.frequency.rawValue,
-            range: AKChorus.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        depth = AUParameter(
-            identifier: "depth",
-            name: "Depth 0-1",
-            address: AKModulatedDelayParameter.depth.rawValue,
-            range: AKChorus.depthRange,
-            unit: .generic,
-            flags: .default)
-        feedback = AUParameter(
-            identifier: "feedback",
-            name: "Feedback 0-1",
-            address: AKModulatedDelayParameter.feedback.rawValue,
-            range: AKChorus.feedbackRange,
-            unit: .generic,
-            flags: .default)
-        dryWetMix = AUParameter(
-            identifier: "dryWetMix",
-            name: "Dry Wet Mix 0-1",
-            address: AKModulatedDelayParameter.dryWetMix.rawValue,
-            range: AKChorus.dryWetMixRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [frequency, depth, feedback, dryWetMix])
-
-        frequency.value = AUValue(AKChorus.defaultFrequency)
-        depth.value = AUValue(AKChorus.defaultDepth)
-        feedback.value = AUValue(AKChorus.defaultFeedback)
-        dryWetMix.value = AUValue(AKChorus.defaultDryWetMix)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.hpp
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.hpp
@@ -49,17 +49,18 @@ AKDSPRef createFlangerDSP(void);
 
 #else
 
+#import "AKDSPBase.hpp"
 #import "AKModulatedDelay.hpp"
-#import "AKLinearParameterRamp.hpp"
+#import "ParameterRamper.hpp"
 
 struct AKModulatedDelayDSP : AKDSPBase, AKModulatedDelay
 {
 private:
     // ramped parameters
-    AKLinearParameterRamp frequencyRamp;
-    AKLinearParameterRamp depthRamp;
-    AKLinearParameterRamp feedbackRamp;
-    AKLinearParameterRamp dryWetMixRamp;
+    ParameterRamper frequencyRamp;
+    ParameterRamper depthRamp;
+    ParameterRamper feedbackRamp;
+    ParameterRamper dryWetMixRamp;
 
 public:
     AKModulatedDelayDSP(AKModulatedDelayType type);

--- a/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
@@ -48,7 +48,6 @@ const float kAKFlanger_MaxDryWetMix = kFlangerMaxDryWetMix;
 
 AKModulatedDelayDSP::AKModulatedDelayDSP(AKModulatedDelayType type)
     : AKModulatedDelay(type)
-    , AKDSPBase()
 {
     parameters[AKModulatedDelayParameterFrequency] = &frequencyRamp;
     parameters[AKModulatedDelayParameterDepth] = &depthRamp;
@@ -92,23 +91,22 @@ void AKModulatedDelayDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCoun
 
     // process in chunks of maximum length CHUNKSIZE
     for (int frameIndex = 0; frameIndex < frameCount; frameIndex += CHUNKSIZE) {
-        int frameOffset = int(frameIndex + bufferOffset);
         int chunkSize = frameCount - frameIndex;
         if (chunkSize > CHUNKSIZE) chunkSize = CHUNKSIZE;
 
         // ramp parameters
-        frequencyRamp.advanceTo(now + frameOffset);
-        depthRamp.advanceTo(now + frameOffset);
-        feedbackRamp.advanceTo(now + frameOffset);
-        dryWetMixRamp.advanceTo(now + frameOffset);
+        frequencyRamp.stepBy(chunkSize);
+        depthRamp.stepBy(chunkSize);
+        feedbackRamp.stepBy(chunkSize);
+        dryWetMixRamp.stepBy(chunkSize);
 
         // apply changes
-        setModFrequencyHz(frequencyRamp.getValue());
-        modDepthFraction = depthRamp.getValue();
-        float fb = feedbackRamp.getValue();
+        setModFrequencyHz(frequencyRamp.get());
+        modDepthFraction = depthRamp.get();
+        float fb = feedbackRamp.get();
         setLeftFeedback(fb);
         setRightFeedback(fb);
-        dryWetMix = dryWetMixRamp.getValue();
+        dryWetMix = dryWetMixRamp.get();
 
         // process
         Render(channelCount, chunkSize, inBuffers, outBuffers);

--- a/AudioKit/Common/Nodes/Effects/Modulation/Flanger/AKFlangerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Flanger/AKFlangerAudioUnit.swift
@@ -4,13 +4,37 @@ import AVFoundation
 
 public class AKFlangerAudioUnit: AKAudioUnitBase {
 
-    var frequency: AUParameter!
+    var frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (Hz)",
+        address: AKModulatedDelayParameter.frequency.rawValue,
+        range: AKFlanger.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    var depth: AUParameter!
+    var depth = AUParameter(
+       identifier: "depth",
+       name: "Depth 0-1",
+       address: AKModulatedDelayParameter.depth.rawValue,
+       range: AKFlanger.depthRange,
+       unit: .generic,
+       flags: .default)
 
-    var feedback: AUParameter!
+    var feedback = AUParameter(
+       identifier: "feedback",
+       name: "Feedback 0-1",
+       address: AKModulatedDelayParameter.feedback.rawValue,
+       range: AKFlanger.feedbackRange,
+       unit: .generic,
+       flags: .default)
 
-    var dryWetMix: AUParameter!
+    var dryWetMix = AUParameter(
+       identifier: "dryWetMix",
+       name: "Dry Wet Mix 0-1",
+       address: AKModulatedDelayParameter.dryWetMix.rawValue,
+       range: AKFlanger.dryWetMixRange,
+       unit: .generic,
+       flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createFlangerDSP()
@@ -20,40 +44,6 @@ public class AKFlangerAudioUnit: AKAudioUnitBase {
                          options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
 
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (Hz)",
-            address: AKModulatedDelayParameter.frequency.rawValue,
-            range: AKFlanger.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        depth = AUParameter(
-            identifier: "depth",
-            name: "Depth 0-1",
-            address: AKModulatedDelayParameter.depth.rawValue,
-            range: AKFlanger.depthRange,
-            unit: .generic,
-            flags: .default)
-        feedback = AUParameter(
-            identifier: "feedback",
-            name: "Feedback 0-1",
-            address: AKModulatedDelayParameter.feedback.rawValue,
-            range: AKFlanger.feedbackRange,
-            unit: .generic,
-            flags: .default)
-        dryWetMix = AUParameter(
-            identifier: "dryWetMix",
-            name: "Dry Wet Mix 0-1",
-            address: AKModulatedDelayParameter.dryWetMix.rawValue,
-            range: AKFlanger.dryWetMixRange,
-            unit: .generic,
-            flags: .default)
-
         parameterTree = AUParameterTree.createTree(withChildren: [frequency, depth, feedback, dryWetMix])
-
-        frequency.value = Float(AKFlanger.defaultFrequency)
-        depth.value = Float(AKFlanger.defaultDepth)
-        feedback.value = Float(AKFlanger.defaultFeedback)
-        dryWetMix.value = Float(AKFlanger.defaultDryWetMix)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaser.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaser.swift
@@ -3,153 +3,103 @@
 /// A stereo phaser This is a stereo phaser, generated from Faust code taken
 /// from the Guitarix project.
 ///
-open class AKPhaser: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKPhaserAudioUnit
+open class AKPhaser: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "phas")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKPhaserAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Notch Minimum Frequency
-    public static let notchMinimumFrequencyRange: ClosedRange<Double> = 20 ... 5_000
+    public static let notchMinimumFrequencyRange: ClosedRange<AUValue> = 20 ... 5000
 
     /// Lower and upper bounds for Notch Maximum Frequency
-    public static let notchMaximumFrequencyRange: ClosedRange<Double> = 20 ... 10_000
+    public static let notchMaximumFrequencyRange: ClosedRange<AUValue> = 20 ... 10000
 
     /// Lower and upper bounds for Notch Width
-    public static let notchWidthRange: ClosedRange<Double> = 10 ... 5_000
+    public static let notchWidthRange: ClosedRange<AUValue> = 10 ... 5000
 
     /// Lower and upper bounds for Notch Frequency
-    public static let notchFrequencyRange: ClosedRange<Double> = 1.1 ... 4.0
+    public static let notchFrequencyRange: ClosedRange<AUValue> = 1.1 ... 4.0
 
     /// Lower and upper bounds for Vibrato Mode
-    public static let vibratoModeRange: ClosedRange<Double> = 0 ... 1
+    public static let vibratoModeRange: ClosedRange<AUValue> = 0 ... 1
 
     /// Lower and upper bounds for Depth
-    public static let depthRange: ClosedRange<Double> = 0 ... 1
+    public static let depthRange: ClosedRange<AUValue> = 0 ... 1
 
     /// Lower and upper bounds for Feedback
-    public static let feedbackRange: ClosedRange<Double> = 0 ... 1
+    public static let feedbackRange: ClosedRange<AUValue> = 0 ... 1
 
     /// Lower and upper bounds for Inverted
-    public static let invertedRange: ClosedRange<Double> = 0 ... 1
+    public static let invertedRange: ClosedRange<AUValue> = 0 ... 1
 
     /// Lower and upper bounds for Lfo Bpm
-    public static let lfoBPMRange: ClosedRange<Double> = 24 ... 360
+    public static let lfoBPMRange: ClosedRange<AUValue> = 24 ... 360
 
     /// Initial value for Notch Minimum Frequency
-    public static let defaultNotchMinimumFrequency: Double = 100
+    public static let defaultNotchMinimumFrequency: AUValue = 100
 
     /// Initial value for Notch Maximum Frequency
-    public static let defaultNotchMaximumFrequency: Double = 800
+    public static let defaultNotchMaximumFrequency: AUValue = 800
 
     /// Initial value for Notch Width
-    public static let defaultNotchWidth: Double = 1_000
+    public static let defaultNotchWidth: AUValue = 1000
 
     /// Initial value for Notch Frequency
-    public static let defaultNotchFrequency: Double = 1.5
+    public static let defaultNotchFrequency: AUValue = 1.5
 
     /// Initial value for Vibrato Mode
-    public static let defaultVibratoMode: Double = 1
+    public static let defaultVibratoMode: AUValue = 1
 
     /// Initial value for Depth
-    public static let defaultDepth: Double = 1
+    public static let defaultDepth: AUValue = 1
 
     /// Initial value for Feedback
-    public static let defaultFeedback: Double = 0
+    public static let defaultFeedback: AUValue = 0
 
     /// Initial value for Inverted
-    public static let defaultInverted: Double = 0
+    public static let defaultInverted: AUValue = 0
 
     /// Initial value for Lfo Bpm
-    public static let defaultLfoBPM: Double = 30
+    public static let defaultLfoBPM: AUValue = 30
 
     /// Notch Minimum Frequency
-    @objc open var notchMinimumFrequency: Double = defaultNotchMinimumFrequency {
-        willSet {
-            let clampedValue = AKPhaser.notchMinimumFrequencyRange.clamp(newValue)
-            guard notchMinimumFrequency != clampedValue else { return }
-            internalAU?.notchMinimumFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let notchMinimumFrequency = AKNodeParameter(identifier: "notchMinimumFrequency")
 
     /// Notch Maximum Frequency
-    @objc open var notchMaximumFrequency: Double = defaultNotchMaximumFrequency {
-        willSet {
-            let clampedValue = AKPhaser.notchMaximumFrequencyRange.clamp(newValue)
-            guard notchMaximumFrequency != clampedValue else { return }
-            internalAU?.notchMaximumFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let notchMaximumFrequency = AKNodeParameter(identifier: "notchMaximumFrequency")
 
     /// Between 10 and 5000
-    @objc open var notchWidth: Double = defaultNotchWidth {
-        willSet {
-            let clampedValue = AKPhaser.notchWidthRange.clamp(newValue)
-            guard notchWidth != clampedValue else { return }
-            internalAU?.notchWidth.value = AUValue(clampedValue)
-        }
-    }
+    public let notchWidth = AKNodeParameter(identifier: "notchWidth")
 
     /// Between 1.1 and 4
-    @objc open var notchFrequency: Double = defaultNotchFrequency {
-        willSet {
-            let clampedValue = AKPhaser.notchFrequencyRange.clamp(newValue)
-            guard notchFrequency != clampedValue else { return }
-            internalAU?.notchFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let notchFrequency = AKNodeParameter(identifier: "notchFrequency")
 
     /// Direct or Vibrato (default)
-    @objc open var vibratoMode: Double = defaultVibratoMode {
-        willSet {
-            let clampedValue = AKPhaser.vibratoModeRange.clamp(newValue)
-            guard vibratoMode != clampedValue else { return }
-            internalAU?.vibratoMode.value = AUValue(clampedValue)
-        }
-    }
+    public let vibratoMode = AKNodeParameter(identifier: "vibratoMode")
 
     /// Between 0 and 1
-    @objc open var depth: Double = defaultDepth {
-        willSet {
-            let clampedValue = AKPhaser.depthRange.clamp(newValue)
-            guard depth != clampedValue else { return }
-            internalAU?.depth.value = AUValue(clampedValue)
-        }
-    }
+    public let depth = AKNodeParameter(identifier: "depth")
 
     /// Between 0 and 1
-    @objc open var feedback: Double = defaultFeedback {
-        willSet {
-            let clampedValue = AKPhaser.feedbackRange.clamp(newValue)
-            guard feedback != clampedValue else { return }
-            internalAU?.feedback.value = AUValue(clampedValue)
-        }
-    }
+    public let feedback = AKNodeParameter(identifier: "feedback")
 
     /// 1 or 0
-    @objc open var inverted: Double = defaultInverted {
-        willSet {
-            let clampedValue = AKPhaser.invertedRange.clamp(newValue)
-            guard inverted != clampedValue else { return }
-            internalAU?.inverted.value = AUValue(clampedValue)
-        }
-    }
+    public let inverted = AKNodeParameter(identifier: "inverted")
 
     /// Between 24 and 360
-    @objc open var lfoBPM: Double = defaultLfoBPM {
-        willSet {
-            let clampedValue = AKPhaser.lfoBPMRange.clamp(newValue)
-            guard lfoBPM != clampedValue else { return }
-            internalAU?.lfoBPM.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let lfoBPM = AKNodeParameter(identifier: "lfoBPM")
 
     // MARK: - Initialization
 
@@ -169,46 +119,36 @@ open class AKPhaser: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        notchMinimumFrequency: Double = defaultNotchMinimumFrequency,
-        notchMaximumFrequency: Double = defaultNotchMaximumFrequency,
-        notchWidth: Double = defaultNotchWidth,
-        notchFrequency: Double = defaultNotchFrequency,
-        vibratoMode: Double = defaultVibratoMode,
-        depth: Double = defaultDepth,
-        feedback: Double = defaultFeedback,
-        inverted: Double = defaultInverted,
-        lfoBPM: Double = defaultLfoBPM
+        notchMinimumFrequency: AUValue = defaultNotchMinimumFrequency,
+        notchMaximumFrequency: AUValue = defaultNotchMaximumFrequency,
+        notchWidth: AUValue = defaultNotchWidth,
+        notchFrequency: AUValue = defaultNotchFrequency,
+        vibratoMode: AUValue = defaultVibratoMode,
+        depth: AUValue = defaultDepth,
+        feedback: AUValue = defaultFeedback,
+        inverted: AUValue = defaultInverted,
+        lfoBPM: AUValue = defaultLfoBPM
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.notchMinimumFrequency.associate(with: self.internalAU, value: notchMinimumFrequency)
+            self.notchMaximumFrequency.associate(with: self.internalAU, value: notchMaximumFrequency)
+            self.notchWidth.associate(with: self.internalAU, value: notchWidth)
+            self.notchFrequency.associate(with: self.internalAU, value: notchFrequency)
+            self.vibratoMode.associate(with: self.internalAU, value: vibratoMode)
+            self.depth.associate(with: self.internalAU, value: depth)
+            self.feedback.associate(with: self.internalAU, value: feedback)
+            self.inverted.associate(with: self.internalAU, value: inverted)
+            self.lfoBPM.associate(with: self.internalAU, value: lfoBPM)
+
             input?.connect(to: self)
-
-            self.notchMinimumFrequency = notchMinimumFrequency
-            self.notchMaximumFrequency = notchMaximumFrequency
-            self.notchWidth = notchWidth
-            self.notchFrequency = notchFrequency
-            self.vibratoMode = vibratoMode
-            self.depth = depth
-            self.feedback = feedback
-            self.inverted = inverted
-            self.lfoBPM = lfoBPM
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserAudioUnit.swift
@@ -4,114 +4,86 @@ import AVFoundation
 
 public class AKPhaserAudioUnit: AKAudioUnitBase {
 
-    private(set) var notchMinimumFrequency: AUParameter!
+    let notchMinimumFrequency = AUParameter(
+        identifier: "notchMinimumFrequency",
+        name: "Notch Minimum Frequency",
+        address: AKPhaserParameter.notchMinimumFrequency.rawValue,
+        range: AKPhaser.notchMinimumFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var notchMaximumFrequency: AUParameter!
+    let notchMaximumFrequency = AUParameter(
+        identifier: "notchMaximumFrequency",
+        name: "Notch Maximum Frequency",
+        address: AKPhaserParameter.notchMaximumFrequency.rawValue,
+        range: AKPhaser.notchMaximumFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var notchWidth: AUParameter!
+    let notchWidth = AUParameter(
+        identifier: "notchWidth",
+        name: "Between 10 and 5000",
+        address: AKPhaserParameter.notchWidth.rawValue,
+        range: AKPhaser.notchWidthRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var notchFrequency: AUParameter!
+    let notchFrequency = AUParameter(
+        identifier: "notchFrequency",
+        name: "Between 1.1 and 4",
+        address: AKPhaserParameter.notchFrequency.rawValue,
+        range: AKPhaser.notchFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var vibratoMode: AUParameter!
+    let vibratoMode = AUParameter(
+        identifier: "vibratoMode",
+        name: "Direct or Vibrato (default)",
+        address: AKPhaserParameter.vibratoMode.rawValue,
+        range: AKPhaser.vibratoModeRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var depth: AUParameter!
+    let depth = AUParameter(
+        identifier: "depth",
+        name: "Between 0 and 1",
+        address: AKPhaserParameter.depth.rawValue,
+        range: AKPhaser.depthRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var feedback: AUParameter!
+    let feedback = AUParameter(
+        identifier: "feedback",
+        name: "Between 0 and 1",
+        address: AKPhaserParameter.feedback.rawValue,
+        range: AKPhaser.feedbackRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var inverted: AUParameter!
+    let inverted = AUParameter(
+        identifier: "inverted",
+        name: "1 or 0",
+        address: AKPhaserParameter.inverted.rawValue,
+        range: AKPhaser.invertedRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var lfoBPM: AUParameter!
+    let lfoBPM = AUParameter(
+        identifier: "lfoBPM",
+        name: "Between 24 and 360",
+        address: AKPhaserParameter.lfoBPM.rawValue,
+        range: AKPhaser.lfoBPMRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPhaserDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        notchMinimumFrequency = AUParameter(
-            identifier: "notchMinimumFrequency",
-            name: "Notch Minimum Frequency",
-            address: AKPhaserParameter.notchMinimumFrequency.rawValue,
-            range: AKPhaser.notchMinimumFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        notchMaximumFrequency = AUParameter(
-            identifier: "notchMaximumFrequency",
-            name: "Notch Maximum Frequency",
-            address: AKPhaserParameter.notchMaximumFrequency.rawValue,
-            range: AKPhaser.notchMaximumFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        notchWidth = AUParameter(
-            identifier: "notchWidth",
-            name: "Between 10 and 5000",
-            address: AKPhaserParameter.notchWidth.rawValue,
-            range: AKPhaser.notchWidthRange,
-            unit: .hertz,
-            flags: .default)
-        notchFrequency = AUParameter(
-            identifier: "notchFrequency",
-            name: "Between 1.1 and 4",
-            address: AKPhaserParameter.notchFrequency.rawValue,
-            range: AKPhaser.notchFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        vibratoMode = AUParameter(
-            identifier: "vibratoMode",
-            name: "Direct or Vibrato (default)",
-            address: AKPhaserParameter.vibratoMode.rawValue,
-            range: AKPhaser.vibratoModeRange,
-            unit: .generic,
-            flags: .default)
-        depth = AUParameter(
-            identifier: "depth",
-            name: "Between 0 and 1",
-            address: AKPhaserParameter.depth.rawValue,
-            range: AKPhaser.depthRange,
-            unit: .generic,
-            flags: .default)
-        feedback = AUParameter(
-            identifier: "feedback",
-            name: "Between 0 and 1",
-            address: AKPhaserParameter.feedback.rawValue,
-            range: AKPhaser.feedbackRange,
-            unit: .generic,
-            flags: .default)
-        inverted = AUParameter(
-            identifier: "inverted",
-            name: "1 or 0",
-            address: AKPhaserParameter.inverted.rawValue,
-            range: AKPhaser.invertedRange,
-            unit: .generic,
-            flags: .default)
-        lfoBPM = AUParameter(
-            identifier: "lfoBPM",
-            name: "Between 24 and 360",
-            address: AKPhaserParameter.lfoBPM.rawValue,
-            range: AKPhaser.lfoBPMRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [notchMinimumFrequency,
-                                                                  notchMaximumFrequency,
-                                                                  notchWidth,
-                                                                  notchFrequency,
-                                                                  vibratoMode,
-                                                                  depth,
-                                                                  feedback,
-                                                                  inverted,
-                                                                  lfoBPM])
-
-        notchMinimumFrequency.value = AUValue(AKPhaser.defaultNotchMinimumFrequency)
-        notchMaximumFrequency.value = AUValue(AKPhaser.defaultNotchMaximumFrequency)
-        notchWidth.value = AUValue(AKPhaser.defaultNotchWidth)
-        notchFrequency.value = AUValue(AKPhaser.defaultNotchFrequency)
-        vibratoMode.value = AUValue(AKPhaser.defaultVibratoMode)
-        depth.value = AUValue(AKPhaser.defaultDepth)
-        feedback.value = AUValue(AKPhaser.defaultFeedback)
-        inverted.value = AUValue(AKPhaser.defaultInverted)
-        lfoBPM.value = AUValue(AKPhaser.defaultLfoBPM)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [notchMinimumFrequency, notchMaximumFrequency, notchWidth, notchFrequency, vibratoMode, depth, feedback, inverted, lfoBPM])
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKPhaserDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createPhaserDSP() {
     return new AKPhaserDSP();
@@ -9,15 +9,15 @@ extern "C" AKDSPRef createPhaserDSP() {
 
 struct AKPhaserDSP::InternalData {
     sp_phaser *phaser;
-    AKLinearParameterRamp notchMinimumFrequencyRamp;
-    AKLinearParameterRamp notchMaximumFrequencyRamp;
-    AKLinearParameterRamp notchWidthRamp;
-    AKLinearParameterRamp notchFrequencyRamp;
-    AKLinearParameterRamp vibratoModeRamp;
-    AKLinearParameterRamp depthRamp;
-    AKLinearParameterRamp feedbackRamp;
-    AKLinearParameterRamp invertedRamp;
-    AKLinearParameterRamp lfoBPMRamp;
+    ParameterRamper notchMinimumFrequencyRamp;
+    ParameterRamper notchMaximumFrequencyRamp;
+    ParameterRamper notchWidthRamp;
+    ParameterRamper notchFrequencyRamp;
+    ParameterRamper vibratoModeRamp;
+    ParameterRamper depthRamp;
+    ParameterRamper feedbackRamp;
+    ParameterRamper invertedRamp;
+    ParameterRamper lfoBPMRamp;
 };
 
 AKPhaserDSP::AKPhaserDSP() : data(new InternalData) {
@@ -54,28 +54,15 @@ void AKPhaserDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->notchMinimumFrequencyRamp.advanceTo(now + frameOffset);
-            data->notchMaximumFrequencyRamp.advanceTo(now + frameOffset);
-            data->notchWidthRamp.advanceTo(now + frameOffset);
-            data->notchFrequencyRamp.advanceTo(now + frameOffset);
-            data->vibratoModeRamp.advanceTo(now + frameOffset);
-            data->depthRamp.advanceTo(now + frameOffset);
-            data->feedbackRamp.advanceTo(now + frameOffset);
-            data->invertedRamp.advanceTo(now + frameOffset);
-            data->lfoBPMRamp.advanceTo(now + frameOffset);
-        }
-
-        *data->phaser->MinNotch1Freq = data->notchMinimumFrequencyRamp.getValue();
-        *data->phaser->MaxNotch1Freq = data->notchMaximumFrequencyRamp.getValue();
-        *data->phaser->Notch_width = data->notchWidthRamp.getValue();
-        *data->phaser->NotchFreq = data->notchFrequencyRamp.getValue();
-        *data->phaser->VibratoMode = data->vibratoModeRamp.getValue();
-        *data->phaser->depth = data->depthRamp.getValue();
-        *data->phaser->feedback_gain = data->feedbackRamp.getValue();
-        *data->phaser->invert = data->invertedRamp.getValue();
-        *data->phaser->lfobpm = data->lfoBPMRamp.getValue();
+        *data->phaser->MinNotch1Freq = data->notchMinimumFrequencyRamp.getAndStep();
+        *data->phaser->MaxNotch1Freq = data->notchMaximumFrequencyRamp.getAndStep();
+        *data->phaser->Notch_width = data->notchWidthRamp.getAndStep();
+        *data->phaser->NotchFreq = data->notchFrequencyRamp.getAndStep();
+        *data->phaser->VibratoMode = data->vibratoModeRamp.getAndStep();
+        *data->phaser->depth = data->depthRamp.getAndStep();
+        *data->phaser->feedback_gain = data->feedbackRamp.getAndStep();
+        *data->phaser->invert = data->invertedRamp.getAndStep();
+        *data->phaser->lfobpm = data->lfoBPMRamp.getAndStep();
 
         float *tmpin[2];
         float *tmpout[2];

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKPitchShifterAudioUnit: AKAudioUnitBase {
 
-    private(set) var shift: AUParameter!
+    let shift = AUParameter(
+        identifier: "shift",
+        name: "Pitch shift (in semitones)",
+        address: AKPitchShifterParameter.shift.rawValue,
+        range: AKPitchShifter.shiftRange,
+        unit: .relativeSemiTones,
+        flags: .default)
 
-    private(set) var windowSize: AUParameter!
+    let windowSize = AUParameter(
+        identifier: "windowSize",
+        name: "Window size (in samples)",
+        address: AKPitchShifterParameter.windowSize.rawValue,
+        range: AKPitchShifter.windowSizeRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var crossfade: AUParameter!
+    let crossfade = AUParameter(
+        identifier: "crossfade",
+        name: "Crossfade (in samples)",
+        address: AKPitchShifterParameter.crossfade.rawValue,
+        range: AKPitchShifter.crossfadeRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPitchShifterDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        shift = AUParameter(
-            identifier: "shift",
-            name: "Pitch shift (in semitones)",
-            address: AKPitchShifterParameter.shift.rawValue,
-            range: AKPitchShifter.shiftRange,
-            unit: .relativeSemiTones,
-            flags: .default)
-        windowSize = AUParameter(
-            identifier: "windowSize",
-            name: "Window size (in samples)",
-            address: AKPitchShifterParameter.windowSize.rawValue,
-            range: AKPitchShifter.windowSizeRange,
-            unit: .hertz,
-            flags: .default)
-        crossfade = AUParameter(
-            identifier: "crossfade",
-            name: "Crossfade (in samples)",
-            address: AKPitchShifterParameter.crossfade.rawValue,
-            range: AKPitchShifter.crossfadeRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [shift, windowSize, crossfade])
-
-        shift.value = AUValue(AKPitchShifter.defaultShift)
-        windowSize.value = AUValue(AKPitchShifter.defaultWindowSize)
-        crossfade.value = AUValue(AKPitchShifter.defaultCrossfade)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverb.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverb.swift
@@ -9,18 +9,18 @@
 /// decorrelation delay lines in parallel at the output.
 ///
 open class AKChowningReverb: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKChowningReverbAudioUnit
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "jcrv")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKChowningReverbAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
-
+    
+    // MARK: - Parameters
+    
     // MARK: - Initialization
 
     /// Initialize this reverb node
@@ -32,26 +32,14 @@ open class AKChowningReverb: AKNode, AKToggleable, AKComponent, AKInput {
         _ input: AKNode? = nil
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+
             input?.connect(to: self)
-
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbAudioUnit.swift
@@ -9,10 +9,9 @@ public class AKChowningReverbAudioUnit: AKAudioUnitBase {
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [])
-
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKCombFilterReverbAudioUnit: AKAudioUnitBase {
 
-    private(set) var reverbDuration: AUParameter!
+    let reverbDuration = AUParameter(
+        identifier: "reverbDuration",
+        name: "Reverb Duration (Seconds)",
+        address: AKCombFilterReverbParameter.reverbDuration.rawValue,
+        range: AKCombFilterReverb.reverbDurationRange,
+        unit: .seconds,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createCombFilterReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        reverbDuration = AUParameter(
-            identifier: "reverbDuration",
-            name: "Reverb Duration (Seconds)",
-            address: AKCombFilterReverbParameter.reverbDuration.rawValue,
-            range: AKCombFilterReverb.reverbDurationRange,
-            unit: .seconds,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [reverbDuration])
-
-        reverbDuration.value = AUValue(AKCombFilterReverb.defaultReverbDuration)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionAudioUnit.swift
@@ -13,10 +13,9 @@ public class AKConvolutionAudioUnit: AKAudioUnitBase {
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [])
-
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKCostelloReverbAudioUnit: AKAudioUnitBase {
 
-    private(set) var feedback: AUParameter!
+    let feedback = AUParameter(
+        identifier: "feedback",
+        name: "Feedback",
+        address: AKCostelloReverbParameter.feedback.rawValue,
+        range: AKCostelloReverb.feedbackRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var cutoffFrequency: AUParameter!
+    let cutoffFrequency = AUParameter(
+        identifier: "cutoffFrequency",
+        name: "Cutoff Frequency",
+        address: AKCostelloReverbParameter.cutoffFrequency.rawValue,
+        range: AKCostelloReverb.cutoffFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createCostelloReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        feedback = AUParameter(
-            identifier: "feedback",
-            name: "Feedback",
-            address: AKCostelloReverbParameter.feedback.rawValue,
-            range: AKCostelloReverb.feedbackRange,
-            unit: .generic,
-            flags: .default)
-        cutoffFrequency = AUParameter(
-            identifier: "cutoffFrequency",
-            name: "Cutoff Frequency",
-            address: AKCostelloReverbParameter.cutoffFrequency.rawValue,
-            range: AKCostelloReverb.cutoffFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [feedback, cutoffFrequency])
-
-        feedback.value = AUValue(AKCostelloReverb.defaultFeedback)
-        cutoffFrequency.value = AUValue(AKCostelloReverb.defaultCutoffFrequency)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbPresets.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbPresets.swift
@@ -5,21 +5,21 @@ public extension AKCostelloReverb {
 
     /// Short Tail Reverb
     func presetShortTailCostelloReverb() {
-        cutoffFrequency = 3_849.614
-        feedback = 0.172
+        cutoffFrequency.value = 3_849.614
+        feedback.value = 0.172
     }
 
     /// Low Ringing Long Tail Reverb
     func presetLowRingingLongTailCostelloReverb() {
-        cutoffFrequency = 860.435
-        feedback = 0.990
+        cutoffFrequency.value = 860.435
+        feedback.value = 0.990
     }
 
     /// Print out current values in case you want to save it as a preset
     func printCurrentValuesAsPreset() {
         AKLog("public func presetSomeNewReverb() {")
-        AKLog("    cutoffFrequency = \(String(format: "%0.3f", cutoffFrequency))")
-        AKLog("    feedback = \(String(format: "%0.3f", feedback))")
+        AKLog("    cutoffFrequency = \(String(format: "%0.3f", cutoffFrequency.value))")
+        AKLog("    feedback = \(String(format: "%0.3f", feedback.value))")
         AKLog("}\n")
     }
 

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverb.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverb.swift
@@ -6,36 +6,34 @@
 /// 1/1000, or 60dB down from its original amplitude).  Output will begin to
 /// appear immediately.
 ///
-open class AKFlatFrequencyResponseReverb: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKFlatFrequencyResponseReverbAudioUnit
+open class AKFlatFrequencyResponseReverb: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "alps")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKFlatFrequencyResponseReverbAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Reverb Duration
-    public static let reverbDurationRange: ClosedRange<Double> = 0 ... 10
+    public static let reverbDurationRange: ClosedRange<AUValue> = 0 ... 10
 
     /// Initial value for Reverb Duration
-    public static let defaultReverbDuration: Double = 0.5
+    public static let defaultReverbDuration: AUValue = 0.5
 
     /// Initial value for Loop Duration
-    public static let defaultLoopDuration: Double = 0.1
+    public static let defaultLoopDuration: AUValue = 0.1
 
     /// The duration in seconds for a signal to decay to 1/1000, or 60dB down from its original amplitude.
-    @objc open var reverbDuration: Double = defaultReverbDuration {
-        willSet {
-            let clampedValue = AKFlatFrequencyResponseReverb.reverbDurationRange.clamp(newValue)
-            guard reverbDuration != clampedValue else { return }
-            internalAU?.reverbDuration.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let reverbDuration = AKNodeParameter(identifier: "reverbDuration")
 
     // MARK: - Initialization
 
@@ -48,32 +46,21 @@ open class AKFlatFrequencyResponseReverb: AKNode, AKToggleable, AKComponent, AKI
     ///
     public init(
         _ input: AKNode? = nil,
-        reverbDuration: Double = defaultReverbDuration,
-        loopDuration: Double = defaultLoopDuration
+        reverbDuration: AUValue = defaultReverbDuration,
+        loopDuration: AUValue = defaultLoopDuration
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.reverbDuration.associate(with: self.internalAU, value: reverbDuration)
+
             input?.connect(to: self)
-
-            self.reverbDuration = reverbDuration
-            self.internalAU?.setLoopDuration(Float(loopDuration))
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbAudioUnit.swift
@@ -4,30 +4,22 @@ import AVFoundation
 
 public class AKFlatFrequencyResponseReverbAudioUnit: AKAudioUnitBase {
 
-    private(set) var reverbDuration: AUParameter!
+    let reverbDuration = AUParameter(
+        identifier: "reverbDuration",
+        name: "Reverb Duration (Seconds)",
+        address: AKFlatFrequencyResponseReverbParameter.reverbDuration.rawValue,
+        range: AKFlatFrequencyResponseReverb.reverbDurationRange,
+        unit: .seconds,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createFlatFrequencyResponseReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        reverbDuration = AUParameter(
-            identifier: "reverbDuration",
-            name: "Reverb Duration (Seconds)",
-            address: AKFlatFrequencyResponseReverbParameter.reverbDuration.rawValue,
-            range: AKFlatFrequencyResponseReverb.reverbDurationRange,
-            unit: .seconds,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [reverbDuration])
-
-        reverbDuration.value = AUValue(AKFlatFrequencyResponseReverb.defaultReverbDuration)
-    }
-
-    public func setLoopDuration(_ loopDuration: Float) {
-        setLoopDurationFlatFrequencyResponseReverbDSP(dsp, loopDuration)
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverb.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverb.swift
@@ -2,168 +2,112 @@
 
 /// 8 FDN stereo zitareverb algorithm, imported from Faust.
 ///
-open class AKZitaReverb: AKNode, AKToggleable, AKComponent, AKInput {
-    public typealias AKAudioUnitType = AKZitaReverbAudioUnit
+open class AKZitaReverb: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "zita")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKZitaReverbAudioUnit
+    
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Predelay
-    public static let predelayRange: ClosedRange<Double> = 0.0 ... 200.0
+    public static let predelayRange: ClosedRange<AUValue> = 0.0 ... 200.0
 
     /// Lower and upper bounds for Crossover Frequency
-    public static let crossoverFrequencyRange: ClosedRange<Double> = 10.0 ... 1_000.0
+    public static let crossoverFrequencyRange: ClosedRange<AUValue> = 10.0 ... 1000.0
 
     /// Lower and upper bounds for Low Release Time
-    public static let lowReleaseTimeRange: ClosedRange<Double> = 0.0 ... 10.0
+    public static let lowReleaseTimeRange: ClosedRange<AUValue> = 0.0 ... 10.0
 
     /// Lower and upper bounds for Mid Release Time
-    public static let midReleaseTimeRange: ClosedRange<Double> = 0.0 ... 10.0
+    public static let midReleaseTimeRange: ClosedRange<AUValue> = 0.0 ... 10.0
 
     /// Lower and upper bounds for Damping Frequency
-    public static let dampingFrequencyRange: ClosedRange<Double> = 10.0 ... 22_050.0
+    public static let dampingFrequencyRange: ClosedRange<AUValue> = 10.0 ... 22050.0
 
     /// Lower and upper bounds for Equalizer Frequency1
-    public static let equalizerFrequency1Range: ClosedRange<Double> = 10.0 ... 1_000.0
+    public static let equalizerFrequency1Range: ClosedRange<AUValue> = 10.0 ... 1000.0
 
     /// Lower and upper bounds for Equalizer Level1
-    public static let equalizerLevel1Range: ClosedRange<Double> = -100.0 ... 10.0
+    public static let equalizerLevel1Range: ClosedRange<AUValue> = -100.0 ... 10.0
 
     /// Lower and upper bounds for Equalizer Frequency2
-    public static let equalizerFrequency2Range: ClosedRange<Double> = 10.0 ... 22_050.0
+    public static let equalizerFrequency2Range: ClosedRange<AUValue> = 10.0 ... 22050.0
 
     /// Lower and upper bounds for Equalizer Level2
-    public static let equalizerLevel2Range: ClosedRange<Double> = -100.0 ... 10.0
+    public static let equalizerLevel2Range: ClosedRange<AUValue> = -100.0 ... 10.0
 
     /// Lower and upper bounds for Dry Wet Mix
-    public static let dryWetMixRange: ClosedRange<Double> = 0.0 ... 1.0
+    public static let dryWetMixRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
     /// Initial value for Predelay
-    public static let defaultPredelay: Double = 60.0
+    public static let defaultPredelay: AUValue = 60.0
 
     /// Initial value for Crossover Frequency
-    public static let defaultCrossoverFrequency: Double = 200.0
+    public static let defaultCrossoverFrequency: AUValue = 200.0
 
     /// Initial value for Low Release Time
-    public static let defaultLowReleaseTime: Double = 3.0
+    public static let defaultLowReleaseTime: AUValue = 3.0
 
     /// Initial value for Mid Release Time
-    public static let defaultMidReleaseTime: Double = 2.0
+    public static let defaultMidReleaseTime: AUValue = 2.0
 
     /// Initial value for Damping Frequency
-    public static let defaultDampingFrequency: Double = 6_000.0
+    public static let defaultDampingFrequency: AUValue = 6000.0
 
     /// Initial value for Equalizer Frequency1
-    public static let defaultEqualizerFrequency1: Double = 315.0
+    public static let defaultEqualizerFrequency1: AUValue = 315.0
 
     /// Initial value for Equalizer Level1
-    public static let defaultEqualizerLevel1: Double = 0.0
+    public static let defaultEqualizerLevel1: AUValue = 0.0
 
     /// Initial value for Equalizer Frequency2
-    public static let defaultEqualizerFrequency2: Double = 1_500.0
+    public static let defaultEqualizerFrequency2: AUValue = 1500.0
 
     /// Initial value for Equalizer Level2
-    public static let defaultEqualizerLevel2: Double = 0.0
+    public static let defaultEqualizerLevel2: AUValue = 0.0
 
     /// Initial value for Dry Wet Mix
-    public static let defaultDryWetMix: Double = 1.0
+    public static let defaultDryWetMix: AUValue = 1.0
 
     /// Delay in ms before reverberation begins.
-    @objc open var predelay: Double = defaultPredelay {
-        willSet {
-            let clampedValue = AKZitaReverb.predelayRange.clamp(newValue)
-            guard predelay != clampedValue else { return }
-            internalAU?.predelay.value = AUValue(clampedValue)
-        }
-    }
+    public let predelay = AKNodeParameter(identifier: "predelay")
 
     /// Crossover frequency separating low and middle frequencies (Hz).
-    @objc open var crossoverFrequency: Double = defaultCrossoverFrequency {
-        willSet {
-            let clampedValue = AKZitaReverb.crossoverFrequencyRange.clamp(newValue)
-            guard crossoverFrequency != clampedValue else { return }
-            internalAU?.crossoverFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let crossoverFrequency = AKNodeParameter(identifier: "crossoverFrequency")
 
     /// Time (in seconds) to decay 60db in low-frequency band.
-    @objc open var lowReleaseTime: Double = defaultLowReleaseTime {
-        willSet {
-            let clampedValue = AKZitaReverb.lowReleaseTimeRange.clamp(newValue)
-            guard lowReleaseTime != clampedValue else { return }
-            internalAU?.lowReleaseTime.value = AUValue(clampedValue)
-        }
-    }
+    public let lowReleaseTime = AKNodeParameter(identifier: "lowReleaseTime")
 
     /// Time (in seconds) to decay 60db in mid-frequency band.
-    @objc open var midReleaseTime: Double = defaultMidReleaseTime {
-        willSet {
-            let clampedValue = AKZitaReverb.midReleaseTimeRange.clamp(newValue)
-            guard midReleaseTime != clampedValue else { return }
-            internalAU?.midReleaseTime.value = AUValue(clampedValue)
-        }
-    }
+    public let midReleaseTime = AKNodeParameter(identifier: "midReleaseTime")
 
     /// Frequency (Hz) at which the high-frequency T60 is half the middle-band's T60.
-    @objc open var dampingFrequency: Double = defaultDampingFrequency {
-        willSet {
-            let clampedValue = AKZitaReverb.dampingFrequencyRange.clamp(newValue)
-            guard dampingFrequency != clampedValue else { return }
-            internalAU?.dampingFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let dampingFrequency = AKNodeParameter(identifier: "dampingFrequency")
 
     /// Center frequency of second-order Regalia Mitra peaking equalizer section 1.
-    @objc open var equalizerFrequency1: Double = defaultEqualizerFrequency1 {
-        willSet {
-            let clampedValue = AKZitaReverb.equalizerFrequency1Range.clamp(newValue)
-            guard equalizerFrequency1 != clampedValue else { return }
-            internalAU?.equalizerFrequency1.value = AUValue(clampedValue)
-        }
-    }
+    public let equalizerFrequency1 = AKNodeParameter(identifier: "equalizerFrequency1")
 
     /// Peak level in dB of second-order Regalia-Mitra peaking equalizer section 1
-    @objc open var equalizerLevel1: Double = defaultEqualizerLevel1 {
-        willSet {
-            let clampedValue = AKZitaReverb.equalizerLevel1Range.clamp(newValue)
-            guard equalizerLevel1 != clampedValue else { return }
-            internalAU?.equalizerLevel1.value = AUValue(clampedValue)
-        }
-    }
+    public let equalizerLevel1 = AKNodeParameter(identifier: "equalizerLevel1")
 
     /// Center frequency of second-order Regalia Mitra peaking equalizer section 2.
-    @objc open var equalizerFrequency2: Double = defaultEqualizerFrequency2 {
-        willSet {
-            let clampedValue = AKZitaReverb.equalizerFrequency2Range.clamp(newValue)
-            guard equalizerFrequency2 != clampedValue else { return }
-            internalAU?.equalizerFrequency2.value = AUValue(clampedValue)
-        }
-    }
+    public let equalizerFrequency2 = AKNodeParameter(identifier: "equalizerFrequency2")
 
     /// Peak level in dB of second-order Regalia-Mitra peaking equalizer section 2
-    @objc open var equalizerLevel2: Double = defaultEqualizerLevel2 {
-        willSet {
-            let clampedValue = AKZitaReverb.equalizerLevel2Range.clamp(newValue)
-            guard equalizerLevel2 != clampedValue else { return }
-            internalAU?.equalizerLevel2.value = AUValue(clampedValue)
-        }
-    }
+    public let equalizerLevel2 = AKNodeParameter(identifier: "equalizerLevel2")
 
     /// 0 = all dry, 1 = all wet
-    @objc open var dryWetMix: Double = defaultDryWetMix {
-        willSet {
-            let clampedValue = AKZitaReverb.dryWetMixRange.clamp(newValue)
-            guard dryWetMix != clampedValue else { return }
-            internalAU?.dryWetMix.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let dryWetMix = AKNodeParameter(identifier: "dryWetMix")
 
     // MARK: - Initialization
 
@@ -184,48 +128,38 @@ open class AKZitaReverb: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        predelay: Double = defaultPredelay,
-        crossoverFrequency: Double = defaultCrossoverFrequency,
-        lowReleaseTime: Double = defaultLowReleaseTime,
-        midReleaseTime: Double = defaultMidReleaseTime,
-        dampingFrequency: Double = defaultDampingFrequency,
-        equalizerFrequency1: Double = defaultEqualizerFrequency1,
-        equalizerLevel1: Double = defaultEqualizerLevel1,
-        equalizerFrequency2: Double = defaultEqualizerFrequency2,
-        equalizerLevel2: Double = defaultEqualizerLevel2,
-        dryWetMix: Double = defaultDryWetMix
+        predelay: AUValue = defaultPredelay,
+        crossoverFrequency: AUValue = defaultCrossoverFrequency,
+        lowReleaseTime: AUValue = defaultLowReleaseTime,
+        midReleaseTime: AUValue = defaultMidReleaseTime,
+        dampingFrequency: AUValue = defaultDampingFrequency,
+        equalizerFrequency1: AUValue = defaultEqualizerFrequency1,
+        equalizerLevel1: AUValue = defaultEqualizerLevel1,
+        equalizerFrequency2: AUValue = defaultEqualizerFrequency2,
+        equalizerLevel2: AUValue = defaultEqualizerLevel2,
+        dryWetMix: AUValue = defaultDryWetMix
         ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.predelay.associate(with: self.internalAU, value: predelay)
+            self.crossoverFrequency.associate(with: self.internalAU, value: crossoverFrequency)
+            self.lowReleaseTime.associate(with: self.internalAU, value: lowReleaseTime)
+            self.midReleaseTime.associate(with: self.internalAU, value: midReleaseTime)
+            self.dampingFrequency.associate(with: self.internalAU, value: dampingFrequency)
+            self.equalizerFrequency1.associate(with: self.internalAU, value: equalizerFrequency1)
+            self.equalizerLevel1.associate(with: self.internalAU, value: equalizerLevel1)
+            self.equalizerFrequency2.associate(with: self.internalAU, value: equalizerFrequency2)
+            self.equalizerLevel2.associate(with: self.internalAU, value: equalizerLevel2)
+            self.dryWetMix.associate(with: self.internalAU, value: dryWetMix)
+
             input?.connect(to: self)
-
-            self.predelay = predelay
-            self.crossoverFrequency = crossoverFrequency
-            self.lowReleaseTime = lowReleaseTime
-            self.midReleaseTime = midReleaseTime
-            self.dampingFrequency = dampingFrequency
-            self.equalizerFrequency1 = equalizerFrequency1
-            self.equalizerLevel1 = equalizerLevel1
-            self.equalizerFrequency2 = equalizerFrequency2
-            self.equalizerLevel2 = equalizerLevel2
-            self.dryWetMix = dryWetMix
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbAudioUnit.swift
@@ -4,125 +4,94 @@ import AVFoundation
 
 public class AKZitaReverbAudioUnit: AKAudioUnitBase {
 
-    private(set) var predelay: AUParameter!
+    let predelay = AUParameter(
+        identifier: "predelay",
+        name: "Delay in ms before reverberation begins.",
+        address: AKZitaReverbParameter.predelay.rawValue,
+        range: AKZitaReverb.predelayRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var crossoverFrequency: AUParameter!
+    let crossoverFrequency = AUParameter(
+        identifier: "crossoverFrequency",
+        name: "Crossover frequency separating low and middle frequencies (Hz).",
+        address: AKZitaReverbParameter.crossoverFrequency.rawValue,
+        range: AKZitaReverb.crossoverFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var lowReleaseTime: AUParameter!
+    let lowReleaseTime = AUParameter(
+        identifier: "lowReleaseTime",
+        name: "Time (in seconds) to decay 60db in low-frequency band.",
+        address: AKZitaReverbParameter.lowReleaseTime.rawValue,
+        range: AKZitaReverb.lowReleaseTimeRange,
+        unit: .seconds,
+        flags: .default)
 
-    private(set) var midReleaseTime: AUParameter!
+    let midReleaseTime = AUParameter(
+        identifier: "midReleaseTime",
+        name: "Time (in seconds) to decay 60db in mid-frequency band.",
+        address: AKZitaReverbParameter.midReleaseTime.rawValue,
+        range: AKZitaReverb.midReleaseTimeRange,
+        unit: .seconds,
+        flags: .default)
 
-    private(set) var dampingFrequency: AUParameter!
+    let dampingFrequency = AUParameter(
+        identifier: "dampingFrequency",
+        name: "Frequency (Hz) at which the high-frequency T60 is half the middle-band's T60.",
+        address: AKZitaReverbParameter.dampingFrequency.rawValue,
+        range: AKZitaReverb.dampingFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var equalizerFrequency1: AUParameter!
+    let equalizerFrequency1 = AUParameter(
+        identifier: "equalizerFrequency1",
+        name: "Center frequency of second-order Regalia Mitra peaking equalizer section 1.",
+        address: AKZitaReverbParameter.equalizerFrequency1.rawValue,
+        range: AKZitaReverb.equalizerFrequency1Range,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var equalizerLevel1: AUParameter!
+    let equalizerLevel1 = AUParameter(
+        identifier: "equalizerLevel1",
+        name: "Peak level in dB of second-order Regalia-Mitra peaking equalizer section 1",
+        address: AKZitaReverbParameter.equalizerLevel1.rawValue,
+        range: AKZitaReverb.equalizerLevel1Range,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var equalizerFrequency2: AUParameter!
+    let equalizerFrequency2 = AUParameter(
+        identifier: "equalizerFrequency2",
+        name: "Center frequency of second-order Regalia Mitra peaking equalizer section 2.",
+        address: AKZitaReverbParameter.equalizerFrequency2.rawValue,
+        range: AKZitaReverb.equalizerFrequency2Range,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var equalizerLevel2: AUParameter!
+    let equalizerLevel2 = AUParameter(
+        identifier: "equalizerLevel2",
+        name: "Peak level in dB of second-order Regalia-Mitra peaking equalizer section 2",
+        address: AKZitaReverbParameter.equalizerLevel2.rawValue,
+        range: AKZitaReverb.equalizerLevel2Range,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var dryWetMix: AUParameter!
+    let dryWetMix = AUParameter(
+        identifier: "dryWetMix",
+        name: "0 = all dry, 1 = all wet",
+        address: AKZitaReverbParameter.dryWetMix.rawValue,
+        range: AKZitaReverb.dryWetMixRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createZitaReverbDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        predelay = AUParameter(
-            identifier: "predelay",
-            name: "Delay in ms before reverberation begins.",
-            address: AKZitaReverbParameter.predelay.rawValue,
-            range: AKZitaReverb.predelayRange,
-            unit: .generic,
-            flags: .default)
-        crossoverFrequency = AUParameter(
-            identifier: "crossoverFrequency",
-            name: "Crossover frequency separating low and middle frequencies (Hz).",
-            address: AKZitaReverbParameter.crossoverFrequency.rawValue,
-            range: AKZitaReverb.crossoverFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        lowReleaseTime = AUParameter(
-            identifier: "lowReleaseTime",
-            name: "Time (in seconds) to decay 60db in low-frequency band.",
-            address: AKZitaReverbParameter.lowReleaseTime.rawValue,
-            range: AKZitaReverb.lowReleaseTimeRange,
-            unit: .seconds,
-            flags: .default)
-        midReleaseTime = AUParameter(
-            identifier: "midReleaseTime",
-            name: "Time (in seconds) to decay 60db in mid-frequency band.",
-            address: AKZitaReverbParameter.midReleaseTime.rawValue,
-            range: AKZitaReverb.midReleaseTimeRange,
-            unit: .seconds,
-            flags: .default)
-        dampingFrequency = AUParameter(
-            identifier: "dampingFrequency",
-            name: "Frequency (Hz) at which the high-frequency T60 is half the middle-band's T60.",
-            address: AKZitaReverbParameter.dampingFrequency.rawValue,
-            range: AKZitaReverb.dampingFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        equalizerFrequency1 = AUParameter(
-            identifier: "equalizerFrequency1",
-            name: "Center frequency of second-order Regalia Mitra peaking equalizer section 1.",
-            address: AKZitaReverbParameter.equalizerFrequency1.rawValue,
-            range: AKZitaReverb.equalizerFrequency1Range,
-            unit: .hertz,
-            flags: .default)
-        equalizerLevel1 = AUParameter(
-            identifier: "equalizerLevel1",
-            name: "Peak level in dB of second-order Regalia-Mitra peaking equalizer section 1",
-            address: AKZitaReverbParameter.equalizerLevel1.rawValue,
-            range: AKZitaReverb.equalizerLevel1Range,
-            unit: .generic,
-            flags: .default)
-        equalizerFrequency2 = AUParameter(
-            identifier: "equalizerFrequency2",
-            name: "Center frequency of second-order Regalia Mitra peaking equalizer section 2.",
-            address: AKZitaReverbParameter.equalizerFrequency2.rawValue,
-            range: AKZitaReverb.equalizerFrequency2Range,
-            unit: .hertz,
-            flags: .default)
-        equalizerLevel2 = AUParameter(
-            identifier: "equalizerLevel2",
-            name: "Peak level in dB of second-order Regalia-Mitra peaking equalizer section 2",
-            address: AKZitaReverbParameter.equalizerLevel2.rawValue,
-            range: AKZitaReverb.equalizerLevel2Range,
-            unit: .generic,
-            flags: .default)
-        dryWetMix = AUParameter(
-            identifier: "dryWetMix",
-            name: "0 = all dry, 1 = all wet",
-            address: AKZitaReverbParameter.dryWetMix.rawValue,
-            range: AKZitaReverb.dryWetMixRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [predelay,
-                                                                  crossoverFrequency,
-                                                                  lowReleaseTime,
-                                                                  midReleaseTime,
-                                                                  dampingFrequency,
-                                                                  equalizerFrequency1,
-                                                                  equalizerLevel1,
-                                                                  equalizerFrequency2,
-                                                                  equalizerLevel2,
-                                                                  dryWetMix])
-
-        predelay.value = AUValue(AKZitaReverb.defaultPredelay)
-        crossoverFrequency.value = AUValue(AKZitaReverb.defaultCrossoverFrequency)
-        lowReleaseTime.value = AUValue(AKZitaReverb.defaultLowReleaseTime)
-        midReleaseTime.value = AUValue(AKZitaReverb.defaultMidReleaseTime)
-        dampingFrequency.value = AUValue(AKZitaReverb.defaultDampingFrequency)
-        equalizerFrequency1.value = AUValue(AKZitaReverb.defaultEqualizerFrequency1)
-        equalizerLevel1.value = AUValue(AKZitaReverb.defaultEqualizerLevel1)
-        equalizerFrequency2.value = AUValue(AKZitaReverb.defaultEqualizerFrequency2)
-        equalizerLevel2.value = AUValue(AKZitaReverb.defaultEqualizerLevel2)
-        dryWetMix.value = AUValue(AKZitaReverb.defaultDryWetMix)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [predelay, crossoverFrequency, lowReleaseTime, midReleaseTime, dampingFrequency, equalizerFrequency1, equalizerLevel1, equalizerFrequency2, equalizerLevel2, dryWetMix])
     }
 }

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKZitaReverbDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createZitaReverbDSP() {
     return new AKZitaReverbDSP();
@@ -9,16 +9,16 @@ extern "C" AKDSPRef createZitaReverbDSP() {
 
 struct AKZitaReverbDSP::InternalData {
     sp_zitarev *zitarev;
-    AKLinearParameterRamp predelayRamp;
-    AKLinearParameterRamp crossoverFrequencyRamp;
-    AKLinearParameterRamp lowReleaseTimeRamp;
-    AKLinearParameterRamp midReleaseTimeRamp;
-    AKLinearParameterRamp dampingFrequencyRamp;
-    AKLinearParameterRamp equalizerFrequency1Ramp;
-    AKLinearParameterRamp equalizerLevel1Ramp;
-    AKLinearParameterRamp equalizerFrequency2Ramp;
-    AKLinearParameterRamp equalizerLevel2Ramp;
-    AKLinearParameterRamp dryWetMixRamp;
+    ParameterRamper predelayRamp;
+    ParameterRamper crossoverFrequencyRamp;
+    ParameterRamper lowReleaseTimeRamp;
+    ParameterRamper midReleaseTimeRamp;
+    ParameterRamper dampingFrequencyRamp;
+    ParameterRamper equalizerFrequency1Ramp;
+    ParameterRamper equalizerLevel1Ramp;
+    ParameterRamper equalizerFrequency2Ramp;
+    ParameterRamper equalizerLevel2Ramp;
+    ParameterRamper dryWetMixRamp;
 };
 
 AKZitaReverbDSP::AKZitaReverbDSP() : data(new InternalData) {
@@ -56,30 +56,16 @@ void AKZitaReverbDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bu
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->predelayRamp.advanceTo(now + frameOffset);
-            data->crossoverFrequencyRamp.advanceTo(now + frameOffset);
-            data->lowReleaseTimeRamp.advanceTo(now + frameOffset);
-            data->midReleaseTimeRamp.advanceTo(now + frameOffset);
-            data->dampingFrequencyRamp.advanceTo(now + frameOffset);
-            data->equalizerFrequency1Ramp.advanceTo(now + frameOffset);
-            data->equalizerLevel1Ramp.advanceTo(now + frameOffset);
-            data->equalizerFrequency2Ramp.advanceTo(now + frameOffset);
-            data->equalizerLevel2Ramp.advanceTo(now + frameOffset);
-            data->dryWetMixRamp.advanceTo(now + frameOffset);
-        }
-
-        *data->zitarev->in_delay = data->predelayRamp.getValue();
-        *data->zitarev->lf_x = data->crossoverFrequencyRamp.getValue();
-        *data->zitarev->rt60_low = data->lowReleaseTimeRamp.getValue();
-        *data->zitarev->rt60_mid = data->midReleaseTimeRamp.getValue();
-        *data->zitarev->hf_damping = data->dampingFrequencyRamp.getValue();
-        *data->zitarev->eq1_freq = data->equalizerFrequency1Ramp.getValue();
-        *data->zitarev->eq1_level = data->equalizerLevel1Ramp.getValue();
-        *data->zitarev->eq2_freq = data->equalizerFrequency2Ramp.getValue();
-        *data->zitarev->eq2_level = data->equalizerLevel2Ramp.getValue();
-        *data->zitarev->mix = data->dryWetMixRamp.getValue();
+        *data->zitarev->in_delay = data->predelayRamp.getAndStep();
+        *data->zitarev->lf_x = data->crossoverFrequencyRamp.getAndStep();
+        *data->zitarev->rt60_low = data->lowReleaseTimeRamp.getAndStep();
+        *data->zitarev->rt60_mid = data->midReleaseTimeRamp.getAndStep();
+        *data->zitarev->hf_damping = data->dampingFrequencyRamp.getAndStep();
+        *data->zitarev->eq1_freq = data->equalizerFrequency1Ramp.getAndStep();
+        *data->zitarev->eq1_level = data->equalizerLevel1Ramp.getAndStep();
+        *data->zitarev->eq2_freq = data->equalizerFrequency2Ramp.getAndStep();
+        *data->zitarev->eq2_level = data->equalizerLevel2Ramp.getAndStep();
+        *data->zitarev->mix = data->dryWetMixRamp.getAndStep();
 
         float *tmpin[2];
         float *tmpout[2];

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoise.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoise.swift
@@ -2,64 +2,53 @@
 
 /// Brownian noise generator
 ///
-open class AKBrownianNoise: AKNode, AKToggleable, AKComponent {
-    public typealias AKAudioUnitType = AKBrownianNoiseAudioUnit
+open class AKBrownianNoise: AKNode, AKToggleable, AKComponent, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(generator: "bron")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKBrownianNoiseAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Amplitude
-    public static let amplitudeRange: ClosedRange<Double> = 0.0 ... 1.0
+    public static let amplitudeRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
     /// Initial value for Amplitude
-    public static let defaultAmplitude: Double = 1.0
+    public static let defaultAmplitude: AUValue = 1.0
 
     /// Amplitude. (Value between 0-1).
-    @objc open var amplitude: Double = defaultAmplitude {
-        willSet {
-            let clampedValue = AKBrownianNoise.amplitudeRange.clamp(newValue)
-            guard amplitude != clampedValue else { return }
-            internalAU?.amplitude.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let amplitude = AKNodeParameter(identifier: "amplitude")
 
     // MARK: - Initialization
-
+    
     /// Initialize this brown-noise node
     ///
     /// - Parameters:
     ///   - amplitude: Amplitude. (Value between 0-1).
     ///
     public init(
-        amplitude: Double = defaultAmplitude
+        amplitude: AUValue = defaultAmplitude
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-
-            self.amplitude = amplitude
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.amplitude.associate(with: self.internalAU, value: amplitude)
         }
-    }
 
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKBrownianNoiseAudioUnit: AKAudioUnitBase {
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKBrownianNoiseParameter.amplitude.rawValue,
+        range: AKBrownianNoise.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createBrownianNoiseDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKBrownianNoiseParameter.amplitude.rawValue,
-            range: AKBrownianNoise.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [amplitude])
-
-        amplitude.value = AUValue(AKBrownianNoise.defaultAmplitude)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKPinkNoiseAudioUnit: AKAudioUnitBase {
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKPinkNoiseParameter.amplitude.rawValue,
+        range: AKPinkNoise.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPinkNoiseDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKPinkNoiseParameter.amplitude.rawValue,
-            range: AKPinkNoise.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [amplitude])
-
-        amplitude.value = AUValue(AKPinkNoise.defaultAmplitude)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKPinkNoiseDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createPinkNoiseDSP() {
     return new AKPinkNoiseDSP();
@@ -9,7 +9,7 @@ extern "C" AKDSPRef createPinkNoiseDSP() {
 
 struct AKPinkNoiseDSP::InternalData {
     sp_pinknoise *pinknoise;
-    AKLinearParameterRamp amplitudeRamp;
+    ParameterRamper amplitudeRamp;
 };
 
 AKPinkNoiseDSP::AKPinkNoiseDSP() : data(new InternalData) {
@@ -37,12 +37,7 @@ void AKPinkNoiseDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buf
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->amplitudeRamp.advanceTo(now + frameOffset);
-        }
-
-        data->pinknoise->amp = data->amplitudeRamp.getValue();
+        data->pinknoise->amp = data->amplitudeRamp.getAndStep();
 
         float temp = 0;
         for (int channel = 0; channel < channelCount; ++channel) {

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoise.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoise.swift
@@ -2,65 +2,53 @@
 
 /// White noise generator
 ///
-open class AKWhiteNoise: AKNode, AKToggleable, AKComponent {
-    public typealias AKAudioUnitType = AKWhiteNoiseAudioUnit
+open class AKWhiteNoise: AKNode, AKToggleable, AKComponent, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(generator: "wnoz")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKWhiteNoiseAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Amplitude
-    public static let amplitudeRange: ClosedRange<Double> = 0.0 ... 1.0
+    public static let amplitudeRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
     /// Initial value for Amplitude
-    public static let defaultAmplitude: Double = 1
+    public static let defaultAmplitude: AUValue = 1
 
     /// Amplitude. (Value between 0-1).
-    @objc open var amplitude: Double = defaultAmplitude {
-        willSet {
-            let clampedValue = AKWhiteNoise.amplitudeRange.clamp(newValue)
-            guard amplitude != clampedValue else { return }
-            internalAU?.amplitude.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let amplitude = AKNodeParameter(identifier: "amplitude")
 
     // MARK: - Initialization
-
+    
     /// Initialize this noise node
     ///
     /// - Parameters:
     ///   - amplitude: Amplitude. (Value between 0-1).
     ///
     public init(
-        amplitude: Double = defaultAmplitude
+        amplitude: AUValue = defaultAmplitude
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-
-            self.amplitude = amplitude
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.amplitude.associate(with: self.internalAU, value: amplitude)
         }
 
-    }
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKWhiteNoiseAudioUnit: AKAudioUnitBase {
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKWhiteNoiseParameter.amplitude.rawValue,
+        range: AKWhiteNoise.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createWhiteNoiseDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKWhiteNoiseParameter.amplitude.rawValue,
-            range: AKWhiteNoise.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [amplitude])
-
-        amplitude.value = AUValue(AKWhiteNoise.defaultAmplitude)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKWhiteNoiseDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createWhiteNoiseDSP() {
     return new AKWhiteNoiseDSP();
@@ -9,7 +9,7 @@ extern "C" AKDSPRef createWhiteNoiseDSP() {
 
 struct AKWhiteNoiseDSP::InternalData {
     sp_noise *noise;
-    AKLinearParameterRamp amplitudeRamp;
+    ParameterRamper amplitudeRamp;
 };
 
 AKWhiteNoiseDSP::AKWhiteNoiseDSP() : data(new InternalData) {
@@ -37,12 +37,7 @@ void AKWhiteNoiseDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bu
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->amplitudeRamp.advanceTo(now + frameOffset);
-        }
-
-        data->noise->amp = data->amplitudeRamp.getValue();
+        data->noise->amp = data->amplitudeRamp.getAndStep();
 
         float temp = 0;
         for (int channel = 0; channel < channelCount; ++channel) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorAudioUnit.swift
@@ -4,70 +4,54 @@ import AVFoundation
 
 public class AKFMOscillatorAudioUnit: AKAudioUnitBase {
 
-    private(set) var baseFrequency: AUParameter!
+    let baseFrequency = AUParameter(
+        identifier: "baseFrequency",
+        name: "Base Frequency (Hz)",
+        address: AKFMOscillatorParameter.baseFrequency.rawValue,
+        range: AKFMOscillator.baseFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var carrierMultiplier: AUParameter!
+    let carrierMultiplier = AUParameter(
+        identifier: "carrierMultiplier",
+        name: "Carrier Multiplier",
+        address: AKFMOscillatorParameter.carrierMultiplier.rawValue,
+        range: AKFMOscillator.carrierMultiplierRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var modulatingMultiplier: AUParameter!
+    let modulatingMultiplier = AUParameter(
+        identifier: "modulatingMultiplier",
+        name: "Modulating Multiplier",
+        address: AKFMOscillatorParameter.modulatingMultiplier.rawValue,
+        range: AKFMOscillator.modulatingMultiplierRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var modulationIndex: AUParameter!
+    let modulationIndex = AUParameter(
+        identifier: "modulationIndex",
+        name: "Modulation Index",
+        address: AKFMOscillatorParameter.modulationIndex.rawValue,
+        range: AKFMOscillator.modulationIndexRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKFMOscillatorParameter.amplitude.rawValue,
+        range: AKFMOscillator.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createFMOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        baseFrequency = AUParameter(
-            identifier: "baseFrequency",
-            name: "Base Frequency (Hz)",
-            address: AKFMOscillatorParameter.baseFrequency.rawValue,
-            range: AKFMOscillator.baseFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        carrierMultiplier = AUParameter(
-            identifier: "carrierMultiplier",
-            name: "Carrier Multiplier",
-            address: AKFMOscillatorParameter.carrierMultiplier.rawValue,
-            range: AKFMOscillator.carrierMultiplierRange,
-            unit: .generic,
-            flags: .default)
-        modulatingMultiplier = AUParameter(
-            identifier: "modulatingMultiplier",
-            name: "Modulating Multiplier",
-            address: AKFMOscillatorParameter.modulatingMultiplier.rawValue,
-            range: AKFMOscillator.modulatingMultiplierRange,
-            unit: .generic,
-            flags: .default)
-        modulationIndex = AUParameter(
-            identifier: "modulationIndex",
-            name: "Modulation Index",
-            address: AKFMOscillatorParameter.modulationIndex.rawValue,
-            range: AKFMOscillator.modulationIndexRange,
-            unit: .generic,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKFMOscillatorParameter.amplitude.rawValue,
-            range: AKFMOscillator.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [baseFrequency,
-                                                                  carrierMultiplier,
-                                                                  modulatingMultiplier,
-                                                                  modulationIndex,
-                                                                  amplitude])
-
-        baseFrequency.value = AUValue(AKFMOscillator.defaultBaseFrequency)
-        carrierMultiplier.value = AUValue(AKFMOscillator.defaultCarrierMultiplier)
-        modulatingMultiplier.value = AUValue(AKFMOscillator.defaultModulatingMultiplier)
-        modulationIndex.value = AUValue(AKFMOscillator.defaultModulationIndex)
-        amplitude.value = AUValue(AKFMOscillator.defaultAmplitude)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [baseFrequency, carrierMultiplier, modulatingMultiplier, modulationIndex, amplitude])
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorPresets.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorPresets.swift
@@ -5,41 +5,41 @@ public extension AKFMOscillator {
 
     /// Stun Ray Preset
     func presetStunRay() {
-        baseFrequency = 200
-        carrierMultiplier = 90
-        modulatingMultiplier = 10
-        modulationIndex = 25
+        baseFrequency.value = 200
+        carrierMultiplier.value = 90
+        modulatingMultiplier.value = 10
+        modulationIndex.value = 25
     }
 
     /// Fog Horn Preset
     func presetFogHorn() {
-        baseFrequency = 25
-        carrierMultiplier = 10
-        modulatingMultiplier = 5
-        modulationIndex = 10
+        baseFrequency.value = 25
+        carrierMultiplier.value = 10
+        modulatingMultiplier.value = 5
+        modulationIndex.value = 10
     }
 
     /// Buzzer Preset
     func presetBuzzer() {
-        baseFrequency = 400
-        carrierMultiplier = 28
-        modulatingMultiplier = 0.5
-        modulationIndex = 100
+        baseFrequency.value = 400
+        carrierMultiplier.value = 28
+        modulatingMultiplier.value = 0.5
+        modulationIndex.value = 100
     }
 
     /// Spiral Preset
     func presetSpiral() {
-        baseFrequency = 5
-        carrierMultiplier = 280
-        modulatingMultiplier = 0.2
-        modulationIndex = 100
+        baseFrequency.value = 5
+        carrierMultiplier.value = 280
+        modulatingMultiplier.value = 0.2
+        modulationIndex.value = 100
     }
 
     /// Wobble Preset
     func presetWobble() {
-        baseFrequency = 20
-        carrierMultiplier = 10
-        modulatingMultiplier = 0.9
-        modulationIndex = 20
+        baseFrequency.value = 20
+        carrierMultiplier.value = 10
+        modulatingMultiplier.value = 0.9
+        modulationIndex.value = 20
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorAudioUnit.swift
@@ -4,70 +4,58 @@ import AVFoundation
 
 public class AKMorphingOscillatorAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (in Hz)",
+        address: AKMorphingOscillatorParameter.frequency.rawValue,
+        range: AKMorphingOscillator.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude (typically a value between 0 and 1).",
+        address: AKMorphingOscillatorParameter.amplitude.rawValue,
+        range: AKMorphingOscillator.amplitudeRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var index: AUParameter!
+    let index = AUParameter(
+        identifier: "index",
+        name: "Index of the wavetable to use (fractional are okay).",
+        address: AKMorphingOscillatorParameter.index.rawValue,
+        range: AKMorphingOscillator.indexRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var detuningOffset: AUParameter!
+    let detuningOffset = AUParameter(
+        identifier: "detuningOffset",
+        name: "Frequency offset (Hz)",
+        address: AKMorphingOscillatorParameter.detuningOffset.rawValue,
+        range: AKMorphingOscillator.detuningOffsetRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var detuningMultiplier: AUParameter!
+    let detuningMultiplier = AUParameter(
+        identifier: "detuningMultiplier",
+        name: "Frequency detuning multiplier",
+        address: AKMorphingOscillatorParameter.detuningMultiplier.rawValue,
+        range: AKMorphingOscillator.detuningMultiplierRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createMorphingOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (in Hz)",
-            address: AKMorphingOscillatorParameter.frequency.rawValue,
-            range: AKMorphingOscillator.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude (typically a value between 0 and 1).",
-            address: AKMorphingOscillatorParameter.amplitude.rawValue,
-            range: AKMorphingOscillator.amplitudeRange,
-            unit: .hertz,
-            flags: .default)
-        index = AUParameter(
-            identifier: "index",
-            name: "Index of the wavetable to use (fractional are okay).",
-            address: AKMorphingOscillatorParameter.index.rawValue,
-            range: AKMorphingOscillator.indexRange,
-            unit: .hertz,
-            flags: .default)
-        detuningOffset = AUParameter(
-            identifier: "detuningOffset",
-            name: "Frequency offset (Hz)",
-            address: AKMorphingOscillatorParameter.detuningOffset.rawValue,
-            range: AKMorphingOscillator.detuningOffsetRange,
-            unit: .hertz,
-            flags: .default)
-        detuningMultiplier = AUParameter(
-            identifier: "detuningMultiplier",
-            name: "Frequency detuning multiplier",
-            address: AKMorphingOscillatorParameter.detuningMultiplier.rawValue,
-            range: AKMorphingOscillator.detuningMultiplierRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [frequency,
                                                                   amplitude,
                                                                   index,
                                                                   detuningOffset,
                                                                   detuningMultiplier])
-
-        frequency.value = AUValue(AKMorphingOscillator.defaultFrequency)
-        amplitude.value = AUValue(AKMorphingOscillator.defaultAmplitude)
-        index.value = AUValue(AKMorphingOscillator.defaultIndex)
-        detuningOffset.value = AUValue(AKMorphingOscillator.defaultDetuningOffset)
-        detuningMultiplier.value = AUValue(AKMorphingOscillator.defaultDetuningMultiplier)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
@@ -64,7 +64,7 @@ void AKMorphingOscillatorDSP::process(AUAudioFrameCount frameCount, AUAudioFrame
 
         data->oscmorph->freq = data->frequencyRamp.getAndStep() * data->detuningMultiplierRamp.getAndStep() + data->detuningOffsetRamp.getAndStep();
         data->oscmorph->amp = data->amplitudeRamp.getAndStep();
-        data->oscmorph->wtpos = data->indexRamp.getAndStep();
+        data->oscmorph->wtpos = data->indexRamp.getAndStep() / 3.f;
 
         float temp = 0;
         for (int channel = 0; channel < channelCount; ++channel) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKMorphingOscillatorDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 #include <vector>
 
 extern "C" AKDSPRef createMorphingOscillatorDSP() {
@@ -12,11 +12,11 @@ struct AKMorphingOscillatorDSP::InternalData {
     sp_oscmorph *oscmorph;
     sp_ftbl *ft_array[4];
     std::vector<float> waveforms[4];
-    AKLinearParameterRamp frequencyRamp;
-    AKLinearParameterRamp amplitudeRamp;
-    AKLinearParameterRamp indexRamp;
-    AKLinearParameterRamp detuningOffsetRamp;
-    AKLinearParameterRamp detuningMultiplierRamp;
+    ParameterRamper frequencyRamp;
+    ParameterRamper amplitudeRamp;
+    ParameterRamper indexRamp;
+    ParameterRamper detuningOffsetRamp;
+    ParameterRamper detuningMultiplierRamp;
 };
 
 AKMorphingOscillatorDSP::AKMorphingOscillatorDSP() : data(new InternalData) {
@@ -62,18 +62,9 @@ void AKMorphingOscillatorDSP::process(AUAudioFrameCount frameCount, AUAudioFrame
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->frequencyRamp.advanceTo(now + frameOffset);
-            data->amplitudeRamp.advanceTo(now + frameOffset);
-            data->indexRamp.advanceTo(now + frameOffset);
-            data->detuningOffsetRamp.advanceTo(now + frameOffset);
-            data->detuningMultiplierRamp.advanceTo(now + frameOffset);
-        }
-
-        data->oscmorph->freq = data->frequencyRamp.getValue() * data->detuningMultiplierRamp.getValue() + data->detuningOffsetRamp.getValue();
-        data->oscmorph->amp = data->amplitudeRamp.getValue();
-        data->oscmorph->wtpos = data->indexRamp.getValue();
+        data->oscmorph->freq = data->frequencyRamp.getAndStep() * data->detuningMultiplierRamp.getAndStep() + data->detuningOffsetRamp.getAndStep();
+        data->oscmorph->amp = data->amplitudeRamp.getAndStep();
+        data->oscmorph->wtpos = data->indexRamp.getAndStep();
 
         float temp = 0;
         for (int channel = 0; channel < channelCount; ++channel) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
@@ -3,84 +3,63 @@
 /// Reads from the table sequentially and repeatedly at given frequency. Linear
 /// interpolation is applied for table look up from internal phase values.
 ///
-open class AKOscillator: AKNode, AKToggleable, AKComponent {
-    public typealias AKAudioUnitType = AKOscillatorAudioUnit
+open class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(generator: "oscl")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKOscillatorAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     fileprivate var waveform: AKTable?
 
     /// Lower and upper bounds for Frequency
-    public static let frequencyRange: ClosedRange<Double> = 0.0 ... 20_000.0
+    public static let frequencyRange: ClosedRange<AUValue> = 0.0 ... 20000.0
 
     /// Lower and upper bounds for Amplitude
-    public static let amplitudeRange: ClosedRange<Double> = 0.0 ... 10.0
+    public static let amplitudeRange: ClosedRange<AUValue> = 0.0 ... 10.0
 
     /// Lower and upper bounds for Detuning Offset
-    public static let detuningOffsetRange: ClosedRange<Double> = -1_000.0 ... 1_000.0
+    public static let detuningOffsetRange: ClosedRange<AUValue> = -1000.0 ... 1000.0
 
     /// Lower and upper bounds for Detuning Multiplier
-    public static let detuningMultiplierRange: ClosedRange<Double> = 0.9 ... 1.11
+    public static let detuningMultiplierRange: ClosedRange<AUValue> = 0.9 ... 1.11
 
     /// Initial value for Frequency
-    public static let defaultFrequency: Double = 440.0
+    public static let defaultFrequency: AUValue = 440.0
 
     /// Initial value for Amplitude
-    public static let defaultAmplitude: Double = 1.0
+    public static let defaultAmplitude: AUValue = 1.0
 
     /// Initial value for Detuning Offset
-    public static let defaultDetuningOffset: Double = 0.0
+    public static let defaultDetuningOffset: AUValue = 0.0
 
     /// Initial value for Detuning Multiplier
-    public static let defaultDetuningMultiplier: Double = 1.0
+    public static let defaultDetuningMultiplier: AUValue = 1.0
 
     /// Frequency in cycles per second
-    @objc open var frequency: Double = defaultFrequency {
-        willSet {
-            let clampedValue = AKOscillator.frequencyRange.clamp(newValue)
-            guard frequency != clampedValue else { return }
-            internalAU?.frequency.value = AUValue(clampedValue)
-        }
-    }
+    public let frequency = AKNodeParameter(identifier: "frequency")
 
     /// Output Amplitude.
-    @objc open var amplitude: Double = defaultAmplitude {
-        willSet {
-            let clampedValue = AKOscillator.amplitudeRange.clamp(newValue)
-            guard amplitude != clampedValue else { return }
-            internalAU?.amplitude.value = AUValue(clampedValue)
-        }
-    }
+    public let amplitude = AKNodeParameter(identifier: "amplitude")
 
     /// Frequency offset in Hz.
-    @objc open var detuningOffset: Double = defaultDetuningOffset {
-        willSet {
-            let clampedValue = AKOscillator.detuningOffsetRange.clamp(newValue)
-            guard detuningOffset != clampedValue else { return }
-            internalAU?.detuningOffset.value = AUValue(clampedValue)
-        }
-    }
+    public let detuningOffset = AKNodeParameter(identifier: "detuningOffset")
 
     /// Frequency detuning multiplier
-    @objc open var detuningMultiplier: Double = defaultDetuningMultiplier {
-        willSet {
-            let clampedValue = AKOscillator.detuningMultiplierRange.clamp(newValue)
-            guard detuningMultiplier != clampedValue else { return }
-            internalAU?.detuningMultiplier.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let detuningMultiplier = AKNodeParameter(identifier: "detuningMultiplier")
 
     // MARK: - Initialization
-
+    
     /// Initialize this oscillator node
     ///
     /// - Parameters:
@@ -90,38 +69,30 @@ open class AKOscillator: AKNode, AKToggleable, AKComponent {
     ///   - detuningOffset: Frequency offset in Hz.
     ///   - detuningMultiplier: Frequency detuning multiplier
     ///
-    @objc public init(
+    public init(
         waveform: AKTable = AKTable(.sine),
-        frequency: Double = defaultFrequency,
-        amplitude: Double = defaultAmplitude,
-        detuningOffset: Double = defaultDetuningOffset,
-        detuningMultiplier: Double = defaultDetuningMultiplier
+        frequency: AUValue = defaultFrequency,
+        amplitude: AUValue = defaultAmplitude,
+        detuningOffset: AUValue = defaultDetuningOffset,
+        detuningMultiplier: AUValue = defaultDetuningMultiplier
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
             self.waveform = waveform
-            self.frequency = frequency
-            self.amplitude = amplitude
-            self.detuningOffset = detuningOffset
-            self.detuningMultiplier = detuningMultiplier
+            self.frequency.associate(with: self.internalAU, value: frequency)
+            self.amplitude.associate(with: self.internalAU, value: amplitude)
+            self.detuningOffset.associate(with: self.internalAU, value: detuningOffset)
+            self.detuningMultiplier.associate(with: self.internalAU, value: detuningMultiplier)
 
             self.internalAU?.setWavetable(waveform.content)
         }
-    }
 
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorAudioUnit.swift
@@ -4,59 +4,46 @@ import AVFoundation
 
 public class AKOscillatorAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (Hz)",
+        address: AKOscillatorParameter.frequency.rawValue,
+        range: AKOscillator.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKOscillatorParameter.amplitude.rawValue,
+        range: AKOscillator.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var detuningOffset: AUParameter!
+    let detuningOffset = AUParameter(
+        identifier: "detuningOffset",
+        name: "Frequency offset (Hz)",
+        address: AKOscillatorParameter.detuningOffset.rawValue,
+        range: AKOscillator.detuningOffsetRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var detuningMultiplier: AUParameter!
+    let detuningMultiplier = AUParameter(
+        identifier: "detuningMultiplier",
+        name: "Frequency detuning multiplier",
+        address: AKOscillatorParameter.detuningMultiplier.rawValue,
+        range: AKOscillator.detuningMultiplierRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (Hz)",
-            address: AKOscillatorParameter.frequency.rawValue,
-            range: AKOscillator.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKOscillatorParameter.amplitude.rawValue,
-            range: AKOscillator.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-        detuningOffset = AUParameter(
-            identifier: "detuningOffset",
-            name: "Frequency offset (Hz)",
-            address: AKOscillatorParameter.detuningOffset.rawValue,
-            range: AKOscillator.detuningOffsetRange,
-            unit: .hertz,
-            flags: .default)
-        detuningMultiplier = AUParameter(
-            identifier: "detuningMultiplier",
-            name: "Frequency detuning multiplier",
-            address: AKOscillatorParameter.detuningMultiplier.rawValue,
-            range: AKOscillator.detuningMultiplierRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [frequency,
-                                                                  amplitude,
-                                                                  detuningOffset,
-                                                                  detuningMultiplier])
-
-        frequency.value = AUValue(AKOscillator.defaultFrequency)
-        amplitude.value = AUValue(AKOscillator.defaultAmplitude)
-        detuningOffset.value = AUValue(AKOscillator.defaultDetuningOffset)
-        detuningMultiplier.value = AUValue(AKOscillator.defaultDetuningMultiplier)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [frequency, amplitude, detuningOffset, detuningMultiplier])
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillator.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillator.swift
@@ -6,94 +6,67 @@
 /// different rates in order to warp the waveform. For example, pdhalf can
 /// smoothly transition a sinewave into something approximating a sawtooth wave.
 ///
-open class AKPWMOscillator: AKNode, AKToggleable, AKComponent {
-    public typealias AKAudioUnitType = AKPWMOscillatorAudioUnit
+open class AKPWMOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
+    
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(generator: "pwmo")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKPWMOscillatorAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Frequency
-    public static let frequencyRange = 0.0 ... 20_000.0
+    public static let frequencyRange: ClosedRange<AUValue> = 0.0 ... 20_000.0
 
     /// Lower and upper bounds for Amplitude
-    public static let amplitudeRange = 0.0 ... 10.0
+    public static let amplitudeRange: ClosedRange<AUValue> = 0.0 ... 10.0
 
     /// Lower and upper bounds for Pulse Width
-    public static let pulseWidthRange = 0.0 ... 1.0
+    public static let pulseWidthRange: ClosedRange<AUValue> = 0.0 ... 1.0
 
     /// Lower and upper bounds for Detuning Offset
-    public static let detuningOffsetRange = -1_000.0 ... 1_000.0
+    public static let detuningOffsetRange: ClosedRange<AUValue> = -1_000.0 ... 1_000.0
 
     /// Lower and upper bounds for Detuning Multiplier
-    public static let detuningMultiplierRange = 0.9 ... 1.11
+    public static let detuningMultiplierRange: ClosedRange<AUValue> = 0.9 ... 1.11
 
     /// Initial value for Frequency
-    public static let defaultFrequency = 440.0
+    public static let defaultFrequency: AUValue = 440.0
 
     /// Initial value for Amplitude
-    public static let defaultAmplitude = 1.0
+    public static let defaultAmplitude: AUValue = 1.0
 
     /// Initial value for Pulse Width
-    public static let defaultPulseWidth = 0.5
+    public static let defaultPulseWidth: AUValue = 0.5
 
     /// Initial value for Detuning Offset
-    public static let defaultDetuningOffset = 0.0
+    public static let defaultDetuningOffset: AUValue = 0.0
 
     /// Initial value for Detuning Multiplier
-    public static let defaultDetuningMultiplier = 1.0
+    public static let defaultDetuningMultiplier: AUValue = 1.0
 
     /// Frequency in cycles per second
-    @objc open var frequency: Double = defaultFrequency {
-        willSet {
-            let clampedValue = AKPWMOscillator.frequencyRange.clamp(newValue)
-            guard frequency != clampedValue else { return }
-            internalAU?.frequency.value = AUValue(clampedValue)
-        }
-    }
+    public let frequency = AKNodeParameter(identifier: "frequency")
 
     /// Output Amplitude.
-    @objc open var amplitude: Double = defaultAmplitude {
-        willSet {
-            let clampedValue = AKPWMOscillator.amplitudeRange.clamp(newValue)
-            guard amplitude != clampedValue else { return }
-            internalAU?.amplitude.value = AUValue(clampedValue)
-        }
-    }
+    public let amplitude = AKNodeParameter(identifier: "amplitude")
 
     /// Duty Cycle Width 0 - 1
-    @objc open var pulseWidth: Double = defaultPulseWidth {
-        willSet {
-            let clampedValue = AKPWMOscillator.pulseWidthRange.clamp(newValue)
-            guard pulseWidth != clampedValue else { return }
-            internalAU?.pulseWidth.value = AUValue(clampedValue)
-        }
-    }
-
+    public let pulseWidth = AKNodeParameter(identifier: "pulseWidth")
+    
     /// Frequency offset in Hz.
-    @objc open var detuningOffset: Double = defaultDetuningOffset {
-        willSet {
-            let clampedValue = AKPWMOscillator.detuningOffsetRange.clamp(newValue)
-            guard detuningOffset != clampedValue else { return }
-            internalAU?.detuningOffset.value = AUValue(clampedValue)
-        }
-    }
+    public let detuningOffset = AKNodeParameter(identifier: "detuningOffset")
 
     /// Frequency detuning multiplier
-    @objc open var detuningMultiplier: Double = defaultDetuningMultiplier {
-        willSet {
-            let clampedValue = AKPWMOscillator.detuningMultiplierRange.clamp(newValue)
-            guard detuningMultiplier != clampedValue else { return }
-            internalAU?.detuningMultiplier.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let detuningMultiplier = AKNodeParameter(identifier: "detuningMultiplier")
 
     // MARK: - Initialization
 
@@ -106,36 +79,27 @@ open class AKPWMOscillator: AKNode, AKToggleable, AKComponent {
     ///   - detuningOffset: Frequency offset in Hz.
     ///   - detuningMultiplier: Frequency detuning multiplier
     ///
-    @objc public init(
-        frequency: Double = 440,
-        amplitude: Double = defaultAmplitude,
-        pulseWidth: Double = defaultPulseWidth,
-        detuningOffset: Double = defaultDetuningOffset,
-        detuningMultiplier: Double = defaultDetuningMultiplier
+    public init(
+        frequency: AUValue = defaultFrequency,
+        amplitude: AUValue = defaultAmplitude,
+        pulseWidth: AUValue = defaultPulseWidth,
+        detuningOffset: AUValue = defaultDetuningOffset,
+        detuningMultiplier: AUValue = defaultDetuningMultiplier
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
 
-            self.frequency = frequency
-            self.amplitude = amplitude
-            self.pulseWidth = pulseWidth
-            self.detuningOffset = detuningOffset
-            self.detuningMultiplier = detuningMultiplier
+            self.frequency.associate(with: self.internalAU, value: frequency)
+            self.amplitude.associate(with: self.internalAU, value: amplitude)
+            self.pulseWidth.associate(with: self.internalAU, value: pulseWidth)
+            self.detuningOffset.associate(with: self.internalAU, value: detuningOffset)
+            self.detuningMultiplier.associate(with: self.internalAU, value: detuningMultiplier)
         }
-    }
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorAudioUnit.swift
@@ -4,15 +4,45 @@ import AVFoundation
 
 public class AKPWMOscillatorAudioUnit: AKAudioUnitBase {
 
-    var frequency: AUParameter!
-
-    var amplitude: AUParameter!
-
-    var pulseWidth: AUParameter!
-
-    var detuningOffset: AUParameter!
-
-    var detuningMultiplier: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (Hz)",
+        address: AKPWMOscillatorParameter.frequency.rawValue,
+        range: AKPWMOscillator.frequencyRange,
+        unit: .hertz,
+        flags: .default)
+    
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKPWMOscillatorParameter.amplitude.rawValue,
+        range: AKPWMOscillator.amplitudeRange,
+        unit: .hertz,
+        flags: .default)
+    
+    let pulseWidth = AUParameter(
+        identifier: "pulseWidth",
+        name: "Pulse Width",
+        address: AKPWMOscillatorParameter.pulseWidth.rawValue,
+        range: AKPWMOscillator.pulseWidthRange,
+        unit: .generic,
+        flags: .default)
+    
+    let detuningOffset = AUParameter(
+        identifier: "detuningOffset",
+        name: "Frequency offset (Hz)",
+        address: AKPWMOscillatorParameter.detuningOffset.rawValue,
+        range: AKPWMOscillator.detuningOffsetRange,
+        unit: .hertz,
+        flags: .default)
+    
+    let detuningMultiplier = AUParameter(
+        identifier: "detuningMultiplier",
+        name: "Frequency detuning multiplier",
+        address: AKPWMOscillatorParameter.detuningMultiplier.rawValue,
+        range: AKPWMOscillator.detuningMultiplierRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPWMOscillatorDSP()
@@ -21,53 +51,11 @@ public class AKPWMOscillatorAudioUnit: AKAudioUnitBase {
     public override init(componentDescription: AudioComponentDescription,
                          options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (Hz)",
-            address: AKPWMOscillatorParameter.frequency.rawValue,
-            range: AKPWMOscillator.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKPWMOscillatorParameter.amplitude.rawValue,
-            range: AKPWMOscillator.amplitudeRange,
-            unit: .hertz,
-            flags: .default)
-        pulseWidth = AUParameter(
-            identifier: "pulseWidth",
-            name: "Pulse Width",
-            address: AKPWMOscillatorParameter.pulseWidth.rawValue,
-            range: AKPWMOscillator.pulseWidthRange,
-            unit: .generic,
-            flags: .default)
-        detuningOffset = AUParameter(
-            identifier: "detuningOffset",
-            name: "Frequency offset (Hz)",
-            address: AKPWMOscillatorParameter.detuningOffset.rawValue,
-            range: AKPWMOscillator.detuningOffsetRange,
-            unit: .hertz,
-            flags: .default)
-        detuningMultiplier = AUParameter(
-            identifier: "detuningMultiplier",
-            name: "Frequency detuning multiplier",
-            address: AKPWMOscillatorParameter.detuningMultiplier.rawValue,
-            range: AKPWMOscillator.detuningMultiplierRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [frequency,
                                                                   amplitude,
                                                                   pulseWidth,
                                                                   detuningOffset,
                                                                   detuningMultiplier])
-
-        frequency.value = AUValue(AKPWMOscillator.defaultFrequency)
-        amplitude.value = AUValue(AKPWMOscillator.defaultAmplitude)
-        pulseWidth.value = AUValue(AKPWMOscillator.defaultPulseWidth)
-        detuningOffset.value = AUValue(AKPWMOscillator.defaultDetuningOffset)
-        detuningMultiplier.value = AUValue(AKPWMOscillator.defaultDetuningMultiplier)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillator.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillator.swift
@@ -6,99 +6,72 @@
 /// different rates in order to warp the waveform. For example, pdhalf can
 /// smoothly transition a sinewave into something approximating a sawtooth wave.
 ///
-open class AKPhaseDistortionOscillator: AKNode, AKToggleable, AKComponent {
-    public typealias AKAudioUnitType = AKPhaseDistortionOscillatorAudioUnit
+open class AKPhaseDistortionOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(generator: "pdho")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKPhaseDistortionOscillatorAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     fileprivate var waveform: AKTable?
 
     /// Lower and upper bounds for Frequency
-    public static let frequencyRange: ClosedRange<Double> = 0 ... 20_000
+    public static let frequencyRange: ClosedRange<AUValue> = 0 ... 20000
 
     /// Lower and upper bounds for Amplitude
-    public static let amplitudeRange: ClosedRange<Double> = 0 ... 10
+    public static let amplitudeRange: ClosedRange<AUValue> = 0 ... 10
 
     /// Lower and upper bounds for Phase Distortion
-    public static let phaseDistortionRange: ClosedRange<Double> = -1 ... 1
+    public static let phaseDistortionRange: ClosedRange<AUValue> = -1 ... 1
 
     /// Lower and upper bounds for Detuning Offset
-    public static let detuningOffsetRange: ClosedRange<Double> = -1_000 ... 1_000
+    public static let detuningOffsetRange: ClosedRange<AUValue> = -1000 ... 1000
 
     /// Lower and upper bounds for Detuning Multiplier
-    public static let detuningMultiplierRange: ClosedRange<Double> = 0.9 ... 1.11
+    public static let detuningMultiplierRange: ClosedRange<AUValue> = 0.9 ... 1.11
 
     /// Initial value for Frequency
-    public static let defaultFrequency: Double = 440
+    public static let defaultFrequency: AUValue = 440
 
     /// Initial value for Amplitude
-    public static let defaultAmplitude: Double = 1
+    public static let defaultAmplitude: AUValue = 1
 
     /// Initial value for Phase Distortion
-    public static let defaultPhaseDistortion: Double = 0
+    public static let defaultPhaseDistortion: AUValue = 0
 
     /// Initial value for Detuning Offset
-    public static let defaultDetuningOffset: Double = 0
+    public static let defaultDetuningOffset: AUValue = 0
 
     /// Initial value for Detuning Multiplier
-    public static let defaultDetuningMultiplier: Double = 1
+    public static let defaultDetuningMultiplier: AUValue = 1
 
     /// Frequency in cycles per second
-    @objc open var frequency: Double = defaultFrequency {
-        willSet {
-            let clampedValue = AKPhaseDistortionOscillator.frequencyRange.clamp(newValue)
-            guard frequency != clampedValue else { return }
-            internalAU?.frequency.value = AUValue(clampedValue)
-        }
-    }
+    public let frequency = AKNodeParameter(identifier: "frequency")
 
     /// Output Amplitude.
-    @objc open var amplitude: Double = defaultAmplitude {
-        willSet {
-            let clampedValue = AKPhaseDistortionOscillator.amplitudeRange.clamp(newValue)
-            guard amplitude != clampedValue else { return }
-            internalAU?.amplitude.value = AUValue(clampedValue)
-        }
-    }
+    public let amplitude = AKNodeParameter(identifier: "amplitude")
 
     /// Amount of distortion, within the range [-1, 1]. 0 is no distortion.
-    @objc open var phaseDistortion: Double = defaultPhaseDistortion {
-        willSet {
-            let clampedValue = AKPhaseDistortionOscillator.phaseDistortionRange.clamp(newValue)
-            guard phaseDistortion != clampedValue else { return }
-            internalAU?.phaseDistortion.value = AUValue(clampedValue)
-        }
-    }
+    public let phaseDistortion = AKNodeParameter(identifier: "phaseDistortion")
 
     /// Frequency offset in Hz.
-    @objc open var detuningOffset: Double = defaultDetuningOffset {
-        willSet {
-            let clampedValue = AKPhaseDistortionOscillator.detuningOffsetRange.clamp(newValue)
-            guard detuningOffset != clampedValue else { return }
-            internalAU?.detuningOffset.value = AUValue(clampedValue)
-        }
-    }
+    public let detuningOffset = AKNodeParameter(identifier: "detuningOffset")
 
     /// Frequency detuning multiplier
-    @objc open var detuningMultiplier: Double = defaultDetuningMultiplier {
-        willSet {
-            let clampedValue = AKPhaseDistortionOscillator.detuningMultiplierRange.clamp(newValue)
-            guard detuningMultiplier != clampedValue else { return }
-            internalAU?.detuningMultiplier.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let detuningMultiplier = AKNodeParameter(identifier: "detuningMultiplier")
 
     // MARK: - Initialization
-
+    
     /// Initialize this oscillator node
     ///
     /// - Parameters:
@@ -109,40 +82,32 @@ open class AKPhaseDistortionOscillator: AKNode, AKToggleable, AKComponent {
     ///   - detuningOffset: Frequency offset in Hz.
     ///   - detuningMultiplier: Frequency detuning multiplier
     ///
-    @objc public init(
+    public init(
         waveform: AKTable = AKTable(.sine),
-        frequency: Double = defaultFrequency,
-        amplitude: Double = defaultAmplitude,
-        phaseDistortion: Double = defaultPhaseDistortion,
-        detuningOffset: Double = defaultDetuningOffset,
-        detuningMultiplier: Double = defaultDetuningMultiplier
+        frequency: AUValue = defaultFrequency,
+        amplitude: AUValue = defaultAmplitude,
+        phaseDistortion: AUValue = defaultPhaseDistortion,
+        detuningOffset: AUValue = defaultDetuningOffset,
+        detuningMultiplier: AUValue = defaultDetuningMultiplier
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
             self.waveform = waveform
-            self.frequency = frequency
-            self.amplitude = amplitude
-            self.phaseDistortion = phaseDistortion
-            self.detuningOffset = detuningOffset
-            self.detuningMultiplier = detuningMultiplier
+            self.frequency.associate(with: self.internalAU, value: frequency)
+            self.amplitude.associate(with: self.internalAU, value: amplitude)
+            self.phaseDistortion.associate(with: self.internalAU, value: phaseDistortion)
+            self.detuningOffset.associate(with: self.internalAU, value: detuningOffset)
+            self.detuningMultiplier.associate(with: self.internalAU, value: detuningMultiplier)
 
             self.internalAU?.setWavetable(waveform.content)
         }
-    }
 
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorAudioUnit.swift
@@ -4,70 +4,54 @@ import AVFoundation
 
 public class AKPhaseDistortionOscillatorAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (Hz)",
+        address: AKPhaseDistortionOscillatorParameter.frequency.rawValue,
+        range: AKPhaseDistortionOscillator.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKPhaseDistortionOscillatorParameter.amplitude.rawValue,
+        range: AKPhaseDistortionOscillator.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var phaseDistortion: AUParameter!
+    let phaseDistortion = AUParameter(
+        identifier: "phaseDistortion",
+        name: "Amount of distortion, within the range [-1, 1]. 0 is no distortion.",
+        address: AKPhaseDistortionOscillatorParameter.phaseDistortion.rawValue,
+        range: AKPhaseDistortionOscillator.phaseDistortionRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var detuningOffset: AUParameter!
+    let detuningOffset = AUParameter(
+        identifier: "detuningOffset",
+        name: "Frequency offset (Hz)",
+        address: AKPhaseDistortionOscillatorParameter.detuningOffset.rawValue,
+        range: AKPhaseDistortionOscillator.detuningOffsetRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var detuningMultiplier: AUParameter!
+    let detuningMultiplier = AUParameter(
+        identifier: "detuningMultiplier",
+        name: "Frequency detuning multiplier",
+        address: AKPhaseDistortionOscillatorParameter.detuningMultiplier.rawValue,
+        range: AKPhaseDistortionOscillator.detuningMultiplierRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPhaseDistortionOscillatorDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (Hz)",
-            address: AKPhaseDistortionOscillatorParameter.frequency.rawValue,
-            range: AKPhaseDistortionOscillator.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKPhaseDistortionOscillatorParameter.amplitude.rawValue,
-            range: AKPhaseDistortionOscillator.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-        phaseDistortion = AUParameter(
-            identifier: "phaseDistortion",
-            name: "Amount of distortion, within the range [-1, 1]. 0 is no distortion.",
-            address: AKPhaseDistortionOscillatorParameter.phaseDistortion.rawValue,
-            range: AKPhaseDistortionOscillator.phaseDistortionRange,
-            unit: .generic,
-            flags: .default)
-        detuningOffset = AUParameter(
-            identifier: "detuningOffset",
-            name: "Frequency offset (Hz)",
-            address: AKPhaseDistortionOscillatorParameter.detuningOffset.rawValue,
-            range: AKPhaseDistortionOscillator.detuningOffsetRange,
-            unit: .hertz,
-            flags: .default)
-        detuningMultiplier = AUParameter(
-            identifier: "detuningMultiplier",
-            name: "Frequency detuning multiplier",
-            address: AKPhaseDistortionOscillatorParameter.detuningMultiplier.rawValue,
-            range: AKPhaseDistortionOscillator.detuningMultiplierRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [frequency,
-                                                                  amplitude,
-                                                                  phaseDistortion,
-                                                                  detuningOffset,
-                                                                  detuningMultiplier])
-
-        frequency.value = AUValue(AKPhaseDistortionOscillator.defaultFrequency)
-        amplitude.value = AUValue(AKPhaseDistortionOscillator.defaultAmplitude)
-        phaseDistortion.value = AUValue(AKPhaseDistortionOscillator.defaultPhaseDistortion)
-        detuningOffset.value = AUValue(AKPhaseDistortionOscillator.defaultDetuningOffset)
-        detuningMultiplier.value = AUValue(AKPhaseDistortionOscillator.defaultDetuningMultiplier)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [frequency, amplitude, phaseDistortion, detuningOffset, detuningMultiplier])
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDrip.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDrip.swift
@@ -3,127 +3,88 @@
 /// Physical model of the sound of dripping water. When triggered, it will
 /// produce a droplet of water.
 ///
-open class AKDrip: AKNode, AKToggleable, AKComponent {
-    public typealias AKAudioUnitType = AKDripAudioUnit
+open class AKDrip: AKNode, AKToggleable, AKComponent, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(generator: "drip")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKDripAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Intensity
-    public static let intensityRange: ClosedRange<Double> = 0 ... 100
+    public static let intensityRange: ClosedRange<AUValue> = 0 ... 100
 
     /// Lower and upper bounds for Damping Factor
-    public static let dampingFactorRange: ClosedRange<Double> = 0.0 ... 2.0
+    public static let dampingFactorRange: ClosedRange<AUValue> = 0.0 ... 2.0
 
     /// Lower and upper bounds for Energy Return
-    public static let energyReturnRange: ClosedRange<Double> = 0 ... 100
+    public static let energyReturnRange: ClosedRange<AUValue> = 0 ... 100
 
     /// Lower and upper bounds for Main Resonant Frequency
-    public static let mainResonantFrequencyRange: ClosedRange<Double> = 0 ... 22_000
+    public static let mainResonantFrequencyRange: ClosedRange<AUValue> = 0 ... 22000
 
     /// Lower and upper bounds for First Resonant Frequency
-    public static let firstResonantFrequencyRange: ClosedRange<Double> = 0 ... 22_000
+    public static let firstResonantFrequencyRange: ClosedRange<AUValue> = 0 ... 22000
 
     /// Lower and upper bounds for Second Resonant Frequency
-    public static let secondResonantFrequencyRange: ClosedRange<Double> = 0 ... 22_000
+    public static let secondResonantFrequencyRange: ClosedRange<AUValue> = 0 ... 22000
 
     /// Lower and upper bounds for Amplitude
-    public static let amplitudeRange: ClosedRange<Double> = 0 ... 1
+    public static let amplitudeRange: ClosedRange<AUValue> = 0 ... 1
 
     /// Initial value for Intensity
-    public static let defaultIntensity: Double = 10
+    public static let defaultIntensity: AUValue = 10
 
     /// Initial value for Damping Factor
-    public static let defaultDampingFactor: Double = 0.2
+    public static let defaultDampingFactor: AUValue = 0.2
 
     /// Initial value for Energy Return
-    public static let defaultEnergyReturn: Double = 0
+    public static let defaultEnergyReturn: AUValue = 0
 
     /// Initial value for Main Resonant Frequency
-    public static let defaultMainResonantFrequency: Double = 450
+    public static let defaultMainResonantFrequency: AUValue = 450
 
     /// Initial value for First Resonant Frequency
-    public static let defaultFirstResonantFrequency: Double = 600
+    public static let defaultFirstResonantFrequency: AUValue = 600
 
     /// Initial value for Second Resonant Frequency
-    public static let defaultSecondResonantFrequency: Double = 750
+    public static let defaultSecondResonantFrequency: AUValue = 750
 
     /// Initial value for Amplitude
-    public static let defaultAmplitude: Double = 0.3
+    public static let defaultAmplitude: AUValue = 0.3
 
     /// The intensity of the dripping sound.
-    @objc open var intensity: Double = defaultIntensity {
-        willSet {
-            let clampedValue = AKDrip.intensityRange.clamp(newValue)
-            guard intensity != clampedValue else { return }
-            internalAU?.intensity.value = AUValue(clampedValue)
-        }
-    }
+    public let intensity = AKNodeParameter(identifier: "intensity")
 
     /// The damping factor. Maximum value is 2.0.
-    @objc open var dampingFactor: Double = defaultDampingFactor {
-        willSet {
-            let clampedValue = AKDrip.dampingFactorRange.clamp(newValue)
-            guard dampingFactor != clampedValue else { return }
-            internalAU?.dampingFactor.value = AUValue(clampedValue)
-        }
-    }
+    public let dampingFactor = AKNodeParameter(identifier: "dampingFactor")
 
     /// The amount of energy to add back into the system.
-    @objc open var energyReturn: Double = defaultEnergyReturn {
-        willSet {
-            let clampedValue = AKDrip.energyReturnRange.clamp(newValue)
-            guard energyReturn != clampedValue else { return }
-            internalAU?.energyReturn.value = AUValue(clampedValue)
-        }
-    }
+    public let energyReturn = AKNodeParameter(identifier: "energyReturn")
 
     /// Main resonant frequency.
-    @objc open var mainResonantFrequency: Double = defaultMainResonantFrequency {
-        willSet {
-            let clampedValue = AKDrip.mainResonantFrequencyRange.clamp(newValue)
-            guard mainResonantFrequency != clampedValue else { return }
-            internalAU?.mainResonantFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let mainResonantFrequency = AKNodeParameter(identifier: "mainResonantFrequency")
 
     /// The first resonant frequency.
-    @objc open var firstResonantFrequency: Double = defaultFirstResonantFrequency {
-        willSet {
-            let clampedValue = AKDrip.firstResonantFrequencyRange.clamp(newValue)
-            guard firstResonantFrequency != clampedValue else { return }
-            internalAU?.firstResonantFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let firstResonantFrequency = AKNodeParameter(identifier: "firstResonantFrequency")
 
     /// The second resonant frequency.
-    @objc open var secondResonantFrequency: Double = defaultSecondResonantFrequency {
-        willSet {
-            let clampedValue = AKDrip.secondResonantFrequencyRange.clamp(newValue)
-            guard secondResonantFrequency != clampedValue else { return }
-            internalAU?.secondResonantFrequency.value = AUValue(clampedValue)
-        }
-    }
+    public let secondResonantFrequency = AKNodeParameter(identifier: "secondResonantFrequency")
 
     /// Amplitude.
-    @objc open var amplitude: Double = defaultAmplitude {
-        willSet {
-            let clampedValue = AKDrip.amplitudeRange.clamp(newValue)
-            guard amplitude != clampedValue else { return }
-            internalAU?.amplitude.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let amplitude = AKNodeParameter(identifier: "amplitude")
 
     // MARK: - Initialization
-
+    
     /// Initialize this drip node
     ///
     /// - Parameters:
@@ -136,39 +97,31 @@ open class AKDrip: AKNode, AKToggleable, AKComponent {
     ///   - amplitude: Amplitude.
     ///
     public init(
-        intensity: Double = defaultIntensity,
-        dampingFactor: Double = defaultDampingFactor,
-        energyReturn: Double = defaultEnergyReturn,
-        mainResonantFrequency: Double = defaultMainResonantFrequency,
-        firstResonantFrequency: Double = defaultFirstResonantFrequency,
-        secondResonantFrequency: Double = defaultSecondResonantFrequency,
-        amplitude: Double = defaultAmplitude
+        intensity: AUValue = defaultIntensity,
+        dampingFactor: AUValue = defaultDampingFactor,
+        energyReturn: AUValue = defaultEnergyReturn,
+        mainResonantFrequency: AUValue = defaultMainResonantFrequency,
+        firstResonantFrequency: AUValue = defaultFirstResonantFrequency,
+        secondResonantFrequency: AUValue = defaultSecondResonantFrequency,
+        amplitude: AUValue = defaultAmplitude
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-
-            self.intensity = intensity
-            self.dampingFactor = dampingFactor
-            self.energyReturn = energyReturn
-            self.mainResonantFrequency = mainResonantFrequency
-            self.firstResonantFrequency = firstResonantFrequency
-            self.secondResonantFrequency = secondResonantFrequency
-            self.amplitude = amplitude
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.intensity.associate(with: self.internalAU, value: intensity)
+            self.dampingFactor.associate(with: self.internalAU, value: dampingFactor)
+            self.energyReturn.associate(with: self.internalAU, value: energyReturn)
+            self.mainResonantFrequency.associate(with: self.internalAU, value: mainResonantFrequency)
+            self.firstResonantFrequency.associate(with: self.internalAU, value: firstResonantFrequency)
+            self.secondResonantFrequency.associate(with: self.internalAU, value: secondResonantFrequency)
+            self.amplitude.associate(with: self.internalAU, value: amplitude)
         }
-    }
 
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripAudioUnit.swift
@@ -4,92 +4,70 @@ import AVFoundation
 
 public class AKDripAudioUnit: AKAudioUnitBase {
 
-    private(set) var intensity: AUParameter!
+    let intensity = AUParameter(
+        identifier: "intensity",
+        name: "The intensity of the dripping sounds.",
+        address: AKDripParameter.intensity.rawValue,
+        range: AKDrip.intensityRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var dampingFactor: AUParameter!
+    let dampingFactor = AUParameter(
+        identifier: "dampingFactor",
+        name: "The damping factor. Maximum value is 2.0.",
+        address: AKDripParameter.dampingFactor.rawValue,
+        range: AKDrip.dampingFactorRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var energyReturn: AUParameter!
+    let energyReturn = AUParameter(
+        identifier: "energyReturn",
+        name: "The amount of energy to add back into the system.",
+        address: AKDripParameter.energyReturn.rawValue,
+        range: AKDrip.energyReturnRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var mainResonantFrequency: AUParameter!
+    let mainResonantFrequency = AUParameter(
+        identifier: "mainResonantFrequency",
+        name: "Main resonant frequency.",
+        address: AKDripParameter.mainResonantFrequency.rawValue,
+        range: AKDrip.mainResonantFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var firstResonantFrequency: AUParameter!
+    let firstResonantFrequency = AUParameter(
+        identifier: "firstResonantFrequency",
+        name: "The first resonant frequency.",
+        address: AKDripParameter.firstResonantFrequency.rawValue,
+        range: AKDrip.firstResonantFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var secondResonantFrequency: AUParameter!
+    let secondResonantFrequency = AUParameter(
+        identifier: "secondResonantFrequency",
+        name: "The second resonant frequency.",
+        address: AKDripParameter.secondResonantFrequency.rawValue,
+        range: AKDrip.secondResonantFrequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude.",
+        address: AKDripParameter.amplitude.rawValue,
+        range: AKDrip.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createDripDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        intensity = AUParameter(
-            identifier: "intensity",
-            name: "The intensity of the dripping sounds.",
-            address: AKDripParameter.intensity.rawValue,
-            range: AKDrip.intensityRange,
-            unit: .generic,
-            flags: .default)
-        dampingFactor = AUParameter(
-            identifier: "dampingFactor",
-            name: "The damping factor. Maximum value is 2.0.",
-            address: AKDripParameter.dampingFactor.rawValue,
-            range: AKDrip.dampingFactorRange,
-            unit: .generic,
-            flags: .default)
-        energyReturn = AUParameter(
-            identifier: "energyReturn",
-            name: "The amount of energy to add back into the system.",
-            address: AKDripParameter.energyReturn.rawValue,
-            range: AKDrip.energyReturnRange,
-            unit: .generic,
-            flags: .default)
-        mainResonantFrequency = AUParameter(
-            identifier: "mainResonantFrequency",
-            name: "Main resonant frequency.",
-            address: AKDripParameter.mainResonantFrequency.rawValue,
-            range: AKDrip.mainResonantFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        firstResonantFrequency = AUParameter(
-            identifier: "firstResonantFrequency",
-            name: "The first resonant frequency.",
-            address: AKDripParameter.firstResonantFrequency.rawValue,
-            range: AKDrip.firstResonantFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        secondResonantFrequency = AUParameter(
-            identifier: "secondResonantFrequency",
-            name: "The second resonant frequency.",
-            address: AKDripParameter.secondResonantFrequency.rawValue,
-            range: AKDrip.secondResonantFrequencyRange,
-            unit: .hertz,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude.",
-            address: AKDripParameter.amplitude.rawValue,
-            range: AKDrip.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [intensity,
-                                                                  dampingFactor,
-                                                                  energyReturn,
-                                                                  mainResonantFrequency,
-                                                                  firstResonantFrequency,
-                                                                  secondResonantFrequency,
-                                                                  amplitude])
-
-        intensity.value = AUValue(AKDrip.defaultIntensity)
-        dampingFactor.value = AUValue(AKDrip.defaultDampingFactor)
-        energyReturn.value = AUValue(AKDrip.defaultEnergyReturn)
-        mainResonantFrequency.value = AUValue(AKDrip.defaultMainResonantFrequency)
-        firstResonantFrequency.value = AUValue(AKDrip.defaultFirstResonantFrequency)
-        secondResonantFrequency.value = AUValue(AKDrip.defaultSecondResonantFrequency)
-        amplitude.value = AUValue(AKDrip.defaultAmplitude)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [intensity, dampingFactor, energyReturn, mainResonantFrequency, firstResonantFrequency, secondResonantFrequency, amplitude])
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drum Synths/AKDrumSynths.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drum Synths/AKDrumSynths.swift
@@ -18,8 +18,8 @@ open class AKSynthKick: AKMIDIInstrument {
         }
 
         filter = AKMoogLadder(generator)
-        filter.cutoffFrequency = 666
-        filter.resonance = 0.00
+        filter.cutoffFrequency.value = 666
+        filter.resonance.value = 0.00
 
         super.init(midiInputName: midiInputName)
         avAudioUnit = filter.avAudioUnit
@@ -28,8 +28,8 @@ open class AKSynthKick: AKMIDIInstrument {
 
     /// Function to start, play, or activate the node, all do the same thing
     @objc open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel = 0) {
-        filter.cutoffFrequency = (Double(velocity) / 127.0 * 366.0) + 300.0
-        filter.resonance = 1.0 - Double(velocity) / 127.0
+        filter.cutoffFrequency.value = (AUValue(velocity) / 127.0 * 366.0) + 300.0
+        filter.resonance.value = 1.0 - AUValue(velocity) / 127.0
         generator.trigger()
     }
 
@@ -61,7 +61,7 @@ open class AKSynthSnare: AKMIDIInstrument {
         }
 
         filter = AKMoogLadder(generator)
-        filter.cutoffFrequency = 1_666
+        filter.cutoffFrequency.value = AUValue(1_666)
 
         super.init()
         avAudioUnit = filter.avAudioUnit
@@ -70,12 +70,12 @@ open class AKSynthSnare: AKMIDIInstrument {
 
     internal var cutoff: Double = 1_666 {
         didSet {
-            filter.cutoffFrequency = cutoff
+            filter.cutoffFrequency.value = AUValue(cutoff)
         }
     }
     internal var resonance: Double = 0.3 {
         didSet {
-            filter.resonance = resonance
+            filter.resonance.value = AUValue(resonance)
         }
     }
 

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBar.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBar.swift
@@ -2,133 +2,94 @@
 
 /// 
 ///
-open class AKMetalBar: AKNode, AKToggleable, AKComponent {
-    public typealias AKAudioUnitType = AKMetalBarAudioUnit
+open class AKMetalBar: AKNode, AKToggleable, AKComponent, AKAutomatable {
+
+    // MARK: - AKComponent
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(generator: "mbar")
-
-    // MARK: - Properties
+    
+    public typealias AKAudioUnitType = AKMetalBarAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
-
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
+    
+    // MARK: - Parameters
+    
     /// Lower and upper bounds for Left Boundary Condition
-    public static let leftBoundaryConditionRange: ClosedRange<Double> = 1 ... 3
+    public static let leftBoundaryConditionRange: ClosedRange<AUValue> = 1 ... 3
 
     /// Lower and upper bounds for Right Boundary Condition
-    public static let rightBoundaryConditionRange: ClosedRange<Double> = 1 ... 3
+    public static let rightBoundaryConditionRange: ClosedRange<AUValue> = 1 ... 3
 
     /// Lower and upper bounds for Decay Duration
-    public static let decayDurationRange: ClosedRange<Double> = 0 ... 10
+    public static let decayDurationRange: ClosedRange<AUValue> = 0 ... 10
 
     /// Lower and upper bounds for Scan Speed
-    public static let scanSpeedRange: ClosedRange<Double> = 0 ... 100
+    public static let scanSpeedRange: ClosedRange<AUValue> = 0 ... 100
 
     /// Lower and upper bounds for Position
-    public static let positionRange: ClosedRange<Double> = 0 ... 1
+    public static let positionRange: ClosedRange<AUValue> = 0 ... 1
 
     /// Lower and upper bounds for Strike Velocity
-    public static let strikeVelocityRange: ClosedRange<Double> = 0 ... 1_000
+    public static let strikeVelocityRange: ClosedRange<AUValue> = 0 ... 1000
 
     /// Lower and upper bounds for Strike Width
-    public static let strikeWidthRange: ClosedRange<Double> = 0 ... 1
+    public static let strikeWidthRange: ClosedRange<AUValue> = 0 ... 1
 
     /// Initial value for Left Boundary Condition
-    public static let defaultLeftBoundaryCondition: Double = 1
+    public static let defaultLeftBoundaryCondition: AUValue = 1
 
     /// Initial value for Right Boundary Condition
-    public static let defaultRightBoundaryCondition: Double = 1
+    public static let defaultRightBoundaryCondition: AUValue = 1
 
     /// Initial value for Decay Duration
-    public static let defaultDecayDuration: Double = 3
+    public static let defaultDecayDuration: AUValue = 3
 
     /// Initial value for Scan Speed
-    public static let defaultScanSpeed: Double = 0.25
+    public static let defaultScanSpeed: AUValue = 0.25
 
     /// Initial value for Position
-    public static let defaultPosition: Double = 0.2
+    public static let defaultPosition: AUValue = 0.2
 
     /// Initial value for Strike Velocity
-    public static let defaultStrikeVelocity: Double = 500
+    public static let defaultStrikeVelocity: AUValue = 500
 
     /// Initial value for Strike Width
-    public static let defaultStrikeWidth: Double = 0.05
+    public static let defaultStrikeWidth: AUValue = 0.05
 
     /// Initial value for Stiffness
-    public static let defaultStiffness: Double = 3
+    public static let defaultStiffness: AUValue = 3
 
     /// Initial value for High Frequency Damping
-    public static let defaultHighFrequencyDamping: Double = 0.001
+    public static let defaultHighFrequencyDamping: AUValue = 0.001
 
     /// Boundary condition at left end of bar. 1 = clamped, 2 = pivoting, 3 = free
-    @objc open var leftBoundaryCondition: Double = defaultLeftBoundaryCondition {
-        willSet {
-            let clampedValue = AKMetalBar.leftBoundaryConditionRange.clamp(newValue)
-            guard leftBoundaryCondition != clampedValue else { return }
-            internalAU?.leftBoundaryCondition.value = AUValue(clampedValue)
-        }
-    }
+    public let leftBoundaryCondition = AKNodeParameter(identifier: "leftBoundaryCondition")
 
     /// Boundary condition at right end of bar. 1 = clamped, 2 = pivoting, 3 = free
-    @objc open var rightBoundaryCondition: Double = defaultRightBoundaryCondition {
-        willSet {
-            let clampedValue = AKMetalBar.rightBoundaryConditionRange.clamp(newValue)
-            guard rightBoundaryCondition != clampedValue else { return }
-            internalAU?.rightBoundaryCondition.value = AUValue(clampedValue)
-        }
-    }
+    public let rightBoundaryCondition = AKNodeParameter(identifier: "rightBoundaryCondition")
 
     /// 30db decay time (in seconds).
-    @objc open var decayDuration: Double = defaultDecayDuration {
-        willSet {
-            let clampedValue = AKMetalBar.decayDurationRange.clamp(newValue)
-            guard decayDuration != clampedValue else { return }
-            internalAU?.decayDuration.value = AUValue(clampedValue)
-        }
-    }
+    public let decayDuration = AKNodeParameter(identifier: "decayDuration")
 
     /// Speed of scanning the output location.
-    @objc open var scanSpeed: Double = defaultScanSpeed {
-        willSet {
-            let clampedValue = AKMetalBar.scanSpeedRange.clamp(newValue)
-            guard scanSpeed != clampedValue else { return }
-            internalAU?.scanSpeed.value = AUValue(clampedValue)
-        }
-    }
+    public let scanSpeed = AKNodeParameter(identifier: "scanSpeed")
 
     /// Position along bar that strike occurs.
-    @objc open var position: Double = defaultPosition {
-        willSet {
-            let clampedValue = AKMetalBar.positionRange.clamp(newValue)
-            guard position != clampedValue else { return }
-            internalAU?.position.value = AUValue(clampedValue)
-        }
-    }
+    public let position = AKNodeParameter(identifier: "position")
 
     /// Normalized strike velocity
-    @objc open var strikeVelocity: Double = defaultStrikeVelocity {
-        willSet {
-            let clampedValue = AKMetalBar.strikeVelocityRange.clamp(newValue)
-            guard strikeVelocity != clampedValue else { return }
-            internalAU?.strikeVelocity.value = AUValue(clampedValue)
-        }
-    }
+    public let strikeVelocity = AKNodeParameter(identifier: "strikeVelocity")
 
     /// Spatial width of strike.
-    @objc open var strikeWidth: Double = defaultStrikeWidth {
-        willSet {
-            let clampedValue = AKMetalBar.strikeWidthRange.clamp(newValue)
-            guard strikeWidth != clampedValue else { return }
-            internalAU?.strikeWidth.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let strikeWidth = AKNodeParameter(identifier: "strikeWidth")
 
     // MARK: - Initialization
-
+    
     /// Initialize this Bar node
     ///
     /// - Parameters:
@@ -143,41 +104,33 @@ open class AKMetalBar: AKNode, AKToggleable, AKComponent {
     ///   - highFrequencyDamping: High-frequency loss parameter. Keep this small
     ///
     public init(
-        leftBoundaryCondition: Double = defaultLeftBoundaryCondition,
-        rightBoundaryCondition: Double = defaultRightBoundaryCondition,
-        decayDuration: Double = defaultDecayDuration,
-        scanSpeed: Double = defaultScanSpeed,
-        position: Double = defaultPosition,
-        strikeVelocity: Double = defaultStrikeVelocity,
-        strikeWidth: Double = defaultStrikeWidth,
-        stiffness: Double = defaultStiffness,
-        highFrequencyDamping: Double = defaultHighFrequencyDamping
+        leftBoundaryCondition: AUValue = defaultLeftBoundaryCondition,
+        rightBoundaryCondition: AUValue = defaultRightBoundaryCondition,
+        decayDuration: AUValue = defaultDecayDuration,
+        scanSpeed: AUValue = defaultScanSpeed,
+        position: AUValue = defaultPosition,
+        strikeVelocity: AUValue = defaultStrikeVelocity,
+        strikeWidth: AUValue = defaultStrikeWidth,
+        stiffness: AUValue = defaultStiffness,
+        highFrequencyDamping: AUValue = defaultHighFrequencyDamping
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-
-            self.leftBoundaryCondition = leftBoundaryCondition
-            self.rightBoundaryCondition = rightBoundaryCondition
-            self.decayDuration = decayDuration
-            self.scanSpeed = scanSpeed
-            self.position = position
-            self.strikeVelocity = strikeVelocity
-            self.strikeWidth = strikeWidth
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            
+            self.leftBoundaryCondition.associate(with: self.internalAU, value: leftBoundaryCondition)
+            self.rightBoundaryCondition.associate(with: self.internalAU, value: rightBoundaryCondition)
+            self.decayDuration.associate(with: self.internalAU, value: decayDuration)
+            self.scanSpeed.associate(with: self.internalAU, value: scanSpeed)
+            self.position.associate(with: self.internalAU, value: position)
+            self.strikeVelocity.associate(with: self.internalAU, value: strikeVelocity)
+            self.strikeWidth.associate(with: self.internalAU, value: strikeWidth)
         }
-    }
 
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarAudioUnit.swift
@@ -4,92 +4,70 @@ import AVFoundation
 
 public class AKMetalBarAudioUnit: AKAudioUnitBase {
 
-    private(set) var leftBoundaryCondition: AUParameter!
+    let leftBoundaryCondition = AUParameter(
+        identifier: "leftBoundaryCondition",
+        name: "Boundary condition at left end of bar. 1 = clamped, 2 = pivoting, 3 = free",
+        address: AKMetalBarParameter.leftBoundaryCondition.rawValue,
+        range: AKMetalBar.leftBoundaryConditionRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var rightBoundaryCondition: AUParameter!
+    let rightBoundaryCondition = AUParameter(
+        identifier: "rightBoundaryCondition",
+        name: "Boundary condition at right end of bar. 1 = clamped, 2 = pivoting, 3 = free",
+        address: AKMetalBarParameter.rightBoundaryCondition.rawValue,
+        range: AKMetalBar.rightBoundaryConditionRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var decayDuration: AUParameter!
+    let decayDuration = AUParameter(
+        identifier: "decayDuration",
+        name: "30db decay time (in seconds).",
+        address: AKMetalBarParameter.decayDuration.rawValue,
+        range: AKMetalBar.decayDurationRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var scanSpeed: AUParameter!
+    let scanSpeed = AUParameter(
+        identifier: "scanSpeed",
+        name: "Speed of scanning the output location.",
+        address: AKMetalBarParameter.scanSpeed.rawValue,
+        range: AKMetalBar.scanSpeedRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var position: AUParameter!
+    let position = AUParameter(
+        identifier: "position",
+        name: "Position along bar that strike occurs.",
+        address: AKMetalBarParameter.position.rawValue,
+        range: AKMetalBar.positionRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var strikeVelocity: AUParameter!
+    let strikeVelocity = AUParameter(
+        identifier: "strikeVelocity",
+        name: "Normalized strike velocity",
+        address: AKMetalBarParameter.strikeVelocity.rawValue,
+        range: AKMetalBar.strikeVelocityRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var strikeWidth: AUParameter!
+    let strikeWidth = AUParameter(
+        identifier: "strikeWidth",
+        name: "Spatial width of strike.",
+        address: AKMetalBarParameter.strikeWidth.rawValue,
+        range: AKMetalBar.strikeWidthRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createMetalBarDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        leftBoundaryCondition = AUParameter(
-            identifier: "leftBoundaryCondition",
-            name: "Boundary condition at left end of bar. 1 = clamped, 2 = pivoting, 3 = free",
-            address: AKMetalBarParameter.leftBoundaryCondition.rawValue,
-            range: AKMetalBar.leftBoundaryConditionRange,
-            unit: .hertz,
-            flags: .default)
-        rightBoundaryCondition = AUParameter(
-            identifier: "rightBoundaryCondition",
-            name: "Boundary condition at right end of bar. 1 = clamped, 2 = pivoting, 3 = free",
-            address: AKMetalBarParameter.rightBoundaryCondition.rawValue,
-            range: AKMetalBar.rightBoundaryConditionRange,
-            unit: .hertz,
-            flags: .default)
-        decayDuration = AUParameter(
-            identifier: "decayDuration",
-            name: "30db decay time (in seconds).",
-            address: AKMetalBarParameter.decayDuration.rawValue,
-            range: AKMetalBar.decayDurationRange,
-            unit: .hertz,
-            flags: .default)
-        scanSpeed = AUParameter(
-            identifier: "scanSpeed",
-            name: "Speed of scanning the output location.",
-            address: AKMetalBarParameter.scanSpeed.rawValue,
-            range: AKMetalBar.scanSpeedRange,
-            unit: .hertz,
-            flags: .default)
-        position = AUParameter(
-            identifier: "position",
-            name: "Position along bar that strike occurs.",
-            address: AKMetalBarParameter.position.rawValue,
-            range: AKMetalBar.positionRange,
-            unit: .generic,
-            flags: .default)
-        strikeVelocity = AUParameter(
-            identifier: "strikeVelocity",
-            name: "Normalized strike velocity",
-            address: AKMetalBarParameter.strikeVelocity.rawValue,
-            range: AKMetalBar.strikeVelocityRange,
-            unit: .generic,
-            flags: .default)
-        strikeWidth = AUParameter(
-            identifier: "strikeWidth",
-            name: "Spatial width of strike.",
-            address: AKMetalBarParameter.strikeWidth.rawValue,
-            range: AKMetalBar.strikeWidthRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [leftBoundaryCondition,
-                                                                  rightBoundaryCondition,
-                                                                  decayDuration,
-                                                                  scanSpeed,
-                                                                  position,
-                                                                  strikeVelocity,
-                                                                  strikeWidth])
-
-        leftBoundaryCondition.value = AUValue(AKMetalBar.defaultLeftBoundaryCondition)
-        rightBoundaryCondition.value = AUValue(AKMetalBar.defaultRightBoundaryCondition)
-        decayDuration.value = AUValue(AKMetalBar.defaultDecayDuration)
-        scanSpeed.value = AUValue(AKMetalBar.defaultScanSpeed)
-        position.value = AUValue(AKMetalBar.defaultPosition)
-        strikeVelocity.value = AUValue(AKMetalBar.defaultStrikeVelocity)
-        strikeWidth.value = AUValue(AKMetalBar.defaultStrikeWidth)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [leftBoundaryCondition, rightBoundaryCondition, decayDuration, scanSpeed, position, strikeVelocity, strikeWidth])
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringAudioUnit.swift
@@ -4,36 +4,30 @@ import AVFoundation
 
 public class AKPluckedStringAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Variable frequency. Values less than the initial frequency  will be doubled until it is greater than that.",
+        address: AKPluckedStringParameter.frequency.rawValue,
+        range: AKPluckedString.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude",
+        address: AKPluckedStringParameter.amplitude.rawValue,
+        range: AKPluckedString.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPluckedStringDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Variable frequency. Values less than the initial frequency will be doubled until it is greater than that.",
-            address: AKPluckedStringParameter.frequency.rawValue,
-            range: AKPluckedString.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude",
-            address: AKPluckedStringParameter.amplitude.rawValue,
-            range: AKPluckedString.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [frequency, amplitude])
-
-        frequency.value = AUValue(AKPluckedString.defaultFrequency)
-        amplitude.value = AUValue(AKPluckedString.defaultAmplitude)
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTract.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTract.mm
@@ -8,3 +8,63 @@ extern "C" AKDSPRef createVocalTractDSP() {
     AKVocalTractDSP *dsp = new AKVocalTractDSP();
     return dsp;
 }
+
+AKVocalTractDSP::AKVocalTractDSP() {
+    parameters[AKVocalTractParameterFrequency] = &frequencyRamp;
+    parameters[AKVocalTractParameterTonguePosition] = &tonguePositionRamp;
+    parameters[AKVocalTractParameterTongueDiameter] = &tongueDiameterRamp;
+    parameters[AKVocalTractParameterTenseness] = &tensenessRamp;
+    parameters[AKVocalTractParameterNasality] = &nasalityRamp;
+}
+
+void AKVocalTractDSP::init(int channelCount, double sampleRate) {
+    AKSoundpipeDSPBase::init(channelCount, sampleRate);
+
+    sp_vocwrapper_create(&vocwrapper);
+    sp_vocwrapper_init(sp, vocwrapper);
+    vocwrapper->freq = 160.0;
+    vocwrapper->pos = 0.5;
+    vocwrapper->diam = 1.0;
+    vocwrapper->tenseness = 0.6;
+    vocwrapper->nasal = 0.0;
+
+    isStarted = false;
+}
+
+void AKVocalTractDSP::deinit() {
+    AKSoundpipeDSPBase::deinit();
+    sp_vocwrapper_destroy(&vocwrapper);
+}
+
+
+void AKVocalTractDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {
+
+    for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
+        int frameOffset = int(frameIndex + bufferOffset);
+
+        float frequency = frequencyRamp.getAndStep();
+        float tonguePosition = tonguePositionRamp.getAndStep();
+        float tongueDiameter = tongueDiameterRamp.getAndStep();
+        float tenseness = tensenessRamp.getAndStep();
+        float nasality = nasalityRamp.getAndStep();
+        vocwrapper->freq = frequency;
+        vocwrapper->pos = tonguePosition;
+        vocwrapper->diam = tongueDiameter;
+        vocwrapper->tenseness = tenseness;
+        vocwrapper->nasal = nasality;
+
+        float temp = 0;
+        for (int channel = 0; channel < channelCount; ++channel) {
+            float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+
+            if (isStarted) {
+                if (channel == 0) {
+                    sp_vocwrapper_compute(sp, vocwrapper, nil, &temp);
+                }
+                *out = temp;
+            } else {
+                *out = 0.0;
+            }
+        }
+    }
+}

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractAudioUnit.swift
@@ -4,70 +4,54 @@ import AVFoundation
 
 public class AKVocalTractAudioUnit: AKAudioUnitBase {
 
-    private(set) var frequency: AUParameter!
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Glottal frequency.",
+        address: AKVocalTractParameter.frequency.rawValue,
+        range: AKVocalTract.frequencyRange,
+        unit: .hertz,
+        flags: .default)
 
-    private(set) var tonguePosition: AUParameter!
+    let tonguePosition = AUParameter(
+        identifier: "tonguePosition",
+        name: "Tongue position (0-1)",
+        address: AKVocalTractParameter.tonguePosition.rawValue,
+        range: AKVocalTract.tonguePositionRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var tongueDiameter: AUParameter!
+    let tongueDiameter = AUParameter(
+        identifier: "tongueDiameter",
+        name: "Tongue diameter (0-1)",
+        address: AKVocalTractParameter.tongueDiameter.rawValue,
+        range: AKVocalTract.tongueDiameterRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var tenseness: AUParameter!
+    let tenseness = AUParameter(
+        identifier: "tenseness",
+        name: "Vocal tenseness. 0 = all breath. 1=fully saturated.",
+        address: AKVocalTractParameter.tenseness.rawValue,
+        range: AKVocalTract.tensenessRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var nasality: AUParameter!
+    let nasality = AUParameter(
+        identifier: "nasality",
+        name: "Sets the velum size. Larger values of this creates more nasally sounds.",
+        address: AKVocalTractParameter.nasality.rawValue,
+        range: AKVocalTract.nasalityRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createVocalTractDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Glottal frequency.",
-            address: AKVocalTractParameter.frequency.rawValue,
-            range: AKVocalTract.frequencyRange,
-            unit: .hertz,
-            flags: .default)
-        tonguePosition = AUParameter(
-            identifier: "tonguePosition",
-            name: "Tongue position (0-1)",
-            address: AKVocalTractParameter.tonguePosition.rawValue,
-            range: AKVocalTract.tonguePositionRange,
-            unit: .generic,
-            flags: .default)
-        tongueDiameter = AUParameter(
-            identifier: "tongueDiameter",
-            name: "Tongue diameter (0-1)",
-            address: AKVocalTractParameter.tongueDiameter.rawValue,
-            range: AKVocalTract.tongueDiameterRange,
-            unit: .generic,
-            flags: .default)
-        tenseness = AUParameter(
-            identifier: "tenseness",
-            name: "Vocal tenseness. 0 = all breath. 1=fully saturated.",
-            address: AKVocalTractParameter.tenseness.rawValue,
-            range: AKVocalTract.tensenessRange,
-            unit: .generic,
-            flags: .default)
-        nasality = AUParameter(
-            identifier: "nasality",
-            name: "Sets the velum size. Larger values of this creates more nasally sounds.",
-            address: AKVocalTractParameter.nasality.rawValue,
-            range: AKVocalTract.nasalityRange,
-            unit: .generic,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [frequency,
-                                                                  tonguePosition,
-                                                                  tongueDiameter,
-                                                                  tenseness,
-                                                                  nasality])
-
-        frequency.value = AUValue(AKVocalTract.defaultFrequency)
-        tonguePosition.value = AUValue(AKVocalTract.defaultTonguePosition)
-        tongueDiameter.value = AUValue(AKVocalTract.defaultTongueDiameter)
-        tenseness.value = AUValue(AKVocalTract.defaultTenseness)
-        nasality.value = AUValue(AKVocalTract.defaultNasality)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [frequency, tonguePosition, tongueDiameter, tenseness, nasality])
     }
 }

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.hpp
@@ -12,8 +12,6 @@ typedef NS_ENUM(AUParameterAddress, AKVocalTractParameter) {
     AKVocalTractParameterNasality,
 };
 
-#import "AKLinearParameterRamp.hpp"  // have to put this here to get it included in umbrella header
-
 #ifndef __cplusplus
 
 AKDSPRef createVocalTractDSP(void);
@@ -21,86 +19,27 @@ AKDSPRef createVocalTractDSP(void);
 #else
 
 #import "AKSoundpipeDSPBase.hpp"
+#import "ParameterRamper.hpp"
 
 class AKVocalTractDSP : public AKSoundpipeDSPBase {
-
-    sp_vocwrapper *vocwrapper;
-
-private:
-    AKLinearParameterRamp frequencyRamp;
-    AKLinearParameterRamp tonguePositionRamp;
-    AKLinearParameterRamp tongueDiameterRamp;
-    AKLinearParameterRamp tensenessRamp;
-    AKLinearParameterRamp nasalityRamp;
-
 public:
-    AKVocalTractDSP() {
-        parameters[AKVocalTractParameterFrequency] = &frequencyRamp;
-        parameters[AKVocalTractParameterTonguePosition] = &tonguePositionRamp;
-        parameters[AKVocalTractParameterTongueDiameter] = &tongueDiameterRamp;
-        parameters[AKVocalTractParameterTenseness] = &tensenessRamp;
-        parameters[AKVocalTractParameterNasality] = &nasalityRamp;
-    }
+    AKVocalTractDSP();
 
-    void init(int channelCount, double sampleRate) override {
-        AKSoundpipeDSPBase::init(channelCount, sampleRate);
+    void init(int channelCount, double sampleRate) override;
 
-        sp_vocwrapper_create(&vocwrapper);
-        sp_vocwrapper_init(sp, vocwrapper);
-        vocwrapper->freq = 160.0;
-        vocwrapper->pos = 0.5;
-        vocwrapper->diam = 1.0;
-        vocwrapper->tenseness = 0.6;
-        vocwrapper->nasal = 0.0;
+    void deinit() override;
 
-        isStarted = false;
-    }
-
-    void deinit() override {
-        AKSoundpipeDSPBase::deinit();
-        sp_vocwrapper_destroy(&vocwrapper);
-    }
-
-
-    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override {
-
-        for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
-            int frameOffset = int(frameIndex + bufferOffset);
-
-            // do ramping every 8 samples
-            if ((frameOffset & 0x7) == 0) {
-                frequencyRamp.advanceTo(now + frameOffset);
-                tonguePositionRamp.advanceTo(now + frameOffset);
-                tongueDiameterRamp.advanceTo(now + frameOffset);
-                tensenessRamp.advanceTo(now + frameOffset);
-                nasalityRamp.advanceTo(now + frameOffset);
-            }
-            float frequency = frequencyRamp.getValue();
-            float tonguePosition = tonguePositionRamp.getValue();
-            float tongueDiameter = tongueDiameterRamp.getValue();
-            float tenseness = tensenessRamp.getValue();
-            float nasality = nasalityRamp.getValue();
-            vocwrapper->freq = frequency;
-            vocwrapper->pos = tonguePosition;
-            vocwrapper->diam = tongueDiameter;
-            vocwrapper->tenseness = tenseness;
-            vocwrapper->nasal = nasality;
-
-            float temp = 0;
-            for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
-
-                if (isStarted) {
-                    if (channel == 0) {
-                        sp_vocwrapper_compute(sp, vocwrapper, nil, &temp);
-                    }
-                    *out = temp;
-                } else {
-                    *out = 0.0;
-                }
-            }
-        }
-    }
+    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
+    
+private:
+    
+    sp_vocwrapper *vocwrapper;
+    
+    ParameterRamper frequencyRamp;
+    ParameterRamper tonguePositionRamp;
+    ParameterRamper tongueDiameterRamp;
+    ParameterRamper tensenessRamp;
+    ParameterRamper nasalityRamp;
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/PWM Filter Synth/AKPWMOscillatorFilterSynthDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/PWM Filter Synth/AKPWMOscillatorFilterSynthDSPKernel.hpp
@@ -123,7 +123,7 @@ public:
 
     void init(int channelCount, double sampleRate) override {
         AKFilterSynthDSPKernel::init(channelCount, sampleRate);
-        pulseWidthRamper.init();
+        pulseWidthRamper.init(sampleRate);
     }
 
     void reset() override {

--- a/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBankDSPKernel.hpp
@@ -94,7 +94,7 @@ public:
     
     void init(int channelCount, double sampleRate) override {
         AKBankDSPKernel::init(channelCount, sampleRate);
-        pulseWidthRamper.init();
+        pulseWidthRamper.init(sampleRate);
     }
     
     void reset() override {

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPanner.swift
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPanner.swift
@@ -2,16 +2,20 @@
 
 /// Table-lookup panning with linear interpolation
 ///
-open class AKAutoPanner: AKNode, AKToggleable, AKComponent, AKInput {
+open class AKAutoPanner: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
     
     // MARK: - AKComponent
     
-    public typealias AKAudioUnitType = AKAutoPannerAudioUnit
-    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "apan")
+    
+    public typealias AKAudioUnitType = AKAutoPannerAudioUnit
 
     public private(set) var internalAU: AKAudioUnitType?
+    
+    // MARK: - AKAutomatable
+    
+    public private(set) var parameterAutomation: AKParameterAutomation?
 
     // MARK: - Parameters
     
@@ -42,7 +46,9 @@ open class AKAutoPanner: AKNode, AKToggleable, AKComponent, AKInput {
         instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
             
             self.frequency.associate(with: self.internalAU, value: frequency)
             self.depth.associate(with: self.internalAU, value: depth)

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPanner.swift
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPanner.swift
@@ -3,36 +3,23 @@
 /// Table-lookup panning with linear interpolation
 ///
 open class AKAutoPanner: AKNode, AKToggleable, AKComponent, AKInput {
+    
+    // MARK: - AKComponent
+    
     public typealias AKAudioUnitType = AKAutoPannerAudioUnit
+    
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "apan")
 
-    // MARK: - Properties
-
     public private(set) var internalAU: AKAudioUnitType?
 
-    fileprivate var waveform: AKTable?
-
+    // MARK: - Parameters
+    
     /// Frequency (Hz)
-    @objc open var frequency: Double = 10.0 {
-        willSet {
-            guard frequency != newValue else { return }
-            internalAU?.frequency.value = AUValue(newValue)
-        }
-    }
+    public let frequency = AKNodeParameter(identifier: "frequency")
 
     /// Depth
-    @objc open var depth: Double = 1.0 {
-        willSet {
-            guard depth != newValue else { return }
-            internalAU?.depth.value = AUValue(newValue)
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let depth = AKNodeParameter(identifier: "depth")
 
     // MARK: - Initialization
 
@@ -46,36 +33,23 @@ open class AKAutoPanner: AKNode, AKToggleable, AKComponent, AKInput {
     ///
     public init(
         _ input: AKNode? = nil,
-        frequency: Double = 10,
-        depth: Double = 1.0,
+        frequency: AUValue = 10,
+        depth: AUValue = 1.0,
         waveform: AKTable = AKTable(.positiveSine)
     ) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-            input?.connect(to: self)
-
-            self.waveform = waveform
-            self.frequency = frequency
-            self.depth = depth
+            
+            self.frequency.associate(with: self.internalAU, value: frequency)
+            self.depth.associate(with: self.internalAU, value: depth)
 
             self.internalAU?.setWavetable(waveform.content)
+            
+            input?.connect(to: self)
         }
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    @objc open func start() {
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    @objc open func stop() {
-        internalAU?.stop()
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerAudioUnit.swift
@@ -4,10 +4,24 @@ import AVFoundation
 
 public class AKAutoPannerAudioUnit: AKAudioUnitBase {
 
-    var frequency: AUParameter!
-
-    var depth: AUParameter!
-
+    let frequency = AUParameter(
+        identifier: "frequency",
+        name: "Frequency (Hz)",
+        address: AKAutoPannerParameter.frequency.rawValue,
+        range: 0.0...100.0,
+        unit: .hertz,
+        flags: .default
+    )
+    
+    let depth = AUParameter(
+        identifier: "depth",
+        name: "Depth",
+        address: AKAutoPannerParameter.depth.rawValue,
+        range: 0.0...1.0,
+        unit: .generic,
+        flags: .default
+    )
+    
     public override func createDSP() -> AKDSPRef {
         return createAutoPannerDSP()
     }
@@ -16,24 +30,6 @@ public class AKAutoPannerAudioUnit: AKAudioUnitBase {
                          options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
 
-        frequency = AUParameter(
-            identifier: "frequency",
-            name: "Frequency (Hz)",
-            address: 0,
-            range: 0.0...100.0,
-            unit: .hertz,
-            flags: .default)
-        depth = AUParameter(
-            identifier: "depth",
-            name: "Depth",
-            address: 1,
-            range: 0.0...1.0,
-            unit: .generic,
-            flags: .default)
-
         parameterTree = AUParameterTree.createTree(withChildren: [frequency, depth])
-
-        frequency.value = 10.0
-        depth.value = 1.0
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.hpp
@@ -32,10 +32,6 @@ public:
     void deinit() override;
 
     void process(uint32_t frameCount, uint32_t bufferOffset) override;
-    
-    virtual void setParameter(AUParameterAddress address, float value, bool immediate) override;
-    
-    virtual float getParameter(AUParameterAddress address) override;
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.hpp
@@ -32,6 +32,10 @@ public:
     void deinit() override;
 
     void process(uint32_t frameCount, uint32_t bufferOffset) override;
+    
+    virtual void setParameter(AUParameterAddress address, float value, bool immediate) override;
+    
+    virtual float getParameter(AUParameterAddress address) override;
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #import "AKAutoPannerDSP.hpp"
-#import "AKLinearParameterRamp.hpp"
+#import "ParameterRamper.hpp"
 #import <vector>
 
 extern "C" AKDSPRef createAutoPannerDSP() {
@@ -14,8 +14,8 @@ struct AKAutoPannerDSP::InternalData {
     sp_ftbl *tbl;
     sp_panst *panst;
     std::vector<float> wavetable;
-    AKLinearParameterRamp frequencyRamp;
-    AKLinearParameterRamp depthRamp;
+    ParameterRamper frequencyRamp;
+    ParameterRamper depthRamp;
 };
 
 AKAutoPannerDSP::AKAutoPannerDSP() : data(new InternalData) {
@@ -50,12 +50,7 @@ void AKAutoPannerDSP::process(uint32_t frameCount, uint32_t bufferOffset) {
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->frequencyRamp.advanceTo(now + frameOffset);
-            data->depthRamp.advanceTo(now + frameOffset);
-        }
-        data->trem->freq = data->frequencyRamp.getValue();
+        data->trem->freq = data->frequencyRamp.getAndStep();
         data->trem->amp = 1;
 
         float temp = 0;
@@ -75,31 +70,8 @@ void AKAutoPannerDSP::process(uint32_t frameCount, uint32_t bufferOffset) {
         }
         if (isStarted) {
             sp_osc_compute(sp, data->trem, NULL, &temp);
-            data->panst->pan = (2.0 * temp - 1.0) * data->depthRamp.getValue();
+            data->panst->pan = (2.0 * temp - 1.0) * data->depthRamp.getAndStep();
             sp_panst_compute(sp, data->panst, tmpin[0], tmpin[1], tmpout[0], tmpout[1]);
         }
-    }
-}
-
-void AKAutoPannerDSP::setParameter(AUParameterAddress address, float value, bool immediate)
-{
-    switch (address) {
-        case AKAutoPannerParameterDepth:
-            data->depthRamp.setTarget(value, true);
-            break;
-        case AKAutoPannerParameterFrequency:
-            data->frequencyRamp.setTarget(value, true);
-    }
-}
-
-float AKAutoPannerDSP::getParameter(AUParameterAddress address)
-{
-    switch (address) {
-        case AKAutoPannerParameterDepth:
-            return data->depthRamp.getTarget();
-        case AKAutoPannerParameterFrequency:
-            return data->frequencyRamp.getTarget();
-        default:
-            return 0.f;
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
@@ -80,3 +80,26 @@ void AKAutoPannerDSP::process(uint32_t frameCount, uint32_t bufferOffset) {
         }
     }
 }
+
+void AKAutoPannerDSP::setParameter(AUParameterAddress address, float value, bool immediate)
+{
+    switch (address) {
+        case AKAutoPannerParameterDepth:
+            data->depthRamp.setTarget(value, true);
+            break;
+        case AKAutoPannerParameterFrequency:
+            data->frequencyRamp.setTarget(value, true);
+    }
+}
+
+float AKAutoPannerDSP::getParameter(AUParameterAddress address)
+{
+    switch (address) {
+        case AKAutoPannerParameterDepth:
+            return data->depthRamp.getTarget();
+        case AKAutoPannerParameterFrequency:
+            return data->frequencyRamp.getTarget();
+        default:
+            return 0.f;
+    }
+}

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKAutomatable.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKAutomatable.swift
@@ -1,7 +1,5 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
-@objc public protocol AKAutomatable: AnyObject {
+public protocol AKAutomatable: AnyObject {
     var parameterAutomation: AKParameterAutomation? { get }
-    func startAutomation(at audioTime: AVAudioTime?, duration: AVAudioTime?)
-    func stopAutomation()
 }

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.h
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.h
@@ -9,11 +9,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef struct AutomationPoint {
-    AUParameterAddress address;
+    NSString *identifier;
     AUValue value;
     AUEventSampleTime sampleTime;
     AUEventSampleTime anchorTime;
+    AUAudioFrameCount offset;
     AUAudioFrameCount rampDuration;
+    AUValue taper;
+    AUValue skew;
     bool triggered;
 } AutomationPoint;
 
@@ -37,11 +40,21 @@ typedef struct AutomationPoint {
 - (void)stopAutomation;
 
 /// Add a single automation point to the collection
-- (void)addPoint:(AUParameterAddress)address
+- (void)addPoint:(NSString *)identifier
            value:(AUValue)value
       sampleTime:(AUEventSampleTime)sampleTime
       anchorTime:(AUEventSampleTime)anchorTime
     rampDuration:(AUAudioFrameCount)rampDuration;
+
+/// Add a single automation point to the collection with specified taper and skew
+- (void)addPoint:(NSString *)identifier
+           value:(AUValue)value
+      sampleTime:(AUEventSampleTime)sampleTime
+      anchorTime:(AUEventSampleTime)anchorTime
+    rampDuration:(AUAudioFrameCount)rampDuration
+           taper:(AUValue)taper
+            skew:(AUValue)skew
+          offset:(AUAudioFrameCount)offset;
 
 /// Add a single automation point to the collection
 - (void)addPoint:(struct AutomationPoint)point;

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
@@ -86,63 +86,31 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
 
     // MARK: - AKAutomatable
 
-    public func startAutomation(at audioTime: AVAudioTime?, duration: AVAudioTime?) {
-        parameterAutomation?.start(at: audioTime, duration: duration)
-    }
-
-    public func stopAutomation() {
-        parameterAutomation?.stop()
-    }
-
     /// Convenience function for adding a pair of points for both left and right addresses
-    public func addAutomationPoint(value: Double,
+    public func addAutomationPoint(value: AUValue,
                                    at sampleTime: AUEventSampleTime,
                                    anchorTime: AUEventSampleTime,
                                    rampDuration: AUAudioFrameCount = 0,
-                                   taper taperValue: Double? = nil,
-                                   skew skewValue: Double? = nil,
+                                   taper taperValue: AUValue = 1,
+                                   skew skewValue: AUValue = 0,
                                    offset offsetValue: AUAudioFrameCount? = nil) {
-//        guard let leftAddress = internalAU?.leftGain.address,
-//            let rightAddress = internalAU?.rightGain.address else {
-//            AKLog("Param addresses aren't valid")
-//            return
-//        }
-//
-//        // if a taper value is passed in, also add a point with its address to trigger at the same time
-//        if let taperValue = taperValue, let taperAddress = internalAU?.taper.address {
-//            parameterAutomation?.addPoint(taperAddress,
-//                                          value: AUValue(taperValue),
-//                                          sampleTime: sampleTime,
-//                                          anchorTime: anchorTime,
-//                                          rampDuration: rampDuration)
-//        }
-//        // if a skew value is passed in, also add a point with its address to trigger at the same time
-//        if let skewValue = skewValue, let skewAddress = internalAU?.skew.address {
-//            parameterAutomation?.addPoint(skewAddress,
-//                                          value: AUValue(skewValue),
-//                                          sampleTime: sampleTime,
-//                                          anchorTime: anchorTime,
-//                                          rampDuration: rampDuration)
-//        }
-//
-//        // if an offset value is passed in, also add a point with its address to trigger at the same time
-//        if let offsetValue = offsetValue, let offsetAddress = internalAU?.offset.address {
-//            parameterAutomation?.addPoint(offsetAddress,
-//                                          value: AUValue(offsetValue),
-//                                          sampleTime: sampleTime,
-//                                          anchorTime: anchorTime,
-//                                          rampDuration: rampDuration)
-//        }
-//
-//        parameterAutomation?.addPoint(leftAddress,
-//                                      value: AUValue(value),
-//                                      sampleTime: sampleTime,
-//                                      anchorTime: anchorTime,
-//                                      rampDuration: rampDuration)
-//        parameterAutomation?.addPoint(rightAddress,
-//                                      value: AUValue(value),
-//                                      sampleTime: sampleTime,
-//                                      anchorTime: anchorTime,
-//                                      rampDuration: rampDuration)
+
+        parameterAutomation?.addPoint("leftGain",
+                                      value: value,
+                                      sampleTime: sampleTime,
+                                      anchorTime: anchorTime,
+                                      rampDuration: rampDuration,
+                                      taper: taperValue,
+                                      skew: skewValue,
+                                      offset: offsetValue ?? 0)
+        
+        parameterAutomation?.addPoint("rightGain",
+                                      value: value,
+                                      sampleTime: sampleTime,
+                                      anchorTime: anchorTime,
+                                      rampDuration: rampDuration,
+                                      taper: taperValue,
+                                      skew: skewValue,
+                                      offset: offsetValue ?? 0)
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
@@ -55,8 +55,7 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
     ///   - gain: Amplification factor (Default: 1, Minimum: 0)
     ///
     public init(_ input: AKNode? = nil,
-                gain: AUValue = 1,
-                offset: AUValue = 0) {
+                gain: AUValue = 1) {
         super.init(avAudioNode: AVAudioNode())
         
         instantiateAudioUnit() { avAudioUnit in

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFader.swift
@@ -3,96 +3,48 @@
 /// Stereo Fader. Similar to AKBooster but with the addition of
 /// Automation support.
 open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
+    
+    // MARK: - AKComponent
+    
     public typealias AKAudioUnitType = AKFaderAudioUnit
     /// Four letter unique description of the node
     public static let ComponentDescription = AudioComponentDescription(effect: "fder")
-
-    public static var gainRange: ClosedRange<Double> = (0 ... 4)
-
-    // MARK: - Properties
-
+    
     public private(set) var internalAU: AKAudioUnitType?
+    
+    // MARK: - AKAutomatable
+    
     public private(set) var parameterAutomation: AKParameterAutomation?
-
+    
+    // MARK: - Parameters
+    
+    public static var gainRange: ClosedRange<AUValue> = (0 ... 4)
+    
     /// Amplification Factor, from 0 ... 4
-    @objc open var gain: Double = 1 {
+    open var gain: AUValue = 1 {
         willSet {
-            leftGain = gain
-            rightGain = gain
+            leftGain.value = gain
+            rightGain.value = gain
         }
     }
 
     /// Left Channel Amplification Factor
-    @objc open var leftGain: Double = 1 {
-        willSet {
-            let clampedValue = AKFader.gainRange.clamp(newValue)
-            guard leftGain != clampedValue else { return }
-            internalAU?.leftGain.value = AUValue(clampedValue)
-        }
-    }
+    public let leftGain = AKNodeParameter(identifier: "leftGain")
 
     /// Right Channel Amplification Factor
-    @objc open var rightGain: Double = 1 {
-        willSet {
-            let clampedValue = AKFader.gainRange.clamp(newValue)
-            guard rightGain != clampedValue else { return }
-            internalAU?.rightGain.value = AUValue(clampedValue)
-        }
-    }
+    public let rightGain = AKNodeParameter(identifier: "rightGain")
 
     /// Amplification Factor in db
-    @objc open var dB: Double {
+    public var dB: AUValue {
         set { gain = pow(10.0, newValue / 20.0) }
         get { return 20.0 * log10(gain) }
     }
 
-    /// Taper is a positive number where 1=Linear and the 0->1 and 1 and up represent curves on each side of linearity
-    @objc open var taper: Double = 1 {
-        willSet {
-            let clampedValue = (0.0 ... 10.0).clamp(newValue)
-            guard taper != clampedValue else { return }
-            internalAU?.taper.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Skew ranges from zero to one where zero is easing In and 1 is easing Out. default 0.
-    @objc open var skew: Double = 0 {
-        willSet {
-            let clampedValue = (0.0 ... 1.0).clamp(newValue)
-            guard skew != clampedValue else { return }
-            internalAU?.skew.value = AUValue(clampedValue)
-        }
-    }
-
-    /// Offset allows you to start a ramp somewhere in the middle of it. default 0.
-    @objc open var offset: Double = 0 {
-        willSet {
-            let clampedValue = (0.0 ... 1_000_000_000.0).clamp(newValue)
-            guard offset != clampedValue else { return }
-            internalAU?.offset.value = AUValue(clampedValue)
-        }
-    }
-
     /// Flip left and right signal
-    @objc open var flipStereo: Bool = false {
-        willSet {
-            guard flipStereo != newValue else { return }
-            internalAU?.flipStereo.value = newValue ? 1.0 : 0.0
-        }
-    }
+    public let flipStereo = AKNodeParameter(identifier: "flipStereo")
 
     /// Make the output on left and right both be the same combination of incoming left and mixed equally
-    @objc open var mixToMono: Bool = false {
-        willSet {
-            guard mixToMono != newValue else { return }
-            internalAU?.mixToMono.value = newValue ? 1.0 : 0.0
-        }
-    }
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    @objc open var isStarted: Bool {
-        return internalAU?.isStarted ?? false
-    }
+    public let mixToMono = AKNodeParameter(identifier: "mixToMono")
 
     // MARK: - Initialization
 
@@ -103,28 +55,23 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
     ///   - gain: Amplification factor (Default: 1, Minimum: 0)
     ///
     public init(_ input: AKNode? = nil,
-                gain: Double = 1,
-                taper: Double = 1,
-                skew: Double = 0,
-                offset: Double = 0) {
+                gain: AUValue = 1,
+                offset: AUValue = 0) {
         super.init(avAudioNode: AVAudioNode())
-
-        _Self.register()
-        AVAudioUnit._instantiate(with: _Self.ComponentDescription) { avAudioUnit in
+        
+        instantiateAudioUnit() { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
+            
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
+            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+
+            self.leftGain.associate(with: self.internalAU, value: gain)
+            self.rightGain.associate(with: self.internalAU, value: gain)
+            self.flipStereo.associate(with: self.internalAU, value: false)
+            self.mixToMono.associate(with: self.internalAU, value: false)
+            
             input?.connect(to: self)
-
-            self.leftGain = gain
-            self.rightGain = gain
-            self.taper = taper
-            self.skew = skew
-            self.offset = offset
-
-            if let internalAU = self.internalAU {
-                self.parameterAutomation = AKParameterAutomation(internalAU, avAudioUnit: avAudioUnit)
-            }
         }
     }
 
@@ -135,20 +82,6 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
     open override func detach() {
         super.detach()
         parameterAutomation = nil
-    }
-
-    // MARK: - Control
-
-    /// Function to start, play, or activate the node, all do the same thing
-    open func start() {
-        internalAU?.shouldBypassEffect = false
-        internalAU?.start()
-    }
-
-    /// Function to stop or bypass the node, both are equivalent
-    open func stop() {
-        internalAU?.shouldBypassEffect = true
-        internalAU?.stop()
     }
 
     // MARK: - AKAutomatable
@@ -169,47 +102,47 @@ open class AKFader: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable {
                                    taper taperValue: Double? = nil,
                                    skew skewValue: Double? = nil,
                                    offset offsetValue: AUAudioFrameCount? = nil) {
-        guard let leftAddress = internalAU?.leftGain.address,
-            let rightAddress = internalAU?.rightGain.address else {
-            AKLog("Param addresses aren't valid")
-            return
-        }
-
-        // if a taper value is passed in, also add a point with its address to trigger at the same time
-        if let taperValue = taperValue, let taperAddress = internalAU?.taper.address {
-            parameterAutomation?.addPoint(taperAddress,
-                                          value: AUValue(taperValue),
-                                          sampleTime: sampleTime,
-                                          anchorTime: anchorTime,
-                                          rampDuration: rampDuration)
-        }
-        // if a skew value is passed in, also add a point with its address to trigger at the same time
-        if let skewValue = skewValue, let skewAddress = internalAU?.skew.address {
-            parameterAutomation?.addPoint(skewAddress,
-                                          value: AUValue(skewValue),
-                                          sampleTime: sampleTime,
-                                          anchorTime: anchorTime,
-                                          rampDuration: rampDuration)
-        }
-
-        // if an offset value is passed in, also add a point with its address to trigger at the same time
-        if let offsetValue = offsetValue, let offsetAddress = internalAU?.offset.address {
-            parameterAutomation?.addPoint(offsetAddress,
-                                          value: AUValue(offsetValue),
-                                          sampleTime: sampleTime,
-                                          anchorTime: anchorTime,
-                                          rampDuration: rampDuration)
-        }
-
-        parameterAutomation?.addPoint(leftAddress,
-                                      value: AUValue(value),
-                                      sampleTime: sampleTime,
-                                      anchorTime: anchorTime,
-                                      rampDuration: rampDuration)
-        parameterAutomation?.addPoint(rightAddress,
-                                      value: AUValue(value),
-                                      sampleTime: sampleTime,
-                                      anchorTime: anchorTime,
-                                      rampDuration: rampDuration)
+//        guard let leftAddress = internalAU?.leftGain.address,
+//            let rightAddress = internalAU?.rightGain.address else {
+//            AKLog("Param addresses aren't valid")
+//            return
+//        }
+//
+//        // if a taper value is passed in, also add a point with its address to trigger at the same time
+//        if let taperValue = taperValue, let taperAddress = internalAU?.taper.address {
+//            parameterAutomation?.addPoint(taperAddress,
+//                                          value: AUValue(taperValue),
+//                                          sampleTime: sampleTime,
+//                                          anchorTime: anchorTime,
+//                                          rampDuration: rampDuration)
+//        }
+//        // if a skew value is passed in, also add a point with its address to trigger at the same time
+//        if let skewValue = skewValue, let skewAddress = internalAU?.skew.address {
+//            parameterAutomation?.addPoint(skewAddress,
+//                                          value: AUValue(skewValue),
+//                                          sampleTime: sampleTime,
+//                                          anchorTime: anchorTime,
+//                                          rampDuration: rampDuration)
+//        }
+//
+//        // if an offset value is passed in, also add a point with its address to trigger at the same time
+//        if let offsetValue = offsetValue, let offsetAddress = internalAU?.offset.address {
+//            parameterAutomation?.addPoint(offsetAddress,
+//                                          value: AUValue(offsetValue),
+//                                          sampleTime: sampleTime,
+//                                          anchorTime: anchorTime,
+//                                          rampDuration: rampDuration)
+//        }
+//
+//        parameterAutomation?.addPoint(leftAddress,
+//                                      value: AUValue(value),
+//                                      sampleTime: sampleTime,
+//                                      anchorTime: anchorTime,
+//                                      rampDuration: rampDuration)
+//        parameterAutomation?.addPoint(rightAddress,
+//                                      value: AUValue(value),
+//                                      sampleTime: sampleTime,
+//                                      anchorTime: anchorTime,
+//                                      rampDuration: rampDuration)
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderAudioUnit.swift
@@ -3,63 +3,38 @@
 import AVFoundation
 
 public class AKFaderAudioUnit: AKAudioUnitBase {
-    var taper = AUParameter(
-        identifier: "taper",
-        name: "Taper",
-        address: 2,
-        range: 0.1 ... 10.0,
-        unit: .generic,
-        flags: .default
-    )
-
-    var skew = AUParameter(
-        identifier: "skew",
-        name: "Skew",
-        address: 3,
-        range: 0.0 ... 1.0,
-        unit: .generic,
-        flags: .default
-    )
-
-    var offset = AUParameter(
-        identifier: "offset",
-        name: "Offset",
-        address: 4,
-        range: 0.0 ... 1_000_000_000.0,
-        unit: .generic,
-        flags: .default
-    )
-
-    var leftGain = AUParameter(
+    
+    let leftGain = AUParameter(
         identifier: "leftGain",
         name: "Left Gain",
-        address: 0,
+        address: AKFaderParameter.leftGain.rawValue,
         range: AKFader.gainRange,
         unit: .linearGain,
         flags: .default
     )
 
-    var rightGain = AUParameter(
+    let rightGain = AUParameter(
         identifier: "rightGain",
         name: "Right Gain",
-        address: 1,
+        address: AKFaderParameter.rightGain.rawValue,
         range: AKFader.gainRange,
         unit: .linearGain,
         flags: .default
     )
-    var flipStereo = AUParameter(
+    
+    let flipStereo = AUParameter(
         identifier: "flipStereo",
         name: "Flip Stereo",
-        address: 5,
+        address: AKFaderParameter.flipStereo.rawValue,
         range: 0.0 ... 1.0,
         unit: .boolean,
         flags: .default
     )
 
-    var mixToMono = AUParameter(
+    let mixToMono = AUParameter(
         identifier: "mixToMono",
         name: "Mix To Mono",
-        address: 6,
+        address: AKFaderParameter.mixToMono.rawValue,
         range: 0.0 ... 1.0,
         unit: .boolean,
         flags: .default
@@ -75,18 +50,7 @@ public class AKFaderAudioUnit: AKAudioUnitBase {
 
         parameterTree = AUParameterTree.createTree(withChildren: [leftGain,
                                                                   rightGain,
-                                                                  taper,
-                                                                  skew,
-                                                                  offset,
                                                                   flipStereo,
                                                                   mixToMono])
-
-        leftGain.value = 1.0
-        rightGain.value = 1.0
-        taper.value = 1.0
-        skew.value = 0.0
-        offset.value = 0.0
-        flipStereo.value = 0.0
-        mixToMono.value = 0.0
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.hpp
@@ -8,9 +8,6 @@
 typedef NS_ENUM (AUParameterAddress, AKFaderParameter) {
     AKFaderParameterLeftGain,
     AKFaderParameterRightGain,
-    AKFaderParameterTaper,
-    AKFaderParameterSkew,
-    AKFaderParameterOffset,
     AKFaderParameterFlipStereo,
     AKFaderParameterMixToMono
 };
@@ -35,7 +32,6 @@ public:
     void setParameter(AUParameterAddress address, float value, bool immediate) override;
     float getParameter(AUParameterAddress address) override;
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
-    void startRamp(AUParameterAddress address, AUValue value, AUAudioFrameCount duration) override;
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/Fader/AKFaderDSP.mm
@@ -17,6 +17,9 @@ struct AKFaderDSP::InternalData {
 
 AKFaderDSP::AKFaderDSP() : data(new InternalData)
 {
+    parameters[AKFaderParameterLeftGain] = &data->leftGainRamp;
+    parameters[AKFaderParameterRightGain] = &data->rightGainRamp;
+    
     bCanProcessInPlace = true;
 }
 
@@ -24,41 +27,14 @@ AKFaderDSP::AKFaderDSP() : data(new InternalData)
 void AKFaderDSP::setParameter(AUParameterAddress address, AUValue value, bool immediate)
 {
     switch (address) {
-        case AKFaderParameterLeftGain:
-            data->leftGainRamp.setUIValue(value);
-            // ramp to the new value
-            data->leftGainRamp.dezipperCheck(1024);
-            break;
-        case AKFaderParameterRightGain:
-            data->rightGainRamp.setUIValue(value);
-            // ramp to the new value
-            data->rightGainRamp.dezipperCheck(1024);
-            break;
-        case AKFaderParameterTaper:
-            data->leftGainRamp.setTaper(value);
-            data->rightGainRamp.setTaper(value);
-            break;
-        case AKFaderParameterSkew:
-            data->leftGainRamp.setSkew(value);
-            data->rightGainRamp.setSkew(value);
-            break;
-        case AKFaderParameterOffset:
-            data->leftGainRamp.setOffset((AUAudioFrameCount)value);
-            data->rightGainRamp.setOffset((AUAudioFrameCount)value);
-            break;
         case AKFaderParameterFlipStereo:
-            if (value > 0) {
-                data->flipStereo = true;
-            } else {
-                data->flipStereo = false;
-            }
+            data->flipStereo = value > 0.5f;
             break;
         case AKFaderParameterMixToMono:
-            if (value > 0) {
-                data->mixToMono = true;
-            } else {
-                data->mixToMono = false;
-            }
+            data->mixToMono = value > 0.5f;
+            break;
+        default:
+            AKDSPBase::setParameter(address, value, immediate);
     }
 }
 
@@ -66,23 +42,13 @@ void AKFaderDSP::setParameter(AUParameterAddress address, AUValue value, bool im
 float AKFaderDSP::getParameter(AUParameterAddress address)
 {
     switch (address) {
-        case AKFaderParameterLeftGain:
-            return data->leftGainRamp.getUIValue();
-        case AKFaderParameterRightGain:
-            return data->rightGainRamp.getUIValue();
-        case AKFaderParameterTaper:
-            // assume both channels are the same taper?
-            return data->leftGainRamp.getTaper();
-        case AKFaderParameterSkew:
-            return data->leftGainRamp.getSkew();
-        case AKFaderParameterOffset:
-            return data->leftGainRamp.getOffset();
         case AKFaderParameterFlipStereo:
-            return data->flipStereo;
+            return data->flipStereo ? 1.f : 0.f;
         case AKFaderParameterMixToMono:
-            return data->mixToMono;
+            return data->mixToMono ? 1.f : 0.f;
+        default:
+            return AKDSPBase::getParameter(address);
     }
-    return 0;
 }
 
 void AKFaderDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset)
@@ -122,27 +88,27 @@ void AKFaderDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferO
     }
 }
 
-void AKFaderDSP::startRamp(AUParameterAddress address, AUValue value, AUAudioFrameCount duration)
-{
-    // Note, if duration is 0 frames, startRamp will setImmediate
-    switch (address) {
-        case AKFaderParameterLeftGain:
-            data->leftGainRamp.startRamp(value, duration);
-            break;
-        case AKFaderParameterRightGain:
-            data->rightGainRamp.startRamp(value, duration);
-            break;
-        case AKFaderParameterTaper:
-            data->leftGainRamp.setTaper(value);
-            data->rightGainRamp.setTaper(value);
-            break;
-        case AKFaderParameterSkew:
-            data->leftGainRamp.setSkew(value);
-            data->rightGainRamp.setSkew(value);
-            break;
-        case AKFaderParameterOffset:
-            data->leftGainRamp.setOffset(value);
-            data->rightGainRamp.setOffset(value);
-            break;
-    }
-}
+//void AKFaderDSP::startRamp(AUParameterAddress address, AUValue value, AUAudioFrameCount duration)
+//{
+//    // Note, if duration is 0 frames, startRamp will setImmediate
+//    switch (address) {
+//        case AKFaderParameterLeftGain:
+//            data->leftGainRamp.startRamp(value, duration);
+//            break;
+//        case AKFaderParameterRightGain:
+//            data->rightGainRamp.startRamp(value, duration);
+//            break;
+//        case AKFaderParameterTaper:
+//            data->leftGainRamp.setTaper(value);
+//            data->rightGainRamp.setTaper(value);
+//            break;
+//        case AKFaderParameterSkew:
+//            data->leftGainRamp.setSkew(value);
+//            data->rightGainRamp.setSkew(value);
+//            break;
+//        case AKFaderParameterOffset:
+//            data->leftGainRamp.setOffset(value);
+//            data->rightGainRamp.setOffset(value);
+//            break;
+//    }
+//}

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterAudioUnit.swift
@@ -4,11 +4,21 @@ import AVFoundation
 
 public class AKBoosterAudioUnit: AKAudioUnitBase {
 
-    var leftGain: AUParameter!
+    let leftGain = AUParameter(
+        identifier: "leftGain",
+        name: "Left Boosting Amount",
+        address: 0,
+        range: 0.0...2.0,
+        unit: .linearGain,
+        flags: .default)
 
-    var rightGain: AUParameter!
-
-    var rampType: AUParameter!
+    let rightGain = AUParameter(
+        identifier: "rightGain",
+        name: "Right Boosting Amount",
+        address: 1,
+        range: 0.0...2.0,
+        unit: .linearGain,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createBoosterDSP()
@@ -17,35 +27,7 @@ public class AKBoosterAudioUnit: AKAudioUnitBase {
     public override init(componentDescription: AudioComponentDescription,
                          options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        leftGain = AUParameter(
-            identifier: "leftGain",
-            name: "Left Boosting Amount",
-            address: 0,
-            range: 0.0...2.0,
-            unit: .linearGain,
-            flags: .default)
-
-        rightGain = AUParameter(
-            identifier: "rightGain",
-            name: "Right Boosting Amount",
-            address: 1,
-            range: 0.0...2.0,
-            unit: .linearGain,
-            flags: .default)
-
-        rampType = AUParameter(
-            identifier: "rampType",
-            name: "Ramp Type",
-            address: 2,
-            range: 0.0...3.0,
-            unit: .indexed,
-            flags: .default)
-
-        parameterTree = AUParameterTree.createTree(withChildren: [leftGain, rightGain, rampType])
-
-        leftGain.value = 1.0
-        rightGain.value = 1.0
-        rampType.value = AUValue(AKSettings.RampType.linear.rawValue)
+        
+        parameterTree = AUParameterTree.createTree(withChildren: [leftGain, rightGain])
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.hpp
@@ -3,12 +3,10 @@
 #pragma once
 
 #import <AVFoundation/AVFoundation.h>
-#import "AKParameterRamp.hpp"
 
 typedef NS_ENUM (AUParameterAddress, AKBoosterParameter) {
     AKBoosterParameterLeftGain,
-    AKBoosterParameterRightGain,
-    AKBoosterParameterRampType
+    AKBoosterParameterRightGain
 };
 
 #ifndef __cplusplus
@@ -33,8 +31,6 @@ private:
 
 public:
     AKBoosterDSP();
-
-    void setParameter(AUParameterAddress address, float value, bool immediate) override;
 
     void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
 };

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerAudioUnit.swift
@@ -4,26 +4,22 @@ import AVFoundation
 
 public class AKPannerAudioUnit: AKAudioUnitBase {
 
-    private(set) var pan: AUParameter!
+    let pan = AUParameter(
+        identifier: "pan",
+        name: "Panning. A value of -1 is hard left, and a value of 1 is hard right, and 0 is center.",
+        address: AKPannerParameter.pan.rawValue,
+        range: AKPanner.panRange,
+        unit: .generic,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPannerDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        pan = AUParameter(
-            identifier: "pan",
-            name: "Panning. A value of -1 is hard left, and a value of 1 is hard right, and 0 is center.",
-            address: AKPannerParameter.pan.rawValue,
-            range: AKPanner.panRange,
-            unit: .generic,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [pan])
-
-        pan.value = AUValue(AKPanner.defaultPan)
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.mm
@@ -1,7 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "AKPannerDSP.hpp"
-#include "AKLinearParameterRamp.hpp"
+#include "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createPannerDSP() {
     return new AKPannerDSP();
@@ -9,7 +9,7 @@ extern "C" AKDSPRef createPannerDSP() {
 
 struct AKPannerDSP::InternalData {
     sp_panst *panst;
-    AKLinearParameterRamp panRamp;
+    ParameterRamper panRamp;
 };
 
 AKPannerDSP::AKPannerDSP() : data(new InternalData) {
@@ -38,12 +38,7 @@ void AKPannerDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        // do ramping every 8 samples
-        if ((frameOffset & 0x7) == 0) {
-            data->panRamp.advanceTo(now + frameOffset);
-        }
-
-        data->panst->pan = data->panRamp.getValue();
+        data->panst->pan = data->panRamp.getAndStep();
 
         float *tmpin[2];
         float *tmpout[2];

--- a/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderAudioUnit.swift
+++ b/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderAudioUnit.swift
@@ -4,46 +4,38 @@ import AVFoundation
 
 public class AKPhaseLockedVocoderAudioUnit: AKAudioUnitBase {
 
-    private(set) var position: AUParameter!
+    let position = AUParameter(
+        identifier: "position",
+        name: "Position in time. When non-changing it will do a spectral freeze of a the current point in time.",
+        address: AKPhaseLockedVocoderParameter.position.rawValue,
+        range: AKPhaseLockedVocoder.positionRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var amplitude: AUParameter!
+    let amplitude = AUParameter(
+        identifier: "amplitude",
+        name: "Amplitude.",
+        address: AKPhaseLockedVocoderParameter.amplitude.rawValue,
+        range: AKPhaseLockedVocoder.amplitudeRange,
+        unit: .generic,
+        flags: .default)
 
-    private(set) var pitchRatio: AUParameter!
+    let pitchRatio = AUParameter(
+        identifier: "pitchRatio",
+        name: "Pitch ratio. A value of. 1  normal, 2 is double speed, 0.5 is halfspeed, etc.",
+        address: AKPhaseLockedVocoderParameter.pitchRatio.rawValue,
+        range: AKPhaseLockedVocoder.pitchRatioRange,
+        unit: .hertz,
+        flags: .default)
 
     public override func createDSP() -> AKDSPRef {
         return createPhaseLockedVocoderDSP()
     }
 
     public override init(componentDescription: AudioComponentDescription,
-                         options: AudioComponentInstantiationOptions = []) throws {
+                  options: AudioComponentInstantiationOptions = []) throws {
         try super.init(componentDescription: componentDescription, options: options)
-
-        position = AUParameter(
-            identifier: "position",
-            name: "Position in time. When non-changing it will do a spectral freeze of a the current point in time.",
-            address: AKPhaseLockedVocoderParameter.position.rawValue,
-            range: AKPhaseLockedVocoder.positionRange,
-            unit: .generic,
-            flags: .default)
-        amplitude = AUParameter(
-            identifier: "amplitude",
-            name: "Amplitude.",
-            address: AKPhaseLockedVocoderParameter.amplitude.rawValue,
-            range: AKPhaseLockedVocoder.amplitudeRange,
-            unit: .generic,
-            flags: .default)
-        pitchRatio = AUParameter(
-            identifier: "pitchRatio",
-            name: "Pitch ratio. A value of. 1  normal, 2 is double speed, 0.5 is halfspeed, etc.",
-            address: AKPhaseLockedVocoderParameter.pitchRatio.rawValue,
-            range: AKPhaseLockedVocoder.pitchRatioRange,
-            unit: .hertz,
-            flags: .default)
-
+        
         parameterTree = AUParameterTree.createTree(withChildren: [position, amplitude, pitchRatio])
-
-        position.value = AUValue(AKPhaseLockedVocoder.defaultPosition)
-        amplitude.value = AUValue(AKPhaseLockedVocoder.defaultAmplitude)
-        pitchRatio.value = AUValue(AKPhaseLockedVocoder.defaultPitchRatio)
     }
 }

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
@@ -11,26 +11,26 @@ open class AKAbstractPlayer: AKNode {
 
     public struct Fade {
         // a few presets for lack of a better place to put them at the moment
-        public static var linearTaper = (in: 1.0, out: 1.0)
+        public static var linearTaper = (in: AUValue(1.0), out: AUValue(1.0))
 
         // half pipe
-        public static var audioTaper = (in: 3.0, out: 0.333_3)
+        public static var audioTaper = (in: AUValue(3.0), out: AUValue(0.333_3))
 
         // flipped half pipe
-        public static var reverseAudioTaper = (in: 0.333_3, out: 3.0)
+        public static var reverseAudioTaper = (in: AUValue(0.333_3), out: AUValue(3.0))
 
         /// An init is requited for the Fade struct to be used outside of AKPlayer
         // AKAbstractPlayer.Fade()
         public init() {}
 
         /// a constant
-        public static var minimumGain: Double = 0 // 0.0002
+        public static var minimumGain: AUValue = 0 // 0.0002
 
         /// the value that the fader should fade to, settable
-        public var maximumGain: Double = 1
+        public var maximumGain: AUValue = 1
 
         // In properties
-        public var inTime: Double = 0 {
+        public var inTime: AVMusicTimeStamp = 0 {
             willSet {
                 if newValue != inTime { needsUpdate = true }
             }
@@ -39,14 +39,14 @@ open class AKAbstractPlayer: AKNode {
         // if you want to start midway into a fade
         // public var inTimeOffset: Double = 0
 
-        public var inTaper: Double = audioTaper.in {
+        public var inTaper: AUValue = audioTaper.in {
             willSet {
                 if newValue != inTaper { needsUpdate = true }
             }
         }
 
         // the slope adjustment in the taper
-        public var inSkew: Double = 0.333_3
+        public var inSkew: AUValue = 0.333_3
 
         // Out properties
         public var outTime: Double = 0 {
@@ -55,14 +55,14 @@ open class AKAbstractPlayer: AKNode {
             }
         }
 
-        public var outTaper: Double = audioTaper.out {
+        public var outTaper: AUValue = audioTaper.out {
             willSet {
                 if newValue != outTaper { needsUpdate = true }
             }
         }
 
         // the slope adjustment in the taper
-        public var outSkew: Double = 1
+        public var outSkew: AUValue = 1
 
         // if you want to start midway into a fade
         // public var outTimeOffset: Double = 0
@@ -115,7 +115,7 @@ open class AKAbstractPlayer: AKNode {
     @objc public var faderNode: AKFader?
 
     /// Amplification Factor, in the range of 0 to 2
-    @objc public var gain: Double {
+    @objc public var gain: AUValue {
         get {
             return fade.maximumGain
         }
@@ -217,13 +217,13 @@ open class AKAbstractPlayer: AKNode {
         guard let audioTime = audioTime, let faderNode = faderNode else { return }
 
         // reset automation if it is running
-        faderNode.stopAutomation()
+        faderNode.parameterAutomation?.stop()
 
         let inTimeInSamples: AUEventSampleTime = frameOffset
 
         if fade.inTime > 0, offsetTime < fade.inTime {
             // realtime, turn the gain off to be sure it's off before the fade starts
-            faderNode.gain = AUValue(Fade.minimumGain)
+            faderNode.gain = Fade.minimumGain
 
             let inOffset = AUAudioFrameCount(offsetTime * sampleRate)
             let rampDuration = AUAudioFrameCount(fade.inTime * sampleRate)
@@ -305,11 +305,11 @@ open class AKAbstractPlayer: AKNode {
     }
 
     public func resetFader() {
-        faderNode?.gain = AUValue(fade.maximumGain)
+        faderNode?.gain = fade.maximumGain
     }
 
-    public func fadeOut(with time: Double, taper: Double? = nil) {
-        faderNode?.stopAutomation()
+    public func fadeOut(with time: Double, taper: AUValue? = nil) {
+        faderNode?.parameterAutomation?.stop()
         let outFrames = AUAudioFrameCount(time * sampleRate)
         faderNode?.addAutomationPoint(value: Fade.minimumGain,
                                       at: AUEventSampleTimeImmediate,
@@ -318,7 +318,7 @@ open class AKAbstractPlayer: AKNode {
                                       taper: taper ?? fade.outTaper)
 
         let now = AVAudioTime(hostTime: mach_absolute_time(), sampleTime: 0, atRate: sampleRate)
-        faderNode?.startAutomation(at: now, duration: nil)
+        faderNode?.parameterAutomation?.start(at: now, duration: nil)
     }
 
     open override func detach() {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
@@ -130,7 +130,7 @@ open class AKAbstractPlayer: AKNode {
             fade.maximumGain = newValue
 
             // this is the current value of the fader, set immediately
-            faderNode?.gain = newValue
+            faderNode?.gain = AUValue(newValue)
         }
     }
 
@@ -223,7 +223,7 @@ open class AKAbstractPlayer: AKNode {
 
         if fade.inTime > 0, offsetTime < fade.inTime {
             // realtime, turn the gain off to be sure it's off before the fade starts
-            faderNode.gain = Fade.minimumGain
+            faderNode.gain = AUValue(Fade.minimumGain)
 
             let inOffset = AUAudioFrameCount(offsetTime * sampleRate)
             let rampDuration = AUAudioFrameCount(fade.inTime * sampleRate)
@@ -305,7 +305,7 @@ open class AKAbstractPlayer: AKNode {
     }
 
     public func resetFader() {
-        faderNode?.gain = fade.maximumGain
+        faderNode?.gain = AUValue(fade.maximumGain)
     }
 
     public func fadeOut(with time: Double, taper: Double? = nil) {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -115,7 +115,7 @@ extension AKPlayer {
 
     @objc private func autoFadeOutCompletion() {
         playerNode.stop()
-        super.faderNode?.stopAutomation()
+        super.faderNode?.parameterAutomation?.stop()
         isPlaying = false
     }
 
@@ -123,7 +123,7 @@ extension AKPlayer {
         guard isPlaying else { return }
         playerNode.stop()
         if isFaded {
-            super.faderNode?.stopAutomation()
+            super.faderNode?.parameterAutomation?.stop()
         }
         isPlaying = false
     }
@@ -258,7 +258,7 @@ extension AKPlayer {
 
     @objc private func handleComplete() {
         stop()
-        super.faderNode?.stopAutomation()
+        super.faderNode?.parameterAutomation?.stop()
 
         if isLooping {
             startTime = loop.start

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -418,7 +418,7 @@ public class AKPlayer: AKAbstractPlayer {
             // NOTE: duration is currently not implemented
             let audioEndTime = faderTime.offset(seconds: endingTime)
             // turn on the render notification
-            super.faderNode?.startAutomation(at: faderTime, duration: audioEndTime)
+            super.faderNode?.parameterAutomation?.start(at: faderTime, duration: audioEndTime)
         }
 
         pauseTime = nil

--- a/AudioKit/Common/Nodes/Playback/Samplers/Disk Streamer/AKDiskStreamerDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Disk Streamer/AKDiskStreamerDSPKernel.hpp
@@ -22,8 +22,8 @@ public:
 
         sp_wavin_create(&wavin);
 
-        rateRamper.init();
-        volumeRamper.init();
+        rateRamper.init(sampleRate);
+        volumeRamper.init(sampleRate);
     }
 
     void start() {

--- a/AudioKit/Common/Nodes/Playback/Samplers/Wave Table/AKWaveTableDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Wave Table/AKWaveTableDSPKernel.hpp
@@ -25,8 +25,8 @@ public:
         sp_tabread_create(&tabread1);
         sp_tabread_create(&tabread2);
         
-        rateRamper.init();
-        volumeRamper.init();
+        rateRamper.init(sampleRate);
+        volumeRamper.init(sampleRate);
     }
 
 

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngineAudioUnit.swift
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngineAudioUnit.swift
@@ -34,7 +34,7 @@ public class AKSequencerEngineAudioUnit: AKAudioUnitBase {
             identifier: "length",
             name: "Length of the sequence",
             address: AKSequencerEngineParameter.length.rawValue,
-            range: 0.0 ... Double(Float.greatestFiniteMagnitude),
+            range: 0.0 ... Float.greatestFiniteMagnitude,
             unit: .beats,
             flags: .default)
         
@@ -42,7 +42,7 @@ public class AKSequencerEngineAudioUnit: AKAudioUnitBase {
             identifier: "maximumPlayCount",
             name: "Maximum times to loop before stopping",
             address: AKSequencerEngineParameter.maximumPlayCount.rawValue,
-            range: 0.0 ... Double(Int.max),
+            range: 0.0 ... Float(Int.max),
             unit: .generic,
             flags: .default)
         
@@ -50,7 +50,7 @@ public class AKSequencerEngineAudioUnit: AKAudioUnitBase {
             identifier: "position",
             name: "Release Duration",
             address: AKSequencerEngineParameter.position.rawValue,
-            range: 0.0 ... Double(Float.greatestFiniteMagnitude),
+            range: 0.0 ... Float.greatestFiniteMagnitude,
             unit: .beats,
             flags: .default)
         

--- a/Tests/TestCases/AKBoosterTests.swift
+++ b/Tests/TestCases/AKBoosterTests.swift
@@ -35,8 +35,8 @@ class AKBoosterTests: AKTestCase {
         let osc = AKOscillator()
         let booster = AKBooster(osc, gain: 1.0)
         booster.rampDuration = 1
-        booster.leftGain = 0.0
-        booster.rightGain = 0.0
+        booster.leftGain.value = 0.0
+        booster.rightGain.value = 0.0
         osc.connect(to: booster)
         AKManager.output = booster
         try! AKManager.renderToFile(audioFile, duration: 4, prerender: {

--- a/Tests/TestCases/AKCostelloReverbTests.swift
+++ b/Tests/TestCases/AKCostelloReverbTests.swift
@@ -24,8 +24,8 @@ class AKCostelloReverbTests: AKTestCase {
     func testParametersSetAfterInit() {
         let effect = AKCostelloReverb(input)
         effect.rampDuration = 0.0
-        effect.cutoffFrequency = 1_234
-        effect.feedback = 0.95
+        effect.cutoffFrequency.value = 1_234
+        effect.feedback.value = 0.95
         output = effect
         AKTestMD5(commonMD5)
     }

--- a/Tests/TestCases/AKDynaRageCompressorTests.swift
+++ b/Tests/TestCases/AKDynaRageCompressorTests.swift
@@ -10,7 +10,7 @@ class AKDynaRangeCompressorTests: AKTestCase {
         // Need to have a longer test duration to allow for envelope to progress
         duration = 1.0
         input.rampDuration = 0.0
-        input.amplitude = 0.1
+        input.amplitude.value = 0.1
     }
 
     func testAttackTime() {

--- a/Tests/TestCases/AKDynamicRangeCompressorTests.swift
+++ b/Tests/TestCases/AKDynamicRangeCompressorTests.swift
@@ -9,7 +9,7 @@ class AKDynamicRangeCompressorTests: AKTestCase {
         // Need to have a longer test duration to allow for envelope to progress
         duration = 1.0
         input.rampDuration = 0.0
-        input.amplitude = 2.0
+        input.amplitude.value = 2.0
    }
 
     func testAttackDuration() {

--- a/Tests/TestCases/AKFMOscillatorTests.swift
+++ b/Tests/TestCases/AKFMOscillatorTests.swift
@@ -19,11 +19,11 @@ class AKFMOscillatorTests: AKTestCase {
     func testParametersSetAfterInit() {
         oscillator = AKFMOscillator(waveform: AKTable(.square))
         oscillator.rampDuration = 0.0
-        oscillator.baseFrequency = 1_234
-        oscillator.carrierMultiplier = 1.234
-        oscillator.modulatingMultiplier = 1.234
-        oscillator.modulationIndex = 1.234
-        oscillator.amplitude = 0.5
+        oscillator.baseFrequency.value = 1_234
+        oscillator.carrierMultiplier.value = 1.234
+        oscillator.modulatingMultiplier.value = 1.234
+        oscillator.modulationIndex.value = 1.234
+        oscillator.amplitude.value = 0.5
         output = oscillator
         AKTestMD5("8387b7242dbb91c0a1f397a9bb9f2b06")
     }

--- a/Tests/TestCases/AKFaderTests.swift
+++ b/Tests/TestCases/AKFaderTests.swift
@@ -32,7 +32,7 @@ class AKFaderTests: AKTestCase {
     func testFlipStereo() {
         let pan = AKPanner(input, pan: 1.0)
         let fader = AKFader(pan, gain: 1.0)
-        fader.flipStereo = true
+        fader.flipStereo.boolValue = true
         output = fader
         AKTestMD5(flippedMD5)
     }
@@ -40,9 +40,9 @@ class AKFaderTests: AKTestCase {
     func testFlipStereoTwice() {
         let pan = AKPanner(input, pan: 1.0)
         let fader = AKFader(pan, gain: 1.0)
-        fader.flipStereo = true
+        fader.flipStereo.boolValue = true
         let fader2 = AKFader(fader, gain: 1.0)
-        fader2.flipStereo = true
+        fader2.flipStereo.boolValue = true
         output = fader2
         AKTestMD5("6b75baedc4700e335f665785e8648c14")
     }
@@ -50,11 +50,11 @@ class AKFaderTests: AKTestCase {
     func testFlipStereoThrice() {
         let pan = AKPanner(input, pan: 1.0)
         let fader = AKFader(pan, gain: 1.0)
-        fader.flipStereo = true
+        fader.flipStereo.boolValue = true
         let fader2 = AKFader(fader, gain: 1.0)
-        fader2.flipStereo = true
+        fader2.flipStereo.boolValue = true
         let fader3 = AKFader(fader2, gain: 1.0)
-        fader3.flipStereo = true
+        fader3.flipStereo.boolValue = true
         output = fader3
         AKTestMD5(flippedMD5)
     }
@@ -62,7 +62,7 @@ class AKFaderTests: AKTestCase {
     func testMixToMono() {
         let pan = AKPanner(input, pan: 1.0)
         let fader = AKFader(pan, gain: 1.0)
-        fader.mixToMono = true
+        fader.mixToMono.boolValue = true
         output = fader
         AKTestMD5("986675abd9c15378e8f4eb581bf90857")
     }

--- a/Tests/TestCases/AKMorphingOscillatorTests.swift
+++ b/Tests/TestCases/AKMorphingOscillatorTests.swift
@@ -21,11 +21,11 @@ class AKMorphingOscillatorTests: AKTestCase {
     func testParametersSetAfterInit() {
         oscillator = AKMorphingOscillator(waveformArray: waveforms)
         oscillator.rampDuration = 0
-        oscillator.frequency = 1_234
-        oscillator.amplitude = 0.5
-        oscillator.index = 1.234
-        oscillator.detuningOffset = 11
-        oscillator.detuningMultiplier = 1.1
+        oscillator.frequency.value = 1_234
+        oscillator.amplitude.value = 0.5
+        oscillator.index.value = 1.234
+        oscillator.detuningOffset.value = 11
+        oscillator.detuningMultiplier.value = 1.1
         output = oscillator
         AKTestMD5("382e738d40fdda8c38e4b9ad1fbde591")
     }

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -36,8 +36,8 @@ class AKOscillatorTests: AKTestCase {
     func testParametersSetAfterInit() {
         input = AKOscillator(waveform: AKTable(.square))
         input.rampDuration = 0.0
-        input.frequency = 400
-        input.amplitude = 0.5
+        input.frequency.value = 400
+        input.amplitude.value = 0.5
         output = input
         AKTestMD5("615e742bc1412c15237a453c5b49d5e0")
     }

--- a/Tests/TestCases/AKPWMOscillatorTests.swift
+++ b/Tests/TestCases/AKPWMOscillatorTests.swift
@@ -59,11 +59,11 @@ class AKPWMOscillatorTests: AKTestCase {
     func testParametersSetAfterInit() {
         oscillator = AKPWMOscillator()
         oscillator.rampDuration = 0.0
-        oscillator.frequency = 1_234
-        oscillator.amplitude = 0.5
-        oscillator.pulseWidth = 0.75
-        oscillator.detuningOffset = 1.234
-        oscillator.detuningMultiplier = 1.11
+        oscillator.frequency.value = 1_234
+        oscillator.amplitude.value = 0.5
+        oscillator.pulseWidth.value = 0.75
+        oscillator.detuningOffset.value = 1.234
+        oscillator.detuningMultiplier.value = 1.11
         output = oscillator
         AKTestMD5("7701ba67e7b7ddf5fb374d06b2601855")
     }}

--- a/Tests/TestCases/AKPhaseDistortionOscillatorTests.swift
+++ b/Tests/TestCases/AKPhaseDistortionOscillatorTests.swift
@@ -60,11 +60,11 @@ class AKPhaseDistortionOscillatorTests: AKTestCase {
     func testParametersSetAfterInit() {
         oscillator = AKPhaseDistortionOscillator(waveform: AKTable(.square))
         oscillator.rampDuration = 0.0
-        oscillator.frequency = 1_234
-        oscillator.amplitude = 0.5
-        oscillator.phaseDistortion = 1.234
-        oscillator.detuningOffset = 1.234
-        oscillator.detuningMultiplier = 1.1
+        oscillator.frequency.value = 1_234
+        oscillator.amplitude.value = 0.5
+        oscillator.phaseDistortion.value = 1.234
+        oscillator.detuningOffset.value = 1.234
+        oscillator.detuningMultiplier.value = 1.1
         output = oscillator
         AKTestMD5("2e01df8582f3357dd0886066b09eaba9")
     }

--- a/Tests/TestCases/AKVariableDelayTests.swift
+++ b/Tests/TestCases/AKVariableDelayTests.swift
@@ -22,8 +22,8 @@ class AKVariableDelayTests: AKTestCase {
     func testParametersSetAfterInit() {
         let effect = AKVariableDelay(input)
         effect.rampDuration = 0.0
-        effect.time = 0.123_4
-        effect.feedback = 0.95
+        effect.time.value = 0.123_4
+        effect.feedback.value = 0.95
         output = effect
         AKTestMD5("5024a7ef59a303c6f7a6fbebf0486d5e")
     }

--- a/Tests/TestCases/AKVocalTractTests.swift
+++ b/Tests/TestCases/AKVocalTractTests.swift
@@ -17,41 +17,41 @@ class AKVocalTractTests: AKTestCase {
     }
 
     func testFrequency() {
-        vocalTract.frequency = 444.5
+        vocalTract.frequency.value = 444.5
         output = vocalTract
         AKTestMD5("2b396d9594b82055f08a0bc4fa920d7b")
     }
 
     func testNasality() {
-        vocalTract.nasality = 0.6
+        vocalTract.nasality.value = 0.6
         output = vocalTract
         AKTestMD5("71ecb9a92790fffae596c3f46c445f7e")
     }
 
     func testTenseness() {
-        vocalTract.tenseness = 0.5
+        vocalTract.tenseness.value = 0.5
         output = vocalTract
         AKTestMD5("b68e8abc69646b53b0df69c1ba7e33aa")
     }
 
     func testTongueDiameter() {
-        vocalTract.tongueDiameter = 0.4
+        vocalTract.tongueDiameter.value = 0.4
         output = vocalTract
         AKTestMD5("35085ac510e12e74e6c4f0107bb6bfe9")
     }
 
     func testTonguePosition() {
-        vocalTract.tonguePosition = 0.3
+        vocalTract.tonguePosition.value = 0.3
         output = vocalTract
         AKTestMD5("d959f6ad27f11640dab046ed3eca472b")
     }
 
     func testParametersSetAfterInit() {
-        vocalTract.frequency = 234.5
-        vocalTract.tonguePosition = 0.3
-        vocalTract.tongueDiameter = 0.4
-        vocalTract.tenseness = 0.5
-        vocalTract.nasality = 0.6
+        vocalTract.frequency.value = 234.5
+        vocalTract.tonguePosition.value = 0.3
+        vocalTract.tongueDiameter.value = 0.4
+        vocalTract.tenseness.value = 0.5
+        vocalTract.nasality.value = 0.6
         output = vocalTract
         AKTestMD5("0501c323ab9f99c3f6c8a43c74983eec")
     }

--- a/Tests/TestCases/AKWaveTableTests.swift
+++ b/Tests/TestCases/AKWaveTableTests.swift
@@ -16,7 +16,7 @@ class AKWaveTableTests: AKTestCase {
 
     func testReversePlayback() {
         sampler?.startPoint = sampler!.size
-        sampler?.endPoint = 0
+        sampler?.endPoint.value = 0
         afterStart = {
             self.sampler?.play()
         }
@@ -33,7 +33,7 @@ class AKWaveTableTests: AKTestCase {
     }
 
     func testStartOffsetUsingPoints() {
-        sampler?.startPoint = 2_000
+        sampler?.startPoint.value = 2_000
         afterStart = {
             self.sampler?.play()
         }
@@ -50,8 +50,8 @@ class AKWaveTableTests: AKTestCase {
     }
 
     func testEndOffsetUsingSamplePoints() {
-        sampler?.startPoint = 0
-        sampler?.endPoint = 300
+        sampler?.startPoint.value = 0
+        sampler?.endPoint.value = 300
         afterStart = {
             self.sampler?.play()
         }
@@ -68,8 +68,8 @@ class AKWaveTableTests: AKTestCase {
     }
 
     func testSampleSubsectionUsingSamplePoints() {
-        sampler?.startPoint = 300
-        sampler?.endPoint = 600
+        sampler?.startPoint.value = 300
+        sampler?.endPoint.value = 600
         afterStart = {
             self.sampler?.play()
         }
@@ -90,22 +90,22 @@ class AKWaveTableTests: AKTestCase {
 
     func testSampleSubsectionWithResetUsingSamplePoints() {
         sampler?.completionHandler = {
-            self.sampler?.startPoint = 0
+            self.sampler?.startPoint.value = 0
             self.sampler?.endPoint = self.sampler!.size
             self.sampler?.play()
         }
         afterStart = {
-            self.sampler?.startPoint = 300
-            self.sampler?.endPoint = 600
+            self.sampler?.startPoint.value = 300
+            self.sampler?.endPoint.value = 600
             self.sampler?.play()
         }
         AKTestMD5(subsectionResetMD5)
     }
 
     func testForwardLoop() {
-        sampler?.loopStartPoint = 100
-        sampler?.loopEndPoint = 300
-        sampler?.endPoint = 300
+        sampler?.loopStartPoint.value = 100
+        sampler?.loopEndPoint.value = 300
+        sampler?.endPoint.value = 300
         sampler?.loopEnabled = true
         afterStart = {
             self.sampler?.play()
@@ -114,9 +114,9 @@ class AKWaveTableTests: AKTestCase {
     }
 
     func testReverseLoop() {
-        sampler?.loopStartPoint = 300
-        sampler?.loopEndPoint = 100
-        sampler?.endPoint = 300
+        sampler?.loopStartPoint.value = 300
+        sampler?.loopEndPoint.value = 100
+        sampler?.endPoint.value = 300
         sampler?.loopEnabled = true
         afterStart = {
             self.sampler?.play()

--- a/Tests/TestCases/AKZitaReverbTests.swift
+++ b/Tests/TestCases/AKZitaReverbTests.swift
@@ -17,16 +17,16 @@ class AKZitaReverbTests: AKTestCase {
     func testParametersSetAfterInit() {
         let effect = AKZitaReverb(input)
         effect.rampDuration = 0
-        effect.predelay = 10
-        effect.crossoverFrequency = 200
-        effect.lowReleaseTime = 1.5
-        effect.midReleaseTime = 1.0
-        effect.dampingFrequency = 3_000
-        effect.equalizerFrequency1 = 300
-        effect.equalizerLevel1 = 1
-        effect.equalizerFrequency2 = 1_400
-        effect.equalizerLevel2 = -1
-        effect.dryWetMix = 0.5
+        effect.predelay.value = 10
+        effect.crossoverFrequency.value = 200
+        effect.lowReleaseTime.value = 1.5
+        effect.midReleaseTime.value = 1.0
+        effect.dampingFrequency.value = 3_000
+        effect.equalizerFrequency1.value = 300
+        effect.equalizerLevel1.value = 1
+        effect.equalizerFrequency2.value = 1_400
+        effect.equalizerLevel2.value = -1
+        effect.dryWetMix.value = 0.5
         output = effect
         AKTestMD5("b824be4839f14474fb80eca60da317f7")
     }


### PR DESCRIPTION
Consolidates AKNode parameters into AKNodeParameter, which requires a simple one line declaration passing the identifier key of the AUParameter. Once a valid AU is acquired in the node's init(), the AKNodeParameter should be associated with the AUParameter. AKNodeParameters automatically clamp values to the allowed range, offloading this responsibility from AKNodes or DSP code, and allows each parameter's ramp duration, taper, and skew to be set individually.

All DSP parameters now use the ParameterRamper class, rather than AKParameterRamp.

The AKAutomatable protocol has been simplified to only require a single AKParameterAutomation object in any implementing class, and most AKNodes now implement this protocol. All automation-related functions, including start and stop, are now fully inside AKParameterAutomation and not required to be implemented by AKNodes. Additionally, automation points are now identified by their identifier key, rather than their address, to allow decoupling of client-side saved parameter automation and AK-side parameter addresses moving forward.

Each automation point may include an individual taper, skew, and offset (skew/taper/offset are no longer node-wide properties). This is achieved within AKNodeParameter at parameter scheduling time, by or'ing bitwise flags with the most significant bits of the parameter address for each taper/skew/offset property, respectively. This is interpreted by AKDSPBase::startRamp(), which schedules events for each registered parameter automatically. Subclasses no longer implement startRamp().