### PR TITLE
Make it possible to define custom node taps outside of module

### DIFF
--- a/Sources/AudioKit/Analysis/AmplitudeTap.swift
+++ b/Sources/AudioKit/Analysis/AmplitudeTap.swift
@@ -36,7 +36,7 @@ public class AmplitudeTap: BaseTap {
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    override internal func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    override public func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard let floatData = buffer.floatChannelData else { return }
 
         let channelCount = Int(buffer.format.channelCount)

--- a/Sources/AudioKit/Analysis/BaseTap.swift
+++ b/Sources/AudioKit/Analysis/BaseTap.swift
@@ -95,7 +95,7 @@ open class BaseTap: Toggleable {
     }
 
     // overide this method to handle Tap in derived class
-    func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {}
+    open func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {}
 
     /// Remove the tap on the input
     public func stop() {

--- a/Sources/AudioKit/Analysis/FFTTap.swift
+++ b/Sources/AudioKit/Analysis/FFTTap.swift
@@ -25,7 +25,7 @@ open class FFTTap: BaseTap {
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    override internal func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    override open func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard buffer.floatChannelData != nil else { return }
 
         fftData = FFTTap.performFFT(buffer: buffer)

--- a/Sources/AudioKit/Analysis/PitchTap.swift
+++ b/Sources/AudioKit/Analysis/PitchTap.swift
@@ -55,7 +55,7 @@ public class PitchTap: BaseTap {
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    override internal func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    override public func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard let floatData = buffer.floatChannelData else { return }
         let channelCount = Int(buffer.format.channelCount)
         let length = UInt(buffer.frameLength)

--- a/Sources/AudioKit/Analysis/RawDataTap.swift
+++ b/Sources/AudioKit/Analysis/RawDataTap.swift
@@ -24,7 +24,7 @@ open class RawDataTap: BaseTap {
     }
 
     // AVAudioNodeTapBlock - time is unused in this case
-    override internal func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+    override open func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard buffer.floatChannelData != nil else { return }
 
         let arraySize = Int(buffer.frameLength)


### PR DESCRIPTION
Just made Basetap.doHandleTapBlock open so that custom taps can be properly defined outside of the AudioKit module.
Also had to update the access control for overrides in the already defined taps.