### PR TITLE
V5 develop: allow to manually resize Mixer's input busses array

### DIFF
--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -128,37 +128,24 @@ public class Mixer: Node, Toggleable, NamedNode {
     ///
     /// If engine has not yet started, you shouldn't need to use this function.
     /// - Parameter requiredSize: how many input busses you need in the mixer
-    /// - Returns: new input busses array size or its current size in case it's less than required and resize failed, or can't be done.
+    /// - Returns: new input busses array size or its current size in case it's less than required
+    ///  and resize failed, or can't be done.
     public func resizeInputBussesArray(requiredSize: Int) -> Int {
-        
         let busses = mixerAU.auAudioUnit.inputBusses
-        
         guard busses.isCountChangeable else {
-            
             // input busses array is not changeable
-            
             return min(busses.count, requiredSize)
         }
-        
         if busses.count < requiredSize {
-            
             do {
-                
                 try busses.setBusCount(requiredSize)
-                
                 return requiredSize
-                
             } catch _ {
-                
                 // could not resize input busses array to required size
-                
                 return busses.count
             }
-            
         }
-        
         // current input busses array already matches or exceeds required size
-        
         return requiredSize
     }
 }

--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -110,4 +110,55 @@ public class Mixer: Node, Toggleable, NamedNode {
         }
         connections.removeAll()
     }
+    
+    /// Resize underlying AVAudioMixerNode input busses array to accomodate for required count of inputs.
+    ///
+    ///```
+    ///let desiredInputCount = 5
+    ///let allowedCount = mixer.resizeInputBussesArray(requiredSize: desiredInputCount)
+    ///// allowedCount is now 5 or less
+    ///```
+    /// If engine has already started, underlying AVAudioMixerNode won't resize its input busses
+    /// array when new input nodes are added into it, which may eventually cause a crash.
+    ///
+    /// Use this function to avoid that and resize input busses array manually before adding new inputs to the mixer.
+    ///
+    /// If the current busses array size is less than required, it will attempt to resize the array.
+    /// Otherwise, no changes will be made.
+    ///
+    /// If engine has not yet started, you shouldn't need to use this function.
+    /// - Parameter requiredSize: how many input busses you need in the mixer
+    /// - Returns: new input busses array size or its current size in case it's less than required and resize failed, or can't be done.
+    public func resizeInputBussesArray(requiredSize: Int) -> Int {
+        
+        let busses = mixerAU.auAudioUnit.inputBusses
+        
+        guard busses.isCountChangeable else {
+            
+            // input busses array is not changeable
+            
+            return min(busses.count, requiredSize)
+        }
+        
+        if busses.count < requiredSize {
+            
+            do {
+                
+                try busses.setBusCount(requiredSize)
+                
+                return requiredSize
+                
+            } catch _ {
+                
+                // could not resize input busses array to required size
+                
+                return busses.count
+            }
+            
+        }
+        
+        // current input busses array already matches or exceeds required size
+        
+        return requiredSize
+    }
 }


### PR DESCRIPTION
Proposed fix (or rather a workaround) to a crash caused by a adding multiple new inputs to a mixer on the fly. See issue #2366
