### PR TITLE
ExtendingAudioKit cleanup

### DIFF
--- a/Developer/Common/Conductor.swift
+++ b/Developer/Common/Conductor.swift
@@ -121,7 +121,7 @@ class Conductor {
     func controller(_ controller: MIDIByte, value: MIDIByte) {
         switch controller {
         case AKMIDIControl.modulationWheel.rawValue:
-            oscillator.vibratoDepth = 0.5 * Double(value) / 128.0
+            oscillator.vibratoDepth = 0.5 * AUValue(value) / 128.0
         case AKMIDIControl.damperOnOff.rawValue:
             // key-up, key-down and pedal operations are mediated by SDSustainer
             sustainer.sustain(down: value != 0)
@@ -134,9 +134,9 @@ class Conductor {
         let pwValue = Double(pitchWheelValue)
         let scale = (pwValue - 8_192.0) / 8_192.0
         if scale >= 0.0 {
-            oscillator.pitchBend = scale * self.pitchBendUpSemitones
+            oscillator.pitchBend = AUValue(scale * self.pitchBendUpSemitones)
         } else {
-            oscillator.pitchBend = scale * self.pitchBendDownSemitones
+            oscillator.pitchBend = AUValue(scale * self.pitchBendDownSemitones)
         }
     }
 

--- a/Developer/Common/SDBooster/SDBooster.swift
+++ b/Developer/Common/SDBooster/SDBooster.swift
@@ -61,7 +61,7 @@ open class SDBooster: AKNode, AKToggleable, AKComponent, AKInput, AKAutomatable 
             self.avAudioNode = avAudioUnit
 
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
-            self.parameterAutomation = AKParameterAutomation(self.internalAU, avAudioUnit: avAudioUnit)
+            self.parameterAutomation = AKParameterAutomation(avAudioUnit)
 
             self.leftGain.associate(with: self.internalAU, value: gain)
             self.rightGain.associate(with: self.internalAU, value: gain)

--- a/Developer/Common/SDBooster/SDBoosterDSP.hpp
+++ b/Developer/Common/SDBooster/SDBoosterDSP.hpp
@@ -3,7 +3,7 @@
 #pragma once
 
 #import <AVFoundation/AVFoundation.h>
-#import <AKInterop.h>
+#import <AudioKit/AudioKit.h>
 
 typedef NS_ENUM (AUParameterAddress, SDBoosterParameter) {
     SDBoosterParameterLeftGain,
@@ -15,8 +15,6 @@ typedef NS_ENUM (AUParameterAddress, SDBoosterParameter) {
 AKDSPRef createSDBoosterDSP();
 
 #else
-
-#import "AKDSPBase.hpp"
 
 struct SDBoosterDSP : AKDSPBase {
 private:

--- a/Developer/Common/SDBooster/SDBoosterDSP.hpp
+++ b/Developer/Common/SDBooster/SDBoosterDSP.hpp
@@ -14,17 +14,4 @@ typedef NS_ENUM (AUParameterAddress, SDBoosterParameter) {
 
 AKDSPRef createSDBoosterDSP();
 
-#else
-
-struct SDBoosterDSP : AKDSPBase {
-private:
-    struct InternalData;
-    std::unique_ptr<InternalData> data;
-
-public:
-    SDBoosterDSP();
-
-    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
-};
-
 #endif

--- a/Developer/Common/SDBooster/SDBoosterDSP.mm
+++ b/Developer/Common/SDBooster/SDBoosterDSP.mm
@@ -8,9 +8,35 @@ private:
     ParameterRamper rightGainRamp;
 
 public:
-    SDBoosterDSP();
+    SDBoosterDSP() {
+        parameters[SDBoosterParameterLeftGain] = &leftGainRamp;
+        parameters[SDBoosterParameterRightGain] = &rightGainRamp;
 
-    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
+        bCanProcessInPlace = true;
+    }
+
+    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override {
+        for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
+            int frameOffset = int(frameIndex + bufferOffset);
+
+            float lgain = leftGainRamp.getAndStep();
+            float rgain = rightGainRamp.getAndStep();
+
+            for (int channel = 0; channel < channelCount; ++channel) {
+                float *in = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
+                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                if (isStarted) {
+                    if (channel == 0) {
+                        *out = *in * lgain;
+                    } else {
+                        *out = *in * rgain;
+                    }
+                } else {
+                    *out = *in;
+                }
+            }
+        }
+    }
 };
 
 extern "C" AKDSPRef createSDBoosterDSP()
@@ -18,34 +44,3 @@ extern "C" AKDSPRef createSDBoosterDSP()
     return new SDBoosterDSP();
 }
 
-SDBoosterDSP::SDBoosterDSP()
-{
-    parameters[SDBoosterParameterLeftGain] = &leftGainRamp;
-    parameters[SDBoosterParameterRightGain] = &rightGainRamp;
-
-    bCanProcessInPlace = true;
-}
-
-void SDBoosterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset)
-{
-    for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
-        int frameOffset = int(frameIndex + bufferOffset);
-
-        float lgain = leftGainRamp.getAndStep();
-        float rgain = rightGainRamp.getAndStep();
-
-        for (int channel = 0; channel < channelCount; ++channel) {
-            float *in = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-            float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
-            if (isStarted) {
-                if (channel == 0) {
-                    *out = *in * lgain;
-                } else {
-                    *out = *in * rgain;
-                }
-            } else {
-                *out = *in;
-            }
-        }
-    }
-}

--- a/Developer/Common/SDBooster/SDBoosterDSP.mm
+++ b/Developer/Common/SDBooster/SDBoosterDSP.mm
@@ -2,6 +2,17 @@
 
 #include "SDBoosterDSP.hpp"
 
+struct SDBoosterDSP : AKDSPBase {
+private:
+    struct InternalData;
+    std::unique_ptr<InternalData> data;
+
+public:
+    SDBoosterDSP();
+
+    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
+};
+
 extern "C" AKDSPRef createSDBoosterDSP()
 {
     return new SDBoosterDSP();

--- a/Developer/Common/SDBooster/SDBoosterDSP.mm
+++ b/Developer/Common/SDBooster/SDBoosterDSP.mm
@@ -1,7 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "SDBoosterDSP.hpp"
-#import "ParameterRamper.hpp"
 
 extern "C" AKDSPRef createSDBoosterDSP()
 {

--- a/Developer/Common/SDBooster/SDBoosterDSP.mm
+++ b/Developer/Common/SDBooster/SDBoosterDSP.mm
@@ -4,8 +4,8 @@
 
 struct SDBoosterDSP : AKDSPBase {
 private:
-    struct InternalData;
-    std::unique_ptr<InternalData> data;
+    ParameterRamper leftGainRamp;
+    ParameterRamper rightGainRamp;
 
 public:
     SDBoosterDSP();
@@ -18,15 +18,10 @@ extern "C" AKDSPRef createSDBoosterDSP()
     return new SDBoosterDSP();
 }
 
-struct SDBoosterDSP::InternalData {
-    ParameterRamper leftGainRamp;
-    ParameterRamper rightGainRamp;
-};
-
-SDBoosterDSP::SDBoosterDSP() : data(new InternalData)
+SDBoosterDSP::SDBoosterDSP()
 {
-    parameters[SDBoosterParameterLeftGain] = &data->leftGainRamp;
-    parameters[SDBoosterParameterRightGain] = &data->rightGainRamp;
+    parameters[SDBoosterParameterLeftGain] = &leftGainRamp;
+    parameters[SDBoosterParameterRightGain] = &rightGainRamp;
 
     bCanProcessInPlace = true;
 }
@@ -36,8 +31,8 @@ void SDBoosterDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffe
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        float lgain = data->leftGainRamp.getAndStep();
-        float rgain = data->rightGainRamp.getAndStep();
+        float lgain = leftGainRamp.getAndStep();
+        float rgain = rightGainRamp.getAndStep();
 
         for (int channel = 0; channel < channelCount; ++channel) {
             float *in = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;

--- a/Developer/iOS/ExtendingAudioKit/ExtendingAudioKitUsingSource.xcodeproj/project.pbxproj
+++ b/Developer/iOS/ExtendingAudioKit/ExtendingAudioKitUsingSource.xcodeproj/project.pbxproj
@@ -23,6 +23,48 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		297A6D0824B7995200A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299BC248128D000C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB63FB2494B0E0001E1F37;
+			remoteInfo = "STKAudioKit-iOS";
+		};
+		297A6D0A24B7995200A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299BC248128D000C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB654C2494B656001E1F37;
+			remoteInfo = "STKAudioKit-macOS";
+		};
+		297A6D0C24B7995200A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299BC248128D000C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB65F72494B681001E1F37;
+			remoteInfo = "STKAudioKit-tvOS";
+		};
+		297A6D0E24B7995200A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299BC248128D000C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB660224955B0D001E1F37;
+			remoteInfo = "DevoloopAudioKit-iOS";
+		};
+		297A6D1024B7995200A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299BC248128D000C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB6687249560CD001E1F37;
+			remoteInfo = "DevoloopAudioKit-macOS";
+		};
+		297A6D1224B7995200A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299BC248128D000C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB66C7249560CD001E1F37;
+			remoteInfo = "DevoloopAudioKit-tvOS";
+		};
 		EAF299C5248128D000C3804E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = EAF299BC248128D000C3804E /* AudioKit.xcodeproj */;
