### PR TITLE
sequencer realtime safety

### DIFF
--- a/Sources/CAudioKit/Sequencing/SequencerEngine.mm
+++ b/Sources/CAudioKit/Sequencing/SequencerEngine.mm
@@ -9,9 +9,15 @@
 #include <stdio.h>
 #include <atomic>
 #include <mutex>
+#include "TPCircularBuffer.h"
 
 #define NOTEON 0x90
 #define NOTEOFF 0x80
+
+struct SequencerEvent {
+    bool notesOff = false;
+    double seekPosition = NAN;
+};
 
 struct SequencerEngine {
     std::vector<SequenceNote> playingNotes;
@@ -22,14 +28,7 @@ struct SequencerEngine {
     std::atomic<bool> isStarted{false};
     AUScheduleMIDIEventBlock midiBlock = nullptr;
 
-    // Mutex for changes from the main thread.
-    std::mutex updateMutex;
-
-    // Tell the DSP thread to turn off notes.
-    bool notesOff{false};
-
-    // Tell the DSP thread to seek.
-    double seekPosition{NAN};
+    TPCircularBuffer eventQueue;
 
     // Current position as reported to the UI.
     std::atomic<double> uiPosition{0};
@@ -38,6 +37,12 @@ struct SequencerEngine {
         // Try to reserve enough notes so allocation on the DSP
         // thread is unlikely. (This is not ideal)
         playingNotes.reserve(256);
+
+        TPCircularBufferInit(&eventQueue, 4096);
+    }
+
+    ~SequencerEngine() {
+        TPCircularBufferCleanup(&eventQueue);
     }
 
     int beatToSamples(double beat) const {
@@ -98,22 +103,22 @@ struct SequencerEngine {
 
     void processEvents() {
 
-        // Process updates from the main thread.
-        std::unique_lock<std::mutex> lock(updateMutex, std::try_to_lock);
-        if(lock.owns_lock()) {
-            if(notesOff) {
+        int32_t availableBytes;
+        auto* events = (SequencerEvent*) TPCircularBufferTail(&eventQueue, &availableBytes);
+        int n = availableBytes / sizeof(SequencerEvent);
+        for(int i=0;i<n;++i) {
+            auto& event = events[i];
+            if(event.notesOff) {
                 while (playingNotes.size() > 0) {
                     stopPlayingNote(playingNotes[0], 0, 0);
                 }
-                notesOff = false;
             }
 
-            double seekPos = seekPosition;
-            if(!isnan(seekPos)) {
-                seekTo(seekPos);
-                seekPosition = NAN;
+            if(!isnan(event.seekPosition)) {
+                seekTo(event.seekPosition);
             }
         }
+        TPCircularBufferConsume(&eventQueue, n * sizeof(SequencerEvent));
 
     }
 
@@ -242,8 +247,9 @@ double akSequencerEngineGetPosition(SequencerEngineRef engine) {
 }
 
 void akSequencerEngineSeekTo(SequencerEngineRef engine, double position) {
-    std::unique_lock<std::mutex> lock(engine->updateMutex);
-    engine->seekPosition = position;
+    SequencerEvent event;
+    event.seekPosition = position;
+    TPCircularBufferProduceBytes(&engine->eventQueue, &event, sizeof(SequencerEvent));
 }
 
 void akSequencerEngineSetPlaying(SequencerEngineRef engine, bool playing) {
@@ -255,8 +261,9 @@ bool akSequencerEngineIsPlaying(SequencerEngineRef engine) {
 }
 
 void akSequencerEngineStopPlayingNotes(SequencerEngineRef engine) {
-    std::unique_lock<std::mutex> lock(engine->updateMutex);
-    engine->notesOff = true;
+    SequencerEvent event;
+    event.notesOff = true;
+    TPCircularBufferProduceBytes(&engine->eventQueue, &event, sizeof(SequencerEvent));
 }
 
 #endif


### PR DESCRIPTION
Use circular buffer instead of mutex for sequencer engine events.