### PR TITLE
AKPlayer completionHandler

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -244,24 +244,11 @@ extension AKPlayer {
                 return
             }
 
-            #if os(macOS)
             // if the user calls stop() themselves then the currentFrame will be 0 as of 10.14
             // in this case, don't call the completion handler
             if self.currentFrame > 0 {
                 self.handleComplete()
             }
-            #else
-            do {
-                try AKTry {
-                    if self.currentFrame > 0 {
-                        self.handleComplete()
-                    }
-                }
-            } catch let error as NSError {
-                AKLog("Failed to check currentFrame and call completion handler", error,
-                      "Possible Media Service Reset?", type: .error)
-            }
-            #endif
         }
     }
 

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -166,13 +166,15 @@ public class AKPlayer: AKAbstractPlayer {
     /// of frames based on startTime and endTime
     @objc public internal(set) var frameCount: AVAudioFrameCount = 0
 
-    /// - Returns: The current frame while playing
+    /// - Returns: The current frame while playing. It will return 0 on error.
     @objc public var currentFrame: AVAudioFramePosition {
-        if let nodeTime = playerNode.lastRenderTime,
-            let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
-            return playerTime.sampleTime
+        guard playerNode.engine != nil,
+            let nodeTime = playerNode.lastRenderTime,
+            let playerTime = playerNode.playerTime(forNodeTime: nodeTime) else {
+            AKLog("Error getting currentFrame, player may have been detached", type: .error)
+            return 0
         }
-        return 0
+        return playerTime.sampleTime
     }
 
     /// - Returns: Current time of the player in seconds while playing.
@@ -193,7 +195,7 @@ public class AKPlayer: AKAbstractPlayer {
         }
     }
 
-    /// Returns the audioFile's internal processingFormat
+    ///  - Returns: the audioFile's internal processingFormat
     @objc public var processingFormat: AVAudioFormat? {
         return audioFile?.processingFormat
     }


### PR DESCRIPTION
currentFrame should first check for a valid engine. this changes the confusion of someone putting a AKTry in the completionHandler to solve the fix rather than the symptom