### PR TITLE
Cleanup for AKOscillatorDSP

### DIFF
--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
@@ -15,27 +15,4 @@ typedef NS_ENUM(AUParameterAddress, AKOscillatorParameter) {
 
 AKDSPRef createOscillatorDSP(void);
 
-#else
-
-#import "AKSoundpipeDSPBase.hpp"
-
-class AKOscillatorDSP : public AKSoundpipeDSPBase {
-private:
-    struct InternalData;
-    std::unique_ptr<InternalData> data;
- 
-public:
-    AKOscillatorDSP();
-
-    void setWavetable(const float* table, size_t length, int index) override;
-
-    void init(int channelCount, double sampleRate) override;
-
-    void deinit() override;
-
-    void reset() override;
-
-    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
-};
-
 #endif

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -4,6 +4,27 @@
 #include "ParameterRamper.hpp"
 #include <vector>
 
+#import "AKSoundpipeDSPBase.hpp"
+
+class AKOscillatorDSP : public AKSoundpipeDSPBase {
+private:
+    struct InternalData;
+    std::unique_ptr<InternalData> data;
+ 
+public:
+    AKOscillatorDSP();
+
+    void setWavetable(const float* table, size_t length, int index) override;
+
+    void init(int channelCount, double sampleRate) override;
+
+    void deinit() override;
+
+    void reset() override;
+
+    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
+};
+
 extern "C" AKDSPRef createOscillatorDSP() {
     return new AKOscillatorDSP();
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -8,8 +8,13 @@
 
 class AKOscillatorDSP : public AKSoundpipeDSPBase {
 private:
-    struct InternalData;
-    std::unique_ptr<InternalData> data;
+    sp_osc *osc;
+    sp_ftbl *ftbl;
+    std::vector<float> waveform;
+    ParameterRamper frequencyRamp;
+    ParameterRamper amplitudeRamp;
+    ParameterRamper detuningOffsetRamp;
+    ParameterRamper detuningMultiplierRamp;
  
 public:
     AKOscillatorDSP();
@@ -29,57 +34,47 @@ extern "C" AKDSPRef createOscillatorDSP() {
     return new AKOscillatorDSP();
 }
 
-struct AKOscillatorDSP::InternalData {
-    sp_osc *osc;
-    sp_ftbl *ftbl;
-    std::vector<float> waveform;
-    ParameterRamper frequencyRamp;
-    ParameterRamper amplitudeRamp;
-    ParameterRamper detuningOffsetRamp;
-    ParameterRamper detuningMultiplierRamp;
-};
-
-AKOscillatorDSP::AKOscillatorDSP() : data(new InternalData) {
-    parameters[AKOscillatorParameterFrequency] = &data->frequencyRamp;
-    parameters[AKOscillatorParameterAmplitude] = &data->amplitudeRamp;
-    parameters[AKOscillatorParameterDetuningOffset] = &data->detuningOffsetRamp;
-    parameters[AKOscillatorParameterDetuningMultiplier] = &data->detuningMultiplierRamp;
+AKOscillatorDSP::AKOscillatorDSP() {
+    parameters[AKOscillatorParameterFrequency] = &frequencyRamp;
+    parameters[AKOscillatorParameterAmplitude] = &amplitudeRamp;
+    parameters[AKOscillatorParameterDetuningOffset] = &detuningOffsetRamp;
+    parameters[AKOscillatorParameterDetuningMultiplier] = &detuningMultiplierRamp;
 }
 
 void AKOscillatorDSP::setWavetable(const float* table, size_t length, int index) {
-    data->waveform = std::vector<float>(table, table + length);
+    waveform = std::vector<float>(table, table + length);
     reset();
 }
 
 void AKOscillatorDSP::init(int channelCount, double sampleRate) {
     AKSoundpipeDSPBase::init(channelCount, sampleRate);
-    sp_ftbl_create(sp, &data->ftbl, data->waveform.size());
-    std::copy(data->waveform.cbegin(), data->waveform.cend(), data->ftbl->tbl);
-    sp_osc_create(&data->osc);
-    sp_osc_init(sp, data->osc, data->ftbl, 0);
+    sp_ftbl_create(sp, &ftbl, waveform.size());
+    std::copy(waveform.cbegin(), waveform.cend(), ftbl->tbl);
+    sp_osc_create(&osc);
+    sp_osc_init(sp, osc, ftbl, 0);
 }
 
 void AKOscillatorDSP::deinit() {
     AKSoundpipeDSPBase::deinit();
-    sp_osc_destroy(&data->osc);
-    sp_ftbl_destroy(&data->ftbl);
+    sp_osc_destroy(&osc);
+    sp_ftbl_destroy(&ftbl);
 }
 
 void AKOscillatorDSP::reset() {
     AKSoundpipeDSPBase::reset();
     if (!isInitialized) return;
-    sp_osc_init(sp, data->osc, data->ftbl, 0);
+    sp_osc_init(sp, osc, ftbl, 0);
 }
 
 void AKOscillatorDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
         int frameOffset = int(frameIndex + bufferOffset);
 
-        float frequency = data->frequencyRamp.getAndStep();
-        float detuneMultiplier = data->detuningMultiplierRamp.getAndStep();
-        float detuneOffset = data->detuningOffsetRamp.getAndStep();
-        data->osc->freq = frequency * detuneMultiplier + detuneOffset;
-        data->osc->amp = data->amplitudeRamp.getAndStep();
+        float frequency = frequencyRamp.getAndStep();
+        float detuneMultiplier = detuningMultiplierRamp.getAndStep();
+        float detuneOffset = detuningOffsetRamp.getAndStep();
+        osc->freq = frequency * detuneMultiplier + detuneOffset;
+        osc->amp = amplitudeRamp.getAndStep();
 
         float temp = 0;
         for (int channel = 0; channel < channelCount; ++channel) {
@@ -87,7 +82,7 @@ void AKOscillatorDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bu
 
             if (isStarted) {
                 if (channel == 0) {
-                    sp_osc_compute(sp, data->osc, nil, &temp);
+                    sp_osc_compute(sp, osc, nil, &temp);
                 }
                 *out = temp;
             } else {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -17,77 +17,65 @@ private:
     ParameterRamper detuningMultiplierRamp;
  
 public:
-    AKOscillatorDSP();
+    AKOscillatorDSP() {
+        parameters[AKOscillatorParameterFrequency] = &frequencyRamp;
+        parameters[AKOscillatorParameterAmplitude] = &amplitudeRamp;
+        parameters[AKOscillatorParameterDetuningOffset] = &detuningOffsetRamp;
+        parameters[AKOscillatorParameterDetuningMultiplier] = &detuningMultiplierRamp;
+    }
 
-    void setWavetable(const float* table, size_t length, int index) override;
+    void setWavetable(const float* table, size_t length, int index) override {
+        waveform = std::vector<float>(table, table + length);
+        reset();
+    }
 
-    void init(int channelCount, double sampleRate) override;
+    void init(int channelCount, double sampleRate) override {
+        AKSoundpipeDSPBase::init(channelCount, sampleRate);
+        sp_ftbl_create(sp, &ftbl, waveform.size());
+        std::copy(waveform.cbegin(), waveform.cend(), ftbl->tbl);
+        sp_osc_create(&osc);
+        sp_osc_init(sp, osc, ftbl, 0);
+    }
 
-    void deinit() override;
+    void deinit() override {
+        AKSoundpipeDSPBase::deinit();
+        sp_osc_destroy(&osc);
+        sp_ftbl_destroy(&ftbl);
+    }
 
-    void reset() override;
+    void reset() override {
+        AKSoundpipeDSPBase::reset();
+        if (!isInitialized) return;
+        sp_osc_init(sp, osc, ftbl, 0);
+    }
 
-    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override;
+    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override {
+        for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
+            int frameOffset = int(frameIndex + bufferOffset);
+
+            float frequency = frequencyRamp.getAndStep();
+            float detuneMultiplier = detuningMultiplierRamp.getAndStep();
+            float detuneOffset = detuningOffsetRamp.getAndStep();
+            osc->freq = frequency * detuneMultiplier + detuneOffset;
+            osc->amp = amplitudeRamp.getAndStep();
+
+            float temp = 0;
+            for (int channel = 0; channel < channelCount; ++channel) {
+                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+
+                if (isStarted) {
+                    if (channel == 0) {
+                        sp_osc_compute(sp, osc, nil, &temp);
+                    }
+                    *out = temp;
+                } else {
+                    *out = 0.0;
+                }
+            }
+        }
+    }
 };
 
 extern "C" AKDSPRef createOscillatorDSP() {
     return new AKOscillatorDSP();
-}
-
-AKOscillatorDSP::AKOscillatorDSP() {
-    parameters[AKOscillatorParameterFrequency] = &frequencyRamp;
-    parameters[AKOscillatorParameterAmplitude] = &amplitudeRamp;
-    parameters[AKOscillatorParameterDetuningOffset] = &detuningOffsetRamp;
-    parameters[AKOscillatorParameterDetuningMultiplier] = &detuningMultiplierRamp;
-}
-
-void AKOscillatorDSP::setWavetable(const float* table, size_t length, int index) {
-    waveform = std::vector<float>(table, table + length);
-    reset();
-}
-
-void AKOscillatorDSP::init(int channelCount, double sampleRate) {
-    AKSoundpipeDSPBase::init(channelCount, sampleRate);
-    sp_ftbl_create(sp, &ftbl, waveform.size());
-    std::copy(waveform.cbegin(), waveform.cend(), ftbl->tbl);
-    sp_osc_create(&osc);
-    sp_osc_init(sp, osc, ftbl, 0);
-}
-
-void AKOscillatorDSP::deinit() {
-    AKSoundpipeDSPBase::deinit();
-    sp_osc_destroy(&osc);
-    sp_ftbl_destroy(&ftbl);
-}
-
-void AKOscillatorDSP::reset() {
-    AKSoundpipeDSPBase::reset();
-    if (!isInitialized) return;
-    sp_osc_init(sp, osc, ftbl, 0);
-}
-
-void AKOscillatorDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {
-    for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
-        int frameOffset = int(frameIndex + bufferOffset);
-
-        float frequency = frequencyRamp.getAndStep();
-        float detuneMultiplier = detuningMultiplierRamp.getAndStep();
-        float detuneOffset = detuningOffsetRamp.getAndStep();
-        osc->freq = frequency * detuneMultiplier + detuneOffset;
-        osc->amp = amplitudeRamp.getAndStep();
-
-        float temp = 0;
-        for (int channel = 0; channel < channelCount; ++channel) {
-            float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
-
-            if (isStarted) {
-                if (channel == 0) {
-                    sp_osc_compute(sp, osc, nil, &temp);
-                }
-                *out = temp;
-            } else {
-                *out = 0.0;
-            }
-        }
-    }
 }


### PR DESCRIPTION
Simplifies AKOscillatorDSP. Reduces API exposed to clients. Removes unnecessary InternalData struct.