### PR TITLE
Support for multiple virtual inputs and outputs and send midi to specific physical and virtual output

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -403,7 +403,7 @@ extension MIDI {
     /// - Parameters:
     ///   - data: Array of MIDI Bytes
     ///   - time: MIDI Timestamp
-    public func sendMessageWithTime(_ data: [MIDIByte], time: MIDITimeStamp) {
+    public func sendMessageWithTime(_ data: [MIDIByte], time: MIDITimeStamp, endpointsUIDs: [MIDIUniqueID]? = nil) {
         let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)
 
         var packet: UnsafeMutablePointer<MIDIPacket> = MIDIPacketListInit(packetListPointer)

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -295,7 +295,7 @@ extension MIDI {
                 }
 
                 if virtualOutputs != [0] {
-                    endpointsRef.forEach {print(MIDIReceived($0, packetListPointer))}
+                    endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
                 }
             }
         }
@@ -427,7 +427,7 @@ extension MIDI {
         }
 
         if virtualOutputs != [0] {
-            endpointsRef.forEach {print(MIDIReceived($0, packetListPointer))}
+            endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
         }
     }
 }

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -295,7 +295,7 @@ extension MIDI {
                 }
 
                 if virtualOutputs != [0] {
-                    virtualOutputs.forEach {MIDIReceived($0, packetListPointer)}
+                    endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
                 }
             }
         }
@@ -427,10 +427,9 @@ extension MIDI {
         }
 
         if virtualOutputs != [0] {
-            virtualOutputs.forEach {MIDIReceived($0, packetListPointer)}
+            endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
         }
     }
