### PR TITLE
add Xcodegen project file

### DIFF
--- a/AudioKit/Common/Nodes/Generators/Speech Synthesizer/AKSpeechSynthesizer.swift
+++ b/AudioKit/Common/Nodes/Generators/Speech Synthesizer/AKSpeechSynthesizer.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
+#if os(macOS)
+
 /// AudioKit version of Apple's SpeechSynthesis Audio Unit
 ///
 
@@ -131,3 +133,5 @@ public class AKSpeechSynthesizer: AKNode {
         self.modulation = modulation
     }
 }
+
+#endif

--- a/AudioKit/project.yml
+++ b/AudioKit/project.yml
@@ -30,7 +30,7 @@ targets:
       - path: Common/Sequencing
         excludes:
           - "**/*.md"
-      - path: Common/taps
+      - path: Common/Taps
         excludes:
           - "**/*.md"
     settings:

--- a/AudioKit/project.yml
+++ b/AudioKit/project.yml
@@ -24,7 +24,6 @@ targets:
       - path: Common/Nodes
         excludes:
           - "**/*.md"
-          - "Generators/Speech Synthesizer/AKSpeechSynthesizer.swift" # macOS only
       - path: Common/Operations
         excludes:
           - "**/*.md"

--- a/AudioKit/project.yml
+++ b/AudioKit/project.yml
@@ -8,29 +8,10 @@ targets:
     type: framework
     platform: [macOS, iOS]
     sources:
-
-#  Tried this but we need to keep the soundpipe headers in, and sporth headers out
-#      - path: Externals 
-#        excludes:
-#          - "**/*.md" # Would like to include the README files but they need to be kept out of the copy files build phase
-#          # - "Sporth/h/*.h" # Keep sporth headers out of AudioKit interface. plumber.h uses X-macros which mess up Clang's modules
-
-      - path: Externals/AudioKitCore
+      - path: Externals 
         excludes:
           - "**/*.md" # Would like to include the README files but they need to be kept out of the copy files build phase
-      - path: Externals/Soundpipe
-        excludes:
-          - "**/*.md"
-      - path: Externals/SoundpipeExtension
-        excludes:
-          - "**/*.md"
-      - path: Externals/Sporth
-        headerVisibility: project # Keep sporth headers out of AudioKit interface. plumber.h uses X-macros which mess up Clang's modules
-        excludes:
-          - "**/*.md"
-      - path: Externals/Wavpack
-        excludes:
-          - "**/*.md"
+          - "Sporth/h/*.h" # Keep sporth headers out of AudioKit interface. plumber.h uses X-macros which mess up Clang's modules
       - path: Common/Internals
         excludes:
           - "**/*.md"
@@ -54,5 +35,6 @@ targets:
         excludes:
           - "**/*.md"
     settings:
+      HEADER_SEARCH_PATHS: "Externals/Sporth/h" # Need to be able to find the sporth headers.
       GCC_PREPROCESSOR_DEFINITIONS: "$(inherited) AUDIOKIT=1 NO_LIBSNDFILE=1"
           

--- a/AudioKit/project.yml
+++ b/AudioKit/project.yml
@@ -1,0 +1,58 @@
+
+# xcodegen project file for AudioKit frameworks
+
+name: AudioKitGen # when ready, rename this to AudioKit
+
+targets:
+  AudioKit:
+    type: framework
+    platform: [macOS, iOS]
+    sources:
+
+#  Tried this but we need to keep the soundpipe headers in, and sporth headers out
+#      - path: Externals 
+#        excludes:
+#          - "**/README.md" # Would like to include the README files but they need to be kept out of the copy files build phase
+#          # - "Sporth/h/*.h" # Keep sporth headers out of AudioKit interface. plumber.h uses X-macros which mess up Clang's modules
+
+      - path: Externals/AudioKitCore
+        excludes:
+          - "**/README.md" # Would like to include the README files but they need to be kept out of the copy files build phase
+      - path: Externals/Soundpipe
+        excludes:
+          - "**/README.md"
+      - path: Externals/SoundpipeExtension
+        excludes:
+          - "**/README.md"
+      - path: Externals/Sporth
+        headerVisibility: project # Keep sporth headers out of AudioKit interface. plumber.h uses X-macros which mess up Clang's modules
+        excludes:
+          - "**/README.md"
+      - path: Externals/Wavpack
+        excludes:
+          - "**/README.md"
+      - path: Common/Internals
+        excludes:
+          - "**/README.md"
+      - path: Audio Files
+        excludes:
+          - "**/README.md"
+      - path: Common/MIDI
+        excludes:
+          - "**/README.md"
+      - path: Common/Nodes
+        excludes:
+          - "**/README.md"
+          - "Generators/Speech Synthesizer/AKSpeechSynthesizer.swift" # macOS only
+      - path: Common/Operations
+        excludes:
+          - "**/README.md"
+      - path: Common/Sequencing
+        excludes:
+          - "**/README.md"
+      - path: Common/taps
+        excludes:
+          - "**/README.md"
+    settings:
+      GCC_PREPROCESSOR_DEFINITIONS: "$(inherited) AUDIOKIT=1 NO_LIBSNDFILE=1"
+          

--- a/AudioKit/project.yml
+++ b/AudioKit/project.yml
@@ -12,47 +12,47 @@ targets:
 #  Tried this but we need to keep the soundpipe headers in, and sporth headers out
 #      - path: Externals 
 #        excludes:
-#          - "**/README.md" # Would like to include the README files but they need to be kept out of the copy files build phase
+#          - "**/*.md" # Would like to include the README files but they need to be kept out of the copy files build phase
 #          # - "Sporth/h/*.h" # Keep sporth headers out of AudioKit interface. plumber.h uses X-macros which mess up Clang's modules
 
       - path: Externals/AudioKitCore
         excludes:
-          - "**/README.md" # Would like to include the README files but they need to be kept out of the copy files build phase
+          - "**/*.md" # Would like to include the README files but they need to be kept out of the copy files build phase
       - path: Externals/Soundpipe
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Externals/SoundpipeExtension
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Externals/Sporth
         headerVisibility: project # Keep sporth headers out of AudioKit interface. plumber.h uses X-macros which mess up Clang's modules
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Externals/Wavpack
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Common/Internals
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Audio Files
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Common/MIDI
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Common/Nodes
         excludes:
-          - "**/README.md"
+          - "**/*.md"
           - "Generators/Speech Synthesizer/AKSpeechSynthesizer.swift" # macOS only
       - path: Common/Operations
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Common/Sequencing
         excludes:
-          - "**/README.md"
+          - "**/*.md"
       - path: Common/taps
         excludes:
-          - "**/README.md"
+          - "**/*.md"
     settings:
       GCC_PREPROCESSOR_DEFINITIONS: "$(inherited) AUDIOKIT=1 NO_LIBSNDFILE=1"
           


### PR DESCRIPTION
Let's get rid of the un-mergeable xcodeproj 💩.

This is just a start. It compiles on macOS and iOS. tvOS seems to be fairly different in terms of what it supports.