### PR TITLE
EndpointInfo is now Hashable/Equatable

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
@@ -7,7 +7,7 @@
 //
 
 /// MIDI Endpoint Information
-public struct EndpointInfo {
+public struct EndpointInfo:Hashable {
 
     /// Unique name
     public var name = ""
@@ -32,6 +32,24 @@ public struct EndpointInfo {
     /// MIDIEndpointRef
     public var midiEndpointRef:MIDIEndpointRef
     
+    /// MIDIPortRef (this will be set|unset when input|output open|close)
+    public var midiPortRef:MIDIPortRef?
+    
+    /// Equatable
+    public static func == (lhs: EndpointInfo, rhs: EndpointInfo) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+    /// Hashable
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(displayName)
+        hasher.combine(model)
+        hasher.combine(manufacturer)
+        hasher.combine(image)
+        hasher.combine(driverOwner)
+        hasher.combine(midiUniqueID)
+        // midiPortRef is not added into the hash because midiPortRef is changing with every app launch
+    }
     
 }
 

--- a/AudioKit/iOS/AudioKit For iOS.xcodeproj/xcshareddata/xcschemes/AudioKit-iOS.xcscheme
+++ b/AudioKit/iOS/AudioKit For iOS.xcodeproj/xcshareddata/xcschemes/AudioKit-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1100"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
EndpointInfo is now Hashable/Equatable so easier to compare.
Also midiPortRef optional property is added (I'm working on)

@aure can I join slack channel some times I need to ask your opinion about structural changes in AK. I don't want to develop some codes in wrong direction. 
