### PR TITLE
Workaround for AVAudioEngine bug.

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -95,6 +95,9 @@ public class AudioEngine {
             Log("🛑 Start Test Error: \(err)")
         }
 
+        // Work around AVAudioEngine bug.
+        output?.initLastRenderTime()
+
         return AVAudioPCMBuffer(
             pcmFormat: avEngine.manualRenderingFormat,
             frameCapacity: AVAudioFrameCount(samples))!

--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -86,6 +86,17 @@ open class Node {
             }
         }
     }
+
+    /// Work-around for an AVAudioEngine bug.
+    func initLastRenderTime() {
+
+        // We don't have a valid lastRenderTime until we query it.
+        _ = avAudioNode.lastRenderTime
+
+        for connection in connections {
+            connection.initLastRenderTime()
+        }
+    }
 }
 
 /// Protocol for responding to play and stop of MIDI notes

--- a/Tests/AudioKitTests/ParameterAutomationTests.swift
+++ b/Tests/AudioKitTests/ParameterAutomationTests.swift
@@ -132,4 +132,23 @@ class ParameterAutomationTests: XCTestCase {
         XCTAssertEqual(values, [800])
     }
 
+    func testDelayedAutomation() {
+        let engine = AudioEngine()
+        let osc = Oscillator()
+        engine.output = osc
+        osc.amplitude = 0.2
+        osc.start()
+        let audio = engine.startTest(totalDuration: 2.0)
+
+        audio.append(engine.render(duration: 1.0))
+        let events = [AutomationEvent(targetValue: 1320, startTime: 0, rampDuration: 0.1),
+                      AutomationEvent(targetValue: 660, startTime: 0.1, rampDuration: 0.1),
+                      AutomationEvent(targetValue: 1100, startTime: 0.2, rampDuration: 0.1),
+                      AutomationEvent(targetValue: 770, startTime: 0.3, rampDuration: 0.1),
+                      AutomationEvent(targetValue: 880, startTime: 0.4, rampDuration: 0.1)]
+        osc.$frequency.automate(events: events)
+        audio.append(engine.render(duration: 1.0))
+        testMD5(audio)
+    }
+
 }

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -226,6 +226,7 @@ let validatedMD5s: [String: String] = [
     "-[PannerTests testDefault]": "2af4524279fbdcc1b177b15bd7fe4f39",
     "-[PannerTests testPanLeft]": "d71d8e7da371dbf1d6b4b4024d7a3d64",
     "-[PannerTests testPanRight]": "b5e8480523d930f62aeff8c916d64b77",
+    "-[ParameterAutomationTests testDelayedAutomation]": "38b367f91ff734a7d58d081dd13bf8f7",
     "-[PeakLimiterTests testAttackTime]": "e844144c250a4d4f98b8acda3c9c4077",
     "-[PeakLimiterTests testDecayTime]": "7bd2e85d00138f9ba1a39b1c3e600176",
     "-[PeakLimiterTests testDefault]": "7bd2e85d00138f9ba1a39b1c3e600176",


### PR DESCRIPTION
Workaround for suspected AVAudioEngine bug. lastRenderTime needs to be queried before rendering to be valid.