### PR TITLE
Init buffer size in settings w/ sample count

### DIFF
--- a/Sources/CAudioKit/include/DSPBase.h
+++ b/Sources/CAudioKit/include/DSPBase.h
@@ -41,7 +41,6 @@ AK_API void akSetSeed(unsigned int);
 
 #ifdef __cplusplus
 
-#import <Foundation/Foundation.h>
 #import <vector>
 
 /**

--- a/Sources/CAudioKit/include/DSPBase.h
+++ b/Sources/CAudioKit/include/DSPBase.h
@@ -4,7 +4,6 @@
 
 #import "Interop.h"
 #import <AudioToolbox/AudioToolbox.h>
-#import <AVFoundation/AVFoundation.h>
 
 #include <stdarg.h>
 

--- a/Sources/CAudioKit/include/DSPBase.h
+++ b/Sources/CAudioKit/include/DSPBase.h
@@ -48,7 +48,9 @@ AK_API void akSetSeed(unsigned int);
  does not know the type of the subclass at compile time.
  */
 
-class DSPBase {
+struct DSPBase {
+
+private:
 
     std::vector<AudioBufferList*> internalBufferLists;
     

--- a/Sources/CAudioKit/include/Interop.h
+++ b/Sources/CAudioKit/include/Interop.h
@@ -2,18 +2,8 @@
 
 #pragma once
 
-#ifdef __OBJC__
-#define AK_SWIFT_TYPE __attribute((swift_newtype(struct)))
-#else
-#define AK_SWIFT_TYPE
-#endif
-
 /// Pointer to an instance of an DSPBase subclass
-#ifndef __cplusplus
-typedef void* DSPRef AK_SWIFT_TYPE;
-#else
-typedef class DSPBase* DSPRef;
-#endif
+typedef struct DSPBase* DSPRef;
 
 #ifdef __cplusplus
 #define AK_API extern "C"

--- a/Sources/CAudioKit/include/Interop.h
+++ b/Sources/CAudioKit/include/Interop.h
@@ -3,26 +3,10 @@
 #pragma once
 
 #ifdef __OBJC__
-#define AK_ENUM(a) enum __attribute__((enum_extensibility(open))) a : int
 #define AK_SWIFT_TYPE __attribute((swift_newtype(struct)))
 #else
-#define AK_ENUM(a) enum a
 #define AK_SWIFT_TYPE
 #endif
-
-/* EXAMPLE
-
- Define enum in ObjC/C/C++:
- typedef AK_ENUM(Direction){
-     DirectionUp,
-     DirectionRight,
-     DirectionDown,
-     DirectionLeft,
- }AKDirection;
-
- Then use in Swift:
- let direction: Direction = .up
-*/
 
 /// Pointer to an instance of an DSPBase subclass
 #ifndef __cplusplus


### PR DESCRIPTION
Lets you init a BufferSize enum from actual number of samples.
This seems a little weird to be adding this now, I would have thought this already was available, so if this already exists, please point me to that.