### PR TITLE
Add a name to mixer to assist in debugging

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/Node+connectionTreeDescription.swift
+++ b/Sources/AudioKit/Internals/Utilities/Node+connectionTreeDescription.swift
@@ -13,8 +13,8 @@ extension Node {
     private func createConnectionTreeDescription(paddedWith indentation: String = "") -> String {
         var nodeDescription = String(describing: self).components(separatedBy: ".").last ?? "Unknown"
 
-        if let namedSelf = self as? NamedNode {
-            nodeDescription += "(\"\(namedSelf.name)\")"
+        if let namedSelf = self as? NamedNode, let name = namedSelf.name {
+            nodeDescription += "(\"\(name)\")"
         }
 
         var connectionTreeDescription = "\(Node.connectionTreeLinePrefix)\(indentation)↳\(nodeDescription)\n"

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -15,7 +15,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
-    open var name = "AudioKit MIDI Instrument"
+    open var name: String? = "AudioKit MIDI Instrument"
 
     /// Active MPE notes
     open var mpeActiveNotes: [(note: MIDINoteNumber, channel: MIDIChannel)] = []
@@ -38,8 +38,8 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - name: Name to connect with
     ///
     open func enableMIDI(_ midiClient: MIDIClientRef = MIDI.sharedInstance.client,
-                         name: String = "AudioKit MIDI Instrument") {
-        CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
+                         name: String? = "AudioKit MIDI Instrument") {
+        CheckError(MIDIDestinationCreateWithBlock(midiClient, name! as CFString, &midiIn) { packetList, _ in
             for e in packetList.pointee {
                 e.forEach { (event) in
                     self.handle(event: event)

--- a/Sources/AudioKit/MIDI/MIDINode.swift
+++ b/Sources/AudioKit/MIDI/MIDINode.swift
@@ -14,7 +14,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
     open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
-    open var name = "MIDINode"
+    open var name: String? = "MIDINode"
 
     private var internalNode: PolyphonicNode
 
@@ -41,8 +41,8 @@ open class MIDINode: Node, MIDIListener, NamedNode {
     ///   - name: Name to connect with
     ///
     public func enableMIDI(_ midiClient: MIDIClientRef = MIDI.sharedInstance.client,
-                           name: String = "MIDINode") {
-        CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
+                           name: String? = "MIDINode") {
+        CheckError(MIDIDestinationCreateWithBlock(midiClient, name! as CFString, &midiIn) { packetList, _ in
             for e in packetList.pointee {
                 let event = MIDIEvent(packet: e)
                 guard event.data.count > 2 else {

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -17,7 +17,7 @@ open class MIDISampler: AppleSampler, NamedNode {
     open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
-    open var name = "MIDI Sampler"
+    open var name: String? = "MIDI Sampler"
 
     /// Initialize the MIDI Sampler
     ///
@@ -38,8 +38,8 @@ open class MIDISampler: AppleSampler, NamedNode {
     ///   - name: Name to connect with
     ///
     public func enableMIDI(_ midiClient: MIDIClientRef = MIDI.sharedInstance.client,
-                           name: String = "MIDI Sampler") {
-        CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
+                           name: String? = "MIDI Sampler") {
+        CheckError(MIDIDestinationCreateWithBlock(midiClient, name! as CFString, &midiIn) { packetList, _ in
             for e in packetList.pointee {
                 e.forEach { (event) in
                     if event.length == 3 {

--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -4,9 +4,13 @@ import AVFoundation
 import CAudioKit
 
 /// AudioKit version of Apple's Mixer Node. Mixes a varaiadic list of Nodes.
-public class Mixer: Node, Toggleable {
+public class Mixer: Node, Toggleable, NamedNode {
+
     /// The internal mixer node
     fileprivate var mixerAU = AVAudioMixerNode()
+
+    /// Name of the mixer
+    open var name: String?
 
     /// Output Volume (Default 1)
     public var volume: AUValue = 1.0 {
@@ -33,17 +37,18 @@ public class Mixer: Node, Toggleable {
     }
 
     /// Initialize the mixer node with no inputs, to be connected later
-    public init(volume: AUValue = 1.0) {
+    public init(volume: AUValue = 1.0, name: String? = nil) {
         super.init(avAudioNode: mixerAU)
         self.volume = volume
+        self.name = name ?? self.name
     }
 
     /// Initialize the mixer node with multiple inputs
     ///
     /// - parameter inputs: A variadic list of Nodes
     ///
-    public convenience init(_ inputs: Node...) {
-        self.init(inputs.compactMap { $0 })
+    public convenience init(_ inputs: Node..., name: String? = nil) {
+        self.init(inputs.compactMap { $0 }, name: name)
     }
 
     // swiftlint:enable force_unwrapping
@@ -52,8 +57,8 @@ public class Mixer: Node, Toggleable {
     ///
     /// - parameter inputs: An array of Nodes
     ///
-    public convenience init(_ inputs: [Node]) {
-        self.init()
+    public convenience init(_ inputs: [Node], name: String? = nil) {
+        self.init(name: name)
         connections = inputs
     }
 

--- a/Sources/AudioKit/Nodes/NamedNode.swift
+++ b/Sources/AudioKit/Nodes/NamedNode.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 public protocol NamedNode where Self: Node {
-    var name: String { get set }
+    var name: String? { get set }
 }

--- a/Tests/AudioKitTests/Node Tests/EngineTests.swift
+++ b/Tests/AudioKitTests/Node Tests/EngineTests.swift
@@ -162,4 +162,15 @@ class EngineTests: XCTestCase {
         """)
     }
 
+    func testConnectionTreeDescriptionForMixerWithName() {
+        let engine = AudioEngine()
+        let mixer = Mixer(name: "Some Mixer")
+        engine.output = mixer
+        XCTAssertEqual(engine.connectionTreeDescription,
+        """
+        \(Node.connectionTreeLinePrefix)↳Mixer
+        \(Node.connectionTreeLinePrefix) ↳Mixer("Some Mixer")
+        """)
+    }
+
 }


### PR DESCRIPTION
Hello,

This is one of my few PRs in the real world, so be gentle.

My intent was to start using the `NamedNode` protocol introduced recently by @btfranklin , and expand it to more nodes, starting with the `Mixer` node.

A project often has a bunch of `Mixer` nodes in the tree, and using the `connectionTreeDescription` is less useful if they're all just called `Mixer` in the resulting tree string. If their name was also printed (and the programmer took the time to name each mixer node), this would allow a user to understand what their tree looked like more easily.

Additionally, please note that I tried to make the `name` optional - if you don't want to set it, you shouldn't need to, and the default behavior will remain.

My swift knowledge isn't the deepest I have, so for the `name! as CFString` bits I followed xcode's suggestions, and I'm not sure if that's the best move.

In any case, please let me know if this is an avenue I could/should continue pursuing, adding to other nodes along the way.

Thanks!