### PR TITLE
make maximumFrameCount of renderToFile available for user 

### DIFF
--- a/AudioKit/Common/Internals/AudioKit+SafeConnections.swift
+++ b/AudioKit/Common/Internals/AudioKit+SafeConnections.swift
@@ -117,11 +117,12 @@ extension AudioKit {
     ///
     @available(iOS 11, macOS 10.13, tvOS 11, *)
     @objc public static func renderToFile(_ audioFile: AVAudioFile,
+                                          maximumFrameCount: AVAudioFrameCount = 4_096,
                                           duration: Double,
                                           prerender: (() -> Void)? = nil,
                                           progress: ((Double) -> Void)? = nil) throws {
 
-        try engine.renderToFile(audioFile, duration: duration, prerender: prerender, progress: progress)
+        try engine.renderToFile(audioFile, maximumFrameCount: maximumFrameCount, duration: duration, prerender: prerender, progress: progress)
     }
 
     @available(iOS 11, macOS 10.13, tvOS 11, *)


### PR DESCRIPTION
I'm developing a app which can export user's performance and background music as one wav file. I need to adjust maximumFrameCount to control the progress callback interval. I think this would be a feature to control the progress callback interval.
