### PR TITLE
Parameter reflection

### DIFF
--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -20,6 +20,8 @@ open class AKNode: NSObject {
 
                 for child in mirror.children {
                     if let param = child.value as? Parameter, let label = child.label {
+                        // Property wrappers create a variable with an underscore
+                        // prepended. Drop the underscore to look up the parameter.
                         let name = String(label.dropFirst())
                         param.projectedValue.associate(with: akAudioUnit,
                                                        identifier: name)

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -19,8 +19,10 @@ open class AKNode: NSObject {
                 let mirror = Mirror(reflecting: self)
 
                 for child in mirror.children {
-                    if let param = child.value as? Parameter {
-                        param.projectedValue.associate(with: akAudioUnit)
+                    if let param = child.value as? Parameter, let label = child.label {
+                        let name = String(label.dropFirst())
+                        param.projectedValue.associate(with: akAudioUnit,
+                                                       identifier: name)
                     }
                 }
             }
@@ -162,6 +164,96 @@ public class AKNodeParameter {
     }
 }
 
+/// AKNodeParameter wraps AUParameter in a user-friendly interface and adds some AudioKit-specific functionality.
+/// New version for use with Parameter property wrapper.
+public class AKNodeParameter2 {
+
+    private var dsp: AKDSPRef?
+
+    private var parameter: AUParameter?
+
+    // MARK: Parameter properties
+
+    public var value: AUValue = 0 {
+        didSet {
+            guard let min = parameter?.minValue, let max = parameter?.maxValue else { return }
+            value = (min...max).clamp(value)
+            if value == oldValue { return }
+            parameter?.value = value
+        }
+    }
+
+    public var boolValue: Bool {
+        get { value > 0.5 }
+        set { value = newValue ? 1.0 : 0.0 }
+    }
+
+    public var minValue: AUValue {
+        parameter?.minValue ?? 0
+    }
+
+    public var maxValue: AUValue {
+        parameter?.maxValue ?? 1
+    }
+
+    public var range: ClosedRange<AUValue> {
+        (parameter?.minValue ?? 0) ... (parameter?.maxValue ?? 1)
+    }
+
+    public var rampDuration: Float = Float(AKSettings.rampDuration) {
+        didSet {
+            guard let dsp = dsp, let addr = parameter?.address else { return }
+            setParameterRampDurationDSP(dsp, addr, rampDuration)
+        }
+    }
+
+    public var rampTaper: Float = 1 {
+        didSet {
+            guard let dsp = dsp, let addr = parameter?.address else { return }
+            setParameterRampTaperDSP(dsp, addr, rampTaper)
+        }
+    }
+
+    public var rampSkew: Float = 0 {
+        didSet {
+            guard let dsp = dsp, let addr = parameter?.address else { return }
+            setParameterRampSkewDSP(dsp, addr, rampSkew)
+        }
+    }
+
+    // MARK: Lifecycle
+
+    /// This function should be called from AKNode subclasses as soon as a valid AU is obtained
+    public func associate(with au: AKAudioUnitBase, identifier: String) {
+        dsp = au.dsp
+        parameter = au.parameterTree?[identifier]
+        assert(parameter != nil)
+
+        guard let dsp = dsp, let addr = parameter?.address else { return }
+        setParameterRampDurationDSP(dsp, addr, rampDuration)
+        setParameterRampTaperDSP(dsp, addr, rampTaper)
+        setParameterRampSkewDSP(dsp, addr, rampSkew)
+
+        guard let min = parameter?.minValue, let max = parameter?.maxValue else { return }
+        parameter?.value = (min...max).clamp(value)
+    }
+
+    /// Sends a .touch event to the parameter automation observer, beginning automation recording if
+    /// enabled in AKParameterAutomation.
+    /// A value may be passed as the initial automation value. The current value is used if none is passed.
+    public func beginTouch(value: AUValue? = nil) {
+        guard let value = value ?? parameter?.value else { return }
+        parameter?.setValue(value, originator: nil, atHostTime: 0, eventType: .touch)
+    }
+
+    /// Sends a .release event to the parameter observation observer, ending any automation recording.
+    /// A value may be passed as the final automation value. The current value is used if none is passed.
+    public func endTouch(value: AUValue? = nil) {
+        guard let value = value ?? parameter?.value else { return }
+        parameter?.setValue(value, originator: nil, atHostTime: 0, eventType: .release)
+    }
+}
+
 /// Wraps AKNodeParameter so we can easily assign values to it.
 ///
 /// Instead of`osc.frequency.value = 440`, we have `osc.frequency = 440`
@@ -177,18 +269,16 @@ public class AKNodeParameter {
 @propertyWrapper
 public struct Parameter {
 
-    var param: AKNodeParameter
+    var param = AKNodeParameter2()
 
-    init(_ identifier: String) {
-        param = AKNodeParameter(identifier: identifier)
-    }
+    public init() { }
 
     public var wrappedValue: AUValue {
         get { param.value }
         set { param.value = newValue }
     }
 
-    public var projectedValue: AKNodeParameter {
+    public var projectedValue: AKNodeParameter2 {
         get { param }
         set { param = newValue }
     }

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -13,7 +13,19 @@ open class AKNode: NSObject {
     open var avAudioNode: AVAudioNode
 
     /// The internal AVAudioUnit, which is a subclass of AVAudioNode with more capabilities
-    open var avAudioUnit: AVAudioUnit?
+    open var avAudioUnit: AVAudioUnit? {
+        didSet {
+            if let akAudioUnit = avAudioUnit?.auAudioUnit as? AKAudioUnitBase {
+                let mirror = Mirror(reflecting: self)
+
+                for child in mirror.children {
+                    if let param = child.value as? Parameter {
+                        param.projectedValue.associate(with: akAudioUnit)
+                    }
+                }
+            }
+        }
+    }
 
     /// Returns either the avAudioUnit or avAudioNode (prefers the avAudioUnit if it exists)
     open var avAudioUnitOrNode: AVAudioNode {
@@ -48,7 +60,7 @@ open class AKNode: NSObject {
 }
 
 /// AKNodeParameter wraps AUParameter in a user-friendly interface and adds some AudioKit-specific functionality.
-public struct AKNodeParameter {
+public class AKNodeParameter {
 
     private var dsp: AKDSPRef?
 
@@ -113,7 +125,7 @@ public struct AKNodeParameter {
     }
 
     /// This function should be called from AKNode subclasses as soon as a valid AU is obtained
-    public mutating func associate(with au: AKAudioUnitBase?, value: AUValue? = nil) {
+    public func associate(with au: AKAudioUnitBase?, value: AUValue? = nil) {
         dsp = au?.dsp
         parameter = au?.parameterTree?[identifier]
 
@@ -130,7 +142,7 @@ public struct AKNodeParameter {
     }
 
     /// This function should be called from AKNode subclasses as soon as a valid AU is obtained
-    public mutating func associate(with au: AKAudioUnitBase?, value: Bool) {
+    public func associate(with au: AKAudioUnitBase?, value: Bool) {
         associate(with: au, value: value ? 1.0 : 0.0)
     }
 

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
@@ -78,18 +78,18 @@ open class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     ) {
         super.init(avAudioNode: AVAudioNode())
 
+        self.waveform = waveform
+        self.frequency = frequency
+        self.amplitude = amplitude
+        self.detuningOffset = detuningOffset
+        self.detuningMultiplier = detuningMultiplier
+
         instantiateAudioUnit { avAudioUnit in
             self.avAudioUnit = avAudioUnit
             self.avAudioNode = avAudioUnit
 
             self.internalAU = avAudioUnit.auAudioUnit as? AKAudioUnitType
             self.parameterAutomation = AKParameterAutomation(avAudioUnit)
-
-            self.waveform = waveform
-            self.$frequency.associate(with: self.internalAU, value: frequency)
-            self.$amplitude.associate(with: self.internalAU, value: amplitude)
-            self.$detuningOffset.associate(with: self.internalAU, value: detuningOffset)
-            self.$detuningMultiplier.associate(with: self.internalAU, value: detuningMultiplier)
 
             self.internalAU?.setWavetable(waveform.content)
         }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
@@ -47,16 +47,16 @@ open class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let defaultDetuningMultiplier: AUValue = 1.0
 
     /// Frequency in cycles per second
-    @Parameter("frequency") public var frequency: AUValue
+    @Parameter public var frequency: AUValue
 
     /// Output Amplitude.
-    @Parameter("amplitude") public var amplitude: AUValue
+    @Parameter public var amplitude: AUValue
 
     /// Frequency offset in Hz.
-    @Parameter("detuningOffset") public var detuningOffset: AUValue
+    @Parameter public var detuningOffset: AUValue
 
     /// Frequency detuning multiplier
-    @Parameter("detuningMultiplier") public var detuningMultiplier: AUValue
+    @Parameter public var detuningMultiplier: AUValue
 
     // MARK: - Initialization
 


### PR DESCRIPTION
Further simplifies @Parameter so the AUParameter is deduced from the variable name via reflection. Shows how to upgrade AKOscillator.

AKNodeParameter2 is temporary until all parameters are converted over.