### PR TITLE
fix app freeze on close pitchTap

### DIFF
--- a/Sources/AudioKit/Analysis/AmplitudeTap.swift
+++ b/Sources/AudioKit/Analysis/AmplitudeTap.swift
@@ -7,9 +7,7 @@ import AVFoundation
 /// start() will add the tap, and stop() will remove it.
 public class AmplitudeTap: BaseTap {
     private var amp: [Float] = Array(repeating: 0, count: 2)
-
-
-
+    
     /// Detected amplitude (average of left and right channels
     public var amplitude: Float {
         return amp.reduce(0, +) / 2

--- a/Sources/AudioKit/Analysis/AmplitudeTap.swift
+++ b/Sources/AudioKit/Analysis/AmplitudeTap.swift
@@ -5,49 +5,10 @@ import AVFoundation
 
 /// Tap to do amplitude analysis on any node.
 /// start() will add the tap, and stop() will remove it.
-public class AmplitudeTap: Toggleable {
+public class AmplitudeTap: BaseTap {
     private var amp: [Float] = Array(repeating: 0, count: 2)
 
-    /// Buffer size
-    public private(set) var bufferSize: UInt32
 
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    public private(set) var isStarted: Bool = false
-
-    /// The bus to install the tap onto
-    public var bus: Int = 0 {
-        didSet {
-            if isStarted {
-                stop()
-                start()
-            }
-        }
-    }
-
-    private var _input: Node?
-
-    /// Node to analyze
-    public var input: Node? {
-        get {
-            return _input
-        }
-        set {
-            guard newValue !== _input else { return }
-            let wasStarted = isStarted
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                stop()
-            }
-
-            _input = newValue
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                start()
-            }
-        }
-    }
 
     /// Detected amplitude (average of left and right channels
     public var amplitude: Float {
@@ -72,32 +33,8 @@ public class AmplitudeTap: Toggleable {
     /// - parameter bufferSize: Size of buffer to analyze
     /// - parameter handler: Code to call with new amplitudes
     public init(_ input: Node, bufferSize: UInt32 = 1_024, handler: @escaping (Float) -> Void = { _ in }) {
-        self.bufferSize = bufferSize
-        self.input = input
         self.handler = handler
-    }
-
-    /// Enable the tap on input
-    public func start() {
-        guard let input = input, !isStarted else { return }
-        isStarted = true
-
-        // a node can only have one tap at a time installed on it
-        // make sure any previous tap is removed.
-        // We're making the assumption that the previous tap (if any)
-        // was installed on the same bus as our bus var.
-        removeTap()
-
-        // just double check this here
-        guard input.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
-        }
-
-        input.avAudioUnitOrNode.installTap(onBus: bus,
-                                           bufferSize: bufferSize,
-                                           format: nil,
-                                           block: handleTapBlock(buffer:at:))
+        super.init(input, bufferSize: bufferSize)
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
@@ -107,45 +44,22 @@ public class AmplitudeTap: Toggleable {
         let channelCount = Int(buffer.format.channelCount)
         let length = UInt(buffer.frameLength)
 
-        // Call on the main thread so the client doesn't have to worry
-        // about thread safety.
-        DispatchQueue.main.sync {
-            // n is the channel
-            for n in 0 ..< channelCount {
-                let data = floatData[n]
+        // n is the channel
+        for n in 0 ..< channelCount {
+            let data = floatData[n]
 
-                var rms: Float = 0
-                vDSP_rmsqv(data, 1, &rms, UInt(length))
-                self.amp[n] = rms
-            }
-
-            self.handler(self.amplitude)
+            var rms: Float = 0
+            vDSP_rmsqv(data, 1, &rms, UInt(length))
+            self.amp[n] = rms
         }
+
+        self.handler(self.amplitude)
     }
 
     /// Remove the tap on the input
-    public func stop() {
-        removeTap()
-        isStarted = false
+    public override func stop() {
+        super.stop()
         amp[0] = 0
         amp[1] = 0
-    }
-
-    private func removeTap() {
-        guard input?.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
-        }
-
-        input?.avAudioUnitOrNode.removeTap(onBus: bus)
-    }
-
-    /// Remove the tap and nil out the input reference
-    /// this is important in regard to retain cycles on your input node
-    public func dispose() {
-        if isStarted {
-            stop()
-        }
-        input = nil
     }
 }

--- a/Sources/AudioKit/Analysis/AmplitudeTap.swift
+++ b/Sources/AudioKit/Analysis/AmplitudeTap.swift
@@ -36,7 +36,7 @@ public class AmplitudeTap: BaseTap {
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    internal override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard let floatData = buffer.floatChannelData else { return }
 
         let channelCount = Int(buffer.format.channelCount)

--- a/Sources/AudioKit/Analysis/BaseTap.swift
+++ b/Sources/AudioKit/Analysis/BaseTap.swift
@@ -9,15 +9,6 @@ import Foundation
 import AVFoundation
 
 open class BaseTap: Toggleable {
-    private var unfairLock = os_unfair_lock_s()
-    func lock() {
-        os_unfair_lock_lock(&unfairLock)
-    }
-
-    func unlock() {
-        os_unfair_lock_unlock(&unfairLock)
-    }
-    
     /// Size of buffer to analyze
     public private(set) var bufferSize: UInt32
 
@@ -62,7 +53,7 @@ open class BaseTap: Toggleable {
 
     /// - parameter bufferSize: Size of buffer to analyze
     /// - parameter handler: Callback to call 
-    public init(_ input: Node, bufferSize: UInt32 = 4_096) {
+    public init(_ input: Node, bufferSize: UInt32) {
         self.bufferSize = bufferSize
         self._input = input
     }
@@ -140,5 +131,14 @@ open class BaseTap: Toggleable {
         if isStarted {
             stop()
         }
+    }
+    
+    private var unfairLock = os_unfair_lock_s()
+    func lock() {
+        os_unfair_lock_lock(&unfairLock)
+    }
+
+    func unlock() {
+        os_unfair_lock_unlock(&unfairLock)
     }
 }

--- a/Sources/AudioKit/Analysis/BaseTap.swift
+++ b/Sources/AudioKit/Analysis/BaseTap.swift
@@ -103,7 +103,6 @@ open class BaseTap: Toggleable {
     }
     
     // overide this method to handle Tap in derived class
-
     func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         
     }

--- a/Sources/AudioKit/Analysis/BaseTap.swift
+++ b/Sources/AudioKit/Analysis/BaseTap.swift
@@ -1,0 +1,144 @@
+//
+//  BaseTap.swift
+//  
+//
+//  Created by Gil Hadas on 19/10/2020.
+//
+
+import Foundation
+import AVFoundation
+
+open class BaseTap: Toggleable {
+    private var unfairLock = os_unfair_lock_s()
+    func lock() {
+        os_unfair_lock_lock(&unfairLock)
+    }
+
+    func unlock() {
+        os_unfair_lock_unlock(&unfairLock)
+    }
+    
+    /// Size of buffer to analyze
+    public private(set) var bufferSize: UInt32
+
+    /// Tells whether the node is processing (ie. started, playing, or active)
+    public private(set) var isStarted: Bool = false
+
+    /// The bus to install the tap onto
+    public var bus: Int = 0 {
+        didSet {
+            if isStarted {
+                stop()
+                start()
+            }
+        }
+    }
+
+    private var _input: Node
+
+    /// Input node to analyze
+    public var input: Node {
+        get {
+            return _input
+        }
+        set {
+            guard newValue !== _input else { return }
+            let wasStarted = isStarted
+
+            // if the input changes while it's on, stop and start the tap
+            if wasStarted {
+                stop()
+            }
+
+            _input = newValue
+
+            // if the input changes while it's on, stop and start the tap
+            if wasStarted {
+                start()
+            }
+        }
+    }
+
+
+    /// - parameter bufferSize: Size of buffer to analyze
+    /// - parameter handler: Callback to call 
+    public init(_ input: Node, bufferSize: UInt32 = 4_096) {
+        self.bufferSize = bufferSize
+        self._input = input
+    }
+
+    /// Enable the tap on input
+    public func start() {
+        lock()
+        defer {
+            unlock()
+        }
+        guard !isStarted else { return }
+        isStarted = true
+
+        // a node can only have one tap at a time installed on it
+        // make sure any previous tap is removed.
+        // We're making the assumption that the previous tap (if any)
+        // was installed on the same bus as our bus var.
+        removeTap()
+
+        // just double check this here
+        guard input.avAudioUnitOrNode.engine != nil else {
+            Log("The tapped node isn't attached to the engine")
+           return
+        }
+
+        input.avAudioUnitOrNode.installTap(onBus: bus,
+                                           bufferSize: bufferSize,
+                                           format: nil,
+                                           block: handleTapBlock(buffer:at:))
+    }
+
+    
+    // AVAudioNodeTapBlock - time is unused in this case
+    private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+        // Call on the main thread so the client doesn't have to worry
+        // about thread safety.
+        DispatchQueue.main.async {
+            // Create trackers as needed.
+            self.lock()
+            guard self.isStarted == true else {
+                self.unlock()
+                return
+            }
+            self.doHandleTapBlock(buffer:buffer, at:time)
+            self.unlock()
+        }
+    }
+    
+    // overide this method to handle Tap in derived class
+
+    func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+        
+    }
+
+    /// Remove the tap on the input
+    public func stop() {
+        lock()
+        removeTap()
+        isStarted = false
+        unlock()
+    }
+
+    private func removeTap() {
+        guard input.avAudioUnitOrNode.engine != nil else {
+            Log("The tapped node isn't attached to the engine")
+            return
+        }
+
+        input.avAudioUnitOrNode.removeTap(onBus: bus)
+    }
+
+    /// remove the tap and nil out the input reference
+    /// this is important in regard to retain cycles on your input node
+    public func dispose() {
+        if isStarted {
+            stop()
+        }
+    }
+}

--- a/Sources/AudioKit/Analysis/BaseTap.swift
+++ b/Sources/AudioKit/Analysis/BaseTap.swift
@@ -49,8 +49,7 @@ open class BaseTap: Toggleable {
             }
         }
     }
-
-
+    
     /// - parameter bufferSize: Size of buffer to analyze
     /// - parameter handler: Callback to call 
     public init(_ input: Node, bufferSize: UInt32) {
@@ -84,7 +83,6 @@ open class BaseTap: Toggleable {
                                            format: nil,
                                            block: handleTapBlock(buffer:at:))
     }
-
     
     // AVAudioNodeTapBlock - time is unused in this case
     private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
@@ -97,7 +95,7 @@ open class BaseTap: Toggleable {
                 self.unlock()
                 return
             }
-            self.doHandleTapBlock(buffer:buffer, at:time)
+            self.doHandleTapBlock(buffer:buffer, at: time)
             self.unlock()
         }
     }
