### PR TITLE
fix for the AKMusicTrack MIDI track name not being properly initialized

### DIFF
--- a/AudioKit/Common/Sequencing/Apple Sequencer/AKMusicTrack.swift
+++ b/AudioKit/Common/Sequencing/Apple Sequencer/AKMusicTrack.swift
@@ -94,9 +94,11 @@ open class AKMusicTrack {
         metaEvent.metaEventType = 3 // track or sequence name
         metaEvent.dataLength = UInt32(data.count)
 
-        for i in 0 ..< data.count {
-            metaEvent.data = data[i]
-        }
+        withUnsafeMutablePointer(to: &metaEvent.data, { pointer in
+            for idx in 0 ..< data.count {
+                pointer[idx] = data[idx]
+            }
+        })
 
         let result = MusicTrackNewMetaEvent(musicTrack, MusicTimeStamp(0), &metaEvent)
         if result != 0 {


### PR DESCRIPTION
A small bug in one of AKMusicTrack's initializers prevented the MIDI track name from being set correctly (the code ended up copying the new track's name characters one by one into the same destination position i.e. `dest[0] = src[i]`)

The new `withUnsafeMutablePointer...` code was taken from the other initializer, `init(name:)`