### PR TITLE
adds parameter recording callback

### DIFF
--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -128,7 +128,7 @@ public class AKNodeParameter {
     private var renderObserverToken: Int?
 
     /// Start playback immediately with the specified offset (seconds) from the start of the sequence
-    public func automate(points: [AKParameterAutomationPoint], rate: Double = 1) {
+    public func automate(points: [AKParameterAutomationPoint]) {
         guard var lastTime = avAudioUnit.lastRenderTime else { return }
         guard let parameter = parameter else { return }
 

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -180,6 +180,9 @@ public class AKNodeParameter {
 
             for index in 0..<numberEvents {
                 let event = events[index]
+
+                // Dispatching to main thread avoids the restrictions
+                // required of parameter automation observers.
                 DispatchQueue.main.async {
                     callback(event)
                 }

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -127,7 +127,11 @@ public class AKNodeParameter {
 
     private var renderObserverToken: Int?
 
-    /// Start playback immediately with the specified offset (seconds) from the start of the sequence
+    /// Begin automation immediately.
+    ///
+    /// Time is relative to the approximate time when the function
+    /// is called. This is only sample accurate if called prior to `AKManager.start()`.
+    /// - Parameter points: automation curve
     public func automate(points: [AKParameterAutomationPoint]) {
         guard var lastTime = avAudioUnit.lastRenderTime else { return }
         guard let parameter = parameter else { return }

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -169,6 +169,35 @@ public class AKNodeParameter {
 
     }
 
+    private var parameterObserverToken: AUParameterObserverToken?
+
+    /// Records automation for this parameter.
+    /// - Parameter callback: Called on the main queue for each parameter event.
+    public func recordAutomation(callback: @escaping (AUParameterAutomationEvent) -> Void) {
+
+        guard let parameter = parameter else { return }
+        parameterObserverToken = parameter.token(byAddingParameterAutomationObserver: { (numberEvents, events) in
+
+            for index in 0..<numberEvents {
+                let event = events[index]
+                DispatchQueue.main.async {
+                    callback(event)
+                }
+
+            }
+        })
+    }
+
+    /// Stop calling the function passed to `recordAutomation`
+    public func stopRecording() {
+
+        guard let parameter = parameter else { return }
+
+        if let token = parameterObserverToken {
+            parameter.removeParameterObserver(token)
+        }
+    }
+
     // MARK: Lifecycle
 
     public func set(avAudioUnit: AVAudioUnit) {

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -153,7 +153,6 @@ public class AKNodeParameter {
                                                                   avAudioUnit.auAudioUnit.scheduleParameterBlock,
                                                                   AKSettings.sampleRate,
                                                                   Double(lastTime.sampleTime),
-                                                                  1,
                                                                   automationBaseAddress,
                                                                   points.count) else { return }
 

--- a/AudioKit/Common/Nodes/AKNode.swift
+++ b/AudioKit/Common/Nodes/AKNode.swift
@@ -128,7 +128,7 @@ public class AKNodeParameter {
     private var renderObserverToken: Int?
 
     /// Start playback immediately with the specified offset (seconds) from the start of the sequence
-    public func automate(points: [AKParameterAutomationPoint], offset: Double = 0, rate: Double = 1) {
+    public func automate(points: [AKParameterAutomationPoint], rate: Double = 1) {
         guard var lastTime = avAudioUnit.lastRenderTime else { return }
         guard let parameter = parameter else { return }
 
@@ -139,9 +139,6 @@ public class AKNodeParameter {
             assert(lastTime.isSampleTimeValid)
         }
 
-        let adjustedOffset = offset / rate
-        let time = lastTime.offset(seconds: -adjustedOffset)
-
         stopAutomation()
 
         points.withUnsafeBufferPointer { automationPtr in
@@ -151,7 +148,7 @@ public class AKNodeParameter {
             guard let observer = AKParameterAutomationGetRenderObserver(parameter.address,
                                                                   avAudioUnit.auAudioUnit.scheduleParameterBlock,
                                                                   AKSettings.sampleRate,
-                                                                  Double(time.sampleTime),
+                                                                  Double(lastTime.sampleTime),
                                                                   1,
                                                                   automationBaseAddress,
                                                                   points.count) else { return }

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
@@ -50,7 +50,6 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                                                         AUScheduleParameterBlock scheduleParameterBlock,
                                                         double sampleRate,
                                                         double startSampleTime,
-                                                        double playbackRate,
                                                         const struct AKParameterAutomationPoint* points,
                                                         size_t count);
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -491,7 +491,6 @@ struct RenderObserverData {
 
 static void scheduleAutomationPoint(AUScheduleParameterBlock scheduleParameterBlock,
                                     double sampleRate,
-                                    double playbackRate,
                                     AUEventSampleTime blockTime,
                                     AUParameterAddress address,
                                     const AKParameterAutomationPoint& point,
@@ -512,7 +511,7 @@ static void scheduleAutomationPoint(AUScheduleParameterBlock scheduleParameterBl
     scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime, rampOffset, address | mask, 0);
 
     // set value
-    AUAudioFrameCount rampDuration = point.rampDuration / playbackRate * sampleRate;
+    AUAudioFrameCount rampDuration = point.rampDuration * sampleRate;
     scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime, rampDuration, address, point.targetValue);
 }
 
@@ -522,7 +521,6 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                                                         AUScheduleParameterBlock scheduleParameterBlock,
                                                         double sampleRate,
                                                         double startSampleTime,
-                                                        double playbackRate,
                                                         const struct AKParameterAutomationPoint* points,
                                                         size_t count) {
 
@@ -547,8 +545,8 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
         // Skip forward.
         while (data.iterator != data.points.cend() ) {
 
-            double rampStartTime = data.iterator->startTime / playbackRate;
-            double rampEndTime = rampStartTime + data.iterator->rampDuration / playbackRate;
+            double rampStartTime = data.iterator->startTime;
+            double rampEndTime = rampStartTime + data.iterator->rampDuration;
 
             if (rampStartTime < blockStartTime) {
                 if (rampEndTime <= blockStartTime) {
@@ -558,7 +556,7 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                 else {
                     // we're starting mid-ramp: start immediately with offset
                     AUAudioFrameCount offset = (blockStartTime - rampStartTime) * sampleRate;
-                    scheduleAutomationPoint(scheduleParameterBlock, sampleRate, playbackRate, 0, data.address, *data.iterator, offset);
+                    scheduleAutomationPoint(scheduleParameterBlock, sampleRate, 0, data.address, *data.iterator, offset);
                 }
                 data.iterator++;
             }
@@ -570,11 +568,11 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
 
         // Apply parameter automation for the segment.
         while (data.iterator != data.points.cend()) {
-            double rampStartTime = data.iterator->startTime / playbackRate;
+            double rampStartTime = data.iterator->startTime;
             if (rampStartTime >= blockEndTime) break;
             AUEventSampleTime startTime = (rampStartTime - blockStartTime) * sampleRate;
             if (rampStartTime < blockStartTime) startTime = 0; // should never happen?
-            scheduleAutomationPoint(scheduleParameterBlock, sampleRate, playbackRate, startTime, data.address, *data.iterator, 0);
+            scheduleAutomationPoint(scheduleParameterBlock, sampleRate, startTime, data.address, *data.iterator, 0);
             data.iterator++;
         }
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -536,9 +536,6 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
     {
         if (actionFlags != kAudioUnitRenderAction_PreRender) return;
 
-        // XXX: do we need this?
-        // if (!isPlaying) return;
-
         double blockStartTime = (timestamp->mSampleTime - startSampleTime) / sampleRate;
         double blockEndTime = blockStartTime + frameCount / sampleRate;
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -191,3 +191,32 @@ public extension AKParameterAutomationPoint {
                   rampSkew: 0)
     }
 }
+
+/// Replaces automation over a time range.
+/// - Parameters:
+///   - points: existing automation curve
+///   - newPoints: new automation events
+///   - startTime: start of range to replace
+///   - stopTime: end of range to replace
+/// - Returns: new automation curve
+public func AKReplaceAutomation(points: [AKParameterAutomationPoint],
+                                newPoints: [(Double, AUValue)],
+                                startTime: Double,
+                                stopTime: Double) -> [AKParameterAutomationPoint] {
+    var result = points
+
+    // Clear existing points in segment range.
+    result.removeAll { point in
+        point.startTime >= startTime && point.startTime <= stopTime
+    }
+
+    // Append recorded points.
+    result.append(contentsOf: newPoints.map { pt in
+        AKParameterAutomationPoint(targetValue: pt.1, startTime: pt.0, rampDuration: 0.01)
+    })
+
+    // Sort vector by time.
+    result.sort { $0.startTime < $1.startTime }
+
+    return result
+}

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -221,8 +221,8 @@ public func AKReplaceAutomation(points: [AKParameterAutomationPoint],
     }
 
     // Append recorded points.
-    result.append(contentsOf: newPoints.map { pt in
-        AKParameterAutomationPoint(targetValue: pt.1, startTime: pt.0, rampDuration: 0.01)
+    result.append(contentsOf: newPoints.map { point in
+        AKParameterAutomationPoint(targetValue: point.1, startTime: point.0, rampDuration: 0.01)
     })
 
     // Sort vector by time.

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -192,6 +192,16 @@ public extension AKParameterAutomationPoint {
     }
 }
 
+extension AKParameterAutomationPoint: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.targetValue == rhs.targetValue
+            && lhs.startTime == rhs.startTime
+            && lhs.rampDuration == rhs.rampDuration
+            && lhs.rampTaper == rhs.rampTaper
+            && lhs.rampSkew == rhs.rampSkew
+    }
+}
+
 /// Replaces automation over a time range.
 /// - Parameters:
 ///   - points: existing automation curve

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -132,26 +132,4 @@ class AKOscillatorTests: AKTestCase {
         AKTestMD5("33320d40f5fa6f469d06f877aae338a8")
     }
 
-    func testNewAutomationRecord() {
-
-        let osc = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        AKManager.output = osc
-        try! AKManager.start()
-        osc.start()
-
-        var values:[AUValue] = []
-
-        osc.$frequency.recordAutomation { (event) in
-            values.append(event.value)
-        }
-
-        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
-
-        osc.frequency = 800
-
-        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
-
-        XCTAssertEqual(values, [800])
-    }
-
 }

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -1,6 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 import AudioKit
+import XCTest
 
 class AKOscillatorTests: AKTestCase {
 
@@ -129,6 +130,28 @@ class AKOscillatorTests: AKTestCase {
         // auditionTest()
 
         AKTestMD5("33320d40f5fa6f469d06f877aae338a8")
+    }
+
+    func testNewAutomationRecord() {
+
+        let osc = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
+        AKManager.output = osc
+        try! AKManager.start()
+        osc.start()
+
+        var values:[AUValue] = []
+
+        osc.$frequency.recordAutomation { (event) in
+            values.append(event.value)
+        }
+
+        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
+
+        osc.frequency = 800
+
+        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
+
+        XCTAssertEqual(values, [800])
     }
 
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -126,7 +126,7 @@ class AKParameterAutomationTests: AKTestCase {
                            AKParameterAutomationPoint(targetValue: 880, startTime: 1, rampDuration: 0.1),
                            AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
 
-            let events:[(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
+            let events: [(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
 
             let newPoints = AKReplaceAutomation(points: points,
                                                 newPoints: events,
@@ -148,7 +148,7 @@ class AKParameterAutomationTests: AKTestCase {
                            AKParameterAutomationPoint(targetValue: 880, startTime: 1, rampDuration: 0.1),
                            AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
 
-            let events:[(Double, AUValue)] = [ ]
+            let events: [(Double, AUValue)] = [ ]
 
             let newPoints = AKReplaceAutomation(points: points,
                                                 newPoints: events,

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -48,7 +48,10 @@ class AKParameterAutomationTests: XCTestCase {
         let (addresses, values) = observerTest(automation: automationPoints, sampleTime: 0)
 
         // order is: taper, skew, offset, value
-        XCTAssertEqual(addresses, [9223372036854775850, 4611686018427387946, 2305843009213693994, 42])
+        XCTAssertEqual(addresses, [ (UInt64(1)<<63) | 42,
+                                    (UInt64(1)<<62) | 42,
+                                    (UInt64(1)<<61) | 42,
+                                    42])
         XCTAssertEqual(values, [1.0, 0.0, 0.0, 880.0])
     }
 

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 import AudioKit
 
-class AKParameterAutomationTests: XCTestCase {
+class AKParameterAutomationTests: AKTestCase {
 
     func observerTest(automation: [AKParameterAutomationPoint], sampleTime: Float64) -> ([AUParameterAddress], [AUValue]) {
 

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -119,23 +119,57 @@ class AKParameterAutomationTests: XCTestCase {
 
     func testReplaceAutomation() {
 
-        let points = [ AKParameterAutomationPoint(targetValue: 440, startTime: 0, rampDuration: 0.1),
-                       AKParameterAutomationPoint(targetValue: 880, startTime: 1, rampDuration: 0.1),
-                       AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
+        {
+            let points = [ AKParameterAutomationPoint(targetValue: 440, startTime: 0, rampDuration: 0.1),
+                           AKParameterAutomationPoint(targetValue: 880, startTime: 1, rampDuration: 0.1),
+                           AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
 
-        let events:[(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
+            let events:[(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
 
-        let newPoints = AKReplaceAutomation(points: points,
-                                            newPoints: events,
-                                            startTime: 0.25,
-                                            stopTime: 1.75)
+            let newPoints = AKReplaceAutomation(points: points,
+                                                newPoints: events,
+                                                startTime: 0.25,
+                                                stopTime: 1.75)
 
-        let expected = [ AKParameterAutomationPoint(targetValue: 440, startTime: 0, rampDuration: 0.1),
-                         AKParameterAutomationPoint(targetValue: 100, startTime: 0.5, rampDuration: 0.01),
-                         AKParameterAutomationPoint(targetValue: 200, startTime: 1.5, rampDuration: 0.01),
-                         AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
+            let expected = [ AKParameterAutomationPoint(targetValue: 440, startTime: 0, rampDuration: 0.1),
+                             AKParameterAutomationPoint(targetValue: 100, startTime: 0.5, rampDuration: 0.01),
+                             AKParameterAutomationPoint(targetValue: 200, startTime: 1.5, rampDuration: 0.01),
+                             AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
 
-        XCTAssertEqual(newPoints.count, 4)
-        XCTAssertEqual(newPoints, expected)
+            XCTAssertEqual(newPoints.count, 4)
+            XCTAssertEqual(newPoints, expected)
+        }();
+
+
+        {
+            let points = [ AKParameterAutomationPoint(targetValue: 440, startTime: 0, rampDuration: 0.1),
+                           AKParameterAutomationPoint(targetValue: 880, startTime: 1, rampDuration: 0.1),
+                           AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
+
+            let events:[(Double, AUValue)] = [ ]
+
+            let newPoints = AKReplaceAutomation(points: points,
+                                                newPoints: events,
+                                                startTime: 0,
+                                                stopTime: 2)
+
+            XCTAssertEqual(newPoints, [])
+        }();
+
+        {
+            let points:[AKParameterAutomationPoint] = [ ]
+
+            let events:[(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
+
+            let newPoints = AKReplaceAutomation(points: points,
+                                                newPoints: events,
+                                                startTime: 0,
+                                                stopTime: 2)
+
+            let expected = [ AKParameterAutomationPoint(targetValue: 100, startTime: 0.5, rampDuration: 0.01),
+                             AKParameterAutomationPoint(targetValue: 200, startTime: 1.5, rampDuration: 0.01)]
+
+            XCTAssertEqual(newPoints, expected)
+        }()
     }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -107,5 +107,13 @@ class AKParameterAutomationTests: XCTestCase {
         RunLoop.main.run(until: Date().addingTimeInterval(1.0))
 
         XCTAssertEqual(values, [800])
+
+        osc.$frequency.stopRecording()
+
+        osc.frequency = 500
+
+        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
+
+        XCTAssertEqual(values, [800])
     }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -159,9 +159,9 @@ class AKParameterAutomationTests: AKTestCase {
         }();
 
         {
-            let points:[AKParameterAutomationPoint] = [ ]
+            let points: [AKParameterAutomationPoint] = [ ]
 
-            let events:[(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
+            let events: [(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
 
             let newPoints = AKReplaceAutomation(points: points,
                                                 newPoints: events,

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -28,7 +28,6 @@ class AKParameterAutomationTests: AKTestCase {
                                                    scheduleParameterBlock,
                                                    44100,
                                                    0, // start time
-                                                   1, // playback speed
                                                    automationPtr.baseAddress!,
                                                    automation.count)
         }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -86,4 +86,26 @@ class AKParameterAutomationTests: XCTestCase {
         XCTAssertEqual(addresses, [])
         XCTAssertEqual(values, [])
     }
+
+    func testRecord() {
+
+        let osc = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
+        AKManager.output = osc
+        try! AKManager.start()
+        osc.start()
+
+        var values:[AUValue] = []
+
+        osc.$frequency.recordAutomation { (event) in
+            values.append(event.value)
+        }
+
+        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
+
+        osc.frequency = 800
+
+        RunLoop.main.run(until: Date().addingTimeInterval(1.0))
+
+        XCTAssertEqual(values, [800])
+    }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -116,4 +116,26 @@ class AKParameterAutomationTests: XCTestCase {
 
         XCTAssertEqual(values, [800])
     }
+
+    func testReplaceAutomation() {
+
+        let points = [ AKParameterAutomationPoint(targetValue: 440, startTime: 0, rampDuration: 0.1),
+                       AKParameterAutomationPoint(targetValue: 880, startTime: 1, rampDuration: 0.1),
+                       AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
+
+        let events:[(Double, AUValue)] = [ (0.5, 100), (1.5, 200) ]
+
+        let newPoints = AKReplaceAutomation(points: points,
+                                            newPoints: events,
+                                            startTime: 0.25,
+                                            stopTime: 1.75)
+
+        let expected = [ AKParameterAutomationPoint(targetValue: 440, startTime: 0, rampDuration: 0.1),
+                         AKParameterAutomationPoint(targetValue: 100, startTime: 0.5, rampDuration: 0.01),
+                         AKParameterAutomationPoint(targetValue: 200, startTime: 1.5, rampDuration: 0.01),
+                         AKParameterAutomationPoint(targetValue: 440, startTime: 2, rampDuration: 0.1)]
+
+        XCTAssertEqual(newPoints.count, 4)
+        XCTAssertEqual(newPoints, expected)
+    }
 }


### PR DESCRIPTION
Using a callback gives the user a lot of flexibility (for example: drawing automation points as they are recorded).

Adds a convenience function for reconciling automation events with existing automation curves.

Adds unit tests.

Also simplifies parameter automation implementation.