### PR TITLE
Make MIDIListener functions open so it’s easier to use as a base clas…

### DIFF
--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -105,7 +105,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - portID:     MIDI Unique Port ID
     ///   - offset:     the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDIController(_ controller: MIDIByte,
+    open func receivedMIDIController(_ controller: MIDIByte,
                                        value: MIDIByte, channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
                                        offset: MIDITimeStamp) {
@@ -121,7 +121,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - portID:     MIDI Unique Port ID
     ///   - offset:     the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDIAftertouch(noteNumber: MIDINoteNumber,
+    open func receivedMIDIAftertouch(noteNumber: MIDINoteNumber,
                                        pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
@@ -137,7 +137,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - portID:   MIDI Unique Port ID
     ///   - offset:   the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDIAftertouch(_ pressure: MIDIByte,
+    open func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
                                        offset: MIDITimeStamp) {
@@ -152,7 +152,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - portID:          MIDI Unique Port ID
     ///   - offset:          the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
+    open func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
                                        offset: MIDITimeStamp) {
@@ -167,7 +167,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - portID:   MIDI Unique Port ID
     ///   - offset:   the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDIProgramChange(_ program: MIDIByte,
+    open func receivedMIDIProgramChange(_ program: MIDIByte,
                                           channel: MIDIChannel,
                                           portID: MIDIUniqueID?,
                                           offset: MIDITimeStamp) {
@@ -180,24 +180,24 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     /// - portID:     MIDI Unique Port ID
     /// - offset:     the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDISystemCommand(_ data: [MIDIByte],
+    open func receivedMIDISystemCommand(_ data: [MIDIByte],
                                           portID: MIDIUniqueID?,
                                           offset: MIDITimeStamp) {
         // Do nothing
     }
 
     /// MIDI Setup has changed
-    public func receivedMIDISetupChange() {
+    open func receivedMIDISetupChange() {
         // Do nothing
     }
 
     /// MIDI Object Property has changed
-    public func receivedMIDIPropertyChange(propertyChangeInfo: MIDIObjectPropertyChangeNotification) {
+    open func receivedMIDIPropertyChange(propertyChangeInfo: MIDIObjectPropertyChangeNotification) {
         // Do nothing
     }
 
     /// Generic MIDI Notification
-    public func receivedMIDINotification(notification: MIDINotification) {
+    open func receivedMIDINotification(notification: MIDINotification) {
         // Do nothing
     }
 


### PR DESCRIPTION
As discussed in #general, making the functions from MIDIListener open makes MIDIInstrument a prime target for subclassing when writing your own MIDI instruments
