### PR TITLE
Add akGetParameterAddress

### DIFF
--- a/AudioKit/Common/Internals/AudioKit.h
+++ b/AudioKit/Common/Internals/AudioKit.h
@@ -323,13 +323,6 @@ typedef NS_ENUM(AUParameterAddress, AKMorphingOscillatorParameter) {
     AKMorphingOscillatorParameterDetuningMultiplier,
 };
 
-typedef NS_ENUM(AUParameterAddress, AKOscillatorParameter) {
-    AKOscillatorParameterFrequency,
-    AKOscillatorParameterAmplitude,
-    AKOscillatorParameterDetuningOffset,
-    AKOscillatorParameterDetuningMultiplier,
-};
-
 typedef NS_ENUM(AUParameterAddress, AKPannerParameter) {
     AKPannerParameterPan,
 };

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -9,6 +9,7 @@
 #include <stdarg.h>
 
 AK_API AKDSPRef akCreateDSP(const char* name);
+AK_API AUParameterAddress akGetParameterAddress(const char* className, const char* paramName);
 
 AK_API AUInternalRenderBlock internalRenderBlockDSP(AKDSPRef pDSP);
 
@@ -155,6 +156,9 @@ public:
     /// Adds a function to create a subclass by name.
     static void addCreateFunction(const char* name, CreateFunction func);
 
+    /// Registers a parameter.
+    static void addParameter(const char* className, const char* paramName, AUParameterAddress address);
+
     /// Create a subclass by name.
     static AKDSPRef create(const char* name);
 
