### PR TITLE
Added Tempo Automation

### DIFF
--- a/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTrackMap.swift
+++ b/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTrackMap.swift
@@ -21,19 +21,16 @@ public class AKMIDIFileTrackNoteMap {
     public let midiTrack: AKMIDIFileTrack!
     public let midiFile: AKMIDIFile!
     public let trackNum: Int!
-    //AudioKit midi object reference for later implementation with the AKMIDITempoListener
-    let midi = AKManager.midi
-    public let tempoListener = AKMIDITempoListener(smoothing: 0.98, bpmHistoryLimit: 1)
     public var loNote: Int {
         if noteList.count >= 2 {
-            return (noteList.min(by: { $0.noteNum < $1.noteNum })?.noteNum)!
+            return (noteList.min(by: { $0.noteNum < $1.noteNum })?.noteNum) ?? 0
         } else {
             return 0
         }
     }
     public var hiNote: Int {
         if noteList.count >= 2 {
-            return (noteList.max(by: { $0.noteNum < $1.noteNum })?.noteNum)!
+            return (noteList.max(by: { $0.noteNum < $1.noteNum })?.noteNum) ?? 0
         } else {
             return 0
         }
@@ -42,56 +39,23 @@ public class AKMIDIFileTrackNoteMap {
         //Increment by 1 to properly fit the notes in the MIDI UI View
         return (hiNote - loNote) + 1
     }
-    public var currentTempo: Double {
-        var bpm: Double = 120.0
-        //Get tempo for MIDI file format 1 which has a tempo track
-        if let tempoTrack = midiFile.tempoTrack {
-            let tempoEvent = 81
-            for event in tempoTrack.events {
-                //Make sure the data is at least 6 elements for the proper tempo format
-                if event.data[1] == tempoEvent && event.data.count >= 6 {
-                    let tempo1 = String(event.data[3], radix: 16)
-                    let tempo2 = String(event.data[4], radix: 16)
-                    let tempo3 = String(event.data[5], radix: 16)
-                    let tempoString = tempo1 + tempo2 + tempo3
-                    if let tempoInt = Int(tempoString, radix: 16) {
-                        bpm = 60000000 / tempoInt
-                        return bpm
-                    }
-                }
-            }
-    } else {
-            //Get tempo for MIDI file format 0 which includes the tempo in the track chunks
-            let midiTrack = midiFile.tracks[trackNum]
-            let tempoEvent = 81
-            for event in midiTrack.events {
-                if event.data[1] == tempoEvent && event.data.count >= 6 {
-                    let tempo1 = String(event.data[3], radix: 16)
-                    let tempo2 = String(event.data[4], radix: 16)
-                    let tempo3 = String(event.data[5], radix: 16)
-                    let tempoString = tempo1 + tempo2 + tempo3
-                    if let tempoInt = Int(tempoString, radix: 16) {
-                        bpm = 60_000_000 / tempoInt
-                        return bpm
-                    }
-                }
-            }
-        }
-        return bpm
-    }
 
     public var endOfTrack: Double {
         let midiTrack = midiFile.tracks[trackNum]
         let endOfTrackEvent = 47
         var eventTime = 0.0
         for event in midiTrack.events {
-            //Again, here we make sure the data is in the proper format for a MIDI end of track message before trying to parse it
+            //Again, here we make sure the
+            //data is in the proper format
+            //for a MIDI end of track message before trying to parse it
             if event.data[1] == endOfTrackEvent && event.data.count >= 3 {
-                eventTime = event.positionInBeats! / self.midiFile.ticksPerBeat!
+                eventTime = (event.positionInBeats ?? 0.0) / (self.midiFile.ticksPerBeat ?? 1)
                 return eventTime
             } else {
-                //Some MIDI files may not have this message. Instead, we can grab the position of the last noteOff message
-                if self.noteList.count != 0 {
+                //Some MIDI files may not
+                //have this message. Instead, we can
+                //grab the position of the last noteOff message
+                if self.noteList.isNotEmpty {
                     return self.noteList[self.noteList.count - 1].noteEndTime
                 }
             }
@@ -134,31 +98,47 @@ public class AKMIDIFileTrackNoteMap {
                 //A note played with a velocity of zero is the equivalent
                 //of a noteOff command
                 if velocityEvent == 0 {
-                    eventPosition = event.positionInBeats! / self.midiFile.ticksPerBeat!
+                    eventPosition = (event.positionInBeats ?? 1.0) / (self.midiFile.ticksPerBeat ?? 1)
                     noteNum = Int(data[1])
                     if let prevPosValue = notesInProgress[noteNum]?.0 {
                         notesInProgress[noteNum] = (prevPosValue, eventPosition)
-                        let noteTracker = AKMIDINoteDuration(noteOnPosition: notesInProgress[noteNum]!.0,
-                                                             noteOffPosition: notesInProgress[noteNum]!.1, 
-                                                             noteNum: noteNum)
+                        var noteTracker: AKMIDINoteDuration = AKMIDINoteDuration(
+                            noteOnPosition: 0.0,
+                            noteOffPosition: 0.0, noteNum: 0)
+                        if let note = notesInProgress[noteNum] {
+                            noteTracker = AKMIDINoteDuration(
+                                noteOnPosition:
+                                    note.0,
+                                noteOffPosition:
+                                    note.1,
+                                noteNum: noteNum)
+                        }
                         notesInProgress.removeValue(forKey: noteNum)
                         finalNoteList.append(noteTracker)
                     }
                 } else {
-                    eventPosition = event.positionInBeats! / self.midiFile.ticksPerBeat!
+                    eventPosition = (event.positionInBeats ?? 1.0) / (self.midiFile.ticksPerBeat ?? 1)
                     noteNum = Int(data[1])
                     notesInProgress[noteNum] = (eventPosition, 0.0)
                 }
             }
 
             if eventTypeNum == noteOff {
-                eventPosition = event.positionInBeats! / self.midiFile.ticksPerBeat!
+                eventPosition = (event.positionInBeats ?? 1.0) / (self.midiFile.ticksPerBeat ?? 1)
                 noteNum = Int(data[1])
                 if let prevPosValue = notesInProgress[noteNum]?.0 {
                     notesInProgress[noteNum] = (prevPosValue, eventPosition)
-                    let noteTracker = AKMIDINoteDuration(noteOnPosition: notesInProgress[noteNum]!.0,
-                                                         noteOffPosition: notesInProgress[noteNum]!.1,
-                                                         noteNum: noteNum)
+                    var noteTracker: AKMIDINoteDuration = AKMIDINoteDuration(
+                        noteOnPosition: 0.0,
+                        noteOffPosition: 0.0, noteNum: 0)
+                    if let note = notesInProgress[noteNum] {
+                        noteTracker = AKMIDINoteDuration(
+                            noteOnPosition:
+                                note.0,
+                            noteOffPosition:
+                                note.1,
+                            noteNum: noteNum)
+                    }
                     notesInProgress.removeValue(forKey: noteNum)
                     finalNoteList.append(noteTracker)
                 }
@@ -173,7 +153,7 @@ public class AKMIDIFileTrackNoteMap {
 
     public init(midiFile: AKMIDIFile, trackNum: Int) {
         self.midiFile = midiFile
-        if midiFile.tracks.count != 0 {
+        if midiFile.tracks.isNotEmpty {
             if trackNum > (midiFile.tracks.count - 1) {
                 let trackNum = (midiFile.tracks.count - 1)
                 self.midiTrack = midiFile.tracks[trackNum]
@@ -190,33 +170,5 @@ public class AKMIDIFileTrackNoteMap {
             self.midiTrack = midiFile.tracks[0]
             self.trackNum = 0
         }
-        midi.createVirtualPorts()
-        midi.openInput(uid: 1)
-        midi.openOutput(uid: 1)
-        midi.addListener(tempoListener)
-        tempoListener.clockListener?.addObserver(self)
-        tempoListener.addObserver(self)
-    }
-}
-
-//Example code from the MIDI Connection Manager.swift
-//to implement the AKMIDITempoListener
-extension AKMIDIFileTrackNoteMap: AKMIDITempoObserver {
-    public func receivedTempo(bpm: BPMType, label: String) {
-    }
-}
-
-extension AKMIDIFileTrackNoteMap: AKMIDIBeatObserver {
-    public func preparePlay(continue: Bool) {
-    }
-    public func startFirstBeat(continue: Bool) {
-    }
-    public func stopSRT() {
-    }
-    public func receivedBeatEvent(beat: UInt64) {
-    }
-    func receivedQuantum(quarterNote: UInt8, beat: UInt64, quantum: UInt64) {
-    }
-    public func receivedQuarterNoteBeat(quarterNote: UInt8) {
     }
 }


### PR DESCRIPTION
I added tempo automation support for the `AKMIDITrackView.swift`. Every MIDI file seems to play at the right tempo now. There are a certain 10% of MIDI files which still crash when loaded, most likely due to more unfamiliar meta events. I will continue fixing things and make an example for Mac Catalyst.

On that note, I am able to run this with AudioKit 5.0 which is awesome. However, I updated my iPhone to iOS 14 before and noticed a bug. When setting the MIDI output port for the `AKAppleSequencer` tracks, not all of the MIDI voices are parsed/played to that MIDI port. The sequencer usually picks one voice at random and only plays that. However, if I do not connect any MIDI output ports to the AKAppleSequencer, I notice that all of the default sine wave voices play fine. I feel that this might have something to do with Apple's `MusicSequence` class, and possibly it does not work fully yet on the iOS 14 beta. I downgraded back to iOS 13.5.1, and everything works fine when I build with Xcode 12 on macOS Big Sur. 

I am hoping this won't interfere with my process of creating this for Mac Catalyst. I am not sure if this is something Apple should fix, but I feel as if it is. I will keep investigating and debugging to see if the `MusicSequence` is really the center of this bug.
