### PR TITLE
Added a name to AudioKit Engine's built-in Mixer node

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -108,7 +108,7 @@ public class AudioEngine {
     private func createEngineMixer() {
         guard mainMixerNode == nil else { return }
 
-        let mixer = Mixer()
+        let mixer = Mixer(name: "AudioKit Engine Mixer")
         avEngine.attach(mixer.avAudioNode)
         avEngine.connect(mixer.avAudioNode, to: avEngine.outputNode, format: Settings.audioFormat)
         mainMixerNode = mixer

--- a/Tests/AudioKitTests/Node Tests/EngineTests.swift
+++ b/Tests/AudioKitTests/Node Tests/EngineTests.swift
@@ -157,7 +157,7 @@ class EngineTests: XCTestCase {
         engine.output = oscillator
         XCTAssertEqual(engine.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer("\(MemoryAddress(of: engine.mainMixerNode!).description)")
+        \(Node.connectionTreeLinePrefix)↳Mixer("AudioKit Engine Mixer")
         \(Node.connectionTreeLinePrefix) ↳Oscillator
         """)
     }
@@ -169,8 +169,20 @@ class EngineTests: XCTestCase {
         engine.output = mixerWithName
         XCTAssertEqual(engine.connectionTreeDescription,
         """
-        \(Node.connectionTreeLinePrefix)↳Mixer("\(MemoryAddress(of: engine.mainMixerNode!).description)")
+        \(Node.connectionTreeLinePrefix)↳Mixer("AudioKit Engine Mixer")
         \(Node.connectionTreeLinePrefix) ↳Mixer("\(mixerName)")
+        """)
+    }
+
+    func testConnectionTreeDescriptionForMixerWithoutName() {
+        let engine = AudioEngine()
+        let mixerWithoutName = Mixer()
+        engine.output = mixerWithoutName
+        let addressOfMixerWithoutName = MemoryAddress(of: mixerWithoutName).description
+        XCTAssertEqual(engine.connectionTreeDescription,
+        """
+        \(Node.connectionTreeLinePrefix)↳Mixer("AudioKit Engine Mixer")
+        \(Node.connectionTreeLinePrefix) ↳Mixer("\(addressOfMixerWithoutName)")
         """)
     }
 }

--- a/Tests/AudioKitTests/Node Tests/EngineTests.swift
+++ b/Tests/AudioKitTests/Node Tests/EngineTests.swift
@@ -178,7 +178,7 @@ class EngineTests: XCTestCase {
         let engine = AudioEngine()
         let mixerWithoutName = Mixer()
         engine.output = mixerWithoutName
-        let addressOfMixerWithoutName = MemoryAddress(of: mixerWithoutName).description
+        let addressOfMixerWithoutName = MemoryAddress(of: mixerWithoutName)
         XCTAssertEqual(engine.connectionTreeDescription,
         """
         \(Node.connectionTreeLinePrefix)↳Mixer("AudioKit Engine Mixer")


### PR DESCRIPTION
Added a name to AudioKit Engine's built-in Mixer node. This makes it look much better in the connection tree, and it's nice to have a name for it anyway. Updated the unit tests to match.