### PR TITLE
add scheduleMIDIEvent 

### DIFF
--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -170,6 +170,15 @@ open class PolyphonicNode: Node, Polyphonic {
     open func stop(noteNumber: MIDINoteNumber) {
         Log("Stopping note \(noteNumber), override in subclass")
     }
+
+    public func scheduleMIDIEvent(event: MIDIEvent, offset: UInt64) {
+        if let midiBlock = avAudioUnit?.auAudioUnit.scheduleMIDIEventBlock {
+            event.data.withUnsafeBufferPointer { ptr in
+                guard let ptr = ptr.baseAddress else { return }
+                midiBlock(AUEventSampleTimeImmediate + AUEventSampleTime(offset), 0, event.data.count, ptr)
+            }
+        }
+    }
 }
 
 /// Protocol for dictating that a node can be in a started or stopped state


### PR DESCRIPTION
add scheduleMIDIEvent func on node to allow access to scheduleMIDIEventBlock

This way you can send midi messages directly to the internal AU

It's not used yet - its just there
