### PR TITLE
bug fix -uninitialized AUMIDIEvent caused stream of unwanted midi …

### DIFF
--- a/Sources/CAudioKit/Nodes/Callback Instrument/CallbackInstrumentDSP.mm
+++ b/Sources/CAudioKit/Nodes/Callback Instrument/CallbackInstrumentDSP.mm
@@ -59,7 +59,7 @@ public:
 
     void consumer() {
         int32_t availableBytes;
-        AUMIDIEvent event;
+        AUMIDIEvent event = AUMIDIEvent();
         midiBuffer.try_dequeue(event);
         if(event.length > 0) {
             int32_t messageCount = sizeof(event.data) / 3;

--- a/Tests/AudioKitTests/Sequencing and Automation Tests/CallbackInstrumentTests.swift
+++ b/Tests/AudioKitTests/Sequencing and Automation Tests/CallbackInstrumentTests.swift
@@ -9,13 +9,15 @@ class CallbackInstrumentTests: XCTestCase {
     var instrument = CallbackInstrument()
 
     func getTestSequence() -> NoteEventSequence {
-
         var seq = NoteEventSequence()
         seq.add(noteNumber: 60, position: 0, duration: 0.5)
         seq.add(noteNumber: 62, position: 1, duration: 0.5)
         seq.add(noteNumber: 63, position: 2, duration: 0.5)
-
         return seq
+    }
+    
+    func getEmptyTestSequence() -> NoteEventSequence {
+        return NoteEventSequence()
     }
 
     func testDefault() {
@@ -31,7 +33,7 @@ class CallbackInstrumentTests: XCTestCase {
 
         var data: [MIDIByte] = []
 
-        instrument = CallbackInstrument() { status, data1, data2 in
+        instrument = CallbackInstrument { status, data1, data2 in
             data.append(status)
             data.append(data1)
             data.append(data2)
@@ -52,6 +54,37 @@ class CallbackInstrumentTests: XCTestCase {
         audio.append(engine.render(duration: 3.0))
 
         wait(for: [expect], timeout: 1.0)
+        XCTAssertEqual(data, expectedData)
+    }
+    
+    func testEmptySequence() {
+        let engine = AudioEngine()
+
+        let expect = XCTestExpectation(description: "callback should not be called")
+        /// No matter the expected data, the callback should not be called
+        expect.isInverted = true
+        let expectedData: [MIDIByte] = []
+        var data: [MIDIByte] = []
+        
+        instrument = CallbackInstrument { status, data1, data2 in
+            XCTFail("this callback should not be called")
+            data.append(status)
+            data.append(data1)
+            data.append(data2)
+        }
+
+        let track = SequencerTrack(targetNode: instrument)
+        track.sequence = getEmptyTestSequence()
+        track.loopEnabled = false
+        track.playFromStart()
+
+        engine.output = instrument
+
+        let audio = engine.startTest(totalDuration: 3.0)
+        audio.append(engine.render(duration: 3.0))
+
+        wait(for: [expect], timeout: 1.0)
+        /// If the callback does get called, this will fail our test, adding insult to injury
         XCTAssertEqual(data, expectedData)
     }
 }


### PR DESCRIPTION
I introduced a bug!
By not creating the AUMIDIEvent, the initial values were some noise.
the event.length was not [nil] so the callback interpreted the event bytes.
it was sending these phantom bytes on every callback
I didn't notice it at first with a simple app that I was using to test my other code since I was only printing events that I was scheduling..

as penance, I created a test to assert that there are in fact no notes coming from a callback when there are none sequenced..