### PR TITLE
remove non-existent folder ref from Package file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -57,8 +57,7 @@ let package = Package(
             dependencies: ["CAudioKit"]),
         .testTarget(
             name: "AudioKitTests",
-            dependencies: ["AudioKit"],
-            resources: [.copy("Resources")]),
+            dependencies: ["AudioKit"]),
         .testTarget(
             name: "CAudioKitTests",
             dependencies: ["CAudioKit"])


### PR DESCRIPTION
I have been dragging the AK folder into my dev and test projects and adding it as a framework/library dependency in Xcode's Project File -> Build Phases tab.
It works great! - IF I remove this line..

This commit removes a .copy from the Package.swift file for a folder that ...is not in the repo?
I think it causes an error that is swallowed in other cases, but for the above stated use of AK, it causes stange havoc in xcode when the folder it references is not existing.

I am willing to go into more detail if it is an important line.
Afaict, the line is an error or an old scalpel left in the patient