@@ -169,11 +211,17 @@
 			isa = PBXGroup;
 			children = (
 				EAF299C6248128D000C3804E /* AudioKit.framework */,
-				EAF299C8248128D000C3804E /* AudioKitUI.framework */,
-				EAF299CA248128D000C3804E /* AudioKit.framework */,
-				EAF299CC248128D000C3804E /* AudioKitUI.framework */,
 				EAF299CE248128D000C3804E /* AudioKit.framework */,
+				EAF299CA248128D000C3804E /* AudioKit.framework */,
+				EAF299C8248128D000C3804E /* AudioKitUI.framework */,
 				EAF299D0248128D000C3804E /* AudioKitUI.framework */,
+				EAF299CC248128D000C3804E /* AudioKitUI.framework */,
+				297A6D0924B7995200A3777B /* STKAudioKit.framework */,
+				297A6D0B24B7995200A3777B /* STKAudioKit.framework */,
+				297A6D0D24B7995200A3777B /* STKAudioKit.framework */,
+				297A6D0F24B7995200A3777B /* DevoloopAudioKit.framework */,
+				297A6D1124B7995200A3777B /* DevoloopAudioKit.framework */,
+				297A6D1324B7995200A3777B /* DevoloopAudioKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -220,7 +268,7 @@
 					3429F97E201A25AB00300166 = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1000;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -254,6 +302,48 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		297A6D0924B7995200A3777B /* STKAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = STKAudioKit.framework;
+			remoteRef = 297A6D0824B7995200A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6D0B24B7995200A3777B /* STKAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = STKAudioKit.framework;
+			remoteRef = 297A6D0A24B7995200A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6D0D24B7995200A3777B /* STKAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = STKAudioKit.framework;
+			remoteRef = 297A6D0C24B7995200A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6D0F24B7995200A3777B /* DevoloopAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DevoloopAudioKit.framework;
+			remoteRef = 297A6D0E24B7995200A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6D1124B7995200A3777B /* DevoloopAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DevoloopAudioKit.framework;
+			remoteRef = 297A6D1024B7995200A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6D1324B7995200A3777B /* DevoloopAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DevoloopAudioKit.framework;
+			remoteRef = 297A6D1224B7995200A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		EAF299C6248128D000C3804E /* AudioKit.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -392,7 +482,6 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../../../Frameworks/AudioKit-iOS/\"";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -407,7 +496,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../../Frameworks/AudioKit-iOS/AudioKit.framework/Headers/\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -452,7 +540,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../../../Frameworks/AudioKit-iOS/\"";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -461,7 +548,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../../Frameworks/AudioKit-iOS/AudioKit.framework/Headers/\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
@@ -475,10 +561,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9W69ZP8S5F;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ExtendingAudioKit/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -497,10 +583,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9W69ZP8S5F;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ExtendingAudioKit/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;

--- a/Developer/iOS/ExtendingAudioKit/README.md
+++ b/Developer/iOS/ExtendingAudioKit/README.md
@@ -54,17 +54,6 @@ At this point you should Build your project to make sure everything is OK. This 
 
 Back in your project’s Build Settings, locate the Objective-C Bridging Header item (search for “bridging”). Set it to *$(SRCROOT)/[your project name]-Bridging-Header.h*.
 
-### Prepare to use AudioKit core header files
-Before you can build your own extensions to AudioKit, you need to ensure that your Xcode project can make use of some of AudioKit's core header files.
-
-Locate the Header Search Paths item (search for “search”), and set it to point to the *AudioKit/AudioKit/Common/Internals/CoreAudio* folder:
-
-* Double-click the Header Search Paths edit field; this brings up a large multi-line edit box
-* In the Mac Finder, locate the *AudioKit/Common/Internals/CoreAudio* folder in your cloned copy of the AudioKit source tree and drag it into the edit box
-* Change the default “non-recursive” setting on the right to “recursive”
-* Do the same for *AudioKit/Common/Internals/Utilities*
-* If you're going to base your new AudioKit module on existing C++ classes defined in *AudioKit/Core/AudioKitCore*, do the same for that folder also.
-
 ### Create your own AudioKit module
 
 A simple way to start is to copy one of the simpler **AudioKit** AU source folders to your own project folder (I used **AKBooster**), change all the file/folder names (I changed “AKBooster” to “SDBooster”), then drag the whole folder into your Xcode Project Navigator pane to add it to your project.

--- a/Developer/macOS/ExtendingAudioKit/ExtendingAudioKitUsingSource.xcodeproj/project.pbxproj
+++ b/Developer/macOS/ExtendingAudioKit/ExtendingAudioKitUsingSource.xcodeproj/project.pbxproj
@@ -21,6 +21,48 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		297A6CED24B7933800A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299D824812A3F00C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB63FB2494B0E0001E1F37;
+			remoteInfo = "STKAudioKit-iOS";
+		};
+		297A6CEF24B7933800A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299D824812A3F00C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB654C2494B656001E1F37;
+			remoteInfo = "STKAudioKit-macOS";
+		};
+		297A6CF124B7933800A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299D824812A3F00C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB65F72494B681001E1F37;
+			remoteInfo = "STKAudioKit-tvOS";
+		};
+		297A6CF324B7933800A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299D824812A3F00C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB660224955B0D001E1F37;
+			remoteInfo = "DevoloopAudioKit-iOS";
+		};
+		297A6CF524B7933800A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299D824812A3F00C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB6687249560CD001E1F37;
+			remoteInfo = "DevoloopAudioKit-macOS";
+		};
+		297A6CF724B7933800A3777B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAF299D824812A3F00C3804E /* AudioKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C4DB66C7249560CD001E1F37;
+			remoteInfo = "DevoloopAudioKit-tvOS";
+		};
 		EAF299E124812A4000C3804E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = EAF299D824812A3F00C3804E /* AudioKit.xcodeproj */;
@@ -174,11 +216,17 @@
 			isa = PBXGroup;
 			children = (
 				EAF299E224812A4000C3804E /* AudioKit.framework */,
-				EAF299E424812A4000C3804E /* AudioKitUI.framework */,
-				EAF299E624812A4000C3804E /* AudioKit.framework */,
-				EAF299E824812A4000C3804E /* AudioKitUI.framework */,
 				EAF299EA24812A4000C3804E /* AudioKit.framework */,
+				EAF299E624812A4000C3804E /* AudioKit.framework */,
+				EAF299E424812A4000C3804E /* AudioKitUI.framework */,
 				EAF299EC24812A4000C3804E /* AudioKitUI.framework */,
+				EAF299E824812A4000C3804E /* AudioKitUI.framework */,
+				297A6CEE24B7933800A3777B /* STKAudioKit.framework */,
+				297A6CF024B7933800A3777B /* STKAudioKit.framework */,
+				297A6CF224B7933800A3777B /* STKAudioKit.framework */,
+				297A6CF424B7933800A3777B /* DevoloopAudioKit.framework */,
+				297A6CF624B7933800A3777B /* DevoloopAudioKit.framework */,
+				297A6CF824B7933800A3777B /* DevoloopAudioKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -252,6 +300,48 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		297A6CEE24B7933800A3777B /* STKAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = STKAudioKit.framework;
+			remoteRef = 297A6CED24B7933800A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6CF024B7933800A3777B /* STKAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = STKAudioKit.framework;
+			remoteRef = 297A6CEF24B7933800A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6CF224B7933800A3777B /* STKAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = STKAudioKit.framework;
+			remoteRef = 297A6CF124B7933800A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6CF424B7933800A3777B /* DevoloopAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DevoloopAudioKit.framework;
+			remoteRef = 297A6CF324B7933800A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6CF624B7933800A3777B /* DevoloopAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DevoloopAudioKit.framework;
+			remoteRef = 297A6CF524B7933800A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		297A6CF824B7933800A3777B /* DevoloopAudioKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DevoloopAudioKit.framework;
+			remoteRef = 297A6CF724B7933800A3777B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		EAF299E224812A4000C3804E /* AudioKit.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -465,7 +555,6 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../../Frameworks/AudioKit-macOS/AudioKit.framework/Headers/\"";
 				INFOPLIST_FILE = ExtendingAudioKit/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.ExtendingAudioKit;
@@ -483,7 +572,6 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../../../Frameworks/AudioKit-macOS/AudioKit.framework/Headers/\"";
 				INFOPLIST_FILE = ExtendingAudioKit/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.ExtendingAudioKit;

--- a/Developer/macOS/ExtendingAudioKit/README.md
+++ b/Developer/macOS/ExtendingAudioKit/README.md
@@ -57,17 +57,6 @@ At this point you should Build your project to make sure everything is OK. This 
 
 Back in your project’s Build Settings, locate the Objective-C Bridging Header item (search for “bridging”). Set it to *$(SRCROOT)/[your project name]-Bridging-Header.h*.
 
-### Prepare to use AudioKit core header files
-Before you can build your own extensions to AudioKit, you need to ensure that your Xcode project can make use of some of AudioKit's core header files.
-
-Locate the Header Search Paths item (search for “search”), and set it to point to the *AudioKit/AudioKit/Common/Internals/CoreAudio* folder:
-
-* Double-click the Header Search Paths edit field; this brings up a large multi-line edit box
-* In the Mac Finder, locate the *AudioKit/Common/Internals/CoreAudio* folder in your cloned copy of the AudioKit source tree and drag it into the edit box
-* Change the default “non-recursive” setting on the right to “recursive”
-* Do the same for *AudioKit/Common/Internals/Utilities*
-* If you're going to base your new AudioKit module on existing C++ classes defined in *AudioKit/Core/AudioKitCore*, do the same for that folder also.
-
 ### Create your own AudioKit module
 
 A simple way to start is to copy one of the simpler **AudioKit** AU source folders to your own project folder (I used **AKBooster**), change all the file/folder names (I changed “AKBooster” to “SDBooster”), then drag the whole folder into your Xcode Project Navigator pane to add it to your project.


### PR DESCRIPTION
AudioKit exposes AKDSPBase, so it's no longer necessary to use the core headers directly.

Further clean up and simplify the code.