@@ -190,5 +194,13 @@ struct AKDSPRegistration {
 ///
 /// You'll want to do `AK_REGISTER_DSP(AKMyClass)` in order to be able to call `akCreateDSP("AKMyClass")`
 #define AK_REGISTER_DSP(ClassName) AKDSPRegistration<ClassName> __register##ClassName(#ClassName);
+
+struct AKParameterRegistration {
+    AKParameterRegistration(const char* className, const char* paramName, AUParameterAddress address) {
+        AKDSPBase::addParameter(className, paramName, address);
+    }
+};
+
+#define AK_REGISTER_PARAMETER(ClassName, ParamAddress) AKParameterRegistration __register_param_##ParamAddress(#ClassName, #ParamAddress, ParamAddress);
 
 #endif

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -9,7 +9,7 @@
 #include <stdarg.h>
 
 AK_API AKDSPRef akCreateDSP(const char* name);
-AK_API AUParameterAddress akGetParameterAddress(const char* className, const char* paramName);
+AK_API AUParameterAddress akGetParameterAddress(const char* name);
 
 AK_API AUInternalRenderBlock internalRenderBlockDSP(AKDSPRef pDSP);
 
@@ -157,7 +157,7 @@ public:
     static void addCreateFunction(const char* name, CreateFunction func);
 
     /// Registers a parameter.
-    static void addParameter(const char* className, const char* paramName, AUParameterAddress address);
+    static void addParameter(const char* paramName, AUParameterAddress address);
 
     /// Create a subclass by name.
     static AKDSPRef create(const char* name);
@@ -196,11 +196,11 @@ struct AKDSPRegistration {
 #define AK_REGISTER_DSP(ClassName) AKDSPRegistration<ClassName> __register##ClassName(#ClassName);
 
 struct AKParameterRegistration {
-    AKParameterRegistration(const char* className, const char* paramName, AUParameterAddress address) {
-        AKDSPBase::addParameter(className, paramName, address);
+    AKParameterRegistration(const char* name, AUParameterAddress address) {
+        AKDSPBase::addParameter(name, address);
     }
 };
 
-#define AK_REGISTER_PARAMETER(ClassName, ParamAddress) AKParameterRegistration __register_param_##ParamAddress(#ClassName, #ParamAddress, ParamAddress);
+#define AK_REGISTER_PARAMETER(ParamAddress) AKParameterRegistration __register_param_##ParamAddress(#ParamAddress, ParamAddress);
 
 #endif

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
@@ -346,3 +346,32 @@ AKDSPRef AKDSPBase::create(const char* name) {
 AKDSPRef akCreateDSP(const char* name) {
     return AKDSPBase::create(name);
 }
+
+using DSPParamKey = std::pair<std::string, std::string>;
+using DSPParameterMap = std::map< DSPParamKey, AUParameterAddress >;
+
+static DSPParameterMap* paramMap = nullptr;
+
+AUParameterAddress akGetParameterAddress(const char* className, const char* paramName) {
+
+    assert(paramMap && "akGetParameterAddress: Fatal error: parameter map not initialized.");
+
+    auto iter = paramMap->find(DSPParamKey(className, paramName));
+
+    if(iter == paramMap->end()) {
+        printf("akGetParameterAddress: Unknown parameter name: %s\n", paramName);
+        return 0;
+    }
+
+    return iter->second;
+}
+
+void AKDSPBase::addParameter(const char* className, const char* paramName, AUParameterAddress address) {
+
+    if(paramMap == nullptr) {
+        paramMap = new DSPParameterMap;
+    }
+
+    (*paramMap)[DSPParamKey(className, paramName)] = address;
+
+}

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
@@ -347,31 +347,32 @@ AKDSPRef akCreateDSP(const char* name) {
     return AKDSPBase::create(name);
 }
 
-using DSPParamKey = std::pair<std::string, std::string>;
-using DSPParameterMap = std::map< DSPParamKey, AUParameterAddress >;
+using DSPParameterMap = std::map< std::string, AUParameterAddress >;
 
 static DSPParameterMap* paramMap = nullptr;
 
-AUParameterAddress akGetParameterAddress(const char* className, const char* paramName) {
+AUParameterAddress akGetParameterAddress(const char* name) {
 
     assert(paramMap && "akGetParameterAddress: Fatal error: parameter map not initialized.");
 
-    auto iter = paramMap->find(DSPParamKey(className, paramName));
+    auto iter = paramMap->find(name);
 
     if(iter == paramMap->end()) {
-        printf("akGetParameterAddress: Unknown parameter name: %s\n", paramName);
+        printf("akGetParameterAddress: Unknown parameter name: %s\n", name);
         return 0;
     }
 
     return iter->second;
 }
 
-void AKDSPBase::addParameter(const char* className, const char* paramName, AUParameterAddress address) {
+void AKDSPBase::addParameter(const char* name, AUParameterAddress address) {
 
     if(paramMap == nullptr) {
         paramMap = new DSPParameterMap;
     }
 
-    (*paramMap)[DSPParamKey(className, paramName)] = address;
+    assert(paramMap->count(name) == 0 && "Parameter already registered.");
+
+    (*paramMap)[name] = address;
 
 }

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
@@ -20,7 +20,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let frequencyDef = AKNodeParameterDef(
         identifier: "frequency",
         name: "Frequency (Hz)",
-        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterFrequency"),
+        address: akGetParameterAddress("AKOscillatorParameterFrequency"),
         range: 0.0 ... 20_000.0,
         unit: .hertz,
         flags: .default)
@@ -31,7 +31,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let amplitudeDef = AKNodeParameterDef(
         identifier: "amplitude",
         name: "Amplitude",
-        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterAmplitude"),
+        address: akGetParameterAddress("AKOscillatorParameterAmplitude"),
         range: 0.0 ... 10.0,
         unit: .generic,
         flags: .default)
@@ -42,7 +42,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let detuningOffsetDef = AKNodeParameterDef(
         identifier: "detuningOffset",
         name: "Frequency offset (Hz)",
-        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterDetuningOffset"),
+        address: akGetParameterAddress("AKOscillatorParameterDetuningOffset"),
         range: -1_000.0 ... 1_000.0,
         unit: .hertz,
         flags: .default)
@@ -53,7 +53,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let detuningMultiplierDef = AKNodeParameterDef(
         identifier: "detuningMultiplier",
         name: "Frequency detuning multiplier",
-        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterDetuningMultiplier"),
+        address: akGetParameterAddress("AKOscillatorParameterDetuningMultiplier"),
         range: 0.9 ... 1.11,
         unit: .generic,
         flags: .default)

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillator.swift
@@ -20,7 +20,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let frequencyDef = AKNodeParameterDef(
         identifier: "frequency",
         name: "Frequency (Hz)",
-        address: AKOscillatorParameter.frequency.rawValue,
+        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterFrequency"),
         range: 0.0 ... 20_000.0,
         unit: .hertz,
         flags: .default)
@@ -31,7 +31,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let amplitudeDef = AKNodeParameterDef(
         identifier: "amplitude",
         name: "Amplitude",
-        address: AKOscillatorParameter.amplitude.rawValue,
+        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterAmplitude"),
         range: 0.0 ... 10.0,
         unit: .generic,
         flags: .default)
@@ -42,7 +42,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let detuningOffsetDef = AKNodeParameterDef(
         identifier: "detuningOffset",
         name: "Frequency offset (Hz)",
-        address: AKOscillatorParameter.detuningOffset.rawValue,
+        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterDetuningOffset"),
         range: -1_000.0 ... 1_000.0,
         unit: .hertz,
         flags: .default)
@@ -53,7 +53,7 @@ public class AKOscillator: AKNode, AKToggleable, AKComponent, AKAutomatable {
     public static let detuningMultiplierDef = AKNodeParameterDef(
         identifier: "detuningMultiplier",
         name: "Frequency detuning multiplier",
-        address: AKOscillatorParameter.detuningMultiplier.rawValue,
+        address: akGetParameterAddress("AKOscillatorDSP", "AKOscillatorParameterDetuningMultiplier"),
         range: 0.9 ... 1.11,
         unit: .generic,
         flags: .default)

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -85,7 +85,7 @@ public:
 };
 
 AK_REGISTER_DSP(AKOscillatorDSP)
-AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterFrequency)
-AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterAmplitude)
-AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterDetuningOffset)
-AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterDetuningMultiplier)
+AK_REGISTER_PARAMETER(AKOscillatorParameterFrequency)
+AK_REGISTER_PARAMETER(AKOscillatorParameterAmplitude)
+AK_REGISTER_PARAMETER(AKOscillatorParameterDetuningOffset)
+AK_REGISTER_PARAMETER(AKOscillatorParameterDetuningMultiplier)

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -6,7 +6,7 @@
 
 #include "DebugDSP.h"
 
-typedef NS_ENUM(AUParameterAddress, AKOscillatorParameter) {
+enum AKOscilatorParameter : AUParameterAddress {
     AKOscillatorParameterFrequency,
     AKOscillatorParameterAmplitude,
     AKOscillatorParameterDetuningOffset,

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -6,6 +6,13 @@
 
 #include "DebugDSP.h"
 
+typedef NS_ENUM(AUParameterAddress, AKOscillatorParameter) {
+    AKOscillatorParameterFrequency,
+    AKOscillatorParameterAmplitude,
+    AKOscillatorParameterDetuningOffset,
+    AKOscillatorParameterDetuningMultiplier,
+};
+
 class AKOscillatorDSP : public AKSoundpipeDSPBase {
 private:
     sp_osc *osc;
@@ -78,3 +85,7 @@ public:
 };
 
 AK_REGISTER_DSP(AKOscillatorDSP)
+AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterFrequency)
+AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterAmplitude)
+AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterDetuningOffset)
+AK_REGISTER_PARAMETER(AKOscillatorDSP, AKOscillatorParameterDetuningMultiplier)


### PR DESCRIPTION
- Reduces namespace pollution
- Avoids having to edit AudioKit.h when adding a node
- Demonstrates how to upgrade AKOscillatorDSP.