### PR TITLE
remove print from lfo restart on sampler voice

### DIFF
--- a/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
+++ b/AudioKit/Core/AudioKitCore/Sampler/SamplerVoice.cpp
@@ -241,7 +241,6 @@ namespace AudioKitCore
         if (restartVoiceLFO || !hasStartedVoiceLFO) {
             vibratoLFO.phase = 0;
             hasStartedVoiceLFO = true;
-            printf("restarting lfo\n");
         }
     }
 


### PR DESCRIPTION
Does what it says on the tin

Removes a print that was in there for debug purposes