### PR TITLE
Fix handling multiple MIDI events

### DIFF
--- a/AudioKit/Common/MIDI/AKMIDIInstrument.swift
+++ b/AudioKit/Common/MIDI/AKMIDIInstrument.swift
@@ -44,8 +44,9 @@ open class AKMIDIInstrument: AKPolyphonicNode, AKMIDIListener {
                          name: String = "AudioKit MIDI Instrument") {
         CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
             for e in packetList.pointee {
-                let event = AKMIDIEvent(packet: e)
-                self.handle(event: event)
+                e.forEach { (event) in
+                    self.handle(event: event)
+                }
             }
         })
     }

--- a/AudioKit/Common/MIDI/AKMIDISampler.swift
+++ b/AudioKit/Common/MIDI/AKMIDISampler.swift
@@ -43,11 +43,14 @@ open class AKMIDISampler: AKAppleSampler {
                          name: String = "MIDI Sampler") {
         CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
             for e in packetList.pointee {
-                let event = AKMIDIEvent(packet: e)
-                do {
-                    try self.handle(event: event)
-                } catch let exception {
-                    AKLog("Exception handling MIDI event: \(exception)", log: OSLog.midi, type: .error)
+                e.forEach { (event) in
+                    if event.length == 3 {
+                        do {
+                            try self.handle(event: event)
+                        } catch let exception {
+                            AKLog("Exception handling MIDI event: \(exception)", log: OSLog.midi, type: .error)
+                        }
+                    }
                 }
             }
         })


### PR DESCRIPTION
This pulls the fix from `v5-develop` for `AKMIDISampler` and adds a fix for `AKMIDIInstrument`. See #2271 and #2145.