### PR TITLE
Add engine running check to AudioPlayer

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -208,8 +208,13 @@ public class AudioPlayer: Node {
     ) {
         guard !isPlaying || isPaused else { return }
 
-        guard playerNode.engine != nil else {
+        guard let engine = playerNode.engine else {
             Log("🛑 Error: AudioPlayer must be attached before playback.")
+            return
+        }
+
+        guard engine.isRunning else {
+            Log("🛑 Error: AudioPlayer's engine must be running before playback.")
             return
         }
 


### PR DESCRIPTION
This bug is the bane of my existence and my #1 bug in production still but perhaps this is the fix? 😅

It's often unclear what stops an engine (Siri, route change, etc) but I noticed there was already a check for `isRunning` in the looping code so it seems it would make sense to have it in `play()` as well.