### PR TITLE
Update AKConverter.swift

### DIFF
--- a/AudioKit/Common/Internals/AKConverter.swift
+++ b/AudioKit/Common/Internals/AKConverter.swift
@@ -457,6 +457,11 @@ open class AKConverter: NSObject {
         if format == kAudioFileAIFFType {
             dstFormat.mFormatFlags = dstFormat.mFormatFlags | kLinearPCMFormatFlagIsBigEndian
         }
+        
+        if format == kAudioFileWAVEType && dstFormat.mBitsPerChannel == 8{
+            //if is 8 BIT PER CHANNEL, remove kAudioFormatFlagIsSignedInteger
+            dstFormat.mFormatFlags &= ~kAudioFormatFlagIsSignedInteger
+        }
 
         // Create destination file
         error = ExtAudioFileCreateWithURL(outputURL as CFURL,


### PR DESCRIPTION
fix AKConverter.option support 8 bitDepth (bit per channel) in "wav" format

fix issue #2118 
support bitDepth=8 

Ready to send us a pull request? Please make sure your request is based on the [develop](https://github.com/audiokit/AudioKit/tree/develop) branch of the repository as `master` only holds stable releases.
