### PR TITLE
Fixed MIDI Packets iOS 14 beta

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDISampler.swift
+++ b/AudioKit/Common/MIDI/AKMIDISampler.swift
@@ -37,11 +37,14 @@ open class AKMIDISampler: AKAppleSampler {
                          name: String = "MIDI Sampler") {
         CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
             for e in packetList.pointee {
-                let event = AKMIDIEvent(packet: e)
-                do {
-                    try self.handle(event: event)
-                } catch let exception {
-                    AKLog("Exception handling MIDI event: \(exception)", log: OSLog.midi, type: .error)
+                e.forEach { (event) in
+                    if event.length == 3 {
+                        do {
+                            try self.handle(event: event)
+                        } catch let exception {
+                            AKLog("Exception handling MIDI event: \(exception)", log: OSLog.midi, type: .error)
+                        }
+                    }
                 }
             }
         })


### PR DESCRIPTION
I changed some of the code in `AKMIDISampler.swift` a little bit to fix the MIDI bug in iOS 14 beta I mentioned.

Now all of the MIDI note events can be sent to a sampler. The only thing I'm concerned about is the fact that I changed it so only events with a length of three (note events) can go through.

Please let me know if you have any advice or feedback. I can always change things and resubmit.

Other than that, I've tested this on both iOS 13.5.1 and iOS 14.0, and everything works great.

Thank you.