### PR TITLE
ParameterRamper bug fixes

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
@@ -53,6 +53,7 @@ void ParameterRamper::setImmediate(float value)
 void ParameterRamper::init(float sampleRate)
 {
     data->sampleRate = sampleRate;
+    data->duration = data->defaultRampDuration * sampleRate;
     setImmediate(data->uiValue);
 }
 
@@ -140,7 +141,7 @@ void ParameterRamper::startRamp(float newGoal, uint32_t duration)
     if (duration == 0) {
         setImmediate(newGoal);
     } else {
-        data->startingPoint = data->uiValue;
+        data->startingPoint = get();
         data->duration = duration;
         data->samplesRemaining = duration - data->offset;
         data->goal = data->uiValue = newGoal;


### PR DESCRIPTION
The duration property of ParameterRamper was never initialized, and ramping due to direct setting of parameters (i.e. non-automation) would not ramp smoothly due to setting the start point to the new desired value.