### PR TITLE
Fix test failures with optimization off.

### DIFF
--- a/AudioKit/Common/Nodes/Generators/Polysynths/FM Oscillator Bank/AKFMOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/FM Oscillator Bank/AKFMOscillatorBankDSPKernel.hpp
@@ -43,7 +43,7 @@ protected:
             AKFMOscillatorBankDSPKernel *bankKernel = (AKFMOscillatorBankDSPKernel*)kernel;
             
             float originalFrequency = fosc->freq;
-            fosc->freq *= powf(2, kernel->pitchBend / 12.0);
+            fosc->freq *= exp2f(kernel->pitchBend / 12.0);
             fosc->freq = clamp(fosc->freq, 0.0f, 22050.0f);
             float bentFrequency = fosc->freq;
             
@@ -60,7 +60,7 @@ protected:
                 float x = 0;
                 float depth = kernel->vibratoDepth / 12.0;
                 float variation = sinf((kernel->currentRunningIndex + frameIndex) * 2 * 2 * M_PI * kernel->vibratoRate / kernel->getSampleRate());
-                fosc->freq = bentFrequency * powf(2, depth * variation);
+                fosc->freq = bentFrequency * exp2f(depth * variation);
                 sp_adsr_compute(kernel->getSpData(), adsr, &internalGate, &amp);
                 sp_fosc_compute(kernel->getSpData(), fosc, nil, &x);
                 *outL++ += amp * x;

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Morphing Oscillator Bank/AKMorphingOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Morphing Oscillator Bank/AKMorphingOscillatorBankDSPKernel.hpp
@@ -60,7 +60,7 @@ protected:
                 float x = 0;
                 float depth = kernel->vibratoDepth / 12.0;
                 float variation = sinf((kernel->currentRunningIndex + frameIndex) * 2 * 2 * M_PI * kernel->vibratoRate / kernel->getSampleRate());
-                osc->freq = bentFrequency * powf(2, depth * variation);
+                osc->freq = bentFrequency * exp2f(depth * variation);
                 
                 sp_adsr_compute(kernel->getSpData(), adsr, &internalGate, &amp);
                 sp_oscmorph_compute(kernel->getSpData(), osc, nil, &x);

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Oscillator Bank/AKOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Oscillator Bank/AKOscillatorBankDSPKernel.hpp
@@ -55,7 +55,7 @@ protected:
                 float x = 0;
                 float depth = kernel->vibratoDepth / 12.0;
                 float variation = sinf((kernel->currentRunningIndex + frameIndex) * 2 * 2 * M_PI * kernel->vibratoRate / kernel->getSampleRate());
-                osc->freq = bentFrequency * powf(2, depth * variation);
+                osc->freq = bentFrequency * exp2f(depth * variation);
                 
                 sp_adsr_compute(kernel->getSpData(), adsr, &internalGate, &amp);
                 sp_osc_compute(kernel->getSpData(), osc, nil, &x);

--- a/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/PWM Oscillator Bank/AKPWMOscillatorBankDSPKernel.hpp
@@ -44,7 +44,7 @@ protected:
             auto bankKernel = (AKPWMOscillatorBankDSPKernel*)kernel;
             
             float originalFrequency = *blsquare->freq;
-            *blsquare->freq *= powf(2, kernel->pitchBend / 12.0);
+            *blsquare->freq *= exp2f(kernel->pitchBend / 12.0);
             *blsquare->freq = clamp(*blsquare->freq, 0.0f, 22050.0f);
             float bentFrequency = *blsquare->freq;
             
@@ -59,7 +59,7 @@ protected:
                 float x = 0;
                 float depth = kernel->vibratoDepth / 12.0;
                 float variation = sinf((kernel->currentRunningIndex + frameIndex) * 2 * 2 * M_PI * kernel->vibratoRate / kernel->getSampleRate());
-                *blsquare->freq = bentFrequency * powf(2, depth * variation);
+                *blsquare->freq = bentFrequency * exp2f(depth * variation);
                 sp_adsr_compute(kernel->getSpData(), adsr, &internalGate, &amp);
                 sp_blsquare_compute(kernel->getSpData(), blsquare, nil, &x);
                 *outL++ += amp * x;

--- a/AudioKit/Common/Nodes/Generators/Polysynths/Phase Distortion Oscillator Bank/AKPhaseDistortionOscillatorBankDSPKernel.hpp
+++ b/AudioKit/Common/Nodes/Generators/Polysynths/Phase Distortion Oscillator Bank/AKPhaseDistortionOscillatorBankDSPKernel.hpp
@@ -53,7 +53,7 @@ protected:
             auto bankKernel = (AKPhaseDistortionOscillatorBankDSPKernel*)kernel;
             
             float originalFrequency = phs->freq;
-            phs->freq *= powf(2, kernel->pitchBend / 12.0);
+            phs->freq *= exp2f(kernel->pitchBend / 12.0);
             phs->freq = clamp(phs->freq, 0.0f, 22050.0f);
             float bentFrequency = phs->freq;
             
@@ -70,7 +70,7 @@ protected:
                 float ph = 0;
                 float depth = kernel->vibratoDepth / 12.0;
                 float variation = sinf((kernel->currentRunningIndex + frameIndex) * 2 * 2 * M_PI * kernel->vibratoRate / kernel->getSampleRate());
-                phs->freq = bentFrequency * powf(2, depth * variation);
+                phs->freq = bentFrequency * exp2f(depth * variation);
                 
                 sp_adsr_compute(kernel->getSpData(), adsr, &internalGate, &amp);
                 


### PR DESCRIPTION
The optimizer will substitue powf -> exp2f, which produces slightly different results.