### PR TITLE
Convert Int64 sample lengths to Sample in AKAudiofile

### DIFF
--- a/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile+ProcessingAsynchronously.swift
@@ -271,8 +271,8 @@ extension AKAudioFile {
     public func exportAsynchronously(name: String,
                                      baseDir: BaseDirectory,
                                      exportFormat: ExportFormat,
-                                     fromSample: Int64 = 0,
-                                     toSample: Int64 = 0,
+                                     fromSample: Sample = 0,
+                                     toSample: Sample = 0,
                                      callback: @escaping AsyncProcessCallback) {
         // clear this initially
         currentExportSession = nil
@@ -309,8 +309,8 @@ extension AKAudioFile {
         }
 
         // In and OUT times trimming settings
-        let inFrame: Int64
-        let outFrame: Int64
+        let inFrame: Sample
+        let outFrame: Sample
 
         if toSample == 0 {
             outFrame = samplesCount
@@ -318,7 +318,7 @@ extension AKAudioFile {
             outFrame = min(samplesCount, toSample)
         }
 
-        inFrame = abs(min(samplesCount, fromSample))
+        inFrame = min(samplesCount, fromSample)
 
         if outFrame <= inFrame {
             AKLog("ERROR AKAudioFile export: In time must be less than Out time")
@@ -401,8 +401,8 @@ extension AKAudioFile {
             // Sets the output file encoding (avoid .wav encoded as m4a...)
             internalExportSession.outputFileType = AVFileType(rawValue: exportFormat.UTI as String as String)
 
-            let startTime = CMTimeMake(value: inFrame, timescale: Int32(sampleRate))
-            let stopTime = CMTimeMake(value: outFrame, timescale: Int32(sampleRate))
+            let startTime = CMTimeMake(value: Int64(inFrame), timescale: Int32(sampleRate))
+            let stopTime = CMTimeMake(value: Int64(outFrame), timescale: Int32(sampleRate))
             let timeRange = CMTimeRangeFromTimeToTime(start: startTime, end: stopTime)
             internalExportSession.timeRange = timeRange
 

--- a/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
+++ b/AudioKit/Common/Internals/Audio File/AKAudioFile.swift
@@ -29,8 +29,8 @@ extension AVAudioCommonFormat: CustomStringConvertible {
 
     /// The number of samples can be accessed by .length property,
     /// but samplesCount has a less ambiguous meaning
-    open var samplesCount: Int64 {
-        return length
+    open var samplesCount: Sample {
+        return Sample(length)
     }
 
     /// strange that sampleRate is a Double and not an Integer

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -107,24 +107,31 @@ open class AKNodeParameter {
 
     // MARK: Lifecycle
 
-    public init(identifier: String) {
+    public init(identifier: String, value: AUValue = 0) {
         self.identifier = identifier
-    }
-
-    /// This function should be called from AKNode subclasses as soon as a valid AU is obtained
-    public func associate(with au: AKAudioUnitBase?, value: AUValue) {
-        dsp = au?.dsp
-        parameter = au?.parameterTree?[identifier]
+        self.value = value
 
         // set initial value (and ensure initial value is set)
         self.value = value
         guard let min = parameter?.minValue, let max = parameter?.maxValue else { return }
         parameter?.value = (min...max).clamp(value)
+    }
+
+    /// This function should be called from AKNode subclasses as soon as a valid AU is obtained
+    public func associate(with au: AKAudioUnitBase?, value: AUValue? = nil) {
+        dsp = au?.dsp
+        parameter = au?.parameterTree?[identifier]
 
         guard let dsp = dsp, let addr = parameter?.address else { return }
         setParameterRampDurationDSP(dsp, addr, rampDuration)
         setParameterRampTaperDSP(dsp, addr, rampTaper)
         setParameterRampSkewDSP(dsp, addr, rampSkew)
+
+        let value = value ?? self.value
+        // set initial value (and ensure initial value is set)
+        self.value = value
+        guard let min = parameter?.minValue, let max = parameter?.maxValue else { return }
+        parameter?.value = (min...max).clamp(value)
     }
 
     /// This function should be called from AKNode subclasses as soon as a valid AU is obtained


### PR DESCRIPTION
AVAudioFile uses Int64 for sample length, but that can't ever be negative anyway. We also already have Sample (UInt32) so this addresses that.