### PR TITLE
AKPlayer, bug fix for mismatched sample rate fade out scheduling

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -55,6 +55,9 @@ extension AKPlayer {
         } else {
             // if there are no fades, be sure to reset this
             super.resetFader()
+
+            // if gain is neutral, take the fader out
+            if gain == 1 { bypassFader() }
         }
     }
 }

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -149,7 +149,6 @@ extension AKPlayer {
     public func fadeOutAndStop(time: TimeInterval) {
         guard isPlaying else { return }
 
-        // creates if necessary only
         startFader()
 
         // Provides a convenience for a quick fade out when a user presses stop.


### PR DESCRIPTION
If the player is at a different sample rate than AKSettings, timing compensation is needed for fades to be scheduled correctly