### PR TITLE
removed TPCircularBuffer from CallbackInstrumentDSP

### DIFF
--- a/Sources/CAudioKit/Nodes/Callback Instrument/CallbackInstrumentDSP.mm
+++ b/Sources/CAudioKit/Nodes/Callback Instrument/CallbackInstrumentDSP.mm
@@ -1,7 +1,9 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
 
 #include "DSPBase.h"
-#import "TPCircularBuffer.h"
+#import "../../Internals/Utilities/readerwriterqueue.h"
+
+using moodycamel::ReaderWriterQueue;
 
 typedef void (^CMIDICallback)(uint8_t, uint8_t, uint8_t);
 
@@ -9,11 +11,11 @@ class CallbackInstrumentDSP : public DSPBase {
 public:
     // MARK: Member Functions
 
-    TPCircularBuffer midiBuffer;
+//    TPCircularBuffer midiBuffer;
+    ReaderWriterQueue<AUMIDIEvent> midiBuffer;
     NSTimer* timer;
 
     CallbackInstrumentDSP() {
-        TPCircularBufferInit(&midiBuffer, 4096);
         // Hopefully this polling interval is ok.
         timer = [NSTimer scheduledTimerWithTimeInterval:0.01
                                                 repeats:true
@@ -23,7 +25,6 @@ public:
     }
 
     ~CallbackInstrumentDSP() {
-        TPCircularBufferCleanup(&midiBuffer);
         [timer invalidate];
     }
     
@@ -54,24 +55,24 @@ public:
 
     void handleMIDIEvent(AUMIDIEvent const& midiEvent) override {
         if (midiEvent.length != 3) return;
-        TPCircularBufferProduceBytes(&midiBuffer, midiEvent.data, 3);
+        midiBuffer.enqueue(midiEvent);
     }
 
     void consumer() {
         int32_t availableBytes;
-        uint8_t* data = (uint8_t*) TPCircularBufferTail(&midiBuffer, &availableBytes);
-        if(data) {
-            int32_t messageCount = availableBytes / 3;
+        AUMIDIEvent event;
+        midiBuffer.try_dequeue(event);
+        if(event.length > 0) {
+            int32_t messageCount = sizeof(event.data) / 3;
 
             if(callback) {
                 for(int messageIndex=0; messageIndex < messageCount; ++messageIndex) {
-                    uint8_t status = data[3*messageIndex];
-                    uint8_t data1 = data[3*messageIndex+1];
-                    uint8_t data2 = data[3*messageIndex+2];
+                    uint8_t status = event.data[3*messageIndex];
+                    uint8_t data1 = event.data[3*messageIndex+1];
+                    uint8_t data2 = event.data[3*messageIndex+2];
                     callback(status, data1, data2);
                 }
             }
-            TPCircularBufferConsume(&midiBuffer, messageCount * 3);
         }
     }
     


### PR DESCRIPTION
This removes TPCircularBuffer from CallbackInstrumentDSP
I rean the tests and the CallbackInstrument tests passed.

There were some failures, I think they are unrelated:

> /PROJECTS/AudioKit/Tests/AudioKitTests/ValidatedMD5s.swift:8: error: -[AudioKitTests.TransientShaperTests testParameters] : XCTAssertTrue failed - 
> FAILEDMD5 "-[TransientShaperTests testParameters]": "d7a80c25d932da6093b7cd53eb827e65",
> Test Case '-[AudioKitTests.TransientShaperTests testParameters]' failed (0.274 seconds).
> Test Suite 'TransientShaperTests' failed at 2021-02-06 21:31:26.918.
> 	 Executed 6 tests, with 2 failures (0 unexpected) in 1.639 (1.641) seconds
> 	 Executed 4 tests, with 0 failures (0 unexpected) in 0.952 (0.954) seconds
> 	 Executed 1 test, with 0 failures (0 unexpected) in 0.281 (0.282) seconds
> 	 Executed 1 test, with 0 failures (0 unexpected) in 0.263 (0.263) seconds
> 	 Executed 2 tests, with 0 failures (0 unexpected) in 0.486 (0.487) seconds
> 	 Executed 13 tests, with 13 tests skipped and 0 failures (0 unexpected) in 0.044 (0.048) seconds
> 	 Executed 1 test, with 0 failures (0 unexpected) in 0.293 (0.293) seconds
> 	 Executed 7 tests, with 0 failures (0 unexpected) in 8.056 (8.059) seconds
> 	 Executed 2 tests, with 0 failures (0 unexpected) in 0.622 (0.622) seconds
> 	 Executed 8 tests, with 0 failures (0 unexpected) in 1.878 (1.880) seconds
> 	 Executed 3 tests, with 0 failures (0 unexpected) in 0.737 (0.739) seconds
> 	 Executed 2 tests, with 0 failures (0 unexpected) in 0.450 (0.451) seconds
> 	 Executed 3 tests, with 0 failures (0 unexpected) in 0.794 (0.795) seconds
> Test Suite 'AudioKitTests.xctest' failed at 2021-02-06 21:31:41.796.
> 	 Executed 622 tests, with 13 tests skipped and 2 failures (0 unexpected) in 140.325 (140.627) seconds
> Test Suite 'All tests' failed at 2021-02-06 21:31:41.798.
> 	 Executed 622 tests, with 13 tests skipped and 2 failures (0 unexpected) in 140.325 (140.629) seconds