### PR TITLE
Use single multi-platform framework target

### DIFF
--- a/AudioKit/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit/AudioKit.xcodeproj/project.pbxproj
@@ -12300,7 +12300,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
 				PRODUCT_NAME = AudioKit;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -12335,7 +12335,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
 				PRODUCT_NAME = AudioKit;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;

--- a/AudioKit/AudioKit.xcodeproj/project.pbxproj
+++ b/AudioKit/AudioKit.xcodeproj/project.pbxproj
@@ -71,6 +71,9 @@
 		291F62EE24C4FB3C00B754F9 /* DebugDSP.c in Sources */ = {isa = PBXBuildFile; fileRef = 291F62EA24C4FB3C00B754F9 /* DebugDSP.c */; };
 		291F62EF24C4FB3C00B754F9 /* DebugDSP.c in Sources */ = {isa = PBXBuildFile; fileRef = 291F62EA24C4FB3C00B754F9 /* DebugDSP.c */; };
 		291F62F024C4FB3C00B754F9 /* DebugDSP.c in Sources */ = {isa = PBXBuildFile; fileRef = 291F62EA24C4FB3C00B754F9 /* DebugDSP.c */; };
+		291F631624C54EF100B754F9 /* AKSettings+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4801EE124BD8E9C0049BA55 /* AKSettings+macOS.swift */; };
+		291F631724C54F1B00B754F9 /* DeviceUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A53B0224BF4C3B004BDDEB /* DeviceUtils.swift */; };
+		291F631824C54F3800B754F9 /* AVAudioEngine+Devices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A53B3624BF5F32004BDDEB /* AVAudioEngine+Devices.swift */; };
 		29A53B0324BF4C3B004BDDEB /* DeviceUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A53B0224BF4C3B004BDDEB /* DeviceUtils.swift */; };
 		29A53B3724BF5F32004BDDEB /* AVAudioEngine+Devices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A53B3624BF5F32004BDDEB /* AVAudioEngine+Devices.swift */; };
 		29AB123424C2337C00547AA5 /* MIDIMetaEvent+allocate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AB123324C2337C00547AA5 /* MIDIMetaEvent+allocate.swift */; };
@@ -10169,7 +10172,9 @@
 				C4A9164F1C24F95E006C1A15 /* periodicTrigger.swift in Sources */,
 				C49D696D1D1F1DE300BF018A /* AKFMOscillatorBank.swift in Sources */,
 				C49B13F0204A06B7009C7C8E /* allpass.c in Sources */,
+				291F631824C54F3800B754F9 /* AVAudioEngine+Devices.swift in Sources */,
 				C45380911C3A5C0C00A51738 /* AKWhiteNoise.swift in Sources */,
+				291F631624C54EF100B754F9 /* AKSettings+macOS.swift in Sources */,
 				C49D69561D1F1C6500BF018A /* AKPWMOscillator.swift in Sources */,
 				B1FC58042328AED40098C14F /* AKAutomatable.swift in Sources */,
 				C49B13DD204A06B7009C7C8E /* tgate.c in Sources */,
@@ -10274,6 +10279,7 @@
 				C49B1483204A06B8009C7C8E /* tone.c in Sources */,
 				C49B146A204A06B7009C7C8E /* randh.c in Sources */,
 				C49B144C204A06B7009C7C8E /* clip.c in Sources */,
+				291F631724C54F1B00B754F9 /* DeviceUtils.swift in Sources */,
 				C421DCDF1D39650000E15879 /* AKPhaseDistortionOscillator.swift in Sources */,
 				C42223E721BC69D1007E3424 /* AKAutoPanner.swift in Sources */,
 				C49B13DA204A06B7009C7C8E /* metro.c in Sources */,
@@ -12294,6 +12300,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
 				PRODUCT_NAME = AudioKit;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -12328,6 +12335,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
 				PRODUCT_NAME = AudioKit;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;

