### PR TITLE
Add regression testing of internal DSP state

### DIFF
--- a/AudioKit/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit/AudioKit.xcodeproj/project.pbxproj
@@ -65,6 +65,12 @@
 		22D8FAB9248E8BBD0009EE7C /* AKParameterAutomation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 22D8FAB5248E8BBD0009EE7C /* AKParameterAutomation.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		22D8FABA248E8BBD0009EE7C /* AKParameterAutomation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 22D8FAB5248E8BBD0009EE7C /* AKParameterAutomation.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		22D8FABB248E8BBD0009EE7C /* AKParameterAutomation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 22D8FAB5248E8BBD0009EE7C /* AKParameterAutomation.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		291F62EB24C4FB3C00B754F9 /* DebugDSP.h in Headers */ = {isa = PBXBuildFile; fileRef = 291F62E924C4FB3C00B754F9 /* DebugDSP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		291F62EC24C4FB3C00B754F9 /* DebugDSP.h in Headers */ = {isa = PBXBuildFile; fileRef = 291F62E924C4FB3C00B754F9 /* DebugDSP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		291F62ED24C4FB3C00B754F9 /* DebugDSP.h in Headers */ = {isa = PBXBuildFile; fileRef = 291F62E924C4FB3C00B754F9 /* DebugDSP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		291F62EE24C4FB3C00B754F9 /* DebugDSP.c in Sources */ = {isa = PBXBuildFile; fileRef = 291F62EA24C4FB3C00B754F9 /* DebugDSP.c */; };
+		291F62EF24C4FB3C00B754F9 /* DebugDSP.c in Sources */ = {isa = PBXBuildFile; fileRef = 291F62EA24C4FB3C00B754F9 /* DebugDSP.c */; };
+		291F62F024C4FB3C00B754F9 /* DebugDSP.c in Sources */ = {isa = PBXBuildFile; fileRef = 291F62EA24C4FB3C00B754F9 /* DebugDSP.c */; };
 		29A53B0324BF4C3B004BDDEB /* DeviceUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A53B0224BF4C3B004BDDEB /* DeviceUtils.swift */; };
 		29A53B3724BF5F32004BDDEB /* AVAudioEngine+Devices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A53B3624BF5F32004BDDEB /* AVAudioEngine+Devices.swift */; };
 		29AB123424C2337C00547AA5 /* MIDIMetaEvent+allocate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AB123324C2337C00547AA5 /* MIDIMetaEvent+allocate.swift */; };
@@ -3641,6 +3647,8 @@
 		22D8FAB0248E8B8C0009EE7C /* AKParameterAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AKParameterAutomation.swift; sourceTree = "<group>"; };
 		22D8FAB4248E8BBD0009EE7C /* AKParameterAutomation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AKParameterAutomation.mm; sourceTree = "<group>"; };
 		22D8FAB5248E8BBD0009EE7C /* AKParameterAutomation.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = AKParameterAutomation.hpp; sourceTree = "<group>"; };
+		291F62E924C4FB3C00B754F9 /* DebugDSP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DebugDSP.h; sourceTree = "<group>"; };
+		291F62EA24C4FB3C00B754F9 /* DebugDSP.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = DebugDSP.c; sourceTree = "<group>"; };
 		29A53B0224BF4C3B004BDDEB /* DeviceUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceUtils.swift; sourceTree = "<group>"; };
 		29A53B3624BF5F32004BDDEB /* AVAudioEngine+Devices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAudioEngine+Devices.swift"; sourceTree = "<group>"; };
 		29AB123324C2337C00547AA5 /* MIDIMetaEvent+allocate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MIDIMetaEvent+allocate.swift"; sourceTree = "<group>"; };
@@ -5213,6 +5221,8 @@
 				C4BC749E203023CC00062B11 /* Exception Catcher */,
 				551AAC291F61F42100A14C0D /* Synchronization */,
 				C43322FA1FE05F0100330AEC /* Timeline */,
