### PR TITLE
V5 develop

### DIFF
--- a/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
+++ b/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
@@ -66,10 +66,10 @@ open class AudioUnitBase: AUAudioUnit {
     }
 
     private var _parameterTree: AUParameterTree?
-    
+
     /// Parameter address offset - useful for grouping multiple AudioKit node parameters in a custom Audio Unit
     public var addressOffset: AUParameterAddress?
-    
+
     /// Parameter tree
     override public var parameterTree: AUParameterTree? {
         get { return _parameterTree }

--- a/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
+++ b/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
@@ -67,6 +67,7 @@ open class AudioUnitBase: AUAudioUnit {
 
     private var _parameterTree: AUParameterTree?
     
+    /// Parameter address offset - useful for grouping multiple AudioKit node parameters in a custom Audio Unit
     public var addressOffset: AUParameterAddress?
     
     /// Parameter tree

--- a/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
+++ b/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
@@ -67,6 +67,8 @@ open class AudioUnitBase: AUAudioUnit {
 
     private var _parameterTree: AUParameterTree?
     
+    public var addressOffset: AUParameterAddress?
+    
     /// Parameter tree
     override public var parameterTree: AUParameterTree? {
         get { return _parameterTree }
@@ -74,11 +76,11 @@ open class AudioUnitBase: AUAudioUnit {
             _parameterTree = newValue
 
             _parameterTree?.implementorValueObserver = { [unowned self] parameter, value in
-                setParameterValueDSP(self.dsp, parameter.address, value)
+                setParameterValueDSP(self.dsp, parameter.address - (addressOffset ?? 0), value)
             }
 
             _parameterTree?.implementorValueProvider = { [unowned self] parameter in
-                getParameterValueDSP(self.dsp, parameter.address)
+                getParameterValueDSP(self.dsp, parameter.address - (addressOffset ?? 0))
             }
 
             _parameterTree?.implementorStringFromValueCallback = { parameter, value in


### PR DESCRIPTION
I am working on creating an Audio Unit effect built with AudioKit nodes. When I was working on this, I thought it might be useful to have a way to automatically add parameters for each node inside a custom Audio Unit. I ran into some trouble with parameters having the same address, so I added an offset to distinguish parameters if needed and organize them into groups based on the AudioKit nodes.
