### PR TITLE
DSP kernel cleanup

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -41,9 +41,7 @@ void deleteDSP(AKDSPRef pDSP);
 #else
 
 #import <Foundation/Foundation.h>
-#import <algorithm>
 #import <vector>
-#import <map>
 
 /**
  Base class for DSPKernels. Many of the methods are virtual, because the base AudioUnit class

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -68,8 +68,10 @@ protected:
 
     // current time in samples
     AUEventSampleTime now = 0;
+
+    static constexpr int maxParameters = 128;
     
-    std::map<AUParameterAddress, class ParameterRamper*> parameters;
+    class ParameterRamper* parameters[maxParameters];
 
 public:
     

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPKernel.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPKernel.hpp
@@ -13,7 +13,9 @@ protected:
 public:
     AKDSPKernel(int channelCount, float sampleRate) : channels(channelCount), sampleRate(sampleRate) { }
     AKDSPKernel();
-    
+    AKDSPKernel(const AKDSPKernel&) = delete; // non copyable
+    AKDSPKernel& operator=( const AKDSPKernel& ) = delete; // non copyable
+
     float getSampleRate() { return sampleRate; }
 
     virtual ~AKDSPKernel() { }

--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
@@ -35,11 +35,6 @@ ParameterRamper::ParameterRamper(float value) : data(new InternalData)
     setImmediate(value);
 }
 
-ParameterRamper::ParameterRamper(const ParameterRamper& other)
-: data(new InternalData(*other.data))
-{
-}
-
 ParameterRamper::~ParameterRamper() = default;
 
 void ParameterRamper::setImmediate(float value)

--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
@@ -14,7 +14,6 @@
 #include <math.h>
 
 struct ParameterRamper::InternalData {
-    float clampLow, clampHigh;
     float uiValue;
     float sampleRate;
     float defaultRampDuration = 0.02;

--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.cpp
@@ -10,8 +10,7 @@
 #include "ParameterRamper.hpp"
 
 #import <AudioToolbox/AUAudioUnit.h>
-#import <libkern/OSAtomic.h>
-#import <stdatomic.h>
+#include <atomic>
 #include <math.h>
 
 struct ParameterRamper::InternalData {
@@ -26,7 +25,7 @@ struct ParameterRamper::InternalData {
     float goal;
     uint32_t duration;
     uint32_t samplesRemaining;
-    volatile atomic_int changeCounter = 0;
+    std::atomic_int changeCounter{0};
     int32_t updateCounter = 0;
 };
 

--- a/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/Apple Code/ParameterRamper.hpp
@@ -18,8 +18,10 @@ private:
 
 public:
     ParameterRamper(float value = 0.f);
-    ParameterRamper(const ParameterRamper& other);
+    ParameterRamper(const ParameterRamper& other) = delete; // non copyable
     ~ParameterRamper();
+
+    ParameterRamper& operator=( const ParameterRamper& ) = delete; // non copyable
 
     void setImmediate(float value);
 

--- a/AudioKit/Common/Internals/CoreAudio/Bank/AKBankDSPKernel.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/Bank/AKBankDSPKernel.hpp
@@ -150,14 +150,14 @@ public:
     int playingNotesCount = 0;
     bool resetted = false;
     
-    ParameterRamper attackDurationRamper = 0.1;
-    ParameterRamper decayDurationRamper = 0.1;
-    ParameterRamper sustainLevelRamper = 1.0;
-    ParameterRamper releaseDurationRamper = 0.1;
-    ParameterRamper pitchBendRamper = 0;
-    ParameterRamper vibratoDepthRamper = 0;
-    ParameterRamper vibratoRateRamper = 0;
-    ParameterRamper detuningOffsetRamper = 0;
+    ParameterRamper attackDurationRamper{0.1};
+    ParameterRamper decayDurationRamper{0.1};
+    ParameterRamper sustainLevelRamper{1.0};
+    ParameterRamper releaseDurationRamper{0.1};
+    ParameterRamper pitchBendRamper{0};
+    ParameterRamper vibratoDepthRamper{0};
+    ParameterRamper vibratoRateRamper{0};
+    ParameterRamper detuningOffsetRamper{0};
 
     // standard bank kernel functions
     virtual void startNote(int note, int velocity) {

--- a/AudioKit/Common/Internals/CoreAudio/Filter Synth/AKFilterSynthDSPKernel.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/Filter Synth/AKFilterSynthDSPKernel.hpp
@@ -194,22 +194,22 @@ public:
     int playingNotesCount = 0;
     bool resetted = false;
     
-    ParameterRamper attackDurationRamper = 0.1;
-    ParameterRamper decayDurationRamper = 0.1;
-    ParameterRamper sustainLevelRamper = 1.0;
-    ParameterRamper releaseDurationRamper = 0.1;
-    ParameterRamper pitchBendRamper = 0;
-    ParameterRamper vibratoDepthRamper = 0;
-    ParameterRamper vibratoRateRamper = 0;
-    ParameterRamper filterCutoffFrequencyRamper = 0.1;
-    ParameterRamper filterResonanceRamper = 0.1;
-    ParameterRamper filterAttackDurationRamper = 0.1;
-    ParameterRamper filterDecayDurationRamper = 0.1;
-    ParameterRamper filterSustainLevelRamper = 1.0;
-    ParameterRamper filterReleaseDurationRamper = 0.1;
-    ParameterRamper filterEnvelopeStrengthRamper = 0.0;
-    ParameterRamper filterLFODepthRamper = 0;
-    ParameterRamper filterLFORateRamper = 0;
+    ParameterRamper attackDurationRamper{0.1};
+    ParameterRamper decayDurationRamper{0.1};
+    ParameterRamper sustainLevelRamper{1.0};
+    ParameterRamper releaseDurationRamper{0.1};
+    ParameterRamper pitchBendRamper{0};
+    ParameterRamper vibratoDepthRamper{0};
+    ParameterRamper vibratoRateRamper{0};
+    ParameterRamper filterCutoffFrequencyRamper{0.1};
+    ParameterRamper filterResonanceRamper{0.1};
+    ParameterRamper filterAttackDurationRamper{0.1};
+    ParameterRamper filterDecayDurationRamper{0.1};
+    ParameterRamper filterSustainLevelRamper{1.0};
+    ParameterRamper filterReleaseDurationRamper{0.1};
+    ParameterRamper filterEnvelopeStrengthRamper{0.0};
+    ParameterRamper filterLFODepthRamper{0};
+    ParameterRamper filterLFORateRamper{0};
     
     // standard filter synth kernel functions
     void startNote(int note, int velocity) {

--- a/AudioKit/Common/Nodes/Generators/Polysynths/FM Oscillator Bank/AKFMOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/FM Oscillator Bank/AKFMOscillatorBankDSPKernel.hpp
@@ -215,7 +215,7 @@ private:
     float modulationIndex = 1;
     
 public:
-    ParameterRamper carrierMultiplierRamper = 1.0;
-    ParameterRamper modulatingMultiplierRamper = 1;
-    ParameterRamper modulationIndexRamper = 1;
+    ParameterRamper carrierMultiplierRamper{1.0};
+    ParameterRamper modulatingMultiplierRamper{1};
+    ParameterRamper modulationIndexRamper{1};
 };

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/FM Oscillator Filter Synth/AKFMOscillatorFilterSynthDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/FM Oscillator Filter Synth/AKFMOscillatorFilterSynthDSPKernel.hpp
@@ -244,7 +244,7 @@ private:
     float modulationIndex = 1;
 
 public:
-    ParameterRamper carrierMultiplierRamper = 1.0;
-    ParameterRamper modulatingMultiplierRamper = 1;
-    ParameterRamper modulationIndexRamper = 1;
+    ParameterRamper carrierMultiplierRamper{1.0};
+    ParameterRamper modulatingMultiplierRamper{1};
+    ParameterRamper modulationIndexRamper{1};
 };

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/Morphing Oscillator Filter Synth/AKMorphingOscillatorFilterSynthDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/Morphing Oscillator Filter Synth/AKMorphingOscillatorFilterSynthDSPKernel.hpp
@@ -203,7 +203,7 @@ private:
     float index = 0;
 
 public:
-    ParameterRamper indexRamper = 0.0;
+    ParameterRamper indexRamper{0.0};
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/PWM Filter Synth/AKPWMOscillatorFilterSynthDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/PWM Filter Synth/AKPWMOscillatorFilterSynthDSPKernel.hpp
@@ -193,7 +193,7 @@ private:
     float pulseWidth = 0.5;
 
 public:
-    ParameterRamper pulseWidthRamper = 0.5;
+    ParameterRamper pulseWidthRamper{0.5};
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/Phase Distortion Filter Synth/AKPhaseDistortionOscillatorFilterSynthDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Filter Polysynths/Phase Distortion Filter Synth/AKPhaseDistortionOscillatorFilterSynthDSPKernel.hpp
@@ -217,5 +217,5 @@ private:
     float phaseDistortion = 0.0;
 
 public:
-    ParameterRamper phaseDistortionRamper = 0.0;
+    ParameterRamper phaseDistortionRamper{0.0};
 };

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Morphing Oscillator Bank/AKMorphingOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Morphing Oscillator Bank/AKMorphingOscillatorBankDSPKernel.hpp
@@ -174,7 +174,7 @@ private:
     float index = 0;
     
 public:
-    ParameterRamper indexRamper = 0.0;
+    ParameterRamper indexRamper{0.0};
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBankDSPKernel.hpp
@@ -164,7 +164,7 @@ private:
     float pulseWidth = 0.5;
     
 public:
-    ParameterRamper pulseWidthRamper = 0.5;
+    ParameterRamper pulseWidthRamper{0.5};
 };
 
 #endif

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Phase Distortion Oscillator Bank/AKPhaseDistortionOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Phase Distortion Oscillator Bank/AKPhaseDistortionOscillatorBankDSPKernel.hpp
@@ -188,5 +188,5 @@ private:
     float phaseDistortion = 0.0;
     
 public:
-    ParameterRamper phaseDistortionRamper = 0.0;
+    ParameterRamper phaseDistortionRamper{0.0};
 };

--- a/AudioKit/Common/Nodes/Mixing/Fader/AKFaderDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Fader/AKFaderDSP.mm
@@ -6,8 +6,8 @@
 
 struct AKFaderDSP : AKDSPBase {
 private:
-    ParameterRamper leftGainRamp = 1.0;
-    ParameterRamper rightGainRamp = 1.0;
+    ParameterRamper leftGainRamp{1.0};
+    ParameterRamper rightGainRamp{1.0};
     bool flipStereo = false;
     bool mixToMono = false;
 

--- a/AudioKit/Common/Nodes/Playback/Samplers/Disk Streamer/AKDiskStreamerDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Disk Streamer/AKDiskStreamerDSPKernel.hpp
@@ -305,8 +305,8 @@ private:
 public:
     bool started = false;
     bool resetted = false;
-    ParameterRamper rateRamper = 1;
-    ParameterRamper volumeRamper = 1;
+    ParameterRamper rateRamper{1};
+    ParameterRamper volumeRamper{1};
     AKCCallback completionHandler = nullptr;
     AKCCallback loadCompletionHandler = nullptr;
     AKCCallback loopCallback = nullptr;

--- a/AudioKit/Common/Nodes/Playback/Samplers/Wave Table/AKWaveTableDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Wave Table/AKWaveTableDSPKernel.hpp
@@ -356,8 +356,8 @@ private:
 public:
     bool started = false;
     bool resetted = false;
-    ParameterRamper rateRamper = 1;
-    ParameterRamper volumeRamper = 1;
+    ParameterRamper rateRamper{1};
+    ParameterRamper volumeRamper{1};
     AKCCallback completionHandler = nullptr;
     AKCCallback loadCompletionHandler = nullptr;
     AKCCallback loopCallback = nullptr;

--- a/AudioKit/STKAudioKit/Mandolin/AKMandolinDSPKernel.hpp
+++ b/AudioKit/STKAudioKit/Mandolin/AKMandolinDSPKernel.hpp
@@ -49,8 +49,8 @@ public:
     bool started = false;
     bool resetted = false;
 
-    ParameterRamper detuneRamper = 1;
-    ParameterRamper bodySizeRamper = 1;
+    ParameterRamper detuneRamper{1};
+    ParameterRamper bodySizeRamper{1};
 };
 
 


### PR DESCRIPTION
The introduction of a maximum of 128 parameters avoids the use of std::map on the audio thread. Could get rid of that maximum by changing every kernel to return a pointer to an array of parameters.