### PR TITLE
Fixed error "Index out of range" for VirtualInputs and VirtualOutputs

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI.swift
+++ b/Sources/AudioKit/MIDI/MIDI.swift
@@ -22,7 +22,7 @@ public class MIDI {
     public var inputPorts = [MIDIUniqueID: MIDIPortRef]()
 
     /// Array of Virtual MIDI Input destination
-    public var virtualInputs = [MIDIPortRef]()
+    public var virtualInputs = [MIDIPortRef()]
 
     /// MIDI In Port Name
     internal let inputPortName: CFString = "MIDI In Port" as CFString
@@ -31,7 +31,7 @@ public class MIDI {
     public var outputPort = MIDIPortRef()
 
     /// Array of Virtual MIDI output
-    public var virtualOutputs = [MIDIPortRef]()
+    public var virtualOutputs = [MIDIPortRef()]
 
     /// MIDI Out Port Name
     var outputPortName: CFString = "MIDI Out Port" as CFString


### PR DESCRIPTION
Originally, virtualInput and virtualsOutputs where MidiPortRef with a value of 0
In the previous commit, I replaced `MidiportRef()` by `[MidiPortRef]()` wich create an empty array of MidiPortRef.
Replacing `[MidiPortRef]()` by `[MidiPortRef()]` should solve the issue by creating an array of MidiPortRef whose first value is 0