@@ -120,7 +118,6 @@ open class BaseTap: Toggleable {
             Log("The tapped node isn't attached to the engine")
             return
         }
-
         input.avAudioUnitOrNode.removeTap(onBus: bus)
     }
 

--- a/Sources/AudioKit/Analysis/FFTTap.swift
+++ b/Sources/AudioKit/Analysis/FFTTap.swift
@@ -26,7 +26,7 @@ open class FFTTap: BaseTap {
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    internal override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard buffer.floatChannelData != nil else { return }
 
         fftData = FFTTap.performFFT(buffer: buffer)

--- a/Sources/AudioKit/Analysis/FFTTap.swift
+++ b/Sources/AudioKit/Analysis/FFTTap.swift
@@ -5,52 +5,10 @@ import AVFoundation
 import CAudioKit
 
 /// FFT Calculation for any node
-open class FFTTap: Toggleable {
-
-    /// Size of buffer to analyze
-    public private(set) var bufferSize: UInt32
+open class FFTTap: BaseTap {
 
     /// Array of FFT data
     open var fftData: [Float]
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    public private(set) var isStarted: Bool = false
-
-    /// The bus to install the tap onto
-    public var bus: Int = 0 {
-        didSet {
-            if isStarted {
-                stop()
-                start()
-            }
-        }
-    }
-
-    private var _input: Node
-
-    /// Input node to analyze
-    public var input: Node {
-        get {
-            return _input
-        }
-        set {
-            guard newValue !== _input else { return }
-            let wasStarted = isStarted
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                stop()
-            }
-
-            _input = newValue
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                start()
-            }
-        }
-    }
-
     /// Type of callback
     public typealias Handler = ([Float]) -> Void
 
@@ -62,45 +20,17 @@ open class FFTTap: Toggleable {
     /// - parameter bufferSize: Size of buffer to analyze
     /// - parameter handler: Callback to call when FFT is calculated
     public init(_ input: Node, bufferSize: UInt32 = 4_096, handler: @escaping Handler) {
-        self.bufferSize = bufferSize
-        self._input = input
         self.handler = handler
         self.fftData = Array(repeating: 0.0, count: Int(bufferSize))
-    }
-
-    /// Enable the tap on input
-    public func start() {
-        guard !isStarted else { return }
-        isStarted = true
-
-        // a node can only have one tap at a time installed on it
-        // make sure any previous tap is removed.
-        // We're making the assumption that the previous tap (if any)
-        // was installed on the same bus as our bus var.
-        removeTap()
-
-        // just double check this here
-        guard input.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
-        }
-
-        input.avAudioUnitOrNode.installTap(onBus: bus,
-                                           bufferSize: bufferSize,
-                                           format: nil,
-                                           block: handleTapBlock(buffer:at:))
+        super.init(input, bufferSize: bufferSize)
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard buffer.floatChannelData != nil else { return }
 
-        // Call on the main thread so the client doesn't have to worry
-        // about thread safety.
-        DispatchQueue.main.sync {
-            fftData = FFTTap.performFFT(buffer: buffer)
-            handler(fftData)
-        }
+        fftData = FFTTap.performFFT(buffer: buffer)
+        handler(fftData)
     }
 
     static func performFFT(buffer: AVAudioPCMBuffer) -> [Float] {
@@ -158,26 +88,9 @@ open class FFTTap: Toggleable {
     }
 
     /// Remove the tap on the input
-    public func stop() {
-        removeTap()
-        isStarted = false
+    override public func stop() {
+        super.stop()
         for i in 0 ..< fftData.count { fftData[i] = 0.0 }
     }
-
-    private func removeTap() {
-        guard input.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
-        }
-
-        input.avAudioUnitOrNode.removeTap(onBus: bus)
-    }
-
-    /// remove the tap and nil out the input reference
-    /// this is important in regard to retain cycles on your input node
-    public func dispose() {
-        if isStarted {
-            stop()
-        }
-    }
 }
+

--- a/Sources/AudioKit/Analysis/PitchTap.swift
+++ b/Sources/AudioKit/Analysis/PitchTap.swift
@@ -39,7 +39,6 @@ public class PitchTap: BaseTap {
         super.init(input, bufferSize: bufferSize)
     }
 
-
     deinit {
         for tracker in trackers {
             akPitchTrackerDestroy(tracker)

--- a/Sources/AudioKit/Analysis/PitchTap.swift
+++ b/Sources/AudioKit/Analysis/PitchTap.swift
@@ -5,51 +5,10 @@ import CAudioKit
 
 /// Tap to do pitch tracking on any node.
 /// start() will add the tap, and stop() will remove it.
-public class PitchTap: Toggleable {
+public class PitchTap: BaseTap {
     private var pitch: [Float] = [0, 0]
     private var amp: [Float] = [0, 0]
     private var trackers: [PitchTrackerRef] = []
-
-    /// Size of buffer to analyze
-    public private(set) var bufferSize: UInt32
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    public private(set) var isStarted: Bool = false
-
-    /// The bus to install the tap onto
-    public var bus: Int = 0 {
-        didSet {
-            if isStarted {
-                stop()
-                start()
-            }
-        }
-    }
-
-    private var _input: Node
-
-    /// Input node to analyze
-    public var input: Node {
-        get {
-            return _input
-        }
-        set {
-            guard newValue !== _input else { return }
-            let wasStarted = isStarted
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                stop()
-            }
-
-            _input = newValue
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                start()
-            }
-        }
-    }
 
     /// Detected amplitude (average of left and right channels)
     public var amplitude: Float {
@@ -65,111 +24,60 @@ public class PitchTap: Toggleable {
     public var rightPitch: Float {
         return pitch[1]
     }
-
     /// Callback type
     public typealias Handler = ([Float], [Float]) -> Void
 
     private var handler: Handler = { _, _ in }
 
     /// Initialize the pitch tap
-    /// 
+    ///
     /// - parameter input: Node to analyze
     /// - parameter bufferSize: Size of buffer to analyze
     /// - parameter handler: Callback to call on each analysis pass
     public init(_ input: Node, bufferSize: UInt32 = 4_096, handler: @escaping Handler) {
-        self.bufferSize = bufferSize
-        self._input = input
         self.handler = handler
+        super.init(input, bufferSize: bufferSize)
     }
+
 
     deinit {
         for tracker in trackers {
             akPitchTrackerDestroy(tracker)
         }
     }
-
-    /// Enable the tap on input
-    public func start() {
-        guard !isStarted else { return }
-        isStarted = true
-
-        // a node can only have one tap at a time installed on it
-        // make sure any previous tap is removed.
-        // We're making the assumption that the previous tap (if any)
-        // was installed on the same bus as our bus var.
-        removeTap()
-
-        // just double check this here
-        guard input.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
-        }
-
-        input.avAudioUnitOrNode.installTap(onBus: bus,
-                                           bufferSize: bufferSize,
-                                           format: nil,
-                                           block: handleTapBlock(buffer:at:))
-    }
-
-    // AVAudioNodeTapBlock - time is unused in this case
-    private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
-        guard let floatData = buffer.floatChannelData else { return }
-
-        let channelCount = Int(buffer.format.channelCount)
-        let length = UInt(buffer.frameLength)
-
-        // Call on the main thread so the client doesn't have to worry
-        // about thread safety.
-        DispatchQueue.main.sync {
-            // Create trackers as needed.
-            while self.trackers.count < channelCount {
-                self.trackers.append(akPitchTrackerCreate(UInt32(Settings.audioFormat.sampleRate), 4_096, 20))
-            }
-
-            while self.amp.count < channelCount {
-                self.amp.append(0)
-                self.pitch.append(0)
-            }
-
-            // n is the channel
-            for n in 0 ..< channelCount {
-                let data = floatData[n]
-
-                akPitchTrackerAnalyze(trackers[n], data, UInt32(length))
-
-                var a: Float = 0
-                var f: Float = 0
-                akPitchTrackerGetResults(trackers[n], &a, &f)
-                self.amp[n] = a
-                self.pitch[n] = f
-            }
-            self.handler(pitch, amp)
-        }
-    }
-
-    /// Remove the tap on the input
-    public func stop() {
-        removeTap()
-        isStarted = false
+    override public func stop() {
+        super.stop()
         for i in 0 ..< pitch.count {
             pitch[i] = 0.0
         }
     }
 
-    private func removeTap() {
-        guard input.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
+    // AVAudioNodeTapBlock - time is unused in this case
+    override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+        guard let floatData = buffer.floatChannelData else { return }
+        let channelCount = Int(buffer.format.channelCount)
+        let length = UInt(buffer.frameLength)
+        while self.trackers.count < channelCount {
+            self.trackers.append(akPitchTrackerCreate(UInt32(Settings.audioFormat.sampleRate), 4_096, 20))
         }
 
-        input.avAudioUnitOrNode.removeTap(onBus: bus)
-    }
-
-    /// remove the tap and nil out the input reference
-    /// this is important in regard to retain cycles on your input node
-    public func dispose() {
-        if isStarted {
-            stop()
+        while self.amp.count < channelCount {
+            self.amp.append(0)
+            self.pitch.append(0)
         }
+
+        // n is the channel
+        for n in 0 ..< channelCount {
+            let data = floatData[n]
+
+            akPitchTrackerAnalyze(self.trackers[n], data, UInt32(length))
+
+            var a: Float = 0
+            var f: Float = 0
+            akPitchTrackerGetResults(self.trackers[n], &a, &f)
+            self.amp[n] = a
+            self.pitch[n] = f
+        }
+        self.handler(self.pitch, self.amp)
     }
 }

--- a/Sources/AudioKit/Analysis/PitchTap.swift
+++ b/Sources/AudioKit/Analysis/PitchTap.swift
@@ -52,7 +52,7 @@ public class PitchTap: BaseTap {
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    internal override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard let floatData = buffer.floatChannelData else { return }
         let channelCount = Int(buffer.format.channelCount)
         let length = UInt(buffer.frameLength)

--- a/Sources/AudioKit/Analysis/RawDataTap.swift
+++ b/Sources/AudioKit/Analysis/RawDataTap.swift
@@ -5,52 +5,9 @@ import Accelerate
 import CAudioKit
 
 /// Get the raw data for any node
-open class RawDataTap: Toggleable {
-
-    /// Size of buffer to
-    public private(set) var bufferSize: UInt32
-
+open class RawDataTap: BaseTap {
     /// Array of Raw data
     open var data: [Float]
-
-    /// Tells whether the node is processing (ie. started, playing, or active)
-    public private(set) var isStarted: Bool = false
-
-    /// The bus to install the tap onto
-    public var bus: Int = 0 {
-        didSet {
-            if isStarted {
-                stop()
-                start()
-            }
-        }
-    }
-
-    private var _input: Node
-
-    /// Input node to analyze
-    public var input: Node {
-        get {
-            return _input
-        }
-        set {
-            guard newValue !== _input else { return }
-            let wasStarted = isStarted
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                stop()
-            }
-
-            _input = newValue
-
-            // if the input changes while it's on, stop and start the tap
-            if wasStarted {
-                start()
-            }
-        }
-    }
-
     /// Callback type
     public typealias Handler = ([Float]) -> Void
 
@@ -62,70 +19,23 @@ open class RawDataTap: Toggleable {
     /// - parameter bufferSize: Size of buffer to analyze
     /// - parameter handler: Callback to call when results are available
     public init(_ input: Node, bufferSize: UInt32 = 4_096, handler: @escaping Handler) {
-        self.bufferSize = bufferSize
-        self._input = input
-        self.handler = handler
         self.data = Array(repeating: 0.0, count: Int(bufferSize))
+        super.init(input, bufferSize: bufferSize)
     }
-
-    /// Enable the tap on input
-    public func start() {
-        guard !isStarted else { return }
-        isStarted = true
-
-        // a node can only have one tap at a time installed on it
-        // make sure any previous tap is removed.
-        // We're making the assumption that the previous tap (if any)
-        // was installed on the same bus as our bus var.
-        removeTap()
-
-        // just double check this here
-        guard input.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
-        }
-
-        input.avAudioUnitOrNode.installTap(onBus: bus,
-                                           bufferSize: bufferSize,
-                                           format: nil,
-                                           block: handleTapBlock(buffer:at:))
-    }
-
     // AVAudioNodeTapBlock - time is unused in this case
-    private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
 
         guard buffer.floatChannelData != nil else { return }
 
-        // Call on the main thread so the client doesn't have to worry
-        // about thread safety.
-        DispatchQueue.main.sync {
-            let arraySize = Int(buffer.frameLength)
-            data = Array(UnsafeBufferPointer(start: buffer.floatChannelData![0], count:arraySize))
-            handler(data)
-        }
+        let arraySize = Int(buffer.frameLength)
+        data = Array(UnsafeBufferPointer(start: buffer.floatChannelData![0], count:arraySize))
+        handler(data)
     }
 
     /// Remove the tap on the input
-    public func stop() {
-        removeTap()
-        isStarted = false
+    override public func stop() {
+        super.stop()
         for i in 0 ..< data.count { data[i] = 0.0 }
     }
 
-    private func removeTap() {
-        guard input.avAudioUnitOrNode.engine != nil else {
-            Log("The tapped node isn't attached to the engine")
-            return
-        }
-
-        input.avAudioUnitOrNode.removeTap(onBus: bus)
-    }
-
-    /// remove the tap and nil out the input reference
-    /// this is important in regard to retain cycles on your input node
-    public func dispose() {
-        if isStarted {
-            stop()
-        }
-    }
 }

--- a/Sources/AudioKit/Analysis/RawDataTap.swift
+++ b/Sources/AudioKit/Analysis/RawDataTap.swift
@@ -23,7 +23,7 @@ open class RawDataTap: BaseTap {
         super.init(input, bufferSize: bufferSize)
     }
     // AVAudioNodeTapBlock - time is unused in this case
-    override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    internal override func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
 
         guard buffer.floatChannelData != nil else { return }
 


### PR DESCRIPTION
Add  BaseTap Class as base class that handle common code for tap classes.
Replace handleTapBlock  using sync with async - this solved the mutex deadlock that cause app to freeze on removeTap
Adding locking for thread safe  call to the handle block.
Please verify that the  async replacement does not break the original behaviour.
