### PR TITLE
Add argument to change buffer size of AKFFTTap

### DIFF
--- a/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
+++ b/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
@@ -9,17 +9,28 @@
 /// FFT Calculation for any node
 open class AKFFTTap: NSObject, EZAudioFFTDelegate {
 
-    internal let bufferSize: UInt32 = 1_024
+    public let fftSize: AKSettings.BufferLength
+    
+    internal var bufferSize: UInt32 {
+        get {
+            fftSize.samplesCount
+        }
+    }
     internal var fft: EZAudioFFT?
 
     /// Array of FFT data
-    @objc open var fftData = [Double](zeros: 512)
+    @objc open var fftData: [Double]
 
     /// Initialze the FFT calculation on a given node
     ///
-    /// - parameter input: Node on whose output the FFT will be computed
+    /// - parameters:
+    ///   - input: Node on whose output the FFT will be computed
+    ///   - fftSize: The sample size of the FFT buffer
     ///
-    public init(_ input: AKNode) {
+    public init(_ input: AKNode, fftSize: AKSettings.BufferLength = .veryLong) {
+        self.fftSize = fftSize
+        self.fftData = [Double](zeros: Int(self.fftSize.samplesCount / 2))
+        
         super.init()
         fft = EZAudioFFT(maximumBufferSize: vDSP_Length(bufferSize),
                          sampleRate: Float(AKSettings.sampleRate),

--- a/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
+++ b/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
@@ -10,12 +10,7 @@
 open class AKFFTTap: NSObject, EZAudioFFTDelegate {
 
     public let fftSize: AKSettings.BufferLength
-    
-    internal var bufferSize: UInt32 {
-        get {
-            fftSize.samplesCount
-        }
-    }
+    internal var bufferSize: UInt32 { fftSize.samplesCount }
     internal var fft: EZAudioFFT?
 
     /// Array of FFT data
@@ -30,7 +25,6 @@ open class AKFFTTap: NSObject, EZAudioFFTDelegate {
     public init(_ input: AKNode, fftSize: AKSettings.BufferLength = .veryLong) {
         self.fftSize = fftSize
         self.fftData = [Double](zeros: Int(self.fftSize.samplesCount / 2))
-        
         super.init()
         fft = EZAudioFFT(maximumBufferSize: vDSP_Length(bufferSize),
                          sampleRate: Float(AKSettings.sampleRate),


### PR DESCRIPTION
This resolves #2078 

The argument `fftSize` has been added to the init function of AKFFTTap, to define a custom buffer size.

A default value of .veryLong (1024 samples) has been set, this way the old api still works.