### PR TITLE
#2554 MIDI note offs for playing notes when sequencer stops

### DIFF
--- a/Sources/AudioKit/Sequencing/Sequencer/SequencerTrack.swift
+++ b/Sources/AudioKit/Sequencing/Sequencer/SequencerTrack.swift
@@ -89,6 +89,7 @@ open class SequencerTrack {
     /// Stop playback
     public func stop() {
         akSequencerEngineSetPlaying(engine, false)
+        akSequencerEngineStopPlayingNotes(engine)
     }
 
     /// Set the current position to the start ofthe track


### PR DESCRIPTION
I am forgoing any points for tests this time, since there is currently no precedent to test this correctly in code.
I have done some QA with an app I have for testing starting stopping, loops, no loops, and note trigger / loop boundary edge cases