### PR TITLE
EndpointInfo is now Codable.

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
@@ -7,7 +7,8 @@
 //
 
 /// MIDI Endpoint Information
-public struct EndpointInfo: Hashable {
+
+public struct EndpointInfo:Hashable, Codable {
 
     /// Unique name
     public var name = ""
@@ -48,7 +49,29 @@ public struct EndpointInfo: Hashable {
         hasher.combine(image)
         hasher.combine(driverOwner)
         hasher.combine(midiUniqueID)
-        // midiPortRef is not added into the hash because midiPortRef is changing with every app launch
+        hasher.combine(midiPortRef)
+    }
+
+    
+    /// init
+    public init(name:String,
+         displayName:String,
+         model:String,
+         manufacturer:String,
+         image:String,
+         driverOwner:String,
+         midiUniqueID: MIDIUniqueID,
+         midiEndpointRef:MIDIEndpointRef,
+         midiPortRef:MIDIPortRef? = nil ) {
+        self.name = name
+        self.displayName = displayName
+        self.model = model
+        self.manufacturer = manufacturer
+        self.image = image
+        self.driverOwner = driverOwner
+        self.midiUniqueID = midiUniqueID
+        self.midiEndpointRef = midiEndpointRef
+        self.midiPortRef = midiPortRef
     }
 
 }


### PR DESCRIPTION
So we can persist last used ```EndpointInfo``` easy.

_(this update is not effecting any previous use of this object, safe.)_