### PR TITLE
CallbackLoop internal reliability improvement.

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/CallbackLoop.swift
+++ b/Sources/AudioKit/Internals/Utilities/CallbackLoop.swift
@@ -57,8 +57,23 @@ public class CallbackLoop: NSObject {
     /// Callback function
     @objc func update() {
         if isRunning {
+            if !Thread.isMainThread {
+                DispatchQueue.main.async { [self] in
+                    self.updateInternal()
+                }
+            }
+            else {
+                self.updateInternal()
+            }
+        }
+    }
+    
+    /// Call the callback function.
+    /// self.perform only works when executed on the main thread. Called from self.update()
+    @objc internal func updateInternal() {
+        if isRunning {
             self.internalHandler()
-            self.perform(#selector(update),
+            self.perform(#selector(updateInternal),
                          with: nil,
                          afterDelay: duration,
                          inModes: [.common])

--- a/Sources/AudioKit/Internals/Utilities/CallbackLoop.swift
+++ b/Sources/AudioKit/Internals/Utilities/CallbackLoop.swift
@@ -61,8 +61,7 @@ public class CallbackLoop: NSObject {
                 DispatchQueue.main.async { [self] in
                     self.updateInternal()
                 }
-            }
-            else {
+            } else {
                 self.updateInternal()
             }
         }

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -14,7 +14,7 @@ So, first we'll start out with a list of things that are just not in AudioKit 5 
 
 4. `AKAudioUnitManager` was removed. A project to demonstrate this functionality has been started [here](https://github.com/AudioKit/AudioUnitManager).
 
-5. `AKMetronome` has been removed. Its easy enough to create a metronome with `Sequencer` and one track. This will be demonstrated in the examples project.
+5. `AKMetronome` has been removed. Its easy enough to create a metronome with `Sequencer` and one track. This will be demonstrated in the Cookbook examples project.
 
 ## Significantly Changed
 
@@ -301,6 +301,6 @@ Also, `AKMicrophoneTracker` was removed. Using an `AudioEngine`'s `InputNode` al
 | ClipMergerError                        | -                                  | Original programmer hired by Apple and not available for maintaining.                                                                                        |
 | ClipRecordingError                     | -                                  | Original programmer hired by Apple and not available for maintaining.                                                                                        |
 | FileClip                               | -                                  | Original programmer hired by Apple and not available for maintaining.                                                                                        |
-| MultitouchGestureRecognizer            | MultitouchGestureRecognizer        | Original programmer hired by Apple and not available for maintaining.                                                                                        |
+| MultitouchGestureRecognizer            | MultitouchGestureRecognizer        |                                                                                       |
 | random(_:_:)                           | -                                  | Use AUValue's random(in:) method.                                                                                                                            |
 


### PR DESCRIPTION
The perform function does not work on a thread other than main. As a result if start() is called, it may only initiate one callback, rather than regular callbacks at the given interval. This PR does a thread check to guarantee execution on main and continuous callbacks.