### PR TITLE
Fft changes

### DIFF
--- a/AudioKit/Common/Internals/EZAudio/EZAudioFFT.m
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioFFT.m
@@ -35,6 +35,7 @@ typedef struct EZAudioFFTInfo
     FFTSetup       fftSetup;
     COMPLEX_SPLIT  complexA;
     float         *outFFTData;
+    float         *windowData;
     vDSP_Length    outFFTDataLength;
     float         *inversedFFTData;
     vDSP_Length    maxFrequencyIndex;
@@ -67,6 +68,7 @@ typedef struct EZAudioFFTInfo
     free(self.info->complexA.realp);
     free(self.info->complexA.imagp);
     free(self.info->outFFTData);
+    free(self.info->windowData);
     free(self.info->inversedFFTData);
 }
 
@@ -141,6 +143,10 @@ typedef struct EZAudioFFTInfo
     self.info->complexA.realp = (float *)malloc(maximumSizePerComponentBytes);
     self.info->complexA.imagp = (float *)malloc(maximumSizePerComponentBytes);
     self.info->outFFTData = (float *)malloc(maximumSizePerComponentBytes);
+
+    self.info->windowData = (float *)malloc(maximumBufferSizeBytes);
+
+
     memset(self.info->outFFTData, 0, maximumSizePerComponentBytes);
     self.info->inversedFFTData = (float *)malloc(maximumSizePerComponentBytes);
 }
@@ -161,8 +167,13 @@ typedef struct EZAudioFFTInfo
     //
     vDSP_Length log2n = log2f(bufferSize);
     long nOver2 = bufferSize / 2;
-    float mFFTNormFactor = 1.0 / (2 * bufferSize);
-    vDSP_ctoz((COMPLEX*)buffer, 2, &(self.info->complexA), 1, nOver2);
+    float mFFTNormFactor = 1.0 / bufferSize;
+
+    vDSP_hann_window(self.info->windowData, bufferSize, 0);
+    vDSP_vmul(buffer, 1, self.info->windowData, 1, self.info->windowData, 1, bufferSize);
+
+    vDSP_ctoz((COMPLEX*)self.info->windowData, 2, &(self.info->complexA), 1, nOver2);
+
     vDSP_fft_zrip(self.info->fftSetup, &(self.info->complexA), 1, log2n, FFT_FORWARD);
     vDSP_vsmul(self.info->complexA.realp, 1, &mFFTNormFactor, self.info->complexA.realp, 1, nOver2);
     vDSP_vsmul(self.info->complexA.imagp, 1, &mFFTNormFactor, self.info->complexA.imagp, 1, nOver2);

--- a/AudioKit/Common/Internals/EZAudio/EZAudioFFT.m
+++ b/AudioKit/Common/Internals/EZAudio/EZAudioFFT.m
@@ -161,7 +161,7 @@ typedef struct EZAudioFFTInfo
     //
     vDSP_Length log2n = log2f(bufferSize);
     long nOver2 = bufferSize / 2;
-    float mFFTNormFactor = 10.0 / (2 * bufferSize);
+    float mFFTNormFactor = 1.0 / (2 * bufferSize);
     vDSP_ctoz((COMPLEX*)buffer, 2, &(self.info->complexA), 1, nOver2);
     vDSP_fft_zrip(self.info->fftSetup, &(self.info->complexA), 1, log2n, FFT_FORWARD);
     vDSP_vsmul(self.info->complexA.realp, 1, &mFFTNormFactor, self.info->complexA.realp, 1, nOver2);

--- a/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
+++ b/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
@@ -22,9 +22,9 @@ open class AKFFTTap: NSObject, EZAudioFFTDelegate {
     /// Setup a callback for FFT data
     /// - parameters;
     ///   - f: a function to call when new FFT Data is available
-    
-    open func onData(f: @escaping FFTCallback) {
-        self.onData = f
+
+    open func onData(callback: @escaping FFTCallback) {
+        self.onData = callback
     }
     /// Initialze the FFT calculation on a given node
     ///
@@ -68,8 +68,8 @@ open class AKFFTTap: NSObject, EZAudioFFTDelegate {
                         updatedWithFFTData fftData: UnsafeMutablePointer<Float>,
                         bufferSize: vDSP_Length) {
         DispatchQueue.main.async { () -> Void in
-            for i in 0..<Int(bufferSize) {
-                self.fftData[i] = Double(fftData[i])
+            for idx in 0..<Int(bufferSize) {
+                self.fftData[idx] = Double(fftData[idx])
             }
             self.onData?(self.fftData)
         }

--- a/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
+++ b/AudioKit/Common/Taps/FFT Tap/AKFFTTap.swift
@@ -15,7 +15,16 @@ open class AKFFTTap: NSObject, EZAudioFFTDelegate {
 
     /// Array of FFT data
     @objc open var fftData: [Double]
+    internal var onData: FFTCallback?
+    public typealias FFTCallback = ([Double]) -> Void
 
+    /// Setup a callback for FFT data
+    /// - parameters;
+    ///   - f: a function to call when new FFT Data is available
+    
+    open func onData(f: @escaping FFTCallback) {
+        self.onData = f
+    }
     /// Initialze the FFT calculation on a given node
     ///
     /// - parameters:
@@ -51,9 +60,10 @@ open class AKFFTTap: NSObject, EZAudioFFTDelegate {
                         updatedWithFFTData fftData: UnsafeMutablePointer<Float>,
                         bufferSize: vDSP_Length) {
         DispatchQueue.main.async { () -> Void in
-            for i in 0..<512 {
+            for i in 0..<Int(bufferSize) {
                 self.fftData[i] = Double(fftData[i])
             }
+            self.onData?(self.fftData)
         }
     }
 }


### PR DESCRIPTION
Some tweaks for EZAudioFFT and AKFFTTap

- allow for a callback from AKFFTTap when new FFT data is available. 
- apply a Hann window to the data before running the fft function
- normalize the FFT results by 1/N instead of 10/(2 * N).  technically maybe this should be 1/2n, but in my experiments this looks pretty good, once transformed to dB it lines up pretty well with eg https://audiomotion.me/public/#!.  I scoured the web here for information about how this should be "correctly" normalized, I couldn't find a great answer.  Apple says you should at least divide by 2.  I think.
- provide all the data back, no matter what the FFT Size is.
- remove the audio unit tap when AKFFTTap is destroyed
