### PR TITLE
Add case harmonic(partialAmplitudes: [Float])

### DIFF
--- a/Sources/AudioKit/Internals/Table/Table.swift
+++ b/Sources/AudioKit/Internals/Table/Table.swift
@@ -3,7 +3,7 @@
 import AVFoundation
 
 /// Supported default table types
-public enum TableType: Int, Codable, CaseIterable {
+public enum TableType {
     /// Standard sine waveform
     case sine
 
@@ -33,6 +33,9 @@ public enum TableType: Int, Codable, CaseIterable {
 
     /// Reversed sawtooth waveform from 0-1
     case positiveReverseSawtooth
+    
+    /// Sine root + harmonics, with harmonic amplitudes as percentages of root amplitude
+    case harmonic([Float])
 
     /// Zeros
     case zero
@@ -42,7 +45,7 @@ public enum TableType: Int, Codable, CaseIterable {
 }
 
 /// A table of values accessible as a waveform or lookup mechanism
-public class Table: NSObject, MutableCollection, Codable {
+public class Table: NSObject, MutableCollection {
     /// Index by an integer
     public typealias Index = Int
     /// Index distance, or count
@@ -141,6 +144,8 @@ public class Table: NSObject, MutableCollection, Codable {
             positiveReverseSawtoothWave()
         case .positiveSquare:
             positiveSquareWave()
+        case let .harmonic(partialAmplitudes):
+            harmonicWave(with: partialAmplitudes)
         case .zero:
             zero()
         case .custom:
@@ -236,6 +241,24 @@ public class Table: NSObject, MutableCollection, Codable {
     func standardSineWave() {
         for i in indices {
             content[i] = Float(sin(2 * 3.14_159_265 * Float(i + phaseOffset) / Float(count)))
+        }
+    }
+    
+    /// Instantiate the table as root frequency with partials, where the partial amplitudes are a percentage of the root frequency amplitude
+    func harmonicWave(with partialAmplitudes: [Float]) {
+        for i in indices {
+            var sum: Float = 0
+            
+            // Root
+            sum = Float(sin(2 * 3.14_159_265 * Float(i + phaseOffset) / Float(count)))
+
+            // Partials
+            for j in 0..<partialAmplitudes.count {
+                let partial = Float(sin(2 * 3.14_159_265 * Float((i * (j + 2)) + phaseOffset) / Float(count)))
+                sum += partial * partialAmplitudes[j]
+            }
+            
+            content[i] = sum
         }
     }
 

--- a/Sources/AudioKit/Internals/Table/Table.swift
+++ b/Sources/AudioKit/Internals/Table/Table.swift
@@ -255,7 +255,12 @@ public class Table: NSObject, MutableCollection {
 
             // Partials
             for ampIndex in 0..<partialAmplitudes.count {
-                let partial = Float(sin(2 * 3.14_159_265 * Float((index * (ampIndex + 2)) + phaseOffset) / Float(count)))
+                let partial =
+                    Float(
+                        sin(2 * 3.14_159_265 *
+                                Float((index * (ampIndex + 2)) + phaseOffset)
+                                / Float(count))
+                    )
                 sum += partial * partialAmplitudes[ampIndex]
             }
 

--- a/Sources/AudioKit/Internals/Table/Table.swift
+++ b/Sources/AudioKit/Internals/Table/Table.swift
@@ -33,7 +33,7 @@ public enum TableType {
 
     /// Reversed sawtooth waveform from 0-1
     case positiveReverseSawtooth
-    
+
     /// Sine root + harmonics, with harmonic amplitudes as percentages of root amplitude
     case harmonic([Float])
 
@@ -243,22 +243,23 @@ public class Table: NSObject, MutableCollection {
             content[i] = Float(sin(2 * 3.14_159_265 * Float(i + phaseOffset) / Float(count)))
         }
     }
-    
-    /// Instantiate the table as root frequency with partials, where the partial amplitudes are a percentage of the root frequency amplitude
+
+    /// Instantiate the table as root frequency with partials, where the partial amplitudes are
+    /// a percentage of the root frequency amplitude
     func harmonicWave(with partialAmplitudes: [Float]) {
-        for i in indices {
+        for index in indices {
             var sum: Float = 0
-            
+
             // Root
-            sum = Float(sin(2 * 3.14_159_265 * Float(i + phaseOffset) / Float(count)))
+            sum = Float(sin(2 * 3.14_159_265 * Float(index + phaseOffset) / Float(count)))
 
             // Partials
-            for j in 0..<partialAmplitudes.count {
-                let partial = Float(sin(2 * 3.14_159_265 * Float((i * (j + 2)) + phaseOffset) / Float(count)))
-                sum += partial * partialAmplitudes[j]
+            for ampIndex in 0..<partialAmplitudes.count {
+                let partial = Float(sin(2 * 3.14_159_265 * Float((index * (ampIndex + 2)) + phaseOffset) / Float(count)))
+                sum += partial * partialAmplitudes[ampIndex]
             }
-            
-            content[i] = sum
+
+            content[index] = sum
         }
     }
 

--- a/Tests/AudioKitTests/TableTests.swift
+++ b/Tests/AudioKitTests/TableTests.swift
@@ -46,4 +46,14 @@ class TableTests: XCTestCase {
         testMD5(audio)
     }
 
+    func testHarmonicWithPartialAmplitudes() {
+        let engine = AudioEngine()
+        let partialAmplitudes: [Float] = [0.8, 0.2, 0.3, 0.06, 0.12, 0.0015]
+        let input = Oscillator(waveform: Table(.harmonic(partialAmplitudes)))
+        engine.output = input
+        input.start()
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+        testMD5(audio)
+    }
 }

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -382,6 +382,7 @@ let validatedMD5s: [String: String] = [
     "-[TableTests testSawtooth]": "7a3dc1fdc7f7c4d113ba9d1119143e67",
     "-[TableTests testSine]": "f4cc261bdf98ae17320f9561941c8664",
     "-[TableTests testTriangle]": "54fb40c15242198d45b31b6a79187d07",
+	"-[TableTests testHarmonicWithPartialAmplitudes]": "75d01266f4d35ea0074a1bf469d63f27",
     "-[TanhDistortionTests testDefault]": "b3a07866018f81cc2e3572769e76ae17",
     "-[TanhDistortionTests testNegativeShapeParameter]": "a91935bdd8a161196c06d9294a58213d",
     "-[TanhDistortionTests testParameters]": "f5975f4dcf5ec3b1801b62ad7d16ed5e",


### PR DESCRIPTION
As discussed on Slack in #general, I'm looking for an alternative to the old AKFourierSeriesTableGenerator. This is my attempt to recreate it - add a type with an array of amplitudes as an option

To make this happen, I removed Int, Codable, CaseIterable from enum TableType and Codable from class Table. I could not see they were used as this in the repo, so I’m curious if this is a breaking change and for the motivation of adopting these. Making it codable again should probably be fine if needed, but if the enum needs to be represented by an Int, then I should probably find another approach