+				291F62E924C4FB3C00B754F9 /* DebugDSP.h */,
+				291F62EA24C4FB3C00B754F9 /* DebugDSP.c */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -8177,6 +8187,7 @@
 				C4A43294200618650005BFE4 /* AKChowningReverbDSP.hpp in Headers */,
 				B11F88772329B8F000CB8D3F /* AKFaderDSP.hpp in Headers */,
 				C45380531C3A5A4300A51738 /* AKOperationGeneratorAudioUnit.h in Headers */,
+				291F62EB24C4FB3C00B754F9 /* DebugDSP.h in Headers */,
 				C40C414E1C40E3A5009D870B /* EZAudio.h in Headers */,
 				C4077B02200875B000E5923C /* AKFormantFilterDSP.hpp in Headers */,
 				C464078B20105D5500299119 /* AKPluckedStringDSP.hpp in Headers */,
@@ -8740,6 +8751,7 @@
 				EAA62C3A247F3A5B00BF4CDB /* AKAudioUnit.h in Headers */,
 				EAA62C3B247F3A5B00BF4CDB /* AKPhaseDistortionOscillatorFilterSynthDSPKernel.hpp in Headers */,
 				EAA62C3D247F3A5B00BF4CDB /* md5.h in Headers */,
+				291F62ED24C4FB3C00B754F9 /* DebugDSP.h in Headers */,
 				EAA62C3F247F3A5B00BF4CDB /* dr_wav.h in Headers */,
 				EAA62C40247F3A5B00BF4CDB /* AudioKit.h in Headers */,
 				EAA62C41247F3A5B00BF4CDB /* AKModulatedDelay.hpp in Headers */,
@@ -9063,6 +9075,7 @@
 				EAA631E7247F44E200BF4CDB /* AKChowningReverbDSP.hpp in Headers */,
 				EAA631EA247F44E200BF4CDB /* AKFaderDSP.hpp in Headers */,
 				EAA631EC247F44E200BF4CDB /* AKOperationGeneratorAudioUnit.h in Headers */,
+				291F62EC24C4FB3C00B754F9 /* DebugDSP.h in Headers */,
 				EAA631EF247F44E200BF4CDB /* EZAudio.h in Headers */,
 				EAA631F0247F44E200BF4CDB /* AKFormantFilterDSP.hpp in Headers */,
 				EAA631F2247F44E200BF4CDB /* AKPluckedStringDSP.hpp in Headers */,
@@ -10301,6 +10314,7 @@
 				C4AA7C001FD2A7C000040720 /* AKTimelineTap.m in Sources */,
 				FE2C8B2820DAC67500009BAC /* AKDiskStreamer.swift in Sources */,
 				34BB6745205AC238000E5450 /* unpack3_seek.c in Sources */,
+				291F62EE24C4FB3C00B754F9 /* DebugDSP.c in Sources */,
 				C49B146F204A06B7009C7C8E /* writecode.c in Sources */,
 				C49B13E5204A06B7009C7C8E /* conv.c in Sources */,
 			);
@@ -10890,6 +10904,7 @@
 				EAA62A49247F3A5B00BF4CDB /* EnvelopeGeneratorBase.cpp in Sources */,
 				EAA62A4A247F3A5B00BF4CDB /* AKPresetManager.m in Sources */,
 				EAA62A4B247F3A5B00BF4CDB /* AKManager+Status.swift in Sources */,
+				291F62F024C4FB3C00B754F9 /* DebugDSP.c in Sources */,
 				EAA62A4C247F3A5B00BF4CDB /* fosc.c in Sources */,
 				EAA62A50247F3A5B00BF4CDB /* AKBoosterDSP.mm in Sources */,
 				EAA62A51247F3A5B00BF4CDB /* AKAudioUnit.mm in Sources */,
