### PR TITLE
Remove partially implemented support for multiple output busses.

### DIFF
--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.hpp
@@ -82,7 +82,7 @@ public:
     virtual ~AKDSPBase() {}
     
     std::vector<AudioBufferList*> inputBufferLists;
-    std::vector<AudioBufferList*> outputBufferLists;
+    AudioBufferList* outputBufferList = nullptr;
     
     AUInternalRenderBlock internalRenderBlock();
     

--- a/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AKDSPBase.mm
@@ -17,7 +17,7 @@ size_t inputBusCountDSP(AKDSPRef pDSP)
 
 size_t outputBusCountDSP(AKDSPRef pDSP)
 {
-    return pDSP->outputBufferLists.size();
+    return 1; // We don't currently support multiple output busses.
 }
 
 bool canProcessInPlaceDSP(AKDSPRef pDSP)
@@ -104,7 +104,6 @@ AKDSPBase::AKDSPBase()
 : channelCount(2)   // best guess
 , sampleRate(44100) // best guess
 , inputBufferLists(1)
-, outputBufferLists(1)
 {
     std::fill(parameters, parameters+maxParameters, nullptr);
 }
@@ -126,6 +125,9 @@ AUInternalRenderBlock AKDSPBase::internalRenderBlock()
         const AURenderEvent        *realtimeEventListHead,
         AURenderPullInputBlock      pullInputBlock)
     {
+
+        assert( (outputBusNumber == 0) && "We don't yet support multiple output busses" );
+
         if (pullInputBlock) {
             if (bCanProcessInPlace && inputBufferLists.size() == 1) {
                 // pull input directly to output buffer
@@ -152,7 +154,7 @@ AUInternalRenderBlock AKDSPBase::internalRenderBlock()
             }
         }
         
-        outputBufferLists[0] = outputData;
+        outputBufferList = outputData;
         
         processWithEvents(timestamp, frameCount, realtimeEventListHead);
         

--- a/AudioKit/Common/Internals/CoreAudio/AKSoundpipeDSPBase.mm
+++ b/AudioKit/Common/Internals/CoreAudio/AKSoundpipeDSPBase.mm
@@ -29,7 +29,7 @@ void AKSoundpipeDSPBase::process(AUAudioFrameCount frameCount, AUAudioFrameCount
         int frameOffset = int(frameIndex + bufferOffset);
         for (int channel = 0; channel <  channelCount; ++channel) {
             float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-            float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+            float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
             if (isStarted) {
                 processSample(channel, in, out);

--- a/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Delay/Stereo Delay/AKStereoDelayDSP.mm
@@ -69,10 +69,10 @@ public:
         float *outBuffers[2];
         inBuffers[0]  = (const float *)inputBufferLists[0]->mBuffers[0].mData  + bufferOffset;
         inBuffers[1]  = (const float *)inputBufferLists[0]->mBuffers[1].mData  + bufferOffset;
-        outBuffers[0] = (float *)outputBufferLists[0]->mBuffers[0].mData + bufferOffset;
-        outBuffers[1] = (float *)outputBufferLists[0]->mBuffers[1].mData + bufferOffset;
+        outBuffers[0] = (float *)outputBufferList->mBuffers[0].mData + bufferOffset;
+        outBuffers[1] = (float *)outputBufferList->mBuffers[1].mData + bufferOffset;
         //unsigned inChannelCount = inputBufferLists[0]->mNumberBuffers;
-        //unsigned outChannelCount = outputBufferLists[0]->mNumberBuffers;
+        //unsigned outChannelCount = outputBufferList->mNumberBuffers;
 
         if (!isStarted)
         {

--- a/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Delay/Variable Delay/AKVariableDelayDSP.mm
@@ -67,7 +67,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Bit Crusher/AKBitCrusherDSP.mm
@@ -58,7 +58,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Clipper/AKClipperDSP.mm
@@ -51,7 +51,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Distortion/Tanh Distortion/AKTanhDistortionDSP.mm
@@ -72,7 +72,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Dynamics/Dynamic Range Compressor/AKDynamicRangeCompressorDSP.mm
@@ -72,7 +72,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Amplitude Envelope/AKAmplitudeEnvelopeDSP.mm
@@ -68,7 +68,7 @@ public:
 
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 *out = *in * amp;
             }
         }

--- a/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Envelopes/Tremolo/AKTremoloDSP.mm
@@ -58,7 +58,7 @@ public:
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     sp_osc_compute(sp, trem, NULL, &temp);

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Pass Butterworth Filter/AKBandPassButterworthFilterDSP.mm
@@ -58,7 +58,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Band Reject Butterworth Filter/AKBandRejectButterworthFilterDSP.mm
@@ -58,7 +58,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/DC Block/AKDCBlockDSP.mm
@@ -41,7 +41,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Equalizer Filter/AKEqualizerFilterDSP.mm
@@ -65,7 +65,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Formant Filter/AKFormantFilterDSP.mm
@@ -65,7 +65,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Pass Butterworth Filter/AKHighPassButterworthFilterDSP.mm
@@ -51,7 +51,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/High Shelf Parametric Equalizer Filter/AKHighShelfParametricEqualizerFilterDSP.mm
@@ -69,7 +69,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Korg Low Pass Filter/AKKorgLowPassFilterDSP.mm
@@ -65,7 +65,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Pass Butterworth Filter/AKLowPassButterworthFilterDSP.mm
@@ -51,7 +51,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Low Shelf Parametric Equalizer Filter/AKLowShelfParametricEqualizerFilterDSP.mm
@@ -69,7 +69,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Modal Resonance Filter/AKModalResonanceFilterDSP.mm
@@ -58,7 +58,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Moog Ladder/AKMoogLadderDSP.mm
@@ -58,7 +58,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Peaking Parametric Equalizer Filter/AKPeakingParametricEqualizerFilterDSP.mm
@@ -69,7 +69,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/ResonantFilter/AKResonantFilterDSP.mm
@@ -58,7 +58,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Roland TB-303 Filter/AKRolandTB303FilterDSP.mm
@@ -72,7 +72,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/String Resonator/AKStringResonatorDSP.mm
@@ -58,7 +58,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Three Pole Low Pass Filter/AKThreePoleLowpassFilterDSP.mm
@@ -65,7 +65,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Complement Filter/AKToneComplementFilterDSP.mm
@@ -52,7 +52,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Filters/Tone Filter/AKToneFilterDSP.mm
@@ -51,7 +51,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Guitar Processors/Auto Wah/AKAutoWahDSP.mm
@@ -65,7 +65,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Common/AKModulatedDelayDSP.mm
@@ -76,9 +76,9 @@ void AKModulatedDelayDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCoun
     float *inBuffers[2], *outBuffers[2];
     inBuffers[0]  = (float *)inputBufferLists[0]->mBuffers[0].mData  + bufferOffset;
     inBuffers[1]  = (float *)inputBufferLists[0]->mBuffers[1].mData  + bufferOffset;
-    outBuffers[0] = (float *)outputBufferLists[0]->mBuffers[0].mData + bufferOffset;
-    outBuffers[1] = (float *)outputBufferLists[0]->mBuffers[1].mData + bufferOffset;
-    unsigned channelCount = outputBufferLists[0]->mNumberBuffers;
+    outBuffers[0] = (float *)outputBufferList->mBuffers[0].mData + bufferOffset;
+    outBuffers[1] = (float *)outputBufferList->mBuffers[1].mData + bufferOffset;
+    unsigned channelCount = outputBufferList->mNumberBuffers;
 
     if (!isStarted)
     {

--- a/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Modulation/Phaser/AKPhaserDSP.mm
@@ -76,7 +76,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Pitch Shifter/AKPitchShifterDSP.mm
@@ -64,7 +64,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Chowning Reverb/AKChowningReverbDSP.mm
@@ -41,7 +41,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Comb Filter Reverb/AKCombFilterReverbDSP.mm
@@ -57,7 +57,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Convolution/AKConvolutionDSP.mm
@@ -54,7 +54,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Costello Reverb/AKCostelloReverbDSP.mm
@@ -49,7 +49,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Flat Frequency Response Reverb/AKFlatFrequencyResponseReverbDSP.mm
@@ -57,7 +57,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
+++ b/AudioKit/Common/Nodes/Effects/Reverb/Zita Reverb/AKZitaReverbDSP.mm
@@ -80,7 +80,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/Brownian Noise/AKBrownianNoiseDSP.mm
@@ -42,7 +42,7 @@ public:
 
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/Pink Noise/AKPinkNoiseDSP.mm
@@ -41,7 +41,7 @@ public:
             pinknoise->amp = amplitudeRamp.getAndStep();
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Noise/White Noise/AKWhiteNoiseDSP.mm
@@ -41,7 +41,7 @@ public:
             noise->amp = amplitudeRamp.getAndStep();
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/FM Oscillator/AKFMOscillatorDSP.mm
@@ -68,7 +68,7 @@ public:
             fosc->amp = amplitudeRamp.getAndStep();
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Morphing Oscillator/AKMorphingOscillatorDSP.mm
@@ -73,7 +73,7 @@ public:
 
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -66,7 +66,7 @@ public:
 
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/PWM Oscillator/AKPWMOscillatorDSP.mm
@@ -64,7 +64,7 @@ public:
 
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Phase Distortion Oscillator/AKPhaseDistortionOscillatorDSP.mm
@@ -84,7 +84,7 @@ public:
             float ph = 0;
             
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Drip/AKDripDSP.mm
@@ -65,7 +65,7 @@ public:
             drip->amp = amplitudeRamp.getAndStep();
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Metal Bar/AKMetalBarDSP.mm
@@ -65,7 +65,7 @@ public:
             bar->wid = strikeWidthRamp.getAndStep();
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Plucked String/AKPluckedStringDSP.mm
@@ -50,7 +50,7 @@ public:
             pluck->amp = amplitudeRamp.getAndStep();
 
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Physical Models/Vocal Tract/AKVocalTractDSP.mm
@@ -67,7 +67,7 @@ public:
 
             float temp = 0;
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/Common/Nodes/Generators/Synth/AKSynthDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Synth/AKSynthDSP.mm
@@ -166,9 +166,9 @@ void AKSynthDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferO
 
         // get data
         float *outBuffers[2];
-        outBuffers[0] = (float *)outputBufferLists[0]->mBuffers[0].mData + frameOffset;
-        outBuffers[1] = (float *)outputBufferLists[0]->mBuffers[1].mData + frameOffset;
-        unsigned channelCount = outputBufferLists[0]->mNumberBuffers;
+        outBuffers[0] = (float *)outputBufferList->mBuffers[0].mData + frameOffset;
+        outBuffers[1] = (float *)outputBufferList->mBuffers[1].mData + frameOffset;
+        unsigned channelCount = outputBufferList->mNumberBuffers;
         AKCoreSynth::render(channelCount, chunkSize, outBuffers);
     }
 }

--- a/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Auto Panner/AKAutoPannerDSP.mm
@@ -59,7 +59,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (channel < 2) {
                     tmpin[channel] = in;

--- a/AudioKit/Common/Nodes/Mixing/Balancer/AKBalancerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Balancer/AKBalancerDSP.mm
@@ -36,7 +36,7 @@ public:
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in   = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
                 float *comp = (float *)inputBufferLists[1]->mBuffers[channel].mData + frameOffset;
-                float *out  = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out  = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     sp_bal_compute(sp, bal, in, comp, out);

--- a/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Booster/AKBoosterDSP.mm
@@ -29,7 +29,7 @@ public:
 
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (isStarted) {
                     if (channel == 0) {
                         *out = *in * lgain;

--- a/AudioKit/Common/Nodes/Mixing/Fader/AKFaderDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Fader/AKFaderDSP.mm
@@ -62,7 +62,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (channel < 2) {
                     tmpin[channel] = in;

--- a/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Panner/AKPannerDSP.mm
@@ -44,7 +44,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.mm
+++ b/AudioKit/Common/Nodes/Mixing/Stereo Field Limiter/AKStereoFieldLimiterDSP.mm
@@ -28,8 +28,8 @@ public:
             float amount = amountRamp.getAndStep();
 
             if (!isStarted) {
-                outputBufferLists[0]->mBuffers[0] = inputBufferLists[0]->mBuffers[0];
-                outputBufferLists[0]->mBuffers[1] = inputBufferLists[0]->mBuffers[1];
+                outputBufferList->mBuffers[0] = inputBufferLists[0]->mBuffers[0];
+                outputBufferList->mBuffers[1] = inputBufferLists[0]->mBuffers[1];
                 return;
             }
 
@@ -37,7 +37,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Phase-Locked Vocoder/AKPhaseLockedVocoderDSP.mm
@@ -64,8 +64,8 @@ public:
             mincer->amp = amplitudeRamp.getAndStep();
             mincer->pitch = pitchRatioRamp.getAndStep();
 
-            float *outL = (float *)outputBufferLists[0]->mBuffers[0].mData  + frameOffset;
-            float *outR = (float *)outputBufferLists[0]->mBuffers[1].mData + frameOffset;
+            float *outL = (float *)outputBufferList->mBuffers[0].mData  + frameOffset;
+            float *outR = (float *)outputBufferList->mBuffers[1].mData + frameOffset;
             if (isStarted) {
                 sp_mincer_compute(sp, mincer, NULL, outL);
                 *outR = *outL;

--- a/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
+++ b/AudioKit/Common/Nodes/Playback/Samplers/Sampler/AKSamplerDSP.mm
@@ -388,9 +388,9 @@ void AKSamplerDSP::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffe
 
         // get data
         float *outBuffers[2];
-        outBuffers[0] = (float *)outputBufferLists[0]->mBuffers[0].mData + frameOffset;
-        outBuffers[1] = (float *)outputBufferLists[0]->mBuffers[1].mData + frameOffset;
-        unsigned channelCount = outputBufferLists[0]->mNumberBuffers;
+        outBuffers[0] = (float *)outputBufferList->mBuffers[0].mData + frameOffset;
+        outBuffers[1] = (float *)outputBufferList->mBuffers[1].mData + frameOffset;
+        unsigned channelCount = outputBufferList->mNumberBuffers;
         AKCoreSampler::render(channelCount, chunkSize, outBuffers);
     }
 }

--- a/AudioKit/DevoloopAudioKit/DynaRage Tube Compressor/AKDynaRageCompressorDSP.mm
+++ b/AudioKit/DevoloopAudioKit/DynaRage Tube Compressor/AKDynaRageCompressorDSP.mm
@@ -100,7 +100,7 @@ public:
 
             for (int channel = 0; channel < channelCount; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (channel == 0) {

--- a/AudioKit/DevoloopAudioKit/Rhino/AKRhinoGuitarProcessorDSP.mm
+++ b/AudioKit/DevoloopAudioKit/Rhino/AKRhinoGuitarProcessorDSP.mm
@@ -106,7 +106,7 @@ public:
             float *tmpout[2];
             for (int channel = 0; channel < 2; ++channel) {
                 float *in  = (float *)inputBufferLists[0]->mBuffers[channel].mData  + frameOffset;
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 if (channel < 2) {
                     tmpin[channel] = in;
                     tmpout[channel] = out;

--- a/AudioKit/STKAudioKit/Clarinet/AKClarinetDSP.mm
+++ b/AudioKit/STKAudioKit/Clarinet/AKClarinetDSP.mm
@@ -92,7 +92,7 @@ public:
             float amplitude = amplitudeRamp.getValue();
             
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
                 
                 if (isStarted) {
                     if (internalTrigger == 1) {

--- a/AudioKit/STKAudioKit/Flute/AKFluteDSP.mm
+++ b/AudioKit/STKAudioKit/Flute/AKFluteDSP.mm
@@ -91,7 +91,7 @@ public:
             float amplitude = amplitudeRamp.getValue();
 
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (internalTrigger == 1) {

--- a/AudioKit/STKAudioKit/Rhodes Piano/AKRhodesPianoDSP.mm
+++ b/AudioKit/STKAudioKit/Rhodes Piano/AKRhodesPianoDSP.mm
@@ -110,7 +110,7 @@ public:
             float amplitude = amplitudeRamp.getValue();
 
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (internalTrigger == 1) {

--- a/AudioKit/STKAudioKit/Shaker/AKShakerDSP.mm
+++ b/AudioKit/STKAudioKit/Shaker/AKShakerDSP.mm
@@ -69,7 +69,7 @@ public:
             int frameOffset = int(frameIndex + bufferOffset);
 
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (internalTrigger == 1) {

--- a/AudioKit/STKAudioKit/Tubular Bells/AKTubularBellsDSP.mm
+++ b/AudioKit/STKAudioKit/Tubular Bells/AKTubularBellsDSP.mm
@@ -111,7 +111,7 @@ public:
             float amplitude = amplitudeRamp.getValue();
 
             for (int channel = 0; channel < channelCount; ++channel) {
-                float *out = (float *)outputBufferLists[0]->mBuffers[channel].mData + frameOffset;
+                float *out = (float *)outputBufferList->mBuffers[channel].mData + frameOffset;
 
                 if (isStarted) {
                     if (internalTrigger == 1) {


### PR DESCRIPTION
Because the implementation was incomplete (the bus number was not passed to the process function), someone could be rather confused if they tried to write a node with multiple output buses.

(Note that tests will fail due to other breakage)