### PR TITLE
Use override keyword in AKOscillatorDSP (C++ modernization)

### DIFF
--- a/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
+++ b/AudioKit/Common/Nodes/Generators/Oscillators/Oscillator/AKOscillatorDSP.mm
@@ -29,12 +29,12 @@ public:
         parameters[AKOscillatorParameterDetuningMultiplier] = &detuningMultiplierRamp;
     }
 
-    void setWavetable(const float* table, size_t length, int index) {
+    void setWavetable(const float* table, size_t length, int index) override {
         waveform = std::vector<float>(table, table + length);
         reset();
     }
 
-    void init(int channelCount, double sampleRate) {
+    void init(int channelCount, double sampleRate) override {
         AKSoundpipeDSPBase::init(channelCount, sampleRate);
         sp_ftbl_create(sp, &ftbl, waveform.size());
         std::copy(waveform.cbegin(), waveform.cend(), ftbl->tbl);
@@ -42,19 +42,19 @@ public:
         sp_osc_init(sp, osc, ftbl, 0);
     }
 
-    void deinit() {
+    void deinit() override {
         AKSoundpipeDSPBase::deinit();
         sp_osc_destroy(&osc);
         sp_ftbl_destroy(&ftbl);
     }
 
-    void reset() {
+    void reset() override {
         AKSoundpipeDSPBase::reset();
         if (!isInitialized) return;
         sp_osc_init(sp, osc, ftbl, 0);
     }
 
-    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) {
+    void process(AUAudioFrameCount frameCount, AUAudioFrameCount bufferOffset) override {
         for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
             int frameOffset = int(frameIndex + bufferOffset);
 


### PR DESCRIPTION
Demonstrates use of override keyword in AKOscillatorDSP.

Needs to be propagated to other nodes.

The override keyword is useful because if you remove the base class function, you won't leave the subclass functions around.