@@ -11973,6 +11988,7 @@
 				EAA630B9247F44E200BF4CDB /* AKTimelineTap.m in Sources */,
 				EAA630BA247F44E200BF4CDB /* AKDiskStreamer.swift in Sources */,
 				EAA630BB247F44E200BF4CDB /* unpack3_seek.c in Sources */,
+				291F62EF24C4FB3C00B754F9 /* DebugDSP.c in Sources */,
 				EAA630BC247F44E200BF4CDB /* writecode.c in Sources */,
 				EAA630BD247F44E200BF4CDB /* conv.c in Sources */,
 			);

--- a/AudioKit/Common/Internals/AudioKit.h
+++ b/AudioKit/Common/Internals/AudioKit.h
@@ -26,6 +26,7 @@ FOUNDATION_EXPORT const unsigned char AudioKitVersionString[];
 
 // Testing
 #import <AudioKit/md5.h>
+#import <AudioKit/DebugDSP.h>
 
 // Analysis
 #import <AudioKit/AKAmplitudeTrackerAudioUnit.h>

--- a/AudioKit/Common/Internals/Utilities/DebugDSP.c
+++ b/AudioKit/Common/Internals/Utilities/DebugDSP.c
@@ -1,0 +1,48 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+#include "DebugDSP.h"
+
+#include "md5.h"
+#include <stddef.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define MAX_SLOTS 16
+
+static md5_state_t state[MAX_SLOTS];
+static bool active = false;
+
+void AKDebugDSPSetActive(bool activate) {
+    active = activate;
+    if(active) {
+        for(int i=0;i<MAX_SLOTS;++i) {
+            md5_init(state+i);
+        }
+    }
+}
+
+void AKDebugDSP(int slot, float value) {
+    if(active) {
+        assert(slot < MAX_SLOTS);
+        md5_append(state+slot, (md5_byte_t*)&value, sizeof(float));
+    }
+}
+
+bool AKDebugDSPCheck(int slot, const char* expected) {
+    assert(slot < MAX_SLOTS);
+
+    md5_byte_t digest[16];
+    md5_finish(state+slot, digest);
+
+    char digestStr[33];
+    for(int i=0;i<16;++i) {
+        sprintf(digestStr+2*i, "%02x", digest[i]);
+    }
+
+    if(strcmp(digestStr, expected)) {
+        printf("Debug hash %s does not match expected hash %s\n", digestStr, expected);
+        return false;
+    }
+    return true;
+}

--- a/AudioKit/Common/Internals/Utilities/DebugDSP.h
+++ b/AudioKit/Common/Internals/Utilities/DebugDSP.h
@@ -1,0 +1,20 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+#ifndef DebugDSP_h
+#define DebugDSP_h
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void AKDebugDSPSetActive(bool active);
+void AKDebugDSP(int slot, float value);
+bool AKDebugDSPCheck(int slot, const char* expected);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DebugDSP_h */