--- a/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitInstrument.swift
+++ b/AudioKit/Common/Internals/AudioUnit Host/AKAudioUnitInstrument.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 /// Wrapper for audio units that accept MIDI (ie. instruments)
 open class AKAudioUnitInstrument: AKMIDIInstrument {
     /// Initialize the audio unit instrument
@@ -97,3 +99,5 @@ open class AKAudioUnitInstrument: AKMIDIInstrument {
         midiInstrument.sendPitchBend(pitchWheelValue, onChannel: channel)
     }
 }
+
+#endif

--- a/AudioKit/Common/Internals/CoreAudio/AudioUnit+Helpers.swift
+++ b/AudioKit/Common/Internals/CoreAudio/AudioUnit+Helpers.swift
@@ -2,6 +2,8 @@
 
 import CoreAudio
 
+#if !os(macOS)
+
 // MARK: - AudioUnit helpers
 
 /// Get, set, and listen to properties
@@ -128,3 +130,5 @@ public extension OSStatus {
     }
 
 }
+
+#endif

--- a/AudioKit/Common/Internals/Hardware/AVAudioEngine+Devices.swift
+++ b/AudioKit/Common/Internals/Hardware/AVAudioEngine+Devices.swift
@@ -1,7 +1,9 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 import Foundation
+import AVFoundation
 
+#if os(macOS)
 extension AVAudioEngine {
 
     func setDevice(id: AudioDeviceID) {
@@ -40,3 +42,4 @@ extension AVAudioEngine {
     }
 
 }
+#endif

--- a/AudioKit/Common/Internals/Hardware/DeviceUtils.swift
+++ b/AudioKit/Common/Internals/Hardware/DeviceUtils.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if os(macOS)
 import Foundation
 import CoreAudio
 
@@ -153,3 +154,4 @@ struct AudioDeviceUtils {
     }
 
 }
+#endif

--- a/AudioKit/Common/Internals/Hardware/Microphone Tracker/AKMicrophoneTracker.swift
+++ b/AudioKit/Common/Internals/Hardware/Microphone Tracker/AKMicrophoneTracker.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 /// An easy to use class to do usual microphone tracking
 public class AKMicrophoneTracker {
 
@@ -32,3 +34,5 @@ public class AKMicrophoneTracker {
         // Subclass and change this if you like
     }
 }
+
+#endif

