### PR TITLE
Deprecate master/slave language in MIDI function calls

### DIFF
--- a/AudioKit/Common/MIDI/Listeners/AKMIDIClockListener.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDIClockListener.swift
@@ -172,13 +172,24 @@ extension AKMIDIClockListener: AKMIDIBeatObserver {
 // MARK: - MMC Observations interface
 
 extension AKMIDIClockListener: AKMIDITempoObserver {
+
+    @available(*, deprecated, renamed: "midiClockFollowerMode")
     public func midiClockSlaveMode() {
-        AKLog("MIDI Clock Slave", log: OSLog.midi)
+        midiClockFollowerMode()
+    }
+
+    @available(*, deprecated, renamed: "midiClockLeaderEnabled")
+    public func midiClockMasterEnabled() {
+        midiClockLeaderEnabled()
+    }
+
+    public func midiClockFollowerMode() {
+        AKLog("MIDI Clock Follower", log: OSLog.midi)
         quarterNoteQuantumCounter = 0
     }
 
-    public func midiClockMasterEnabled() {
-        AKLog("MIDI Clock Master Enabled", log: OSLog.midi)
+    public func midiClockLeaderEnabled() {
+        AKLog("MIDI Clock Leader Enabled", log: OSLog.midi)
         quarterNoteQuantumCounter = 0
     }
 }

--- a/AudioKit/Common/MIDI/Listeners/AKMIDITempoListener.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDITempoListener.swift
@@ -34,15 +34,15 @@ public typealias BPMType = TimeInterval
 ///
 ///     class YOURCLASS: AKMIDITempoObserver {
 ///         func receivedTempoUpdate(bpm: BPMType, label: String) {  ... }
-///         func midiClockSlaveMode() { ... }
-///         func midiClockMasterEnabled() { ... }
+///         func midiClockFollowerMode() { ... }
+///         func midiClockLeaderEnabled() { ... }
 ///
-/// midiClockSlaveMode() informs client that midi clock messages have been received
-/// and the client may not become the clock master.  The client must stop all
+/// midiClockFollowerMode() informs client that midi clock messages have been received
+/// and the client may not become the clock leader.  The client must stop all
 /// transmission of MIDI clock.
 ///
-/// midiClockMasterEnabled() informs client that midi clock messages have not been seen
-/// in 1.6 seconds and the client is allowed to become the clock master.
+/// midiClockLeaderEnabled() informs client that midi clock messages have not been seen
+/// in 1.6 seconds and the client is allowed to become the clock leader.
 ///
 open class AKMIDITempoListener: NSObject {
 
@@ -220,13 +220,13 @@ extension AKMIDITempoListener {
 
     func midiClockActivityStarted() {
         tempoObservers.forEach { (observer) in
-            observer.midiClockSlaveMode()
+            observer.midiClockLeaderMode()
         }
     }
 
     func midiClockActivityStopped() {
         tempoObservers.forEach { (observer) in
-            observer.midiClockMasterEnabled()
+            observer.midiClockLeaderEnabled()
         }
     }
 

--- a/AudioKit/Common/MIDI/Listeners/AKMIDITempoObserver.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDITempoObserver.swift
@@ -12,10 +12,10 @@ public protocol AKMIDITempoObserver {
 
     /// Called when a clock slave mode is entered and this client is not allowed to become a clock master
     /// This signifies that there is an incoming midi clock detected
-    func midiClockSlaveMode()
+    func midiClockLeaderMode()
 
     /// Called when this client is allowed to become a clock master
-    func midiClockMasterEnabled()
+    func midiClockLeaderEnabled()
 
     /// Called each time the BPM is updated from the midi clock
     ///
@@ -25,11 +25,11 @@ public protocol AKMIDITempoObserver {
 
 public extension AKMIDITempoObserver {
 
-    func midiClockSlaveMode() {
+    func midiClockLeaderMode() {
 
     }
 
-    func midiClockMasterEnabled() {
+    func midiClockLeaderEnabled() {
 
     }
 


### PR DESCRIPTION
Rename functions for "master / slave" in favor of
"leader / follower" when refering to MIDI Clock and
add a deprecated flag to the old function names.