### PR TITLE
Implemented new default naming approach for NamedNodes

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/MemoryAddress.swift
+++ b/Sources/AudioKit/Internals/Utilities/MemoryAddress.swift
@@ -1,0 +1,17 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import Foundation
+
+struct MemoryAddress: CustomStringConvertible {
+
+    let opaquePointerAddress: Int
+
+    var description: String {
+        let size = 2 + 2 * MemoryLayout<UnsafeRawPointer>.size
+        return String(format: "%0\(size)p", opaquePointerAddress)
+    }
+
+    init(of classInstance: AnyObject) {
+        opaquePointerAddress = Int(bitPattern: Unmanaged.passUnretained(classInstance).toOpaque())
+    }
+}

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -15,7 +15,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
-    open var name = "AudioKit MIDI Instrument"
+    open var name = "(unset)"
 
     /// Active MPE notes
     open var mpeActiveNotes: [(note: MIDINoteNumber, channel: MIDIChannel)] = []
@@ -26,7 +26,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///
     public init(midiInputName: String? = nil) {
         super.init(avAudioNode: AVAudioNode())
-        name = midiInputName ?? name
+        name = midiInputName ?? MemoryAddress(of: self).description
         enableMIDI(name: name)
         hideVirtualMIDIPort()
     }
@@ -38,8 +38,9 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - name: Name to connect with
     ///
     open func enableMIDI(_ midiClient: MIDIClientRef = MIDI.sharedInstance.client,
-                         name: String = "AudioKit MIDI Instrument") {
-        CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
+                         name: String? = nil) {
+        let cfName = (name ?? self.name) as CFString
+        CheckError(MIDIDestinationCreateWithBlock(midiClient, cfName, &midiIn) { packetList, _ in
             for e in packetList.pointee {
                 e.forEach { (event) in
                     self.handle(event: event)

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -17,7 +17,7 @@ open class MIDISampler: AppleSampler, NamedNode {
     open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
-    open var name = "MIDI Sampler"
+    open var name = "(unset)"
 
     /// Initialize the MIDI Sampler
     ///
@@ -25,7 +25,7 @@ open class MIDISampler: AppleSampler, NamedNode {
     ///
     public init(name midiOutputName: String? = nil) {
         super.init()
-        name = midiOutputName ?? name
+        name = midiOutputName ?? MemoryAddress(of: self).description
         enableMIDI(name: name)
         hideVirtualMIDIPort()
     }
@@ -38,8 +38,9 @@ open class MIDISampler: AppleSampler, NamedNode {
     ///   - name: Name to connect with
     ///
     public func enableMIDI(_ midiClient: MIDIClientRef = MIDI.sharedInstance.client,
-                           name: String = "MIDI Sampler") {
-        CheckError(MIDIDestinationCreateWithBlock(midiClient, name as CFString, &midiIn) { packetList, _ in
+                           name: String? = nil) {
+        let cfName = (name ?? self.name) as CFString
+        CheckError(MIDIDestinationCreateWithBlock(midiClient, cfName, &midiIn) { packetList, _ in
             for e in packetList.pointee {
                 e.forEach { (event) in
                     if event.length == 3 {

--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -9,7 +9,7 @@ public class Mixer: Node, Toggleable, NamedNode {
     fileprivate var mixerAU = AVAudioMixerNode()
 
     /// Name of the node
-    open var name = "Mixer"
+    open var name = "(unset)"
 
     /// Output Volume (Default 1)
     public var volume: AUValue = 1.0 {
@@ -36,17 +36,17 @@ public class Mixer: Node, Toggleable, NamedNode {
     }
 
     /// Initialize the mixer node with no inputs, to be connected later
-    public init(volume: AUValue = 1.0, name: String = "Mixer") {
+    public init(volume: AUValue = 1.0, name: String? = nil) {
         super.init(avAudioNode: mixerAU)
         self.volume = volume
-        self.name = name
+        self.name = name ?? MemoryAddress(of: self).description
     }
 
     /// Initialize the mixer node with multiple inputs
     ///
     /// - parameter inputs: A variadic list of Nodes
     ///
-    public convenience init(_ inputs: Node..., name: String = "Mixer") {
+    public convenience init(_ inputs: Node..., name: String? = nil) {
         self.init(inputs.compactMap { $0 }, name: name)
     }
 
@@ -56,7 +56,7 @@ public class Mixer: Node, Toggleable, NamedNode {
     ///
     /// - parameter inputs: An array of Nodes
     ///
-    public convenience init(_ inputs: [Node], name: String = "Mixer") {
+    public convenience init(_ inputs: [Node], name: String? = nil) {
         self.init(name: name)
         connections = inputs
     }

--- a/Tests/AudioKitTests/Node Tests/EngineTests.swift
+++ b/Tests/AudioKitTests/Node Tests/EngineTests.swift
@@ -157,11 +157,11 @@ class EngineTests: XCTestCase {
         engine.output = oscillator
         XCTAssertEqual(engine.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
+        \(Node.connectionTreeLinePrefix)↳Mixer("\(MemoryAddress(of: engine.mainMixerNode!).description)")
         \(Node.connectionTreeLinePrefix) ↳Oscillator
         """)
     }
-    
+
     func testConnectionTreeDescriptionForMixerWithName() {
         let engine = AudioEngine()
         let mixerName = "MixerNameFoo"
@@ -169,7 +169,7 @@ class EngineTests: XCTestCase {
         engine.output = mixerWithName
         XCTAssertEqual(engine.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
+        \(Node.connectionTreeLinePrefix)↳Mixer("\(MemoryAddress(of: engine.mainMixerNode!).description)")
         \(Node.connectionTreeLinePrefix) ↳Mixer("\(mixerName)")
         """)
     }

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -166,7 +166,7 @@ class NodeTests: XCTestCase {
         let outputMixer = Mixer()
         engine.output = outputMixer
         let audio = engine.startTest(totalDuration: 1.0)
-        
+
         let osc = Oscillator()
         let mixer = Mixer()
         mixer.addInput(osc)

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -369,10 +369,11 @@ class NodeTests: XCTestCase {
         let osc = Oscillator()
         let verb = CostelloReverb(osc)
         let mixer = Mixer(osc, verb)
+        let mixerAddress = MemoryAddress(of: mixer).description
 
         XCTAssertEqual(mixer.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
+        \(Node.connectionTreeLinePrefix)↳Mixer("\(mixerAddress)")
         \(Node.connectionTreeLinePrefix) ↳Oscillator
         \(Node.connectionTreeLinePrefix) ↳CostelloReverb
         \(Node.connectionTreeLinePrefix)  ↳Oscillator
@@ -384,12 +385,13 @@ class NodeTests: XCTestCase {
         let sampler = MIDISampler(name: nameString)
         let compressor = Compressor(sampler)
         let mixer = Mixer(compressor)
+        let mixerAddress = MemoryAddress(of: mixer).description
 
         XCTAssertEqual(mixer.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer("Mixer")
+        \(Node.connectionTreeLinePrefix)↳Mixer("\(mixerAddress)")
         \(Node.connectionTreeLinePrefix) ↳Compressor
-        \(Node.connectionTreeLinePrefix)  ↳MIDISampler(\"\(nameString)\")
+        \(Node.connectionTreeLinePrefix)  ↳MIDISampler("\(nameString)")
         """)
     }
 


### PR DESCRIPTION
Introduction of a fun new default for `NamedNodes`, inspired by a suggestion by @aure . Now, instead of redundant self-named nodes, the memory address of the instance is the default name, making multiple copies of the same type of node have unique names by default. An example from the unit tests looks like this:

```
AudioKit | ↳Mixer("0x0000000100e8d650")
AudioKit |  ↳Compressor
AudioKit |   ↳MIDISampler("Customized Name")
```

To make this work correctly, some parameters had to be changed to optionals. However, this ends up having **no impact** on the API at all, because all of the parameters already had defaults set anyway. Additionally, any passing of a deliberate `nil` by an API user will still get overwritten with our new default name style. This means we still get to have non-optional name attributes on all of our `NamedNodes`.