--- a/AudioKit/Common/Internals/Utilities/DebugDSP.h
+++ b/AudioKit/Common/Internals/Utilities/DebugDSP.h
@@ -9,8 +9,15 @@
 extern "C" {
 #endif
 
+/// Activate or deactive DSP kernel debugging.
 void AKDebugDSPSetActive(bool active);
+
+/// Update the hash at the selected slot with a new value.
 void AKDebugDSP(int slot, float value);
+
+/// Check the given slot against an expected hash. Call this at the
+/// end of testing to ensure all calls to `AKDebugDSP` for the given
+/// slot are what is expected.
 bool AKDebugDSPCheck(int slot, const char* expected);
 
 #ifdef __cplusplus

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.hpp
@@ -11,6 +11,8 @@ typedef NS_ENUM(AUParameterAddress, AKOscillatorParameter) {
     AKOscillatorParameterDetuningMultiplier,
 };
 
+#define AKOscillatorDebugPhase 0
+
 #ifndef __cplusplus
 
 AKDSPRef createOscillatorDSP(void);

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -5,6 +5,7 @@
 #include <vector>
 
 #import "AKSoundpipeDSPBase.hpp"
+#include "DebugDSP.h"
 
 class AKOscillatorDSP : public AKSoundpipeDSPBase {
 private:
@@ -66,6 +67,7 @@ public:
                 if (isStarted) {
                     if (channel == 0) {
                         sp_osc_compute(sp, osc, nil, &temp);
+                        AKDebugDSP(AKOscillatorDebugPhase, osc->lphs);
                     }
                     *out = temp;
                 } else {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.hpp
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.hpp
@@ -12,6 +12,8 @@ typedef NS_ENUM(AUParameterAddress, AKPhaseDistortionOscillatorParameter) {
     AKPhaseDistortionOscillatorParameterDetuningMultiplier,
 };
 
+#define AKPhaseDistortionOscillatorDebugPhase 0
+
 #ifndef __cplusplus
 
 AKDSPRef createPhaseDistortionOscillatorDSP(void);

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.mm
@@ -5,6 +5,7 @@
 #include <vector>
 
 #import "AKSoundpipeDSPBase.hpp"
+#include "DebugDSP.h"
 
 class AKPhaseDistortionOscillatorDSP : public AKSoundpipeDSPBase {
 private:
@@ -86,6 +87,7 @@ public:
                 if (isStarted) {
                     if (channel == 0) {
                         sp_phasor_compute(sp, phasor, NULL, &ph);
+                        AKDebugDSP(AKPhaseDistortionOscillatorDebugPhase, ph);
                         sp_pdhalf_compute(sp, pdhalf, &ph, &pd);
                         tabread->index = pd;
                         sp_tabread_compute(sp, tabread, NULL, &temp);

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -21,12 +21,14 @@ class AKOscillatorTests: AKTestCase {
         input = AKOscillator(waveform: AKTable(.square), detuningMultiplier: 0.9)
         output = input
         AKTestMD5("591d314b30df8d6af0b2e9df86528af1")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "607f6c8ff1a6ffd0dcd52152ee8cdaae"))
     }
 
     func testDetuningOffset() {
         input = AKOscillator(waveform: AKTable(.square), detuningOffset: 11)
         output = input
         AKTestMD5("c0d0d9e1cb39611efaf0b7b8b8d7c137")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "6a92817df787e4465991fe249b2245d4"))
     }
 
     func testFrequency() {
@@ -43,12 +45,14 @@ class AKOscillatorTests: AKTestCase {
         input.amplitude = 0.5
         output = input
         AKTestMD5("615e742bc1412c15237a453c5b49d5e0")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"))
     }
 
     func testParameters() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.5)
         output = input
         AKTestMD5("615e742bc1412c15237a453c5b49d5e0")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"))
     }
 
     func testAutomationFrequency() {
@@ -63,6 +67,7 @@ class AKOscillatorTests: AKTestCase {
         // auditionTest()
 
         AKTestMD5("9965c44f94946252a78cba4c1f8df1e9")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "9787bab4e82bba7a2ec1dcf34edf8156"))
     }
 
     func testAutomationAmplitude() {
@@ -77,6 +82,7 @@ class AKOscillatorTests: AKTestCase {
         //auditionTest()
 
         AKTestMD5("f1f313f396fd5962a36db24e675df274")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"))
     }
 
     func testAutomationMultiple() {
@@ -92,6 +98,7 @@ class AKOscillatorTests: AKTestCase {
         // auditionTest()
 
         AKTestMD5("33320d40f5fa6f469d06f877aae338a8")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "9787bab4e82bba7a2ec1dcf34edf8156"))
     }
 
     func testNewAutomationFrequency() {
@@ -102,6 +109,7 @@ class AKOscillatorTests: AKTestCase {
         // auditionTest()
 
         AKTestMD5("9965c44f94946252a78cba4c1f8df1e9")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "9787bab4e82bba7a2ec1dcf34edf8156"))
     }
 
     func testNewAutomationAmplitude() {
@@ -112,6 +120,7 @@ class AKOscillatorTests: AKTestCase {
         // auditionTest()
 
         AKTestMD5("f1f313f396fd5962a36db24e675df274")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"))
     }
 
     func testNewAutomationMultiple() {
@@ -123,6 +132,7 @@ class AKOscillatorTests: AKTestCase {
         // auditionTest()
 
         AKTestMD5("33320d40f5fa6f469d06f877aae338a8")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "9787bab4e82bba7a2ec1dcf34edf8156"))
     }
 
 }

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -6,9 +6,12 @@ import XCTest
 class AKOscillatorTests: AKTestCase {
 
     func testAmpitude() {
+        AKDebugDSPSetActive(true)
         input = AKOscillator(waveform: AKTable(.square), amplitude: 0.5)
         output = input
         AKTestMD5("24c58d48adb46e273d63088f6ca30208")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "e23e315b977c7616b02f3b6534115212"));