-
 }
 
 #endif

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -311,8 +311,8 @@ extension MIDI {
 
     /// Send Messsage from MIDI event data
     /// - Parameter event: Event so send
-    public func sendEvent(_ event: MIDIEvent, endpointsUIDs: [MIDIUniqueID]? = nil) {
-        sendMessage(event.data, endpointsUIDs: endpointsUIDs)
+    public func sendEvent(_ event: MIDIEvent, endpointsUIDs: [MIDIUniqueID]? = nil, virtualOutputPorts: [MIDIPortRef]? = nil) {
+        sendMessage(event.data, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note On Message
@@ -323,10 +323,11 @@ extension MIDI {
     public func sendNoteOnMessage(noteNumber: MIDINoteNumber,
                                   velocity: MIDIVelocity,
                                   channel: MIDIChannel = 0,
-                                  endpointsUIDs: [MIDIUniqueID]? = nil) {
+                                  endpointsUIDs: [MIDIUniqueID]? = nil,
+                                  virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOnByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note Off Message
@@ -337,10 +338,11 @@ extension MIDI {
     public func sendNoteOffMessage(noteNumber: MIDINoteNumber,
                                    velocity: MIDIVelocity,
                                    channel: MIDIChannel = 0,
-                                   endpointsUIDs: [MIDIUniqueID]? = nil) {
+                                   endpointsUIDs: [MIDIUniqueID]? = nil,
+                                   virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOffByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Continuous Controller message
@@ -348,10 +350,14 @@ extension MIDI {
     ///   - control: MIDI Control number
     ///   - value: Value to assign
     ///   - channel: MIDI Channel (default: 0)
-    public func sendControllerMessage(_ control: MIDIByte, value: MIDIByte, channel: MIDIChannel = 0, endpointsUIDs: [MIDIUniqueID]? = nil) {
+    public func sendControllerMessage(_ control: MIDIByte,
+                                      value: MIDIByte,
+                                      channel: MIDIChannel = 0,
+                                      endpointsUIDs: [MIDIUniqueID]? = nil,
+                                      virtualOutputPorts: [MIDIPortRef]? = nil) {
         let controlCommand: MIDIByte = MIDIByte(0xB0) + channel
         let message: [MIDIByte] = [controlCommand, control, value]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a pitch bend message.
@@ -359,13 +365,16 @@ extension MIDI {
     /// - Parameters:
     ///   - value: Value of pitch shifting between 0 and 16383. Send 8192 for no pitch bending.
     ///   - channel: Channel you want to send pitch bend message. Defaults 0.
-    public func sendPitchBendMessage(value: UInt16, channel: MIDIChannel = 0, endpointsUIDs: [MIDIUniqueID]? = nil) {
+    public func sendPitchBendMessage(value: UInt16,
+                                     channel: MIDIChannel = 0,
+                                     endpointsUIDs: [MIDIUniqueID]? = nil,
+                                     virtualOutputPorts: [MIDIPortRef]? = nil) {
         let pitchCommand = MIDIByte(0xE0) + channel
         let mask: UInt16 = 0x007F
         let byte1 = MIDIByte(value & mask) // MSB, bit shift right 7
         let byte2 = MIDIByte((value & (mask << 7)) >> 7) // LSB, mask of 127
         let message: [MIDIByte] = [pitchCommand, byte1, byte2]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     // MARK: - Expand api to include MIDITimeStamp
@@ -380,10 +389,11 @@ extension MIDI {
                                           velocity: MIDIVelocity,
                                           channel: MIDIChannel = 0,
                                           time: MIDITimeStamp = 0,
-                                          endpointsUIDs: [MIDIUniqueID]? = nil) {
+                                          endpointsUIDs: [MIDIUniqueID]? = nil,
+                                          virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = MIDIByte(0x90) + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessageWithTime(message, time: time, endpointsUIDs: endpointsUIDs)
+        self.sendMessageWithTime(message, time: time, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note Off Message with timestamp
@@ -396,10 +406,11 @@ extension MIDI {
                                            velocity: MIDIVelocity,
                                            channel: MIDIChannel = 0,
                                            time: MIDITimeStamp = 0,
-                                           endpointsUIDs: [MIDIUniqueID]? = nil) {
+                                           endpointsUIDs: [MIDIUniqueID]? = nil,
+                                           virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = MIDIByte(0x80) + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessageWithTime(message, time: time, endpointsUIDs: endpointsUIDs)
+        self.sendMessageWithTime(message, time: time, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send Message with data with timestamp

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -311,7 +311,9 @@ extension MIDI {
 
     /// Send Messsage from MIDI event data
     /// - Parameter event: Event so send
-    public func sendEvent(_ event: MIDIEvent, endpointsUIDs: [MIDIUniqueID]? = nil, virtualOutputPorts: [MIDIPortRef]? = nil) {
+    public func sendEvent(_ event: MIDIEvent,
+                          endpointsUIDs: [MIDIUniqueID]? = nil,
+                          virtualOutputPorts: [MIDIPortRef]? = nil) {
         sendMessage(event.data, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
@@ -393,7 +395,9 @@ extension MIDI {
                                           virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = MIDIByte(0x90) + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessageWithTime(message, time: time, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
+        self.sendMessageWithTime(message, time: time,
+                                 endpointsUIDs: endpointsUIDs,
+                                 virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note Off Message with timestamp
@@ -410,7 +414,9 @@ extension MIDI {
                                            virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = MIDIByte(0x80) + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessageWithTime(message, time: time, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
+        self.sendMessageWithTime(message, time: time,
+                                 endpointsUIDs: endpointsUIDs,
+                                 virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send Message with data with timestamp

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -243,7 +243,10 @@ extension MIDI {
     /// - Parameters:
     ///   - data: Array of MIDI Bytes
     ///   - offset: Timestamp offset
-    public func sendMessage(_ data: [MIDIByte], offset: MIDITimeStamp = 0, endpointsUIDs: [MIDIUniqueID]? = nil) {
+    public func sendMessage(_ data: [MIDIByte],
+                            offset: MIDITimeStamp = 0,
+                            endpointsUIDs: [MIDIUniqueID]? = nil,
+                            virtualOutputPorts: [MIDIPortRef]? = nil) {
 
         // Create a buffer that is big enough to hold the data to be sent and
         // all the necessary headers.
@@ -295,7 +298,7 @@ extension MIDI {
                 }
 
                 if virtualOutputs != [0] {
-                    endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
+                    virtualOutputPorts?.forEach {MIDIReceived($0, packetListPointer)}
                 }
             }
         }
@@ -403,7 +406,10 @@ extension MIDI {
     /// - Parameters:
     ///   - data: Array of MIDI Bytes
     ///   - time: MIDI Timestamp
-    public func sendMessageWithTime(_ data: [MIDIByte], time: MIDITimeStamp, endpointsUIDs: [MIDIUniqueID]? = nil) {
+    public func sendMessageWithTime(_ data: [MIDIByte],
+                                    time: MIDITimeStamp,
+                                    endpointsUIDs: [MIDIUniqueID]? = nil,
+                                    virtualOutputPorts: [MIDIPortRef]? = nil) {
         let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)
 
         var packet: UnsafeMutablePointer<MIDIPacket> = MIDIPacketListInit(packetListPointer)
@@ -427,7 +433,7 @@ extension MIDI {
         }
 
         if virtualOutputs != [0] {
-            endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
+            virtualOutputPorts?.forEach {MIDIReceived($0, packetListPointer)}
         }
     }
 }

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -295,7 +295,7 @@ extension MIDI {
                 }
 
                 if virtualOutputs != [0] {
-                    endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
+                    endpointsRef.forEach {print(MIDIReceived($0, packetListPointer))}
                 }
             }
         }
@@ -427,7 +427,7 @@ extension MIDI {
         }
 
         if virtualOutputs != [0] {
-            endpointsRef.forEach {MIDIReceived($0, packetListPointer)}
+            endpointsRef.forEach {print(MIDIReceived($0, packetListPointer))}
         }
     }
 }

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -102,7 +102,7 @@ extension MIDI {
            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
                 if virtualInputs.count <= virtualPortIndex {virtualInputs.append(0)}
-                MIDIObjectSetIntegerProperty(virtualOutputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
+                MIDIObjectSetIntegerProperty(virtualInputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {
                 Log("Error \(result) Creating Virtual Output Port: \(virtualPortName) -- \(virtualOutputs[virtualPortIndex])",
                 log: OSLog.midi, type: .error)

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -28,7 +28,7 @@ extension MIDI {
     }
 
     /// Create virtual MIDI input ports
-    public func createVirtualInputPorts(numberOfPort: UInt = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    public func createVirtualInputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualInputPort()
         guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
 
@@ -76,7 +76,7 @@ extension MIDI {
     }
 
     /// Create virtual MIDI output ports
-    public func createVirtualOutputPorts(numberOfPort: UInt = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    public func createVirtualOutputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualOutputPort()
         guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
         var unnamedPortIndex = 1
@@ -101,7 +101,7 @@ extension MIDI {
            }
            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
-                if virtualInputs.count =< virtualPortIndex {virtualInputs.append(0)}
+                if virtualInputs.count <= virtualPortIndex {virtualInputs.append(0)}
                 MIDIObjectSetIntegerProperty(virtualInputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {
                 Log("Error \(result) Creating Virtual Output Port: \(virtualPortName) -- \(virtualOutputs[virtualPortIndex])",

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -60,7 +60,7 @@ extension MIDI {
                 for packet in packetList.pointee {
                     // a Core MIDI packet may contain multiple MIDI events
                     for event in packet {
-                        self.handleMIDIMessage(event, fromInput: virtualInputs[virtualPortIndex])
+                        self.handleMIDIMessage(event, fromInput: uniqueID)
                     }
                 }
             }

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -23,18 +23,18 @@ extension MIDI {
     public func createVirtualPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         Log("Creating \(numberOfPort) virtual input and output ports", log: OSLog.midi)
         destroyVirtualPorts()
-        createMultipleVirtualInputPorts(numberOfPort: numberOfPort, names: names)
-        createMultipleVirtualOutputPorts(numberOfPort: numberOfPort, names: names)
+        createVirtualInputPorts(numberOfPort: numberOfPort, names: names)
+        createVirtualOutputPorts(numberOfPort: numberOfPort, names: names)
     }
 
     /// Create virtual MIDI input ports
     public func createVirtualInputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualInputPort()
-        guard numberOfPort < 0 else { Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
+        guard numberOfPort < 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
 
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
-        for virtualPortIndex in 0...numberOfPorts - 1 {
+        for virtualPortIndex in 0...numberOfPort - 1 {
             var virtualPortName: String
             var uniqueID: Int32
             virtualInputs.append(0)
@@ -49,7 +49,7 @@ extension MIDI {
             if let portID = uniqueIDs?[virtualPortIndex] {
                 uniqueID = portID
             } else {
-                uniqueID = 2_000_001 + unIDPortIndex
+                uniqueID = 2_000_000 + unIDPortIndex
                 unIDPortIndex += 2
            }
 
@@ -76,25 +76,25 @@ extension MIDI {
     }
 
     /// Create virtual MIDI output ports
-    public func createVirtualOutputPorts(numberOfPorts: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    public func createVirtualOutputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualOutputPort()
-        guard numberOfPort < 0 else { Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
+        guard numberOfPort < 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
-        for virtualPortIndex in 0...numberOfPorts - 1 {
+        for virtualPortIndex in 0...numberOfPort - 1 {
             var virtualPortName: String
             var uniqueID: Int32
             virtualOutputs.append(0)
 
-            if names?[virtualPortIndex] != nil {
-                virtualPortName = names![virtualPortIndex]
+            if let portName = names?[virtualPortIndex] {
+                virtualPortName = portName
             } else {
                virtualPortName = String("\(clientName) \(unnamedPortIndex)")
                unnamedPortIndex += 1
            }
 
-            if uniqueIDs?[virtualPortIndex] != nil {
-                uniqueID = uniqueIDs![virtualPortIndex]
+            if let portID = uniqueIDs?[virtualPortIndex] {
+                uniqueID = portID
             } else {
                 uniqueID = 2_000_001 + unIDPortIndex
                 unIDPortIndex += 2

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -20,7 +20,7 @@ extension MIDI {
 
 
      /// Create set of virtual input and output MIDI ports
-    public func createVirtualPorts(numberOfPort: UInt = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    public func createVirtualPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         Log("Creating \(numberOfPort) virtual input and output ports", log: OSLog.midi)
         destroyVirtualPorts()
         createVirtualInputPorts(numberOfPort: numberOfPort, names: names)

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -39,14 +39,14 @@ extension MIDI {
             var uniqueID: Int32
             virtualInputs.append(0)
 
-            if let portName = names?[virtualPortIndex] {
+            if names?.count ?? 0 >= virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
             } else {
                virtualPortName = String("\(clientName) \(unnamedPortIndex)")
                unnamedPortIndex += 1
            }
 
-            if let portID = uniqueIDs?[virtualPortIndex] {
+            if uniqueIDs?.count ?? 0 >= virtualPortIndex, let portID = uniqueIDs?[virtualPortIndex] {
                 uniqueID = portID
             } else {
                 uniqueID = 2_000_000 + unIDPortIndex
@@ -86,14 +86,14 @@ extension MIDI {
             var uniqueID: Int32
             virtualOutputs.append(0)
 
-            if let portName = names?[virtualPortIndex] {
+            if names?.count ?? 0 >= virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
             } else {
                virtualPortName = String("\(clientName) \(unnamedPortIndex)")
                unnamedPortIndex += 1
            }
 
-            if let portID = uniqueIDs?[virtualPortIndex] {
+            if uniqueIDs?.count ?? 0 >= virtualPortIndex, let portID = uniqueIDs?[virtualPortIndex] {
                 uniqueID = portID
             } else {
                 uniqueID = 2_000_001 + unIDPortIndex

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -102,7 +102,7 @@ extension MIDI {
            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
                 if virtualInputs.count <= virtualPortIndex {virtualInputs.append(0)}
-                MIDIObjectSetIntegerProperty(virtualInputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
+                MIDIObjectSetIntegerProperty(virtualOutputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {
                 Log("Error \(result) Creating Virtual Output Port: \(virtualPortName) -- \(virtualOutputs[virtualPortIndex])",
                 log: OSLog.midi, type: .error)

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -101,7 +101,6 @@ extension MIDI {
            }
            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
-//                if virtualInputs.count <= virtualPortIndex {virtualInputs.append(0)}
                 MIDIObjectSetIntegerProperty(virtualOutputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {
                 Log("Error \(result) Creating Virtual Output Port: \(virtualPortName) -- \(virtualOutputs[virtualPortIndex])",

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -101,8 +101,8 @@ extension MIDI {
            }
            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
-                if virtualInputs.count <= virtualPortIndex {virtualInputs.append(0)}
-                MIDIObjectSetIntegerProperty(virtualInputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
+//                if virtualInputs.count <= virtualPortIndex {virtualInputs.append(0)}
+                MIDIObjectSetIntegerProperty(virtualOutputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {
                 Log("Error \(result) Creating Virtual Output Port: \(virtualPortName) -- \(virtualOutputs[virtualPortIndex])",
                 log: OSLog.midi, type: .error)

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -37,7 +37,7 @@ extension MIDI {
         for virtualPortIndex in 0...numberOfPort - 1 {
             var virtualPortName: String
             var uniqueID: Int32
-            virtualInputs.append(0)
+            if virtualPortIndex != 0 {virtualInputs.append(0)}
 
             if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
@@ -84,7 +84,7 @@ extension MIDI {
         for virtualPortIndex in 0...numberOfPort - 1 {
             var virtualPortName: String
             var uniqueID: Int32
-            virtualOutputs.append(0)
+            if virtualPortIndex != 0 {virtualOutputs.append(0)}
 
             if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -30,7 +30,7 @@ extension MIDI {
     /// Create virtual MIDI input ports
     public func createVirtualInputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualInputPort()
-        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
+        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)", log: OSLog.midi, type: .error)}
 
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
@@ -78,7 +78,7 @@ extension MIDI {
     /// Create virtual MIDI output ports
     public func createVirtualOutputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualOutputPort()
-        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
+        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)", log: OSLog.midi, type: .error)}
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
         for virtualPortIndex in 0...numberOfPort - 1 {

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -118,9 +118,9 @@ extension MIDI {
         destroyVirtualOutputPort()
     }
 
-    /// Closes the virtuals input ports, if created one already.
+    /// Closes the virtual input ports, if created one already.
     ///
-    /// - Returns: Returns true if virtuals inputs closed.
+    /// - Returns: Returns true if virtual inputs closed.
     ///
     @discardableResult public func destroyVirtualInputPort() -> Bool {
         if virtualInputs != [0] {
@@ -134,9 +134,9 @@ extension MIDI {
         return false
     }
 
-    /// Closes the virtuals output ports, if created one already.
+    /// Closes the virtual output ports, if created one already.
     ///
-    /// - Returns: Returns true if virtuals outputs closed.
+    /// - Returns: Returns true if virtual outputs closed.
     ///
     @discardableResult public func destroyVirtualOutputPort() -> Bool {
         if virtualOutputs != [0] {

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -20,7 +20,7 @@ extension MIDI {
 
 
      /// Create set of virtual input and output MIDI ports
-    public func createVirtualPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    public func createVirtualPorts(numberOfPort: UInt = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         Log("Creating \(numberOfPort) virtual input and output ports", log: OSLog.midi)
         destroyVirtualPorts()
         createVirtualInputPorts(numberOfPort: numberOfPort, names: names)
@@ -28,7 +28,7 @@ extension MIDI {
     }
 
     /// Create virtual MIDI input ports
-    public func createVirtualInputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    public func createVirtualInputPorts(numberOfPort: UInt = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualInputPort()
         guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
 
@@ -76,7 +76,7 @@ extension MIDI {
     }
 
     /// Create virtual MIDI output ports
-    public func createVirtualOutputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    public func createVirtualOutputPorts(numberOfPort: UInt = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualOutputPort()
         guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
         var unnamedPortIndex = 1
@@ -101,6 +101,7 @@ extension MIDI {
            }
            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
+                if virtualInputs.count =< virtualPortIndex {virtualInputs.append(0)}
                 MIDIObjectSetIntegerProperty(virtualInputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {
                 Log("Error \(result) Creating Virtual Output Port: \(virtualPortName) -- \(virtualOutputs[virtualPortIndex])",

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -39,14 +39,14 @@ extension MIDI {
             var uniqueID: Int32
             virtualInputs.append(0)
 
-            if names?.count ?? 0 >= virtualPortIndex, let portName = names?[virtualPortIndex] {
+            if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
             } else {
                virtualPortName = String("\(clientName) \(unnamedPortIndex)")
                unnamedPortIndex += 1
            }
 
-            if uniqueIDs?.count ?? 0 >= virtualPortIndex, let portID = uniqueIDs?[virtualPortIndex] {
+            if uniqueIDs?.count ?? 0 > virtualPortIndex, let portID = uniqueIDs?[virtualPortIndex] {
                 uniqueID = portID
             } else {
                 uniqueID = 2_000_000 + unIDPortIndex
@@ -86,14 +86,14 @@ extension MIDI {
             var uniqueID: Int32
             virtualOutputs.append(0)
 
-            if names?.count ?? 0 >= virtualPortIndex, let portName = names?[virtualPortIndex] {
+            if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
             } else {
                virtualPortName = String("\(clientName) \(unnamedPortIndex)")
                unnamedPortIndex += 1
            }
 
-            if uniqueIDs?.count ?? 0 >= virtualPortIndex, let portID = uniqueIDs?[virtualPortIndex] {
+            if uniqueIDs?.count ?? 0 > virtualPortIndex, let portID = uniqueIDs?[virtualPortIndex] {
                 uniqueID = portID
             } else {
                 uniqueID = 2_000_001 + unIDPortIndex

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -123,7 +123,7 @@ extension MIDI {
     ///
     @discardableResult public func destroyVirtualInputPort() -> Bool {
         if virtualInputs != [0] {
-            for (index, virtualInput) in virtualInputs.enumerated() {
+            for (index, virtualInput) in virtualInputs.enumerated().reversed() {
                 guard MIDIEndpointDispose(virtualInput) == noErr else {return false}
                 virtualInputs.remove(at: index)
             }
@@ -139,7 +139,7 @@ extension MIDI {
     ///
     @discardableResult public func destroyVirtualOutputPort() -> Bool {
         if virtualOutputs != [0] {
-            for (index, virtualOutput) in virtualOutputs.enumerated() {
+            for (index, virtualOutput) in virtualOutputs.enumerated().reversed() {
                 guard MIDIEndpointDispose(virtualOutput) == noErr else {return false}
                 virtualOutputs.remove(at: index)
             }

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -30,7 +30,8 @@ extension MIDI {
     /// Create virtual MIDI input ports
     public func createVirtualInputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualInputPort()
-        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)", log: OSLog.midi, type: .error)}
+        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",
+                                                 log: OSLog.midi, type: .error)}
 
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
@@ -78,7 +79,8 @@ extension MIDI {
     /// Create virtual MIDI output ports
     public func createVirtualOutputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualOutputPort()
-        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)", log: OSLog.midi, type: .error)}
+        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",
+                                                 log: OSLog.midi, type: .error)}
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
         for virtualPortIndex in 0...numberOfPort - 1 {

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -127,7 +127,7 @@ extension MIDI {
                 guard MIDIEndpointDispose(virtualInput) == noErr else {return false}
                 virtualInputs.remove(at: index)
             }
-            virtualInputs[0] = 0
+            virtualInputs.append(0)
             return true
             }
         return false
@@ -143,7 +143,7 @@ extension MIDI {
                 guard MIDIEndpointDispose(virtualOutput) == noErr else {return false}
                 virtualOutputs.remove(at: index)
             }
-            virtualOutputs[0] = 0
+            virtualOutputs.append(0)
             return true
         }
         return false

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -60,7 +60,7 @@ extension MIDI {
                 for packet in packetList.pointee {
                     // a Core MIDI packet may contain multiple MIDI events
                     for event in packet {
-                        self.handleMIDIMessage(event, fromInput: uniqueID)
+                        self.handleMIDIMessage(event, fromInput: virtualInputs[virtualPortIndex])
                     }
                 }
             }

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -18,82 +18,36 @@ extension MIDI {
     //      * Support hidden uuid generation so the caller can worry about less
     //
 
-    /// Create set of virtual input and output MIDI ports
-    public func createVirtualPorts(_ uniqueID: Int32 = 2_000_000, name: String? = nil) {
-        Log("Creating virtual input and output ports", log: OSLog.midi)
+
+     /// Create set of virtual input and output MIDI ports
+    public func createVirtualPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+        Log("Creating \(numberOfPort) virtual input and output ports", log: OSLog.midi)
         destroyVirtualPorts()
-        createVirtualInputPort(name: name)
-        createVirtualOutputPort(name: name)
+        createMultipleVirtualInputPorts(numberOfPort: numberOfPort, names: names)
+        createMultipleVirtualOutputPorts(numberOfPort: numberOfPort, names: names)
     }
 
-    /// Create a virtual MIDI input port
-    public func createVirtualInputPort(_ uniqueID: Int32 = 2_000_000, name: String? = nil) {
+    /// Create virtual MIDI input ports
+    public func createVirtualInputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualInputPort()
-        let virtualPortname = name ?? String(clientName)
-
-        let result = MIDIDestinationCreateWithBlock(
-            client,
-            virtualPortname as CFString,
-            &virtualInputs[0]) { packetList, _ in
-                for packet in packetList.pointee {
-                    // a Core MIDI packet may contain multiple MIDI events
-                    for event in packet {
-                        self.handleMIDIMessage(event, fromInput: uniqueID)
-                    }
-                }
-        }
-
-        if result == noErr {
-            MIDIObjectSetIntegerProperty(virtualInputs[0], kMIDIPropertyUniqueID, uniqueID)
-        } else {
-            Log("Error \(result) Creating Virtual Input Port: \(virtualPortname) -- \(virtualInputs[0])",
-                log: OSLog.midi, type: .error)
-            CheckError(result)
-        }
-    }
-
-    /// Create a virtual MIDI output port
-    public func createVirtualOutputPort(_ uniqueID: Int32 = 2_000_001, name: String? = nil) {
-        destroyVirtualOutputPort()
-        let virtualPortname = name ?? String(clientName)
-
-        let result = MIDISourceCreate(client, virtualPortname as CFString, &virtualOutputs[0])
-        if result == noErr {
-            MIDIObjectSetIntegerProperty(virtualInputs[0], kMIDIPropertyUniqueID, uniqueID)
-        } else {
-            Log("Error \(result) Creating Virtual Output Port: \(virtualPortname) -- \(virtualOutputs[0])",
-                log: OSLog.midi, type: .error)
-            CheckError(result)
-        }
-    }
-
-     /// Create multiple set of virtual input and output MIDI ports
-    public func createMultipleVirtualPorts(_ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
-        Log("Creating multiple virtual input and output ports", log: OSLog.midi)
-        destroyVirtualPorts()
-        createMultipleVirtualInputPorts(names: names)
-        createMultipleVirtualOutputPorts(names: names)
-    }
-
-    /// Create multiple virtual MIDI input ports
-    public func createMultipleVirtualInputPorts(numberOfPorts: Int = 2, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
-        destroyVirtualInputPort()
+        guard numberOfPort < 0 else { Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
 
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
-        for virtualPortIndex in 1...numberOfPorts {
+        for virtualPortIndex in 0...numberOfPorts - 1 {
             var virtualPortName: String
             var uniqueID: Int32
+            virtualInputs.append(0)
 
-            if names?[virtualPortIndex] != nil {
-                virtualPortName = names![virtualPortIndex]
+            if let portName = names?[virtualPortIndex] {
+                virtualPortName = portName
             } else {
                virtualPortName = String("\(clientName) \(unnamedPortIndex)")
                unnamedPortIndex += 1
            }
 
-            if uniqueIDs?[virtualPortIndex] != nil {
-                uniqueID = uniqueIDs![virtualPortIndex]
+            if let portID = uniqueIDs?[virtualPortIndex] {
+                uniqueID = portID
             } else {
                 uniqueID = 2_000_001 + unIDPortIndex
                 unIDPortIndex += 2
@@ -121,14 +75,16 @@ extension MIDI {
         }
     }
 
-    /// Create multiple virtual MIDI output ports
-    public func createMultipleVirtualOutputPorts(numberOfPorts: Int = 2, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
+    /// Create virtual MIDI output ports
+    public func createVirtualOutputPorts(numberOfPorts: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualOutputPort()
+        guard numberOfPort < 0 else { Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
-        for virtualPortIndex in 1...numberOfPorts {
+        for virtualPortIndex in 0...numberOfPorts - 1 {
             var virtualPortName: String
             var uniqueID: Int32
+            virtualOutputs.append(0)
 
             if names?[virtualPortIndex] != nil {
                 virtualPortName = names![virtualPortIndex]
@@ -160,30 +116,34 @@ extension MIDI {
         destroyVirtualOutputPort()
     }
 
-    /// Closes the virtual input port, if created one already.
+    /// Closes the virtuals input ports, if created one already.
     ///
-    /// - Returns: Returns true if virtual input closed.
+    /// - Returns: Returns true if virtuals inputs closed.
     ///
     @discardableResult public func destroyVirtualInputPort() -> Bool {
-        if virtualInputs[0] != 0 {
-            if MIDIEndpointDispose(virtualInputs[0]) == noErr {
-                virtualInputs[0] = 0
-                return true
+        if virtualInputs != [0] {
+            for (index, virtualInput) in virtualInputs.enumerated() {
+                guard MIDIEndpointDispose(virtualInput) == noErr else {return false}
+                virtualInputs.remove(at: index)
             }
-        }
+            virtualInputs[0] = 0
+            return true
+            }
         return false
     }
 
-    /// Closes the virtual output port, if created one already.
+    /// Closes the virtuals output ports, if created one already.
     ///
-    /// - Returns: Returns true if virtual output closed.
+    /// - Returns: Returns true if virtuals outputs closed.
     ///
     @discardableResult public func destroyVirtualOutputPort() -> Bool {
-        if virtualOutputs[0] != 0 {
-            if MIDIEndpointDispose(virtualOutputs[0]) == noErr {
-                virtualOutputs[0] = 0
-                return true
+        if virtualOutputs != [0] {
+            for (index, virtualOutput) in virtualOutputs.enumerated() {
+                guard MIDIEndpointDispose(virtualOutput) == noErr else {return false}
+                virtualOutputs.remove(at: index)
             }
+            virtualOutputs[0] = 0
+            return true
         }
         return false
     }

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -30,7 +30,7 @@ extension MIDI {
     /// Create virtual MIDI input ports
     public func createVirtualInputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualInputPort()
-        guard numberOfPort < 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
+        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
 
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
@@ -78,7 +78,7 @@ extension MIDI {
     /// Create virtual MIDI output ports
     public func createVirtualOutputPorts(numberOfPort: Int = 1, _ uniqueIDs: [Int32]? = nil, names: [String]? = nil) {
         destroyVirtualOutputPort()
-        guard numberOfPort < 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
+        guard numberOfPort > 0 else { return Log("Error: Number of port to create can't be less than one)",log: OSLog.midi, type: .error)}
         var unnamedPortIndex = 1
         var unIDPortIndex: Int32 = 0
         for virtualPortIndex in 0...numberOfPort - 1 {


### PR DESCRIPTION
- Refactored creation of virtual inputs and outputs
- Fixed numerous bug introduced in previous pull request (add support for multiple virtual inputs and outputs)
- add support to send midi to only specific physical ans virtual output (default send to every open outputs and virtual outputs)
