### PR TITLE
midiUniqueID property added into EndpointInfo

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
@@ -26,20 +26,29 @@ public struct EndpointInfo {
     /// Driver Owner
     public var driverOwner = ""
     
+    /// MIDIUniqueID
+    public var midiUniqueID:MIDIUniqueID
+    
+    /// MIDIEndpointRef
     public var midiEndpointRef:MIDIEndpointRef
+    
+    
 }
 
 extension Collection where Iterator.Element == MIDIEndpointRef {
     var endpointInfos: [EndpointInfo] {
         
-        return self.map { element -> EndpointInfo in
-            EndpointInfo(name:          getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyName),
-                         displayName:   getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyDisplayName),
-                         model:         getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyModel),
-                         manufacturer:  getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyManufacturer),
-                         image:         getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyImage),
-                         driverOwner:   getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyDriverOwner),
-                         midiEndpointRef: element as MIDIEndpointRef)
+        return self.map { (element:MIDIEndpointRef) -> EndpointInfo in
+            EndpointInfo(
+                name:          getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyName),
+                displayName:   getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyDisplayName),
+                model:         getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyModel),
+                manufacturer:  getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyManufacturer),
+                image:         getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyImage),
+                driverOwner:   getMIDIObjectStringProperty(ref: element, property: kMIDIPropertyDriverOwner),
+                midiUniqueID:  getMIDIObjectIntegerProperty(ref: element, property: kMIDIPropertyUniqueID),
+                midiEndpointRef: element
+            )
         }
     }
 }

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/xcshareddata/xcschemes/AudioKit-iOS.xcscheme
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/xcshareddata/xcschemes/AudioKit-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/xcshareddata/xcschemes/AudioKitUI.xcscheme
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/xcshareddata/xcschemes/AudioKitUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Hi @aure,

I'm learning with AudioKit; 
Finally, last - most important property  ```midiUniqueID```  is added into EndpointInfo. Now it is complete for its propose.

There are many little methods like ```midi.inputUIDs``` ,  ```midi.inputNames```
But in fact ```midi.inputInfo``` and ```midi.output.info``` contains everything necessary.

Example:
```
0 : EndpointInfo
    - name : "Session 1"
    - displayName : "Network Session 1"
    - model : ""
    - manufacturer : ""
    - image : "/System/Library/Audio/MIDI Drivers/AppleMIDIRTPDriver.plugin/Contents/Resources/RTPDriverIcon.tiff"
    - driverOwner : "com.apple.AppleMIDIRTPDriver"
    - midiUniqueID : -2011615911
    - midiEndpointRef : 397033478

```

getting midi names, finding midi unique ids with name, finding endPointRef with midi unique id etc.. very long work flow.

I'd like to implement few methods to complete all workflow like;
```midi.inputInfo(for: MIDIUniqueID)``` 
```openInput(with Endpoint)```
```openOutput(with Endpoint)```
```closeInput(with Endpoint)```
```closeOutput(with Endpoint)```

after that we can probably deprecate  ```midi.inputName(for: MIDIUniqueID)``` , ```midi.openInput(name: String)``` etc.. these are not helpful, not object oriented.

@aure what would you think ? I'll do these corrections would you merge?

wish you best



