### PR TITLE
V5 engine output samplerate

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/audition.swift
+++ b/Sources/AudioKit/Internals/Utilities/audition.swift
@@ -11,6 +11,6 @@ public func audition(_ buffer: AVAudioPCMBuffer) {
     try! auditionEngine.start()
     auditionPlayer.scheduleBuffer(buffer, at: nil)
     auditionPlayer.play()
-    sleep(buffer.frameCapacity / 44100)
+    sleep(buffer.frameCapacity / UInt32(buffer.format.sampleRate))
     auditionEngine.stop()
 }

--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -89,4 +89,15 @@ public class Mixer: Node, Toggleable {
         connections.removeAll(where: { $0 === node })
         avAudioNode.disconnect(input: node.avAudioNode)
     }
+
+    /// Remove all inputs from the mixer
+    public func removeAllInputs() {
+        guard connections.isNotEmpty else { return }
+
+        let nodes = connections.map { $0.avAudioNode }
+        for input in nodes {
+            avAudioNode.disconnect(input: input)
+        }
+        connections.removeAll()
+    }
 }


### PR DESCRIPTION
this is mostly about the AudioEngine.avEngine.mainMixerNode that was previously being used for AudioEngine.output. This mixer isn't adopting Settings.audioFormat. I'm unclear other than manually managing this final mixer instance ourselves how you would control the format of that mainMixerNode, but perhaps there is a much simpler solution that I missed.