--- a/AudioKit/Common/Internals/Utilities/Synchronization/AKTiming.swift
+++ b/AudioKit/Common/Internals/Utilities/Synchronization/AKTiming.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+import Foundation
+
 /// A timing protocol used for syncronizing different audio sources.
 @objc public protocol AKTiming {
 

--- a/AudioKit/Common/MIDI/AKBluetoothMIDIButton.swift
+++ b/AudioKit/Common/MIDI/AKBluetoothMIDIButton.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if os(iOS)
 import CoreAudioKit
 
 class AKBTMIDICentralViewController: CABTMIDICentralViewController {
@@ -56,3 +57,4 @@ public class AKBluetoothMIDIButton: UIButton {
     }
 
 }
+#endif

--- a/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Receiving.swift
@@ -12,6 +12,8 @@
 //      * Ports must be identifies using MIDIUniqueIDs because ports can share the same name across devices and clients
 //
 
+#if !os(tvOS)
+
 internal struct MIDISources: Collection {
     typealias Index = Int
     typealias Element = MIDIEndpointRef
@@ -298,3 +300,5 @@ extension AKMIDI {
         return processedEvents
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDI+Sending.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+Sending.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 private let sizeOfMIDIPacketList = MemoryLayout<MIDIPacketList>.size
 private let sizeOfMIDIPacket = MemoryLayout<MIDIPacket>.size
 
@@ -374,3 +376,5 @@ extension AKMIDI {
     }
 
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDI+VirtualPorts.swift
+++ b/AudioKit/Common/MIDI/AKMIDI+VirtualPorts.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import CoreMIDI
 
 extension AKMIDI {
@@ -99,3 +100,5 @@ extension AKMIDI {
         return false
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDI.swift
+++ b/AudioKit/Common/MIDI/AKMIDI.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import CoreMIDI
 
 /// MIDI input and output handler
@@ -93,3 +94,4 @@ public class AKMIDI {
     }
     var incomingSysEx = [MIDIByte]()
 }
+#endif

--- a/AudioKit/Common/MIDI/AKMIDICallbackInstrument.swift
+++ b/AudioKit/Common/MIDI/AKMIDICallbackInstrument.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 /// MIDI Instrument that triggers functions on MIDI note on/off commands
 /// This is used mostly with the AppleSequencer sending to a MIDIEndpointRef
 /// Another callback instrument, AKCallbackInstrument
@@ -104,3 +106,5 @@ open class AKMIDICallbackInstrument: AKMIDIInstrument {
                          data2: pitchWheelValue.lsb)
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEndpointInfo.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 /// MIDI Endpoint Information
 
 public struct EndpointInfo: Hashable, Codable {
@@ -103,3 +104,5 @@ extension AKMIDI {
         return MIDISources().endpointInfos
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDIEvent.swift
+++ b/AudioKit/Common/MIDI/AKMIDIEvent.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import CoreMIDI
 
 /// A container for the values that define a MIDI event
@@ -368,3 +369,5 @@ public struct AKMIDIEvent: AKMIDIMessage {
         return outBytes
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDIInstrument.swift
+++ b/AudioKit/Common/MIDI/AKMIDIInstrument.swift
@@ -3,6 +3,8 @@
 import AVFoundation
 import CoreAudio
 
+#if !os(tvOS)
+
 /// A version of AKInstrument specifically targeted to instruments that
 /// should be triggerable via MIDI or sequenced with the sequencer.
 open class AKMIDIInstrument: AKPolyphonicNode, AKMIDIListener {
@@ -223,3 +225,5 @@ open class AKMIDIInstrument: AKPolyphonicNode, AKMIDIListener {
         MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 1)
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDIListener.swift
+++ b/AudioKit/Common/MIDI/AKMIDIListener.swift
@@ -8,6 +8,7 @@
 /// of interest.
 ///
 
+#if !os(tvOS)
 let AKMIDIListenerLogging = false
 
 public protocol AKMIDIListener {
@@ -308,3 +309,5 @@ public extension AKMIDIListener {
 func == (lhs: AKMIDIListener, rhs: AKMIDIListener) -> Bool {
     return lhs.isEqualTo(rhs)
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDINode.swift
+++ b/AudioKit/Common/MIDI/AKMIDINode.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import AVFoundation
 import CoreAudio
 
@@ -90,3 +91,5 @@ open class AKMIDINode: AKNode, AKMIDIListener {
         }
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDISampler.swift
+++ b/AudioKit/Common/MIDI/AKMIDISampler.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 import AVFoundation
 import CoreAudio
 
@@ -144,3 +146,5 @@ open class AKMIDISampler: AKAppleSampler {
         MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 1)
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/AKMIDITransformer.swift
+++ b/AudioKit/Common/MIDI/AKMIDITransformer.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 public protocol AKMIDITransformer {
     func transform(eventList: [AKMIDIEvent]) -> [AKMIDIEvent]
 }
@@ -19,3 +21,5 @@ public extension AKMIDITransformer {
 func == (lhs: AKMIDITransformer, rhs: AKMIDITransformer) -> Bool {
     return lhs.isEqualTo(rhs)
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDIBeatObserver.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDIBeatObserver.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import Foundation
 
 /// Protocol so that clients may observe beat events
@@ -61,3 +62,4 @@ public extension AKMIDIBeatObserver {
 func == (lhs: AKMIDIBeatObserver, rhs: AKMIDIBeatObserver) -> Bool {
     return lhs.isEqualTo(rhs)
 }
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDIClockListener.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDIClockListener.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import Foundation
 import CoreMIDI
 
@@ -204,3 +205,5 @@ extension AKMIDIClockListener: AKMIDISystemRealTimeObserver {
         sendPreparePlayToObservers(continue: true)
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDIMonoPolyListener.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDIMonoPolyListener.swift
@@ -10,6 +10,8 @@
 //  Subclasses can override monoPolyChange() to observe changes
 //
 
+#if !os(tvOS)
+
 import Foundation
 import CoreMIDI
 
@@ -46,3 +48,5 @@ extension AKMIDIMonoPolyListener: AKMIDIListener {
 
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDIOmniListener.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDIOmniListener.swift
@@ -5,6 +5,7 @@
 //  This class probably needs to support observers as well
 //  so that a client may be able to be notified of state changes
 
+#if !os(tvOS)
 import Foundation
 import CoreMIDI
 
@@ -41,3 +42,5 @@ extension AKMIDIOMNIListener: AKMIDIListener {
 
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDISystemRealTimeListener.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDISystemRealTimeListener.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import Foundation
 import CoreMIDI
 
@@ -111,3 +112,5 @@ extension AKMIDISystemRealTimeListener {
         }
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDISystemRealTimeObserver.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDISystemRealTimeObserver.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 import Foundation
 
 public protocol AKMIDISystemRealTimeObserver {
@@ -44,3 +46,5 @@ extension AKMIDISystemRealTimeObserver {
 func == (lhs: AKMIDISystemRealTimeObserver, rhs: AKMIDISystemRealTimeObserver) -> Bool {
     return lhs.isEqualTo(rhs)
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDITempoListener.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDITempoListener.swift
@@ -12,6 +12,7 @@
 //      https://stackoverflow.com/questions/13562714/calculate-accurate-bpm-from-midi-clock-in-objc-with-coremidi
 //      https://github.com/yderidde/PGMidi/blob/master/Sources/PGMidi/PGMidiSession.mm#L186
 
+#if !os(tvOS)
 import Foundation
 import CoreMIDI
 
@@ -232,3 +233,5 @@ extension AKMIDITempoListener {
         }
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Listeners/AKMIDITempoObserver.swift
+++ b/AudioKit/Common/MIDI/Listeners/AKMIDITempoObserver.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 
+#if !os(tvOS)
+
 public protocol AKMIDITempoObserver {
 
     /// Called when a clock slave mode is entered and this client is not allowed to become a clock master
@@ -39,3 +41,5 @@ public extension AKMIDITempoObserver {
 func == (lhs: AKMIDITempoObserver, rhs: AKMIDITempoObserver) -> Bool {
     return lhs.isEqualTo(rhs)
 }
+
+#endif

--- a/AudioKit/Common/MIDI/MIDIFile/AKMIDIFile.swift
+++ b/AudioKit/Common/MIDI/MIDIFile/AKMIDIFile.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 import Foundation
 
 public struct AKMIDIFile {
@@ -82,3 +84,5 @@ public struct AKMIDIFile {
         self.init(url: URL(fileURLWithPath: path))
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTempoTrack.swift
+++ b/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTempoTrack.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 public struct AKMIDIFileTempoTrack {
 
     public let track: AKMIDIFileTrack
@@ -38,3 +40,5 @@ public struct AKMIDIFileTempoTrack {
         return Float(Double(microsecondsPerSecond / value).roundToDecimalPlaces(4))
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTrack.swift
+++ b/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTrack.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 
+#if !os(tvOS)
+
 public struct AKMIDIFileTrack {
 
     var chunk: MIDIFileTrackChunk
@@ -34,3 +36,5 @@ public struct AKMIDIFileTrack {
         self.chunk = chunk
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTrackMap.swift
+++ b/AudioKit/Common/MIDI/MIDIFile/AKMIDIFileTrackMap.swift
@@ -2,6 +2,8 @@
 
 //Keep track of the note durations and range for later use in mapping
 
+#if !os(tvOS)
+
 public class AKMIDINoteDuration {
     public var noteBeginningTime = 0.0
     public var noteEndTime = 0.0
@@ -172,3 +174,5 @@ public class AKMIDIFileTrackNoteMap {
         }
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Packets/MIDIPacket+Extensions.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacket+Extensions.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 import CoreMIDI
 
 extension MIDIPacket {
@@ -23,3 +25,5 @@ extension MIDIPacket {
         return AKMIDISystemCommand(rawValue: data.0)
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Packets/MIDIPacket+SequenceType.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacket+SequenceType.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import CoreMIDI
 
 /**
@@ -119,3 +120,4 @@ func generatorForTuple(_ tuple: AKRawMIDIPacket) -> AnyIterator<Any> {
     let children = Mirror(reflecting: tuple).children
     return AnyIterator(children.makeIterator().lazy.map { $0.value }.makeIterator())
 }
+#endif

--- a/AudioKit/Common/MIDI/Packets/MIDIPacketList+SequenceType.swift
+++ b/AudioKit/Common/MIDI/Packets/MIDIPacketList+SequenceType.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import CoreMIDI
 
 extension MIDIPacketList: Sequence {
@@ -25,3 +26,5 @@ extension MIDIPacketList: Sequence {
         }
     }
 }
+
+#endif

--- a/AudioKit/Common/MIDI/Utilities/BPM+StatisticalTools.swift
+++ b/AudioKit/Common/MIDI/Utilities/BPM+StatisticalTools.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import Foundation
 
 extension Double {
@@ -250,3 +251,5 @@ struct ValueSmoothing {
         return smoothed
     }
 }
+
+#endif

--- a/AudioKit/Common/Nodes/AKConnection.swift
+++ b/AudioKit/Common/Nodes/AKConnection.swift
@@ -1,5 +1,8 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+import Foundation
+import AVFoundation
+
 /// A transitory used to pass connection information.
 open class AKInputConnection: NSObject {
 

--- a/AudioKit/Common/Nodes/Callback Instrument/AKCallbackInstrument.swift
+++ b/AudioKit/Common/Nodes/Callback Instrument/AKCallbackInstrument.swift
@@ -1,5 +1,6 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
 import Foundation
 
 /// New sample-accurate version of AKCallbackInstrument
@@ -50,3 +51,4 @@ open class AKCallbackInstrument: AKPolyphonicNode, AKComponent {
         internalAU?.destroy()
     }
 }
+#endif

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drum Synths/AKDrumSynths.swift
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drum Synths/AKDrumSynths.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 /// Kick Drum Synthesizer Instrument
 public class AKSynthKick: AKMIDIInstrument {
 
@@ -90,3 +92,5 @@ public class AKSynthSnare: AKMIDIInstrument {
         // Unneeded
     }
 }
+
+#endif

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencer.swift
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencer.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 /// Open-source AudioKit Sequencer
 ///
 /// Up until AudioKit 4.8, this was a different class. The old class is now renamed "AKAppleSequencer"
@@ -180,6 +182,8 @@ open class AKSequencer {
         return track
     }
 }
+
+#endif
 
 /* functions from AKAppleSequencer  to implement
 

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngineAudioUnit.swift
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngineAudioUnit.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 public class AKSequencerEngineAudioUnit: AKAudioUnitBase {
 
     private(set) var tempo: AUParameter!
@@ -115,3 +117,5 @@ public class AKSequencerEngineAudioUnit: AKAudioUnitBase {
         sequencerEngineStopPlayingNotes(dsp)
     }
 }
+
+#endif

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngineDSP.mm
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerEngineDSP.mm
@@ -1,5 +1,9 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#import "TargetConditionals.h"
+
+#if !TARGET_OS_TV
+
 #include "AKSequencerEngineDSP.hpp"
 
 extern "C" AKDSPRef createAKSequencerEngineDSP() {
@@ -41,3 +45,5 @@ extern "C" void sequencerEngineClear(AKDSPRef dsp) {
 extern "C" void sequencerEngineSetAUTarget(AKDSPRef dsp, AudioUnit audioUnit) {
     ((AKSequencerEngineDSP*)dsp)->setTargetAU(audioUnit);
 }
+
+#endif

--- a/AudioKit/Common/Sequencing/Sequencer/AKSequencerTrack.swift
+++ b/AudioKit/Common/Sequencing/Sequencer/AKSequencerTrack.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if !os(tvOS)
+
 import Foundation
 
 /// Audio player that loads a sample into memory
@@ -164,3 +166,5 @@ open class AKSequencerTrack: AKNode, AKComponent {
         internalAU?.stopPlayingNotes()
     }
 }
+
+#endif

--- a/Tests/macOSTestSuiteForDev/macOSTestSuite.xcodeproj/project.pbxproj
+++ b/Tests/macOSTestSuiteForDev/macOSTestSuite.xcodeproj/project.pbxproj
@@ -7,11 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		291F637F24C55A5800B754F9 /* AudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4801EFC24BF66340049BA55 /* AudioKit.framework */; };
+		291F638024C55A5800B754F9 /* AudioKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C4801EFC24BF66340049BA55 /* AudioKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C41910222009A7E10067B5E0 /* AKPannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41910212009A7E00067B5E0 /* AKPannerTests.swift */; };
 		C41910242009A7E90067B5E0 /* AKStereoFieldLimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41910232009A7E80067B5E0 /* AKStereoFieldLimiterTests.swift */; };
 		C464077420105CE400299119 /* AKBrownianNoiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C464077320105CE300299119 /* AKBrownianNoiseTests.swift */; };
 		C464E84E1FB0302A0025629C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C464E84D1FB0302A0025629C /* AppDelegate.swift */; };
-		C4801F1324BF66440049BA55 /* AudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4801EFE24BF66340049BA55 /* AudioKit.framework */; };
 		C4AA7A011FD09BA300040720 /* AKDCBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AA79A11FD09BA300040720 /* AKDCBlockTests.swift */; };
 		C4AA7A021FD09BA300040720 /* smoothDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AA79A21FD09BA300040720 /* smoothDelayTests.swift */; };
 		C4AA7A031FD09BA300040720 /* AKBandPassButterworthFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AA79A31FD09BA300040720 /* AKBandPassButterworthFilterTests.swift */; };
@@ -119,6 +120,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		291F638224C55A6200B754F9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C4801EE924BF66340049BA55 /* AudioKit.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = C42F34FF1C057E03000E937C;
+			remoteInfo = "AudioKit-iOS";
+		};
 		C464E85B1FB0302A0025629C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C464E8421FB0302A0025629C /* Project object */;
@@ -211,6 +219,20 @@
 			remoteInfo = "DevoloopAudioKit-tvOS";
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		291F638124C55A5800B754F9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				291F638024C55A5800B754F9 /* AudioKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		C41910212009A7E00067B5E0 /* AKPannerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AKPannerTests.swift; sourceTree = "<group>"; };
@@ -333,7 +355,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C4801F1324BF66440049BA55 /* AudioKit.framework in Frameworks */,
+				291F637F24C55A5800B754F9 /* AudioKit.framework in Frameworks */,
 				C4D8A00C21981A84002B71EC /* AVFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -537,10 +559,12 @@
 				C464E8461FB0302A0025629C /* Sources */,
 				C464E8471FB0302A0025629C /* Frameworks */,
 				C464E8481FB0302A0025629C /* Resources */,
+				291F638124C55A5800B754F9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				291F638324C55A6200B754F9 /* PBXTargetDependency */,
 			);
 			name = macOSTestSuite;
 			productName = AudioKitTestSuite;
@@ -847,6 +871,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		291F638324C55A6200B754F9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "AudioKit-iOS";
+			targetProxy = 291F638224C55A6200B754F9 /* PBXContainerItemProxy */;
+		};
 		C464E85C1FB0302A0025629C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C464E8491FB0302A0025629C /* macOSTestSuite */;


### PR DESCRIPTION
Instead of three framework targets, use a single target for all platforms.

This just gets things started, showing it can work.

Next steps:
- is to update the build scripts to use the Multiplatform target.
- rename the target and delete the others.