### PR TITLE
FFTTap: Add Ability To Turn Off Normalization

### DIFF
--- a/Sources/AudioKit/Analysis/FFTTap.swift
+++ b/Sources/AudioKit/Analysis/FFTTap.swift
@@ -10,6 +10,8 @@ open class FFTTap: BaseTap {
     open var fftData: [Float]
     /// Type of callback
     public typealias Handler = ([Float]) -> Void
+    /// Determines if the returned FFT data is normalized
+    public var isNormalized: Bool = true
 
     private var handler: Handler = { _ in }
 
@@ -28,11 +30,11 @@ open class FFTTap: BaseTap {
     override internal func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard buffer.floatChannelData != nil else { return }
 
-        fftData = FFTTap.performFFT(buffer: buffer)
+        fftData = FFTTap.performFFT(buffer: buffer, isNormalized: isNormalized)
         handler(fftData)
     }
 
-    static func performFFT(buffer: AVAudioPCMBuffer) -> [Float] {
+    static func performFFT(buffer: AVAudioPCMBuffer, isNormalized: Bool = true) -> [Float] {
         let frameCount = buffer.frameLength
         let log2n = UInt(round(log2(Double(frameCount))))
         let bufferSizePOT = Int(1 << log2n)
@@ -71,17 +73,21 @@ open class FFTTap: BaseTap {
                 var magnitudes = [Float](repeating: 0.0, count: inputCount)
                 vDSP_zvmags(&output, 1, &magnitudes, 1, vDSP_Length(inputCount))
 
-                // Normalising
-                var normalizedMagnitudes = [Float](repeating: 0.0, count: inputCount)
-                vDSP_vsmul(&magnitudes,
-                           1,
-                           [1.0 / (magnitudes.max() ?? 1.0)],
-                           &normalizedMagnitudes,
-                           1,
-                           vDSP_Length(inputCount))
+                if isNormalized {
+                    // Normalising
+                    var normalizedMagnitudes = [Float](repeating: 0.0, count: inputCount)
+                    vDSP_vsmul(&magnitudes,
+                               1,
+                               [1.0 / (magnitudes.max() ?? 1.0)],
+                               &normalizedMagnitudes,
+                               1,
+                               vDSP_Length(inputCount))
 
+                    vDSP_destroy_fftsetup(fftSetup)
+                    return normalizedMagnitudes
+                }
                 vDSP_destroy_fftsetup(fftSetup)
-                return normalizedMagnitudes
+                return magnitudes
             }
         }
     }

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -145,6 +145,7 @@ let validatedMD5s: [String: String] = [
     "-[EqualizerFilterTests testParameters]": "04d2992a5821a9e10f6060af9ad64ad0",
     "-[ExpanderTests testDefault]": "df47ebd58262370633c79f9813780d23",
     "-[FFTTapTests testBasic]": "31521ba97588f48cb20505205b0cd8f3",
+    "-[FFTTapTests testWithoutNormalization]": "df0a73e2987dc2490ff17c0de477fbf3",
     "-[FMOscillatorOperationTests testDefault]": "e82a86ae4e7d47f24eeba9700e4745d4",
     "-[FMOscillatorOperationTests testFMOscillatorOperation]": "691ee890bdeee00f0b5e79d471fd82ee",
     "-[FMOscillatorTests testDefault]": "2ab6d83efd88014de7c8af0cde83f784",


### PR DESCRIPTION
By setting the isNormalized property to false, the fftData returned will no longer be normalized. Default keeps functionality the same as before.
