### PR TITLE
AmplitudeTap: Added StereoMode

### DIFF
--- a/Sources/AudioKit/Analysis/AmplitudeTap.swift
+++ b/Sources/AudioKit/Analysis/AmplitudeTap.swift
@@ -43,8 +43,7 @@ public class AmplitudeTap: BaseTap {
                 bufferSize: UInt32 = 1_024,
                 stereoMode: StereoMode = .center,
                 analysisMode: AnalysisMode = .rms,
-                handler: @escaping (Float) -> Void = { _ in })
-    {
+                handler: @escaping (Float) -> Void = { _ in }) {
         self.handler = handler
         self.stereoMode = stereoMode
         self.analysisMode = analysisMode

--- a/Sources/AudioKit/Analysis/AmplitudeTap.swift
+++ b/Sources/AudioKit/Analysis/AmplitudeTap.swift
@@ -23,8 +23,11 @@ public class AmplitudeTap: BaseTap {
         return amp[1]
     }
 
+    /// Determines if the returned amplitude value is the left, right, or average of the two
+    public var stereoMode: StereoMode = .center
+
     /// Determines if the returned amplitude value is the rms or peak value
-    public var mode: AnalysisMode = .rms
+    public var analysisMode: AnalysisMode = .rms
 
     private var handler: (Float) -> Void = { _ in }
 
@@ -32,14 +35,19 @@ public class AmplitudeTap: BaseTap {
     ///
     /// - parameter input: Node to analyze
     /// - parameter bufferSize: Size of buffer to analyze
+    /// - parameter stereoMode: left, right, or average returned amplitudes
+    /// - parameter analysisMode: rms or peak returned amplitudes
     /// - parameter handler: Code to call with new amplitudes
-    /// - parameter mode: rms or peak returned amplitudes
+
     public init(_ input: Node,
                 bufferSize: UInt32 = 1_024,
-                mode: AnalysisMode = .rms,
-                handler: @escaping (Float) -> Void = { _ in }) {
+                stereoMode: StereoMode = .center,
+                analysisMode: AnalysisMode = .rms,
+                handler: @escaping (Float) -> Void = { _ in })
+    {
         self.handler = handler
-        self.mode = mode
+        self.stereoMode = stereoMode
+        self.analysisMode = analysisMode
         super.init(input, bufferSize: bufferSize)
     }
 
@@ -54,7 +62,7 @@ public class AmplitudeTap: BaseTap {
         for n in 0 ..< channelCount {
             let data = floatData[n]
 
-            if mode == .rms {
+            if analysisMode == .rms {
                 var rms: Float = 0
                 vDSP_rmsqv(data, 1, &rms, UInt(length))
                 amp[n] = rms
@@ -66,7 +74,14 @@ public class AmplitudeTap: BaseTap {
             }
         }
 
-        handler(amplitude)
+        switch stereoMode {
+        case .left:
+            handler(leftAmplitude)
+        case .right:
+            handler(rightAmplitude)
+        case .center:
+            handler(amplitude)
+        }
     }
 
     /// Remove the tap on the input
@@ -80,4 +95,10 @@ public class AmplitudeTap: BaseTap {
 public enum AnalysisMode {
     case rms
     case peak
+}
+
+public enum StereoMode {
+    case left
+    case right
+    case center
 }

--- a/Tests/AudioKitTests/Analysis Tests/AmplitudeTapTests.swift
+++ b/Tests/AudioKitTests/Analysis Tests/AmplitudeTapTests.swift
@@ -42,6 +42,82 @@ class AmplitudeTapTests: XCTestCase {
         }
     }
     
+    func testLeftStereoMode() {
+
+        let engine = AudioEngine()
+
+        var amplitudes: [Float] = []
+
+        let sine = OperationGenerator {
+            let amplitude = Operation.sineWave(frequency: 0.25, amplitude: 1)
+            return Operation.sineWave() * amplitude }
+
+        engine.output = sine
+        sine.start()
+
+        let expect = expectation(description: "wait for amplitudes")
+
+        let tap = AmplitudeTap(sine) { amp in
+            amplitudes.append(amp)
+
+            if amplitudes.count == 10 {
+                expect.fulfill()
+            }
+        }
+        tap.stereoMode = .left
+        tap.start()
+
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+        testMD5(audio)
+
+        wait(for: [expect], timeout: 5.0)
+
+        let knownValues: [Float] = [0.01478241, 0.03954828, 0.06425185, 0.09090047, 0.11480384,
+                                    0.14164367, 0.16560285, 0.19081590, 0.21635467, 0.23850754]
+        for i in 0..<knownValues.count {
+            XCTAssertEqual(amplitudes[i], knownValues[i], accuracy: 0.001)
+        }
+    }
+    
+    func testRightStereoMode() {
+
+        let engine = AudioEngine()
+
+        var amplitudes: [Float] = []
+
+        let sine = OperationGenerator {
+            let amplitude = Operation.sineWave(frequency: 0.25, amplitude: 1)
+            return Operation.sineWave() * amplitude }
+
+        engine.output = sine
+        sine.start()
+
+        let expect = expectation(description: "wait for amplitudes")
+
+        let tap = AmplitudeTap(sine) { amp in
+            amplitudes.append(amp)
+
+            if amplitudes.count == 10 {
+                expect.fulfill()
+            }
+        }
+        tap.stereoMode = .right
+        tap.start()
+
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+        testMD5(audio)
+
+        wait(for: [expect], timeout: 5.0)
+
+        let knownValues: [Float] = [0.01478241, 0.03954828, 0.06425185, 0.09090047, 0.11480384,
+                                    0.14164367, 0.16560285, 0.19081590, 0.21635467, 0.23850754]
+        for i in 0..<knownValues.count {
+            XCTAssertEqual(amplitudes[i], knownValues[i], accuracy: 0.001)
+        }
+    }
+    
     func testPeakAnalysisMode() {
 
         let engine = AudioEngine()
@@ -64,7 +140,7 @@ class AmplitudeTapTests: XCTestCase {
                 expect.fulfill()
             }
         }
-        tap.mode = .peak
+        tap.analysisMode = .peak
         tap.start()
 
         let audio = engine.startTest(totalDuration: 1.0)

--- a/Tests/AudioKitTests/Analysis Tests/AmplitudeTapTests.swift
+++ b/Tests/AudioKitTests/Analysis Tests/AmplitudeTapTests.swift
@@ -41,7 +41,7 @@ class AmplitudeTapTests: XCTestCase {
             XCTAssertEqual(amplitudes[i], knownValues[i], accuracy: 0.001)
         }
     }
-    
+
     func testLeftStereoMode() {
 
         let engine = AudioEngine()
@@ -79,7 +79,7 @@ class AmplitudeTapTests: XCTestCase {
             XCTAssertEqual(amplitudes[i], knownValues[i], accuracy: 0.001)
         }
     }
-    
+
     func testRightStereoMode() {
 
         let engine = AudioEngine()
@@ -117,7 +117,7 @@ class AmplitudeTapTests: XCTestCase {
             XCTAssertEqual(amplitudes[i], knownValues[i], accuracy: 0.001)
         }
     }
-    
+
     func testPeakAnalysisMode() {
 
         let engine = AudioEngine()

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -18,6 +18,8 @@ let validatedMD5s: [String: String] = [
     "-[AmplitudeEnvelopeTests testRelease]": "c65afa7279eef3df9b512b22ffde4d3e",
     "-[AmplitudeEnvelopeTests testDoubleStop]": "c65afa7279eef3df9b512b22ffde4d3e",
     "-[AmplitudeTapTests testDefault]": "b90b7df4d69e57898ee39d89891f8f91",
+    "-[AmplitudeTapTests testLeftStereoMode]": "b90b7df4d69e57898ee39d89891f8f91",
+    "-[AmplitudeTapTests testRightStereoMode]": "b90b7df4d69e57898ee39d89891f8f91",
     "-[AmplitudeTapTests testPeakAnalysisMode]": "b90b7df4d69e57898ee39d89891f8f91",
     "-[AudioPlayerTests testBasic]": "c7e1a8f2293beba52bbbb1967f2586ab",
     "-[AudioPlayerTests testLoop]": "f0a73fe1aca7479cba6a777373ff90a3",


### PR DESCRIPTION
Setting the stereoMode to left or right will now return the left or right amplitude in the handler as opposed to the average amplitude. Default value results in no change to functionality.