### PR TITLE
AKPlayer completionHandler - v5

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKAbstractPlayer.swift
@@ -71,13 +71,13 @@ open class AKAbstractPlayer: AKNode {
         /// So that the Loop struct can be used outside of AKPlayer
         public init() {}
 
-        public var start: Double = 0 {
+        public var start: TimeInterval = 0 {
             willSet {
                 if newValue != start { needsUpdate = true }
             }
         }
 
-        public var end: Double = 0 {
+        public var end: TimeInterval = 0 {
             willSet {
                 if newValue != end { needsUpdate = true }
             }
@@ -128,10 +128,10 @@ open class AKAbstractPlayer: AKNode {
         }
     }
 
-    private var _startTime: Double = 0
+    private var _startTime: TimeInterval = 0
 
     /// Get or set the start time of the player.
-    open var startTime: Double {
+    open var startTime: TimeInterval {
         get {
             return _startTime
         }
@@ -141,10 +141,10 @@ open class AKAbstractPlayer: AKNode {
         }
     }
 
-    private var _endTime: Double = 0
+    private var _endTime: TimeInterval = 0
 
     /// Get or set the end time of the player.
-    open var endTime: Double {
+    open var endTime: TimeInterval {
         get {
             return isLooping ? loop.end : _endTime
         }
@@ -158,7 +158,7 @@ open class AKAbstractPlayer: AKNode {
         }
     }
 
-    public var offsetTime: Double = 0
+    public var offsetTime: TimeInterval = 0
 
     // MARK: - public flags
 
@@ -173,11 +173,11 @@ open class AKAbstractPlayer: AKNode {
 
     // MARK: - stub items, to be implemented in subclasses
 
-    open var duration: Double {
+    open var duration: TimeInterval {
         return 0
     }
 
-    internal var editedDuration: Double {
+    internal var editedDuration: TimeInterval {
         return (duration - startTime) - (duration - endTime)
     }
 
@@ -258,7 +258,7 @@ open class AKAbstractPlayer: AKNode {
         }
     }
 
-    func secondsToFrames(_ value: Double) -> AUAudioFrameCount {
+    func secondsToFrames(_ value: TimeInterval) -> AUAudioFrameCount {
         return AUAudioFrameCount(value * sampleRate)
     }
 
@@ -281,7 +281,7 @@ open class AKAbstractPlayer: AKNode {
         faderNode?.gain = fade.maximumGain
     }
 
-    public func fadeOut(with duration: Double, taper: AUValue? = nil) {
+    public func fadeOut(with duration: TimeInterval, taper: AUValue? = nil) {
         faderNode?.parameterAutomation?.stopPlayback()
         faderNode?.clearAutomationPoints()
         faderNode?.addAutomationPoint(value: Fade.minimumGain,

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKDynamicPlayer.swift
@@ -133,8 +133,8 @@ public class AKDynamicPlayer: AKPlayer {
         }
     }
 
-    override public func play(from startingTime: Double,
-                              to endingTime: Double,
+    override public func play(from startingTime: TimeInterval,
+                              to endingTime: TimeInterval,
                               at audioTime: AVAudioTime?,
                               hostTime: UInt64?) {
         timePitchNode?.start()

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Buffering.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Buffering.swift
@@ -112,7 +112,7 @@ extension AKPlayer {
     ///  - Parameters:
     ///     - inTime specified in seconds, 0 if no fade
     ///     - outTime specified in seconds, 0 if no fade
-    fileprivate func fadeBuffer(inTime: Double = 0, outTime: Double = 0) {
+    fileprivate func fadeBuffer(inTime: TimeInterval = 0, outTime: TimeInterval = 0) {
         guard isBuffered, let buffer = self.buffer else { return }
         if let fadedBuffer = buffer.fade(inTime: inTime,
                                          outTime: outTime) {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -32,7 +32,7 @@ extension AKPlayer {
     /// Mostly applicable to buffered players, this loads the buffer and gets it ready to play.
     /// Otherwise it just sets the edit points and enables the fader if the region
     /// has fade in or out applied to it.
-    public func preroll(from startingTime: Double = 0, to endingTime: Double = 0) {
+    public func preroll(from startingTime: TimeInterval = 0, to endingTime: TimeInterval = 0) {
         var from = startingTime
         var to = endingTime
 
@@ -71,7 +71,7 @@ extension AKPlayer {
     }
 
     /// Play segments of a file
-    public func play(from startingTime: Double, to endingTime: Double = 0) {
+    public func play(from startingTime: TimeInterval, to endingTime: TimeInterval = 0) {
         var to = endingTime
         if to == 0 {
             to = endTime
@@ -101,13 +101,13 @@ extension AKPlayer {
 
     /// Play file using previously set startTime and endTime at some point in the future specified in seconds
     /// with a hostTime reference
-    public func play(when scheduledTime: Double, hostTime: UInt64? = nil) {
+    public func play(when scheduledTime: TimeInterval, hostTime: UInt64? = nil) {
         play(from: startTime, to: endTime, when: scheduledTime, hostTime: hostTime)
     }
 
-    public func play(from startingTime: Double,
-                     to endingTime: Double,
-                     when scheduledTime: Double,
+    public func play(from startingTime: TimeInterval,
+                     to endingTime: TimeInterval,
+                     when scheduledTime: TimeInterval,
                      hostTime: UInt64? = nil) {
         let refTime = hostTime ?? mach_absolute_time()
         var avTime: AVAudioTime?
@@ -355,7 +355,7 @@ extension AKPlayer: AKTiming {
         return isPlaying
     }
 
-    public func setPosition(_ position: Double) {
+    public func setPosition(_ position: TimeInterval) {
         startTime = position
         if isPlaying {
             stop()
@@ -363,14 +363,14 @@ extension AKPlayer: AKTiming {
         }
     }
 
-    public func position(at audioTime: AVAudioTime?) -> Double {
+    public func position(at audioTime: AVAudioTime?) -> TimeInterval {
         guard let playerTime = playerNode.playerTime(forNodeTime: audioTime ?? AVAudioTime.now()) else {
             return startTime
         }
-        return startTime + Double(playerTime.sampleTime) / playerTime.sampleRate
+        return startTime + TimeInterval(playerTime.sampleTime) / playerTime.sampleRate
     }
 
-    public func audioTime(at position: Double) -> AVAudioTime? {
+    public func audioTime(at position: TimeInterval) -> AVAudioTime? {
         let sampleRate = playerNode.outputFormat(forBus: 0).sampleRate
         let sampleTime = (position - startTime) * sampleRate
         let playerTime = AVAudioTime(sampleTime: AVAudioFramePosition(sampleTime), atRate: sampleRate)

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -292,6 +292,10 @@ extension AKPlayer {
 
     @available(iOS 11, macOS 10.13, tvOS 11, *)
     internal func handleCallbackComplete(completionType: AVAudioPlayerNodeCompletionCallbackType) {
+        guard audioFile != nil else {
+            AKLog("Audio file has been disposed.", type: .error)
+            return
+        }
         // it seems to be unstable having any outbound calls from this callback not be sent to main?
         DispatchQueue.main.async {
             // reset the loop if user stopped it

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -292,10 +292,6 @@ extension AKPlayer {
 
     @available(iOS 11, macOS 10.13, tvOS 11, *)
     internal func handleCallbackComplete(completionType: AVAudioPlayerNodeCompletionCallbackType) {
-        guard audioFile != nil else {
-            AKLog("Audio file has been disposed.", type: .error)
-            return
-        }
         // it seems to be unstable having any outbound calls from this callback not be sent to main?
         DispatchQueue.main.async {
             // reset the loop if user stopped it
@@ -306,24 +302,11 @@ extension AKPlayer {
                 return
             }
 
-            #if os(macOS)
             // if the user calls stop() themselves then the currentFrame will be 0 as of 10.14
             // in this case, don't call the completion handler
             if self.currentFrame > 0 {
                 self.handleComplete()
             }
-            #else
-            do {
-                try AKTry {
-                    if self.currentFrame > 0 {
-                        self.handleComplete()
-                    }
-                }
-            } catch let error as NSError {
-                AKLog("Failed to check currentFrame and call completion handler", error,
-                      "Possible Media Service Reset?", type: .error)
-            }
-            #endif
         }
     }
 

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Playback.swift
@@ -274,7 +274,7 @@ extension AKPlayer {
                                        startingFrame: startFrame,
                                        frameCount: frameCount,
                                        at: audioTime,
-                                       completionCallbackType: .dataRendered, // .dataPlayedBack,
+                                       completionCallbackType: .dataRendered,
                                        completionHandler: handleCallbackComplete)
         } else {
             // Fallback on earlier version
@@ -309,7 +309,6 @@ extension AKPlayer {
                 self.handleComplete()
             }
             #else
-            // RF: I'm unsure who added this AKTry here and for what reason exactly?
             do {
                 try AKTry {
                     if self.currentFrame > 0 {

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -144,6 +144,9 @@ public class AKPlayer: AKAbstractPlayer {
 
     /// The current frame while playing
     public var currentFrame: AVAudioFramePosition {
+        // make sure there is a valid engine otherwise this will crash
+        guard playerNode.engine != nil else { return 0 }
+
         if let nodeTime = playerNode.lastRenderTime,
             let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
             return playerTime.sampleTime

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -336,7 +336,10 @@ public class AKPlayer: AKAbstractPlayer {
 
     /// Play using full options. Last in the convenience play chain, all play() commands will end up here
     // Placed in main class to be overriden in subclasses if needed.
-    public func play(from startingTime: TimeInterval, to endingTime: TimeInterval, at audioTime: AVAudioTime?, hostTime: UInt64?) {
+    public func play(from startingTime: TimeInterval,
+                     to endingTime: TimeInterval,
+                     at audioTime: AVAudioTime?,
+                     hostTime: UInt64?) {
         let refTime = hostTime ?? mach_absolute_time()
         var audioTime = audioTime ?? AVAudioTime.now()
         isPlaying = true

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -55,10 +55,10 @@ public class AKPlayer: AKAbstractPlayer {
     internal var startingFrame: AVAudioFramePosition?
     internal var endingFrame: AVAudioFramePosition?
 
-    private var playerTime: Double {
+    private var playerTime: TimeInterval {
         if let nodeTime = playerNode.lastRenderTime,
             let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
-            return Double(playerTime.sampleTime) / playerTime.sampleRate
+            return TimeInterval(playerTime.sampleTime) / playerTime.sampleRate
         }
         return 0
     }
@@ -115,9 +115,9 @@ public class AKPlayer: AKAbstractPlayer {
     public internal(set) var audioFile: AVAudioFile?
 
     /// The duration of the loaded audio file
-    override public var duration: Double {
+    override public var duration: TimeInterval {
         guard let audioFile = audioFile else { return 0 }
-        return Double(audioFile.length) / audioFile.fileFormat.sampleRate
+        return TimeInterval(audioFile.length) / audioFile.fileFormat.sampleRate
     }
 
     override public var sampleRate: Double {
@@ -152,7 +152,7 @@ public class AKPlayer: AKAbstractPlayer {
     }
 
     /// Current time of the player in seconds while playing.
-    public var currentTime: Double {
+    public var currentTime: TimeInterval {
         let currentDuration = (endTime - startTime == 0) ? duration : (endTime - startTime)
         var normalizedPauseTime = 0.0
         if let pauseTime = pauseTime, pauseTime > startTime {
@@ -163,7 +163,7 @@ public class AKPlayer: AKAbstractPlayer {
         return current
     }
 
-    public var pauseTime: Double? {
+    public var pauseTime: TimeInterval? {
         didSet {
             isPaused = pauseTime != nil
         }
@@ -336,7 +336,7 @@ public class AKPlayer: AKAbstractPlayer {
 
     /// Play using full options. Last in the convenience play chain, all play() commands will end up here
     // Placed in main class to be overriden in subclasses if needed.
-    public func play(from startingTime: Double, to endingTime: Double, at audioTime: AVAudioTime?, hostTime: UInt64?) {
+    public func play(from startingTime: TimeInterval, to endingTime: TimeInterval, at audioTime: AVAudioTime?, hostTime: UInt64?) {
         let refTime = hostTime ?? mach_absolute_time()
         var audioTime = audioTime ?? AVAudioTime.now()
         isPlaying = true
@@ -353,7 +353,7 @@ public class AKPlayer: AKAbstractPlayer {
             if renderingMode == .offline, sampleRate != AKSettings.sampleRate {
                 let sampleRateRatio = sampleRate / AKSettings.sampleRate
 
-                let sampleTime = AVAudioFramePosition(Double(audioTime.sampleTime) / sampleRateRatio)
+                let sampleTime = AVAudioFramePosition(TimeInterval(audioTime.sampleTime) / sampleRateRatio)
                 audioTime = AVAudioTime(hostTime: audioTime.hostTime, sampleTime: sampleTime, atRate: sampleRate)
 
                 // AKLog("AKSettings sample rate (\(AKSettings.sampleRate) is mismatched from the player ", sampleRate)

--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer.swift
@@ -137,24 +137,23 @@ public class AKPlayer: AKAbstractPlayer {
         set { playerNode.pan = newValue }
     }
 
-    /// The total frame count that is being playing.
+    /// - Returns: The total frame count that is being playing.
     /// Differs from the audioFile.length as this will be updated with the edited amount
     /// of frames based on startTime and endTime
     public internal(set) var frameCount: AVAudioFrameCount = 0
 
-    /// The current frame while playing
+    /// - Returns: The current frame while playing. It will return 0 on error.
     public var currentFrame: AVAudioFramePosition {
-        // make sure there is a valid engine otherwise this will crash
-        guard playerNode.engine != nil else { return 0 }
-
-        if let nodeTime = playerNode.lastRenderTime,
-            let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
-            return playerTime.sampleTime
+        guard playerNode.engine != nil,
+            let nodeTime = playerNode.lastRenderTime,
+            let playerTime = playerNode.playerTime(forNodeTime: nodeTime) else {
+            AKLog("Error getting currentFrame, player may have been detached", type: .error)
+            return 0
         }
-        return 0
+        return playerTime.sampleTime
     }
 
-    /// Current time of the player in seconds while playing.
+    /// - Returns: Current time of the player in seconds while playing.
     public var currentTime: TimeInterval {
         let currentDuration = (endTime - startTime == 0) ? duration : (endTime - startTime)
         var normalizedPauseTime = 0.0
@@ -172,7 +171,7 @@ public class AKPlayer: AKAbstractPlayer {
         }
     }
 
-    /// Returns the audioFile's internal processingFormat
+    ///  - Returns: the audioFile's internal processingFormat
     public var processingFormat: AVAudioFormat? {
         return audioFile?.processingFormat
     }


### PR DESCRIPTION
currentFrame should first check for a valid engine. this changes the confusion of someone putting a AKTry in the completionHandler to solve the fix rather than the symptom