### PR TITLE
Added mappedExp and mappedInverted

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -317,6 +317,16 @@ extension CGFloat {
     public func mapped(from source: ClosedRange<CGFloat> = 0...1.0, to target: ClosedRange<CGFloat> = 0...1.0) -> CGFloat {
         return ((self - source.lowerBound) / (source.upperBound - source.lowerBound)) * (target.upperBound - target.lowerBound) + target.lowerBound
     }
+    
+    /// Map the value to a new inverted range
+    /// Return a value on [from.lowerBound,from.upperBound] to the inverse of a [to.lowerBound, to.upperBound] range
+    ///
+    /// - Parameters:
+    ///   - from source: Current range (Default: 0...1.0)
+    ///   - to target: Desired range (Default: 0...1.0)
+    public func mappedInverted(from source: ClosedRange<CGFloat> = 0...1.0, to target: ClosedRange<CGFloat> = 0...1.0) -> CGFloat {
+        return target.upperBound - self.mapped(from: source, to: target) + target.lowerBound
+    }
 
     /// Map the value to a new range at a base-10 logarithmic scaling
     /// Return a value on [from.lowerBound,from.upperBound] to a [to.lowerBound, to.upperBound] range
@@ -334,6 +344,19 @@ extension CGFloat {
         } else {
             return ((logN - logStart1 ) / (logStop1 - logStart1)) * (target.upperBound - target.lowerBound) + target.lowerBound
         }
+    }
+    
+    /// Map the value to a new range at a base e^log(n) scaling
+    /// Return a value on [from.lowerBound,from.upperBound] to a [to.lowerBound, to.upperBound] range
+    ///
+    /// - Parameters:
+    ///   - from source: Current range (Default: 0...1.0)
+    ///   - to target: Desired range (Default: 0...1.0)
+    public func mappedExp(from source: ClosedRange<CGFloat> = 0...1.0, to target: ClosedRange<CGFloat> = 0...1.0) -> CGFloat {
+        let logStart2 = log(target.lowerBound);
+        let logStop2 = log(target.upperBound);
+        let scale = (logStop2-logStart2) / (source.upperBound-source.lowerBound);
+        return exp(logStart2 + scale*(self-source.lowerBound))
     }
 }
 


### PR DESCRIPTION
I added a method that does a mapping but then inverts the range. This helps with UI stuff where 0 is the top and height is the bottom.

Also, I added a method that goes from the logarithmic scale back to the linear scale. I called it mappedExp, but I'm not sure that this is an appropriate name. Suggestions for a new name are welcome