### PR TITLE
revert force crash on akplayer

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -352,23 +352,13 @@ public class AKPlayer: AKAbstractPlayer {
 
     // MARK: - Loading
 
-    /// Replace the contents of the player with this url. Note that if your processingFormat changes
-    /// you should dispose this AKPlayer and create a new one instead.
+    /// Replace the contents of the player with this url.
     @objc public func load(url: URL) throws {
         let file = try AVAudioFile(forReading: url)
-        try load(audioFile: file)
+        load(audioFile: file)
     }
 
-    /// Load a new audio file into this player. Note that if your processingFormat changes
-    /// you should dispose this AKPlayer and create a new one instead.
-    @objc public func load(audioFile: AVAudioFile) throws {
-        if audioFile.processingFormat != processingFormat {
-            AKLog("⚠️ Warning: This file is a different format than the previously loaded one. " +
-                "You should make a new AKPlayer instance and reconnect. " +
-                "load() is only available for files that are the same format.")
-            throw NSError(domain: "Processing format doesn't match", code: 0, userInfo: nil)
-        }
-
+    @objc public func load(audioFile: AVAudioFile) {
         self.audioFile = audioFile
         initialize(restartIfPlaying: false)
         // will reset the stored start / end times or update the buffer

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -352,13 +352,23 @@ public class AKPlayer: AKAbstractPlayer {
 
     // MARK: - Loading
 
-    /// Replace the contents of the player with this url.
+    /// Replace the contents of the player with this url. Note that if your processingFormat changes
+    /// you should dispose this AKPlayer and create a new one instead.
     @objc public func load(url: URL) throws {
         let file = try AVAudioFile(forReading: url)
-        load(audioFile: file)
+        try load(audioFile: file)
     }
 
-    @objc public func load(audioFile: AVAudioFile) {
+    /// Load a new audio file into this player. Note that if your processingFormat changes
+    /// you should dispose this AKPlayer and create a new one instead.
+    @objc public func load(audioFile: AVAudioFile) throws {
+        if let format = processingFormat, format != audioFile.processingFormat {
+            AKLog("⚠️ Warning: This file is a different format than the previously loaded one. " +
+                "You should make a new AKPlayer instance and reconnect. " +
+                "load() is only available for files that are the same format.")
+            throw NSError(domain: "Processing format doesn't match", code: 0, userInfo: nil)
+        }
+
         self.audioFile = audioFile
         initialize(restartIfPlaying: false)
         // will reset the stored start / end times or update the buffer


### PR DESCRIPTION
AKPlayer used to load files fine, these changes forcing a check on processingFormat are now making AKPlayer crash on load.

It used to work fine, so I suggest reverting this and re-committing the change when we have tested it.