### PR TITLE
Mixer name redux

### DIFF
--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -4,9 +4,12 @@ import AVFoundation
 import CAudioKit
 
 /// AudioKit version of Apple's Mixer Node. Mixes a varaiadic list of Nodes.
-public class Mixer: Node, Toggleable {
+public class Mixer: Node, Toggleable, NamedNode {
     /// The internal mixer node
     fileprivate var mixerAU = AVAudioMixerNode()
+
+    /// Name of the node
+    open var name = "Mixer"
 
     /// Output Volume (Default 1)
     public var volume: AUValue = 1.0 {
@@ -33,17 +36,18 @@ public class Mixer: Node, Toggleable {
     }
 
     /// Initialize the mixer node with no inputs, to be connected later
-    public init(volume: AUValue = 1.0) {
+    public init(volume: AUValue = 1.0, name: String = "Mixer") {
         super.init(avAudioNode: mixerAU)
         self.volume = volume
+        self.name = name
     }
 
     /// Initialize the mixer node with multiple inputs
     ///
     /// - parameter inputs: A variadic list of Nodes
     ///
-    public convenience init(_ inputs: Node...) {
-        self.init(inputs.compactMap { $0 })
+    public convenience init(_ inputs: Node..., name: String = "Mixer") {
+        self.init(inputs.compactMap { $0 }, name: name)
     }
 
     // swiftlint:enable force_unwrapping
@@ -52,8 +56,8 @@ public class Mixer: Node, Toggleable {
     ///
     /// - parameter inputs: An array of Nodes
     ///
-    public convenience init(_ inputs: [Node]) {
-        self.init()
+    public convenience init(_ inputs: [Node], name: String = "Mixer") {
+        self.init(name: name)
         connections = inputs
     }
 

--- a/Tests/AudioKitTests/Node Tests/EngineTests.swift
+++ b/Tests/AudioKitTests/Node Tests/EngineTests.swift
@@ -157,9 +157,20 @@ class EngineTests: XCTestCase {
         engine.output = oscillator
         XCTAssertEqual(engine.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer
+        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
         \(Node.connectionTreeLinePrefix) ↳Oscillator
         """)
     }
-
+    
+    func testConnectionTreeDescriptionForMixerWithName() {
+        let engine = AudioEngine()
+        let mixerName = "MixerNameFoo"
+        let mixerWithName = Mixer(name: mixerName)
+        engine.output = mixerWithName
+        XCTAssertEqual(engine.connectionTreeDescription,
+        """
+        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
+        \(Node.connectionTreeLinePrefix) ↳Mixer("\(mixerName)")
+        """)
+    }
 }

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -378,7 +378,7 @@ class NodeTests: XCTestCase {
 
         XCTAssertEqual(mixer.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer
+        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
         \(Node.connectionTreeLinePrefix) ↳Oscillator
         \(Node.connectionTreeLinePrefix) ↳CostelloReverb
         \(Node.connectionTreeLinePrefix)  ↳Oscillator
@@ -393,7 +393,7 @@ class NodeTests: XCTestCase {
 
         XCTAssertEqual(mixer.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer
+        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
         \(Node.connectionTreeLinePrefix) ↳Compressor
         \(Node.connectionTreeLinePrefix)  ↳MIDISampler(\"\(nameString)\")
         """)


### PR DESCRIPTION
My intent was to start using the NamedNode protocol introduced recently by @btfranklin , and expand it to more nodes, starting with the Mixer node.

A project often has a bunch of Mixer nodes in the tree, and using the connectionTreeDescription is less useful if they're all just called Mixer in the resulting tree string. If their name was also printed (and the programmer took the time to name each mixer node), this would allow a user to understand what their tree looked like more easily.

Updated note from the last one: @btfranklin is this more along the lines of what you would be looking for? Feels a little awkward to repeat the default a couple times, but whatever, like you said, it's just a debugging tool. And if you have updates that make all this easier, then even better.