### PR TITLE
Default parameter for MIDISampler init

### DIFF
--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -23,7 +23,7 @@ open class MIDISampler: AppleSampler {
     ///
     /// - Parameter midiOutputName: Name of the instrument's MIDI output
     ///
-    public init(name midiOutputName: String) {
+    public init(name midiOutputName: String = "MIDI Sampler") {
         super.init()
         enableMIDI(name: midiOutputName)
         hideVirtualMIDIPort()


### PR DESCRIPTION
Added default parameter value to MIDISampler initializer to enable instance creation without a name being provided explicitly. The enableMIDI method already works like this, but this extends the same intent to the initializer itself.