+        AKDebugDSPSetActive(false)
     }
 
     func testDefault() {
@@ -29,9 +32,12 @@ class AKOscillatorTests: AKTestCase {
     }
 
     func testFrequency() {
+        AKDebugDSPSetActive(true)
         input = AKOscillator(waveform: AKTable(.square), frequency: 400)
         output = input
         AKTestMD5("d3998b51af7f54f1c9088973b931e9af")
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"));
+        AKDebugDSPSetActive(false)
     }
 
     func testParametersSetAfterInit() {

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -6,12 +6,10 @@ import XCTest
 class AKOscillatorTests: AKTestCase {
 
     func testAmpitude() {
-        AKDebugDSPSetActive(true)
         input = AKOscillator(waveform: AKTable(.square), amplitude: 0.5)
         output = input
         AKTestMD5("24c58d48adb46e273d63088f6ca30208")
         XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "e23e315b977c7616b02f3b6534115212"));
-        AKDebugDSPSetActive(false)
     }
 
     func testDefault() {
@@ -32,12 +30,10 @@ class AKOscillatorTests: AKTestCase {
     }
 
     func testFrequency() {
-        AKDebugDSPSetActive(true)
         input = AKOscillator(waveform: AKTable(.square), frequency: 400)
         output = input
         AKTestMD5("d3998b51af7f54f1c9088973b931e9af")
         XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"));
-        AKDebugDSPSetActive(false)
     }
 
     func testParametersSetAfterInit() {

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -9,7 +9,7 @@ class AKOscillatorTests: AKTestCase {
         input = AKOscillator(waveform: AKTable(.square), amplitude: 0.5)
         output = input
         AKTestMD5("24c58d48adb46e273d63088f6ca30208")
-        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "e23e315b977c7616b02f3b6534115212"));
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "e23e315b977c7616b02f3b6534115212"))
     }
 
     func testDefault() {
@@ -33,7 +33,7 @@ class AKOscillatorTests: AKTestCase {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400)
         output = input
         AKTestMD5("d3998b51af7f54f1c9088973b931e9af")
-        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"));
+        XCTAssertTrue(AKDebugDSPCheck(AKOscillatorDebugPhase, "ea430adbf3a856d283cc32e0f9601c9f"))
     }
 
     func testParametersSetAfterInit() {

--- a/Tests/TestCases/AKPhaseDistortionOscillatorTests.swift
+++ b/Tests/TestCases/AKPhaseDistortionOscillatorTests.swift
@@ -1,6 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 import AudioKit
+import XCTest
 
 class AKPhaseDistortionOscillatorTests: AKTestCase {
 
@@ -9,11 +10,13 @@ class AKPhaseDistortionOscillatorTests: AKTestCase {
     override func setUp() {
         oscillator.rampDuration = 0.0
         afterStart = { self.oscillator.start() }
+        AKDebugDSPSetActive(true)
     }
 
     func testDefault() {
         output = oscillator
         AKTestMD5("9bb6df5a3b0bd5587b19e6acf8f6943d")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "2ff3c2b55ba0f31085eb8fded5e7ff7a"))
     }
 
     func testParameters() {
@@ -23,38 +26,49 @@ class AKPhaseDistortionOscillatorTests: AKTestCase {
                                                  phaseDistortion: 1.234,
                                                  detuningOffset: 1.234,
                                                  detuningMultiplier: 1.1)
+        XCTAssertEqual(oscillator.frequency, 1_234)
+        XCTAssertEqual(oscillator.amplitude, 0.5)
+        XCTAssertEqual(oscillator.phaseDistortion, 1.234)
+        XCTAssertEqual(oscillator.detuningOffset, 1.234)
+        XCTAssertEqual(oscillator.detuningMultiplier, 1.1)
         output = oscillator
         AKTestMD5("2e01df8582f3357dd0886066b09eaba9")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "bf40b85d74114c4b9761b90469ad9dd2"))
     }
 
     func testFrequency() {
         oscillator = AKPhaseDistortionOscillator(waveform: AKTable(.square), frequency: 1_234)
         output = oscillator
         AKTestMD5("095709fff34023e66b3f27e2f97d6dbd")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "80f775510e85d64e360e2725dab355d9"))
     }
 
     func testAmplitude() {
         oscillator = AKPhaseDistortionOscillator(waveform: AKTable(.square), amplitude: 0.5)
         output = oscillator
         AKTestMD5("4eeefb56d24b9ad39ec824e34acdcd55")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "2ff3c2b55ba0f31085eb8fded5e7ff7a"))
     }
 
     func testPhaseDistortion() {
         oscillator = AKPhaseDistortionOscillator(waveform: AKTable(.square), phaseDistortion: 1.234)
         output = oscillator
         AKTestMD5("066f3baeb08af73a5d9ae909a7b43a4e")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "2ff3c2b55ba0f31085eb8fded5e7ff7a"))
     }
 
     func testDetuningOffset() {
         oscillator = AKPhaseDistortionOscillator(waveform: AKTable(.square), detuningOffset: 1.234)
         output = oscillator
         AKTestMD5("a63567f271a6d1d5d6b2ba22e80d64ca")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "65fb399238a46d3180b560ee73a358ca"))
     }
 
     func testDetuningMultiplier() {
         oscillator = AKPhaseDistortionOscillator(waveform: AKTable(.square), detuningMultiplier: 1.1)
         output = oscillator
         AKTestMD5("78244cdf0afa2e3030205cebf175e024")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "e1a0a11d757649305cc894e3e22be4a1"))
     }
 
     func testParametersSetAfterInit() {
@@ -67,5 +81,6 @@ class AKPhaseDistortionOscillatorTests: AKTestCase {
         oscillator.detuningMultiplier = 1.1
         output = oscillator
         AKTestMD5("2e01df8582f3357dd0886066b09eaba9")
+        XCTAssertTrue(AKDebugDSPCheck(AKPhaseDistortionOscillatorDebugPhase, "bf40b85d74114c4b9761b90469ad9dd2"))
     }
 }

--- a/Tests/TestCases/AKTestCase.swift
+++ b/Tests/TestCases/AKTestCase.swift
@@ -47,6 +47,7 @@ class AKTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         afterStart = { self.input.start() }
+        AKDebugDSPSetActive(true)
         // This method is called before the invocation of each test method in the class.
     }
 
@@ -55,6 +56,7 @@ class AKTestCase: XCTestCase {
         AKManager.disconnectAllInputs()
         try! AKManager.stop()
         super.tearDown()
+        AKDebugDSPSetActive(false)
     }
 
 }


### PR DESCRIPTION
This allows us to ensure an internal DSP state variable is what we expect for the duration of a test, giving the developer more information when a test fails.

Note that we still need to ensure this doesn't cause any performance issues by using a macro to only call `DebugDSP` during testing.