### PR TITLE
Switch new automation code to linear automation

### DIFF
--- a/AudioKit/Common/Nodes/AKNodeParameter.swift
+++ b/AudioKit/Common/Nodes/AKNodeParameter.swift
@@ -88,8 +88,8 @@ public class AKNodeParameter {
     ///
     /// Time is relative to the approximate time when the function
     /// is called. This is only sample accurate if called prior to `AKManager.start()`.
-    /// - Parameter points: automation curve
-    public func automate(points: [AKAutomationEvent]) {
+    /// - Parameter events: automation curve
+    public func automate(events: [AKAutomationEvent]) {
         var lastTime = avAudioUnit.lastRenderTime ?? AVAudioTime(sampleTime: 0, atRate: AKSettings.sampleRate)
         guard let parameter = parameter else { return }
 
@@ -102,7 +102,7 @@ public class AKNodeParameter {
 
         stopAutomation()
 
-        points.withUnsafeBufferPointer { automationPtr in
+        events.withUnsafeBufferPointer { automationPtr in
 
             guard let automationBaseAddress = automationPtr.baseAddress else { return }
 
@@ -111,7 +111,7 @@ public class AKNodeParameter {
                                                                   AKSettings.sampleRate,
                                                                   Double(lastTime.sampleTime),
                                                                   automationBaseAddress,
-                                                                  points.count) else { return }
+                                                                  events.count) else { return }
 
             renderObserverToken = avAudioUnit.auAudioUnit.token(byAddingRenderObserver: observer)
         }

--- a/AudioKit/Common/Nodes/AKNodeParameter.swift
+++ b/AudioKit/Common/Nodes/AKNodeParameter.swift
@@ -89,7 +89,7 @@ public class AKNodeParameter {
     /// Time is relative to the approximate time when the function
     /// is called. This is only sample accurate if called prior to `AKManager.start()`.
     /// - Parameter points: automation curve
-    public func automate(points: [AKParameterAutomationPoint]) {
+    public func automate(points: [AKAutomationEvent]) {
         var lastTime = avAudioUnit.lastRenderTime ?? AVAudioTime(sampleTime: 0, atRate: AKSettings.sampleRate)
         guard let parameter = parameter else { return }
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
@@ -57,7 +57,7 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                                                         AUScheduleParameterBlock scheduleParameterBlock,
                                                         double sampleRate,
                                                         double startSampleTime,
-                                                        const struct AKParameterAutomationPoint* points,
+                                                        const struct AKAutomationEvent* points,
                                                         size_t count);
 
 #endif

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
@@ -57,7 +57,7 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                                                         AUScheduleParameterBlock scheduleParameterBlock,
                                                         double sampleRate,
                                                         double startSampleTime,
-                                                        const struct AKAutomationEvent* points,
+                                                        const struct AKAutomationEvent* events,
                                                         size_t count);
 
 #endif

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.hpp
@@ -13,6 +13,13 @@ struct AKParameterAutomationPoint {
     float rampSkew;
 };
 
+/// Linear automation segment.
+struct AKAutomationEvent {
+    AUValue targetValue;
+    double startTime;
+    double rampDuration;
+};
+
 typedef struct AKParameterAutomationHelper* AKParameterAutomationHelperRef;
 
 #ifndef __cplusplus

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -492,7 +492,13 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                                                         const struct AKAutomationEvent* eventsArray,
                                                         size_t count) {
 
-    const std::vector<AKAutomationEvent> events{eventsArray, eventsArray+count};
+    std::vector<AKAutomationEvent> events{eventsArray, eventsArray+count};
+
+    // Sort events by start time.
+    std::sort(events.begin(), events.end(), [](auto a, auto b) {
+        return a.startTime < b.startTime;
+    });
+
     __block int index = 0;
 
     return ^void(AudioUnitRenderActionFlags actionFlags,

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -489,10 +489,10 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                                                         AUScheduleParameterBlock scheduleParameterBlock,
                                                         double sampleRate,
                                                         double startSampleTime,
-                                                        const struct AKAutomationEvent* pointsArray,
+                                                        const struct AKAutomationEvent* eventsArray,
                                                         size_t count) {
 
-    const std::vector<AKAutomationEvent> points{pointsArray, pointsArray+count};
+    const std::vector<AKAutomationEvent> events{eventsArray, eventsArray+count};
     __block int index = 0;
 
     return ^void(AudioUnitRenderActionFlags actionFlags,
@@ -510,7 +510,7 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
         // Skip over events completely in the past to determine
         // an initial value.
         for(; index < count; ++index) {
-            auto event = points[index];
+            auto event = events[index];
             if ( !(event.startTime + event.rampDuration < blockStartTime) ) {
                break;
             }
@@ -527,7 +527,7 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
 
         // Apply parameter automation for the segment.
         while (index < count) {
-            auto event = points[index];
+            auto event = events[index];
 
             // Is it after the current block?
             if (event.startTime >= blockEndTime) break;

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -496,20 +496,6 @@ static void scheduleAutomationPoint(AUScheduleParameterBlock scheduleParameterBl
                                     const AKParameterAutomationPoint& point,
                                     AUAudioFrameCount rampOffset)
 {
-    AUParameterAddress mask;
-
-    // set taper (as "value" parameter)
-    mask = (AUParameterAddress)1 << 63;
-    scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime, 0, address | mask, point.rampTaper);
-
-    // set skew (as "value" parameter)
-    mask = (AUParameterAddress)1 << 62;
-    scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime, 0, address | mask, point.rampSkew);
-
-    // set offset (as "duration" parameter)
-    mask = (AUParameterAddress)1 << 61;
-    scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime, rampOffset, address | mask, 0);
-
     // set value
     AUAudioFrameCount rampDuration = point.rampDuration * sampleRate;
     scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime, rampDuration, address, point.targetValue);

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -485,20 +485,21 @@ void AKParameterAutomationHelper::clearAllPoints(AUParameterAddress address)
 
 struct RenderObserverData {
     AUParameterAddress address;
-    std::vector<AKParameterAutomationPoint> points;
-    std::vector<AKParameterAutomationPoint>::const_iterator iterator;
+    std::vector<AKAutomationEvent> points;
+    std::vector<AKAutomationEvent>::const_iterator iterator;
 };
 
 static void scheduleAutomationPoint(AUScheduleParameterBlock scheduleParameterBlock,
                                     double sampleRate,
                                     AUEventSampleTime blockTime,
                                     AUParameterAddress address,
-                                    const AKParameterAutomationPoint& point,
+                                    const AKAutomationEvent& point,
                                     AUAudioFrameCount rampOffset)
 {
-    // set value
-    AUAudioFrameCount rampDuration = point.rampDuration * sampleRate;
-    scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime, rampDuration, address, point.targetValue);
+    scheduleParameterBlock(AUEventSampleTimeImmediate + blockTime,
+                           point.rampDuration * sampleRate,
+                           address,
+                           point.targetValue);
 }
 
 /// Returns a render observer block which will apply the automation to the selected parameter.
@@ -507,7 +508,7 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
                                                         AUScheduleParameterBlock scheduleParameterBlock,
                                                         double sampleRate,
                                                         double startSampleTime,
-                                                        const struct AKParameterAutomationPoint* points,
+                                                        const struct AKAutomationEvent* points,
                                                         size_t count) {
 
     __block RenderObserverData data;

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -509,7 +509,7 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
 
         // Skip over events completely in the past to determine
         // an initial value.
-        for(index = 0; index < count; ++index) {
+        for(; index < count; ++index) {
             auto event = points[index];
             if ( !(event.startTime + event.rampDuration < blockStartTime) ) {
                break;

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -502,12 +502,8 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
     {
         if (actionFlags != kAudioUnitRenderAction_PreRender) return;
 
-        printf("frameCount: %d\n", frameCount);
-
         double blockStartTime = (timestamp->mSampleTime - startSampleTime) / sampleRate;
         double blockEndTime = blockStartTime + frameCount / sampleRate;
-
-        printf("block: [%f, %f]\n", blockStartTime, blockEndTime);
 
         AUValue initial = NAN;
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.mm
@@ -537,9 +537,16 @@ AURenderObserver AKParameterAutomationGetRenderObserver(AUParameterAddress addre
             if (event.startTime >= blockEndTime) break;
 
             AUEventSampleTime startTime = (event.startTime - blockStartTime) * sampleRate;
+            AUAudioFrameCount duration = event.rampDuration * sampleRate;
+
+            // If the event has already started, ensure we hit the targetValue
+            // at the appropriate time.
+            if(startTime < 0) {
+                duration += startTime;
+            }
 
             scheduleParameterBlock(startTime,
-                                   event.rampDuration * sampleRate,
+                                   duration,
                                    address,
                                    event.targetValue);
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -270,9 +270,12 @@ public func AKEvaluateAutomation(initialValue: AUValue,
         let start = value
 
         // March t along the segment
-        while t <= endTime {
+        while t <= endTime - resolution {
 
-            value = evalRamp(start: start, segment: point, time: t, endTime: endTime)
+            value = evalRamp(start: start,
+                             segment: point,
+                             time: t + resolution,
+                             endTime: endTime)
 
             result.append(AKParameterAutomationPoint(targetValue: AUValue(value),
                                                      startTime: t,

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -257,8 +257,8 @@ func evalRamp(start: Double,
 ///
 /// - Parameters:
 ///   - initialValue: Starting point
-///   - points: AN array of automation points to convert
-///   - resolution: Duration of each piecewise linear segemtn (in samples?)
+///   - points: An array of automation points to convert
+///   - resolution: Duration of each linear segment in seconds
 ///   
 /// - Returns: A new array of piecewise linear automation points
 public func AKEvaluateAutomation(initialValue: AUValue,

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -256,9 +256,9 @@ func evalRamp(start: Double,
 /// for efficient processing.
 public func AKEvaluateAutomation(initialValue: AUValue,
                                  points: [AKParameterAutomationPoint],
-                                 resolution: Double) -> [AKParameterAutomationPoint] {
+                                 resolution: Double) -> [AKAutomationEvent] {
 
-    var result = [AKParameterAutomationPoint]()
+    var result = [AKAutomationEvent]()
 
     // The last evaluated value
     var value = Double(initialValue)
@@ -268,7 +268,9 @@ public func AKEvaluateAutomation(initialValue: AUValue,
 
         if point.isLinear() {
 
-            result.append(point)
+            result.append(AKAutomationEvent(targetValue: point.targetValue,
+                                            startTime: point.startTime,
+                                            rampDuration: point.rampDuration))
             value = Double(point.targetValue)
 
         } else {
@@ -288,9 +290,9 @@ public func AKEvaluateAutomation(initialValue: AUValue,
                                  time: t + resolution,
                                  endTime: endTime)
 
-                result.append(AKParameterAutomationPoint(targetValue: AUValue(value),
-                                                         startTime: t,
-                                                         rampDuration: resolution))
+                result.append(AKAutomationEvent(targetValue: AUValue(value),
+                                                startTime: t,
+                                                rampDuration: resolution))
 
                 t += resolution
             }

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -250,19 +250,20 @@ public func AKEvaluateAutomation(initialValue: AUValue,
                                   point.startTime + point.rampDuration)
 
         var t = point.startTime
+        let start = value
 
         // March t along the segment
-        while t < endTime {
+        while t <= endTime {
 
             let remain = endTime - t
             let taper = Double(point.rampTaper)
             let goal = point.targetValue
 
-            // x is normalized position in ramp segment, backwards from target
+            // x is normalized position in ramp segment
             let x = (point.rampDuration - remain) / point.rampDuration
-            let taper1 = point.startTime + (goal - value) * pow(x, abs(taper))
-            let absxm1 = abs(point.rampDuration - remain) / (point.rampDuration - 1.0)
-            let taper2 = value + (goal - value) * 1.0 - pow(absxm1, 1.0 / abs(taper))
+            let taper1 = start + (goal - start) * pow(x, abs(taper))
+            let absxm1 = (abs(point.rampDuration - remain) / point.rampDuration) - 1.0
+            let taper2 = start + (goal - start) * 1.0 - pow(absxm1, 1.0 / abs(taper))
 
             value = taper1 * (1.0 - point.rampSkew) + taper2 * point.rampSkew
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -283,7 +283,7 @@ public func AKEvaluateAutomation(initialValue: AUValue,
         } else {
 
             // Cut off the end if another point comes along.
-            let endTime: Double = min(i < points.count - 1 ? points[i].startTime : Double.greatestFiniteMagnitude,
+            let endTime: Double = min(i < points.count - 1 ? points[i + 1].startTime : Double.greatestFiniteMagnitude,
                                       point.startTime + point.rampDuration)
 
             var t = point.startTime
@@ -295,7 +295,7 @@ public func AKEvaluateAutomation(initialValue: AUValue,
                 value = evalRamp(start: start,
                                  segment: point,
                                  time: t + resolution,
-                                 endTime: endTime)
+                                 endTime: point.startTime + point.rampDuration)
 
                 result.append(AKAutomationEvent(targetValue: AUValue(value),
                                                 startTime: t,

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -269,6 +269,7 @@ public func AKEvaluateAutomation(initialValue: AUValue,
         if point.isLinear() {
 
             result.append(point)
+            value = Double(point.targetValue)
 
         } else {
 

--- a/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
+++ b/AudioKit/Common/Nodes/Mixing/Automation/AKParameterAutomation.swift
@@ -246,8 +246,8 @@ func evalRamp(start: Double,
     // x is normalized position in ramp segment
     let x = (segment.rampDuration - remain) / segment.rampDuration
     let taper1 = start + (goal - start) * pow(x, abs(taper))
-    let absxm1 = (abs(segment.rampDuration - remain) / segment.rampDuration) - 1.0
-    let taper2 = start + (goal - start) * 1.0 - pow(absxm1, 1.0 / abs(taper))
+    let absxm1 = abs((segment.rampDuration - remain) / segment.rampDuration - 1.0)
+    let taper2 = start + (goal - start) * (1.0 - pow(absxm1, 1.0 / abs(taper)))
 
     return taper1 * (1.0 - segment.rampSkew) + taper2 * segment.rampSkew
 }

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -103,7 +103,7 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationFrequency() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.5)
-        input.$frequency.automate(points: [AKParameterAutomationPoint(targetValue: 880, startTime: 0, rampDuration: self.duration)])
+        input.$frequency.automate(points: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
         output = input
 
         // auditionTest()
@@ -114,7 +114,7 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationAmplitude() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.$amplitude.automate(points: [AKParameterAutomationPoint(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
+        input.$amplitude.automate(points: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
         output = input
 
         // auditionTest()
@@ -125,8 +125,8 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationMultiple() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.$frequency.automate(points: [AKParameterAutomationPoint(targetValue: 880, startTime: 0, rampDuration: self.duration)])
-        input.$amplitude.automate(points: [AKParameterAutomationPoint(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
+        input.$frequency.automate(points: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
+        input.$amplitude.automate(points: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
         output = input
 
         // auditionTest()

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -57,7 +57,10 @@ class AKOscillatorTests: AKTestCase {
 
     func testAutomationFrequency() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.5)
-        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 880, startTime: 0, rampDuration: duration), to: input.$frequency)
+        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 880,
+                                                                         startTime: 0,
+                                                                         rampDuration: duration),
+                                       to: input.$frequency)
         output = input
 
         afterStart = {
@@ -72,7 +75,10 @@ class AKOscillatorTests: AKTestCase {
 
     func testAutomationAmplitude() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 1.0, startTime: 0, rampDuration: duration), to: input.$amplitude)
+        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 1.0,
+                                                                         startTime: 0,
+                                                                         rampDuration: duration),
+                                       to: input.$amplitude)
         output = input
 
         afterStart = {
@@ -87,8 +93,14 @@ class AKOscillatorTests: AKTestCase {
 
     func testAutomationMultiple() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 880, startTime: 0, rampDuration: duration), to: input.$frequency)
-        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 1.0, startTime: 0, rampDuration: duration), to: input.$amplitude)
+        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 880,
+                                                                         startTime: 0,
+                                                                         rampDuration: duration),
+                                       to: input.$frequency)
+        input.parameterAutomation?.add(point: AKParameterAutomationPoint(targetValue: 1.0,
+                                                                         startTime: 0,
+                                                                         rampDuration: duration),
+                                       to: input.$amplitude)
         output = input
 
         afterStart = {
@@ -103,7 +115,9 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationFrequency() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.5)
-        input.$frequency.automate(events: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
+        input.$frequency.automate(events: [AKAutomationEvent(targetValue: 880,
+                                                             startTime: 0,
+                                                             rampDuration: self.duration)])
         output = input
 
         // auditionTest()
@@ -114,7 +128,9 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationAmplitude() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.$amplitude.automate(events: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
+        input.$amplitude.automate(events: [AKAutomationEvent(targetValue: 1.0,
+                                                             startTime: 0,
+                                                             rampDuration: self.duration)])
         output = input
 
         // auditionTest()
@@ -125,8 +141,12 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationMultiple() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.$frequency.automate(events: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
-        input.$amplitude.automate(events: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
+        input.$frequency.automate(events: [AKAutomationEvent(targetValue: 880,
+                                                             startTime: 0,
+                                                             rampDuration: self.duration)])
+        input.$amplitude.automate(events: [AKAutomationEvent(targetValue: 1.0,
+                                                             startTime: 0,
+                                                             rampDuration: self.duration)])
         output = input
 
         // auditionTest()

--- a/Tests/TestCases/AKOscillatorTests.swift
+++ b/Tests/TestCases/AKOscillatorTests.swift
@@ -103,7 +103,7 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationFrequency() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.5)
-        input.$frequency.automate(points: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
+        input.$frequency.automate(events: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
         output = input
 
         // auditionTest()
@@ -114,7 +114,7 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationAmplitude() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.$amplitude.automate(points: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
+        input.$amplitude.automate(events: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
         output = input
 
         // auditionTest()
@@ -125,8 +125,8 @@ class AKOscillatorTests: AKTestCase {
 
     func testNewAutomationMultiple() {
         input = AKOscillator(waveform: AKTable(.square), frequency: 400, amplitude: 0.0)
-        input.$frequency.automate(points: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
-        input.$amplitude.automate(points: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
+        input.$frequency.automate(events: [AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: self.duration)])
+        input.$amplitude.automate(events: [AKAutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: self.duration)])
         output = input
 
         // auditionTest()

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -182,13 +182,10 @@ class AKParameterAutomationTests: AKTestCase {
         let newPoints = AKEvaluateAutomation(initialValue: 0, points: points, resolution: 0.5)
 
         XCTAssertEqual(newPoints[0].startTime, 0.0)
-        XCTAssertEqual(newPoints[0].targetValue, 0.0)
+        XCTAssertEqual(newPoints[0].targetValue, 0.5)
 
         XCTAssertEqual(newPoints[1].startTime, 0.5)
-        XCTAssertEqual(newPoints[1].targetValue, 0.5)
-
-        XCTAssertEqual(newPoints[2].startTime, 1.0)
-        XCTAssertEqual(newPoints[2].targetValue, 1.0)
+        XCTAssertEqual(newPoints[1].targetValue, 1.0)
 
     }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -189,14 +189,14 @@ class AKParameterAutomationTests: AKTestCase {
 
         // Curved automation will evaluate each segment
         {
-            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 1.0, rampSkew: 0.1)]
+            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 1.0, rampSkew: 0.000001)]
 
             let newPoints = AKEvaluateAutomation(initialValue: 0,
                                                  points: points,
                                                  resolution: 0.5)
 
             XCTAssertEqual(newPoints[0].startTime, 0.0)
-            XCTAssert(fabs(newPoints[0].targetValue - 0.6) < 0.0001)
+            XCTAssert(fabs(newPoints[0].targetValue - 0.5) < 0.0001)
 
             XCTAssertEqual(newPoints[1].startTime, 0.5)
             XCTAssertEqual(newPoints[1].targetValue, 1.0)

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -199,6 +199,21 @@ class AKParameterAutomationTests: AKTestCase {
         XCTAssertEqual(newPoints[1].targetValue, 1.0)
     }
 
+    func testEvaluateAutomationSlightTaper() {
+
+        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 1.00001, rampSkew: 0.0)]
+
+        let newPoints = AKEvaluateAutomation(initialValue: 0,
+                                             points: points,
+                                             resolution: 0.5)
+
+        XCTAssertEqual(newPoints[0].startTime, 0.0)
+        XCTAssert(fabs(newPoints[0].targetValue - 0.5) < 0.0001)
+
+        XCTAssertEqual(newPoints[1].startTime, 0.5)
+        XCTAssertEqual(newPoints[1].targetValue, 1.0)
+    }
+
     func testEvaluateAutomationCurved() {
 
         let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 0.5, rampSkew: 0.1)]

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -175,43 +175,39 @@ class AKParameterAutomationTests: AKTestCase {
         }()
     }
 
-    func testEvaluateAutomation() {
+    func testEvaluateAutomationLinear() {
+        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0)]
 
-        // Linear automation should pass the result through
-        {
-            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0)]
+        let newPoints = AKEvaluateAutomation(initialValue: 0, points: points, resolution: 0.5)
 
-            let newPoints = AKEvaluateAutomation(initialValue: 0, points: points, resolution: 0.5)
+        XCTAssertEqual(points, newPoints)
+    }
 
-            XCTAssertEqual(points, newPoints)
 
-        }();
+    func testEvaluateAutomationAlmostLinear() {
 
-        // Curved automation will evaluate each segment
-        {
-            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 1.0, rampSkew: 0.000001)]
+        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 1.0, rampSkew: 0.000001)]
 
-            let newPoints = AKEvaluateAutomation(initialValue: 0,
-                                                 points: points,
-                                                 resolution: 0.5)
+        let newPoints = AKEvaluateAutomation(initialValue: 0,
+                                             points: points,
+                                             resolution: 0.5)
 
-            XCTAssertEqual(newPoints[0].startTime, 0.0)
-            XCTAssert(fabs(newPoints[0].targetValue - 0.5) < 0.0001)
+        XCTAssertEqual(newPoints[0].startTime, 0.0)
+        XCTAssert(fabs(newPoints[0].targetValue - 0.5) < 0.0001)
 
-            XCTAssertEqual(newPoints[1].startTime, 0.5)
-            XCTAssertEqual(newPoints[1].targetValue, 1.0)
-        }();
+        XCTAssertEqual(newPoints[1].startTime, 0.5)
+        XCTAssertEqual(newPoints[1].targetValue, 1.0)
+    }
 
-        // Curved automation will evaluate each segment
-        {
-            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 0.5, rampSkew: 0.1)]
+    func testEvaluateAutomationCurved() {
 
-            let newPoints = AKEvaluateAutomation(initialValue: 0,
-                                                 points: points,
-                                                 resolution: 0.1)
+        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 0.5, rampSkew: 0.1)]
 
-            XCTAssertEqual(newPoints.count, 10)
-        }();
+        let newPoints = AKEvaluateAutomation(initialValue: 0,
+                                             points: points,
+                                             resolution: 0.1)
+
+        XCTAssertEqual(newPoints.count, 10)
 
     }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -225,4 +225,25 @@ class AKParameterAutomationTests: AKTestCase {
         XCTAssertEqual(newPoints.count, 10)
 
     }
+
+    func testEvaluateAutomationTwoSegment() {
+
+        // One linear, one curved segment.
+        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0),
+                      AKParameterAutomationPoint(targetValue: 0, startTime: 1.0, rampDuration: 1.0, rampTaper: 1.0, rampSkew: 0.000001)]
+
+        let newPoints = AKEvaluateAutomation(initialValue: 0,
+                                             points: points,
+                                             resolution: 0.5)
+
+        XCTAssertEqual(newPoints[0].startTime, 0.0)
+        XCTAssertEqual(newPoints[0].targetValue, 1.0)
+
+        XCTAssertEqual(newPoints[1].startTime, 1.0)
+        XCTAssert(fabs(newPoints[1].targetValue - 0.5) < 0.0001)
+
+        XCTAssertEqual(newPoints[2].startTime, 1.5)
+        XCTAssert(abs(newPoints[2].targetValue) < 0.0001)
+
+    }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -11,7 +11,7 @@ import AudioKit
 
 class AKParameterAutomationTests: AKTestCase {
 
-    func observerTest(automation: [AKParameterAutomationPoint], sampleTime: Float64) -> ([AUParameterAddress], [AUValue]) {
+    func observerTest(automation: [AKAutomationEvent], sampleTime: Float64) -> ([AUParameterAddress], [AUValue]) {
 
         let address = AUParameterAddress(42)
 
@@ -42,7 +42,7 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testSimpleAutomation() throws {
 
-        let automationPoints = [ AKParameterAutomationPoint(targetValue: 880, startTime: 0, rampDuration: 1.0) ]
+        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 1.0) ]
 
         let (addresses, values) = observerTest(automation: automationPoints, sampleTime: 0)
 
@@ -53,7 +53,7 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testPastAutomation() {
 
-        let automationPoints = [ AKParameterAutomationPoint(targetValue: 880, startTime: 0, rampDuration: 0.1) ]
+        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 0.1) ]
 
         let (addresses, values) = observerTest(automation: automationPoints, sampleTime: 44100)
 
@@ -64,8 +64,8 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testPastAutomationTwo() {
 
-        let automationPoints = [ AKParameterAutomationPoint(targetValue: 880, startTime: 0, rampDuration: 0.1),
-                                 AKParameterAutomationPoint(targetValue: 440, startTime: 0.1, rampDuration: 0.1) ]
+        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 0.1),
+                                 AKAutomationEvent(targetValue: 440, startTime: 0.1, rampDuration: 0.1) ]
 
         let (addresses, values) = observerTest(automation: automationPoints, sampleTime: 44100)
 
@@ -77,7 +77,7 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testFutureAutomation() {
 
-        let automationPoints = [ AKParameterAutomationPoint(targetValue: 880, startTime: 1, rampDuration: 0.1) ]
+        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 1, rampDuration: 0.1) ]
 
         let (addresses, values) = observerTest(automation: automationPoints, sampleTime: 0)
 

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -202,5 +202,16 @@ class AKParameterAutomationTests: AKTestCase {
             XCTAssertEqual(newPoints[1].targetValue, 1.0)
         }();
 
+        // Curved automation will evaluate each segment
+        {
+            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 0.5, rampSkew: 0.1)]
+
+            let newPoints = AKEvaluateAutomation(initialValue: 0,
+                                                 points: points,
+                                                 resolution: 0.1)
+
+            XCTAssertEqual(newPoints.count, 10)
+        }();
+
     }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -180,7 +180,9 @@ class AKParameterAutomationTests: AKTestCase {
 
         let newPoints = AKEvaluateAutomation(initialValue: 0, points: points, resolution: 0.5)
 
-        XCTAssertEqual(points, newPoints)
+        XCTAssertEqual(newPoints[0].startTime, 0)
+        XCTAssertEqual(newPoints[0].targetValue, 1)
+        XCTAssertEqual(newPoints[0].rampDuration, 1)
     }
 
 

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -11,7 +11,7 @@ import AudioKit
 
 class AKParameterAutomationTests: AKTestCase {
 
-    func observerTest(automation: [AKAutomationEvent],
+    func observerTest(events: [AKAutomationEvent],
                       sampleTime: Float64,
                       startTime: Double = 0) -> ([AUParameterAddress], [AUValue], [AUAudioFrameCount]) {
 
@@ -27,13 +27,13 @@ class AKParameterAutomationTests: AKTestCase {
             durations.append(rampDuration)
         }
 
-        let observer: AURenderObserver = automation.withUnsafeBufferPointer { automationPtr in
+        let observer: AURenderObserver = events.withUnsafeBufferPointer { automationPtr in
             AKParameterAutomationGetRenderObserver(address,
                                                    scheduleParameterBlock,
                                                    44100,
                                                    startTime, // start time
                                                    automationPtr.baseAddress!,
-                                                   automation.count)
+                                                   events.count)
         }
 
         var timeStamp = AudioTimeStamp()
@@ -46,9 +46,9 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testSimpleAutomation() throws {
 
-        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 1.0) ]
+        let events = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 1.0) ]
 
-        let (addresses, values, _) = observerTest(automation: automationPoints, sampleTime: 0)
+        let (addresses, values, _) = observerTest(events: events, sampleTime: 0)
 
         // order is: taper, skew, offset, value
         XCTAssertEqual(addresses, [42])
@@ -57,9 +57,9 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testPastAutomation() {
 
-        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 0.1) ]
+        let events = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 0.1) ]
 
-        let (addresses, values, _) = observerTest(automation: automationPoints, sampleTime: 44100)
+        let (addresses, values, _) = observerTest(events: events, sampleTime: 44100)
 
         // If the automation is in the past, the value should be set to the final value.
         XCTAssertEqual(addresses, [42])
@@ -68,10 +68,10 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testPastAutomationTwo() {
 
-        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 0.1),
+        let events = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 0.1),
                                  AKAutomationEvent(targetValue: 440, startTime: 0.1, rampDuration: 0.1) ]
 
-        let (addresses, values, _) = observerTest(automation: automationPoints, sampleTime: 44100)
+        let (addresses, values, _) = observerTest(events: events, sampleTime: 44100)
 
         // If the automation is in the past, the value should be set to the final value.
         XCTAssertEqual(addresses, [42])
@@ -81,9 +81,9 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testFutureAutomation() {
 
-        let automationPoints = [ AKAutomationEvent(targetValue: 880, startTime: 1, rampDuration: 0.1) ]
+        let events = [ AKAutomationEvent(targetValue: 880, startTime: 1, rampDuration: 0.1) ]
 
-        let (addresses, values, _) = observerTest(automation: automationPoints, sampleTime: 0)
+        let (addresses, values, _) = observerTest(events: events, sampleTime: 0)
 
         // If the automation is in the future, we should not get anything.
         XCTAssertEqual(addresses, [])
@@ -96,7 +96,7 @@ class AKParameterAutomationTests: AKTestCase {
 
         let events = [AKAutomationEvent(targetValue: 1, startTime: 0, rampDuration: 1.0)]
 
-        let (addresses, values, durations) = observerTest(automation: events, sampleTime: 128)
+        let (addresses, values, durations) = observerTest(events: events, sampleTime: 128)
 
         XCTAssertEqual(addresses, [42])
         XCTAssertEqual(values, [1.0])

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -174,4 +174,21 @@ class AKParameterAutomationTests: AKTestCase {
             XCTAssertEqual(newPoints, expected)
         }()
     }
+
+    func testEvaluateAutomation() {
+
+        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0)]
+
+        let newPoints = AKEvaluateAutomation(initialValue: 0, points: points, resolution: 0.5)
+
+        XCTAssertEqual(newPoints[0].startTime, 0.0)
+        XCTAssertEqual(newPoints[0].targetValue, 0.0)
+
+        XCTAssertEqual(newPoints[1].startTime, 0.5)
+        XCTAssertEqual(newPoints[1].targetValue, 0.5)
+
+        XCTAssertEqual(newPoints[2].startTime, 1.0)
+        XCTAssertEqual(newPoints[2].targetValue, 1.0)
+
+    }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -262,4 +262,27 @@ class AKParameterAutomationTests: AKTestCase {
         XCTAssert(abs(newPoints[2].targetValue) < 0.0001)
 
     }
+
+    func testEvaluateAutomationTwoSegment2() {
+
+        // Curved segment cut off by linear segment.
+        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 2.0, rampTaper: 1.0, rampSkew: 0.000001),
+                      AKParameterAutomationPoint(targetValue: 1, startTime: 1, rampDuration: 0.0)]
+
+        let newPoints = AKEvaluateAutomation(initialValue: 0,
+                                             points: points,
+                                             resolution: 0.5)
+
+        XCTAssertEqual(newPoints[0].startTime, 0.0)
+        XCTAssertEqual(newPoints[0].rampDuration, 0.5)
+        XCTAssertEqual(newPoints[0].targetValue, 0.25)
+
+        XCTAssertEqual(newPoints[1].startTime, 0.5)
+        XCTAssert(fabs(newPoints[1].targetValue - 0.5) < 0.0001)
+
+        XCTAssertEqual(newPoints[2].startTime, 1.0)
+        XCTAssertEqual(newPoints[2].targetValue, 1.0)
+        XCTAssertEqual(newPoints[2].rampDuration, 0.0)
+
+    }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -177,15 +177,30 @@ class AKParameterAutomationTests: AKTestCase {
 
     func testEvaluateAutomation() {
 
-        let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0)]
+        // Linear automation should pass the result through
+        {
+            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0)]
 
-        let newPoints = AKEvaluateAutomation(initialValue: 0, points: points, resolution: 0.5)
+            let newPoints = AKEvaluateAutomation(initialValue: 0, points: points, resolution: 0.5)
 
-        XCTAssertEqual(newPoints[0].startTime, 0.0)
-        XCTAssertEqual(newPoints[0].targetValue, 0.5)
+            XCTAssertEqual(points, newPoints)
 
-        XCTAssertEqual(newPoints[1].startTime, 0.5)
-        XCTAssertEqual(newPoints[1].targetValue, 1.0)
+        }();
+
+        // Curved automation will evaluate each segment
+        {
+            let points = [AKParameterAutomationPoint(targetValue: 1, startTime: 0, rampDuration: 1.0, rampTaper: 1.0, rampSkew: 0.1)]
+
+            let newPoints = AKEvaluateAutomation(initialValue: 0,
+                                                 points: points,
+                                                 resolution: 0.5)
+
+            XCTAssertEqual(newPoints[0].startTime, 0.0)
+            XCTAssert(fabs(newPoints[0].targetValue - 0.6) < 0.0001)
+
+            XCTAssertEqual(newPoints[1].startTime, 0.5)
+            XCTAssertEqual(newPoints[1].targetValue, 1.0)
+        }();
 
     }
 }

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -100,7 +100,7 @@ class AKParameterAutomationTests: AKTestCase {
 
         XCTAssertEqual(addresses, [42])
         XCTAssertEqual(values, [1.0])
-        XCTAssertEqual(durations, [44100])
+        XCTAssertEqual(durations, [UInt32(44100-128)])
     }
 
     func testRecord() {

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -47,11 +47,8 @@ class AKParameterAutomationTests: AKTestCase {
         let (addresses, values) = observerTest(automation: automationPoints, sampleTime: 0)
 
         // order is: taper, skew, offset, value
-        XCTAssertEqual(addresses, [ (UInt64(1)<<63) | 42,
-                                    (UInt64(1)<<62) | 42,
-                                    (UInt64(1)<<61) | 42,
-                                    42])
-        XCTAssertEqual(values, [1.0, 0.0, 0.0, 880.0])
+        XCTAssertEqual(addresses, [42])
+        XCTAssertEqual(values, [880.0])
     }
 
     func testPastAutomation() {

--- a/Tests/TestCases/AKParameterAutomationTests.swift
+++ b/Tests/TestCases/AKParameterAutomationTests.swift
@@ -69,7 +69,7 @@ class AKParameterAutomationTests: AKTestCase {
     func testPastAutomationTwo() {
 
         let events = [ AKAutomationEvent(targetValue: 880, startTime: 0, rampDuration: 0.1),
-                                 AKAutomationEvent(targetValue: 440, startTime: 0.1, rampDuration: 0.1) ]
+                       AKAutomationEvent(targetValue: 440, startTime: 0.1, rampDuration: 0.1) ]
 
         let (addresses, values, _) = observerTest(events: events, sampleTime: 44100)
 


### PR DESCRIPTION
Instead of supporting curved automation in `AKNodeParameter`, provide `AKEvaluateAutomation` which converts curved automation to linear automation. This keeps the DSP side simple and offers compatibility with Apple AUs.