### PR TITLE
Fix midi input offsets

### DIFF
--- a/Sources/AudioKit/MIDI/Listeners/MIDIClockListener.swift
+++ b/Sources/AudioKit/MIDI/Listeners/MIDIClockListener.swift
@@ -61,12 +61,12 @@ public class MIDIClockListener: NSObject {
         quarterNoteQuantumCounter = MIDIByte(quantumCounter % 24)
     }
 
-    func midiClockBeat(time: MIDITimeStamp) {
+    func midiClockBeat(timeStamp: MIDITimeStamp) {
         self.quantumCounter += 1
 
         // quarter notes can only increment when we are playing
         guard srtListener.state == .playing else {
-            sendQuantumUpdateToObservers(time: time)
+            sendQuantumUpdateToObservers(time: timeStamp)
             return
         }
 
@@ -93,7 +93,7 @@ public class MIDIClockListener: NSObject {
         } else if quarterNoteQuantumCounter == quantumsPerQuarterNote {
             quarterNoteQuantumCounter = 0
         }
-        sendQuantumUpdateToObservers(time: time)
+        sendQuantumUpdateToObservers(time: timeStamp)
 
         if sppMIDIBeatQuantumCounter == 6 { sppMIDIBeatQuantumCounter = 0; sppMIDIBeatCounter += 1 }
         sppMIDIBeatQuantumCounter += 1

--- a/Sources/AudioKit/MIDI/Listeners/MIDIMonoPolyListener.swift
+++ b/Sources/AudioKit/MIDI/Listeners/MIDIMonoPolyListener.swift
@@ -40,7 +40,7 @@ extension MIDIMonoPolyListener: MIDIListener {
                                        value: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
                 if controller == MIDIControl.monoOperation.rawValue {
             guard monoMode == false else { return }
             monoMode = true
@@ -71,7 +71,7 @@ extension MIDIMonoPolyListener: MIDIListener {
                                    velocity: MIDIVelocity,
                                    channel: MIDIChannel,
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp) {
+                                   timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -88,7 +88,7 @@ extension MIDIMonoPolyListener: MIDIListener {
                                     velocity: MIDIVelocity,
                                     channel: MIDIChannel,
                                     portID: MIDIUniqueID?,
-                                    offset: MIDITimeStamp) {
+                                    timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -105,7 +105,7 @@ extension MIDIMonoPolyListener: MIDIListener {
                                        pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -120,7 +120,7 @@ extension MIDIMonoPolyListener: MIDIListener {
     public func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -135,7 +135,7 @@ extension MIDIMonoPolyListener: MIDIListener {
     public func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -150,7 +150,7 @@ extension MIDIMonoPolyListener: MIDIListener {
     public func receivedMIDIProgramChange(_ program: MIDIByte,
                                           channel: MIDIChannel,
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -162,7 +162,7 @@ extension MIDIMonoPolyListener: MIDIListener {
     ///
     public func receivedMIDISystemCommand(_ data: [MIDIByte],
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 

--- a/Sources/AudioKit/MIDI/Listeners/MIDIOmniListener.swift
+++ b/Sources/AudioKit/MIDI/Listeners/MIDIOmniListener.swift
@@ -33,7 +33,7 @@ extension MIDIOMNIListener: MIDIListener {
                                    velocity: MIDIVelocity,
                                    channel: MIDIChannel,
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp) {
+                                   timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -50,7 +50,7 @@ extension MIDIOMNIListener: MIDIListener {
                                     velocity: MIDIVelocity,
                                     channel: MIDIChannel,
                                     portID: MIDIUniqueID?,
-                                    offset: MIDITimeStamp) {
+                                    timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -66,7 +66,7 @@ extension MIDIOMNIListener: MIDIListener {
     public func receivedMIDIController(_ controller: MIDIByte,
                                        value: MIDIByte, channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         if controller == MIDIControl.omniModeOff.rawValue {
             guard omniMode == true else { return }
             omniMode = false
@@ -92,7 +92,7 @@ extension MIDIOMNIListener: MIDIListener {
                                        pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -107,7 +107,7 @@ extension MIDIOMNIListener: MIDIListener {
     public func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -122,7 +122,7 @@ extension MIDIOMNIListener: MIDIListener {
     public func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -137,7 +137,7 @@ extension MIDIOMNIListener: MIDIListener {
     public func receivedMIDIProgramChange(_ program: MIDIByte,
                                           channel: MIDIChannel,
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -149,7 +149,7 @@ extension MIDIOMNIListener: MIDIListener {
     ///
     public func receivedMIDISystemCommand(_ data: [MIDIByte],
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 

--- a/Sources/AudioKit/MIDI/Listeners/MIDISystemRealTimeListener.swift
+++ b/Sources/AudioKit/MIDI/Listeners/MIDISystemRealTimeListener.swift
@@ -67,7 +67,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
     /// - portID:     MIDI Unique Port ID
     /// - offset:     the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDISystemCommand(_ data: [MIDIByte], portID: MIDIUniqueID?, offset: MIDITimeStamp) {
+    public func receivedMIDISystemCommand(_ data: [MIDIByte], portID: MIDIUniqueID?, timeStamp: MIDITimeStamp? = nil) {
         if data[0] == MIDISystemCommand.stop.rawValue {
             Log("Incoming MMC [Stop]", log: OSLog.midi)
             let newState = state.event(event: .stop)
@@ -104,7 +104,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
                                    velocity: MIDIVelocity,
                                    channel: MIDIChannel,
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp) {
+                                   timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -121,7 +121,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
                                     velocity: MIDIVelocity,
                                     channel: MIDIChannel,
                                     portID: MIDIUniqueID?,
-                                    offset: MIDITimeStamp) {
+                                    timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -137,7 +137,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
     public func receivedMIDIController(_ controller: MIDIByte,
                                        value: MIDIByte, channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -154,7 +154,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
                                        pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -169,7 +169,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
     public func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -184,7 +184,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
     public func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -199,7 +199,7 @@ extension MIDISystemRealTimeListener: MIDIListener {
     public func receivedMIDIProgramChange(_ program: MIDIByte,
                                           channel: MIDIChannel,
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 

--- a/Sources/AudioKit/MIDI/Listeners/MIDITempoListener.swift
+++ b/Sources/AudioKit/MIDI/Listeners/MIDITempoListener.swift
@@ -194,7 +194,7 @@ extension MIDITempoListener: MIDIListener {
     /// - portID:     MIDI Unique Port ID
     /// - offset:     the offset in samples that this event occurs in the buffer
     ///
-    public func receivedMIDISystemCommand(_ data: [MIDIByte], portID: MIDIUniqueID?, offset: MIDITimeStamp) {
+    public func receivedMIDISystemCommand(_ data: [MIDIByte], portID: MIDIUniqueID?, timeStamp: MIDITimeStamp? = nil) {
         if data[0] == MIDISystemCommand.clock.rawValue {
             clockTimeout?.succeed()
             clockTimeout?.perform {
@@ -202,9 +202,10 @@ extension MIDITempoListener: MIDIListener {
                     midiClockActivityStarted()
                     self.isIncomingClockActive = true
                 }
-                clockEvents.append(offset)
+                let timeStamp = timeStamp ?? 0
+                clockEvents.append(timeStamp)
                 analyze()
-                clockListener?.midiClockBeat(time: offset)
+                clockListener?.midiClockBeat(timeStamp: timeStamp)
             }
         }
         if data[0] == MIDISystemCommand.stop.rawValue {
@@ -213,7 +214,7 @@ extension MIDITempoListener: MIDIListener {
         if data[0] == MIDISystemCommand.start.rawValue {
             resetClockEventsLeavingOne()
         }
-        srtListener.receivedMIDISystemCommand(data, portID: portID, offset: offset)
+        srtListener.receivedMIDISystemCommand(data, portID: portID, timeStamp: timeStamp)
     }
     
     /// Receive the MIDI note on event
@@ -229,7 +230,7 @@ extension MIDITempoListener: MIDIListener {
                                    velocity: MIDIVelocity,
                                    channel: MIDIChannel,
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp) {
+                                   timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -246,7 +247,7 @@ extension MIDITempoListener: MIDIListener {
                                     velocity: MIDIVelocity,
                                     channel: MIDIChannel,
                                     portID: MIDIUniqueID?,
-                                    offset: MIDITimeStamp) {
+                                    timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -262,7 +263,7 @@ extension MIDITempoListener: MIDIListener {
     public func receivedMIDIController(_ controller: MIDIByte,
                                        value: MIDIByte, channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -279,7 +280,7 @@ extension MIDITempoListener: MIDIListener {
                                        pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -294,7 +295,7 @@ extension MIDITempoListener: MIDIListener {
     public func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -309,7 +310,7 @@ extension MIDITempoListener: MIDIListener {
     public func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -324,7 +325,7 @@ extension MIDITempoListener: MIDIListener {
     public func receivedMIDIProgramChange(_ program: MIDIByte,
                                           channel: MIDIChannel,
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 

--- a/Sources/AudioKit/MIDI/MIDI+Receiving.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Receiving.swift
@@ -273,7 +273,7 @@ extension MIDI {
             switch umpMessageType {
             case .Utility32bit, .SystemRealTimeAndCommon32bit, .MIDI1ChannelVoice32bit:
 
-                midiEvents.append(MIDIEvent(data: umpMessageBytes, offset: timeStamp))
+                midiEvents.append(MIDIEvent(data: umpMessageBytes, timeStamp: timeStamp))
                 wordIndex += 1
                 break
             case .Reserved32bit_1, .Reserved32bit_2:
@@ -285,7 +285,7 @@ extension MIDI {
                 let secondWordBytes = byteArray(from: words[wordIndex + 1])
                 umpMessageBytes.append(contentsOf: secondWordBytes)
                 if let completeSysExMessageData = processUMPSysExMessage(with: umpMessageBytes) {
-                    midiEvents.append(MIDIEvent(data: completeSysExMessageData, offset: timeStamp))
+                    midiEvents.append(MIDIEvent(data: completeSysExMessageData, timeStamp: timeStamp))
                 }
                 wordIndex += 2
                 break
@@ -439,7 +439,7 @@ extension MIDI {
 
     internal func handleMIDIMessage(_ event: MIDIEvent, fromInput portID: MIDIUniqueID) {
         for listener in listeners {
-            let offset = event.offset
+            let timeStamp = event.timeStamp
             if let type = event.status?.type {
                 guard let eventChannel = event.channel else {
                     Log("No channel detected in handleMIDIMessage", log: OSLog.midi)
@@ -451,43 +451,43 @@ extension MIDI {
                                                     value: event.data[2],
                                                     channel: MIDIChannel(eventChannel),
                                                     portID: portID,
-                                                    offset: offset)
+                                                    timeStamp: timeStamp)
                 case .channelAftertouch:
                     listener.receivedMIDIAftertouch(event.data[1],
                                                     channel: MIDIChannel(eventChannel),
                                                     portID: portID,
-                                                    offset: offset)
+                                                    timeStamp: timeStamp)
                 case .noteOn:
                     listener.receivedMIDINoteOn(noteNumber: MIDINoteNumber(event.data[1]),
                                                 velocity: MIDIVelocity(event.data[2]),
                                                 channel: MIDIChannel(eventChannel),
                                                 portID: portID,
-                                                offset: offset)
+                                                timeStamp: timeStamp)
                 case .noteOff:
                     listener.receivedMIDINoteOff(noteNumber: MIDINoteNumber(event.data[1]),
                                                  velocity: MIDIVelocity(event.data[2]),
                                                  channel: MIDIChannel(eventChannel),
                                                  portID: portID,
-                                                 offset: offset)
+                                                 timeStamp: timeStamp)
                 case .pitchWheel:
                     listener.receivedMIDIPitchWheel(event.pitchbendAmount ?? 0,
                                                     channel: MIDIChannel(eventChannel),
                                                     portID: portID,
-                                                    offset: offset)
+                                                    timeStamp: timeStamp)
                 case .polyphonicAftertouch:
                     listener.receivedMIDIAftertouch(noteNumber: MIDINoteNumber(event.data[1]),
                                                     pressure: event.data[2],
                                                     channel: MIDIChannel(eventChannel),
                                                     portID: portID,
-                                                    offset: offset)
+                                                    timeStamp: timeStamp)
                 case .programChange:
                     listener.receivedMIDIProgramChange(event.data[1],
                                                        channel: MIDIChannel(eventChannel),
                                                        portID: portID,
-                                                       offset: offset)
+                                                       timeStamp: timeStamp)
                 }
             } else if event.command != nil {
-                listener.receivedMIDISystemCommand(event.data, portID: portID, offset: offset )
+                listener.receivedMIDISystemCommand(event.data, portID: portID, timeStamp: timeStamp )
             } else {
                 Log("No usable status detected in handleMIDIMessage", log: OSLog.midi)
             }

--- a/Sources/AudioKit/MIDI/MIDICallbackInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDICallbackInstrument.swift
@@ -47,7 +47,7 @@ open class MIDICallbackInstrument: MIDIInstrument {
     open override func start(noteNumber: MIDINoteNumber,
                              velocity: MIDIVelocity,
                              channel: MIDIChannel,
-                             offset: MIDITimeStamp = 0) {
+                             timeStamp: MIDITimeStamp? = nil) {
         triggerCallbacks(MIDIStatus(type: .noteOn, channel: channel),
                          data1: noteNumber,
                          data2: velocity)
@@ -62,7 +62,7 @@ open class MIDICallbackInstrument: MIDIInstrument {
     ///
     open override func stop(noteNumber: MIDINoteNumber,
                             channel: MIDIChannel,
-                            offset: MIDITimeStamp = 0) {
+                            timeStamp: MIDITimeStamp? = nil) {
         triggerCallbacks(MIDIStatus(type: .noteOff, channel: channel),
                          data1: noteNumber,
                          data2: 0)
@@ -83,7 +83,7 @@ open class MIDICallbackInstrument: MIDIInstrument {
                                               value: MIDIByte,
                                               channel: MIDIChannel,
                                               portID: MIDIUniqueID? = nil,
-                                              offset: MIDITimeStamp = 0) {
+                                              timeStamp: MIDITimeStamp? = nil) {
         triggerCallbacks(MIDIStatus(type: .controllerChange, channel: channel),
                          data1: controller,
                          data2: value)
@@ -102,7 +102,7 @@ open class MIDICallbackInstrument: MIDIInstrument {
                                               pressure: MIDIByte,
                                               channel: MIDIChannel,
                                               portID: MIDIUniqueID? = nil,
-                                              offset: MIDITimeStamp = 0) {
+                                              timeStamp: MIDITimeStamp? = nil) {
         triggerCallbacks(MIDIStatus(type: .polyphonicAftertouch, channel: channel),
                          data1: noteNumber,
                          data2: pressure)
@@ -119,7 +119,7 @@ open class MIDICallbackInstrument: MIDIInstrument {
     open override func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                               channel: MIDIChannel,
                                               portID: MIDIUniqueID? = nil,
-                                              offset: MIDITimeStamp = 0) {
+                                              timeStamp: MIDITimeStamp? = nil) {
         triggerCallbacks(MIDIStatus(type: .channelAftertouch, channel: channel),
                          data1: pressure,
                          data2: 0)
@@ -136,7 +136,7 @@ open class MIDICallbackInstrument: MIDIInstrument {
     open override func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                               channel: MIDIChannel,
                                               portID: MIDIUniqueID? = nil,
-                                              offset: MIDITimeStamp = 0) {
+                                              timeStamp: MIDITimeStamp? = nil) {
         triggerCallbacks(MIDIStatus(type: .pitchWheel, channel: channel),
                          data1: pitchWheelValue.msb,
                          data2: pitchWheelValue.lsb)

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -71,7 +71,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
                                  velocity: MIDIVelocity,
                                  channel: MIDIChannel,
                                  portID: MIDIUniqueID? = nil,
-                                 offset: MIDITimeStamp = 0) {
+                                 timeStamp: MIDITimeStamp? = nil) {
         mpeActiveNotes.append((noteNumber, channel))
         if velocity > 0 {
             start(noteNumber: noteNumber, velocity: velocity, channel: channel)
@@ -91,7 +91,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
                                   velocity: MIDIVelocity,
                                   channel: MIDIChannel,
                                   portID: MIDIUniqueID? = nil,
-                                  offset: MIDITimeStamp = 0) {
+                                  timeStamp: MIDITimeStamp? = nil) {
         stop(noteNumber: noteNumber, channel: channel)
         mpeActiveNotes.removeAll(where: { $0 == (noteNumber, channel) })
     }
@@ -108,7 +108,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     open func receivedMIDIController(_ controller: MIDIByte,
                                        value: MIDIByte, channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -125,7 +125,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
                                        pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -140,7 +140,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     open func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -155,7 +155,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     open func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -170,7 +170,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     open func receivedMIDIProgramChange(_ program: MIDIByte,
                                           channel: MIDIChannel,
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -182,7 +182,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///
     open func receivedMIDISystemCommand(_ data: [MIDIByte],
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -213,7 +213,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     open func start(noteNumber: MIDINoteNumber,
                     velocity: MIDIVelocity,
                     channel: MIDIChannel,
-                    offset: MIDITimeStamp = 0) {
+                    timeStamp: MIDITimeStamp? = nil) {
         play(noteNumber: noteNumber, velocity: velocity, channel: channel)
     }
 
@@ -225,7 +225,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///
     open func stop(noteNumber: MIDINoteNumber,
                    channel: MIDIChannel,
-                   offset: MIDITimeStamp = 0) {
+                   timeStamp: MIDITimeStamp? = nil) {
         // Override in subclass
     }
 
@@ -237,7 +237,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///
     open func receivedMIDIProgramChange(_ program: MIDIByte,
                                         channel: MIDIChannel,
-                                        offset: MIDITimeStamp = 0) {
+                                        timeStamp: MIDITimeStamp? = nil) {
         // Override in subclass
     }
 
@@ -263,18 +263,18 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
                                        pressure: data3,
                                        channel: channel,
                                        portID: nil,
-                                       offset: 0)
+                                       timeStamp: nil)
             case .channelAftertouch:
                 receivedMIDIAftertouch(data2,
                                        channel: channel,
                                        portID: nil,
-                                       offset: 0)
+                                       timeStamp: nil)
             case .controllerChange:
                 receivedMIDIController(data2,
                                        value: data3,
                                        channel: channel,
                                        portID: nil,
-                                       offset: 0)
+                                       timeStamp: nil)
             case .programChange:
                 receivedMIDIProgramChange(data2, channel: channel)
             case .pitchWheel:
@@ -282,7 +282,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
                                                 byte2: data3),
                                        channel: channel,
                                        portID: nil,
-                                       offset: 0)
+                                       timeStamp: nil)
             }
         }
     }

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -57,9 +57,9 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
                         data2: event.data[1],
                         data3: event.data[2])
     }
-
+    
     // MARK: - Handling MIDI Data
-
+    
     /// Handle MIDI commands that come in externally
     /// - Parameters:
     ///   - noteNumber: MIDI Note Numbe
@@ -79,7 +79,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
             stop(noteNumber: noteNumber, channel: channel)
         }
     }
-
+    
     /// Handle MIDI commands that come in externally
     /// - Parameters:
     ///   - noteNumber: MIDI Note Numbe
@@ -95,7 +95,7 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
         stop(noteNumber: noteNumber, channel: channel)
         mpeActiveNotes.removeAll(where: { $0 == (noteNumber, channel) })
     }
-
+    
     /// Receive a generic controller value
     ///
     /// - Parameters:
@@ -106,12 +106,12 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - offset:     the offset in samples that this event occurs in the buffer
     ///
     open func receivedMIDIController(_ controller: MIDIByte,
-                                       value: MIDIByte, channel: MIDIChannel,
-                                       portID: MIDIUniqueID?,
-                                       timeStamp: MIDITimeStamp? = nil) {
+                                     value: MIDIByte, channel: MIDIChannel,
+                                     portID: MIDIUniqueID?,
+                                     timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
-
+    
     /// Receive single note based aftertouch event
     ///
     /// - Parameters:
@@ -122,13 +122,13 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - offset:     the offset in samples that this event occurs in the buffer
     ///
     open func receivedMIDIAftertouch(noteNumber: MIDINoteNumber,
-                                       pressure: MIDIByte,
-                                       channel: MIDIChannel,
-                                       portID: MIDIUniqueID?,
-                                       timeStamp: MIDITimeStamp? = nil) {
+                                     pressure: MIDIByte,
+                                     channel: MIDIChannel,
+                                     portID: MIDIUniqueID?,
+                                     timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
-
+    
     /// Receive global aftertouch
     ///
     /// - Parameters:
@@ -138,12 +138,12 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - offset:   the offset in samples that this event occurs in the buffer
     ///
     open func receivedMIDIAftertouch(_ pressure: MIDIByte,
-                                       channel: MIDIChannel,
-                                       portID: MIDIUniqueID?,
-                                       timeStamp: MIDITimeStamp? = nil) {
+                                     channel: MIDIChannel,
+                                     portID: MIDIUniqueID?,
+                                     timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
-
+    
     /// Receive pitch wheel value
     ///
     /// - Parameters:
@@ -153,12 +153,12 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - offset:          the offset in samples that this event occurs in the buffer
     ///
     open func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
-                                       channel: MIDIChannel,
-                                       portID: MIDIUniqueID?,
-                                       timeStamp: MIDITimeStamp? = nil) {
+                                     channel: MIDIChannel,
+                                     portID: MIDIUniqueID?,
+                                     timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
-
+    
     /// Receive program change
     ///
     /// - Parameters:
@@ -168,12 +168,12 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     ///   - offset:   the offset in samples that this event occurs in the buffer
     ///
     open func receivedMIDIProgramChange(_ program: MIDIByte,
-                                          channel: MIDIChannel,
-                                          portID: MIDIUniqueID?,
-                                          timeStamp: MIDITimeStamp? = nil) {
+                                        channel: MIDIChannel,
+                                        portID: MIDIUniqueID?,
+                                        timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
-
+    
     /// Receive a MIDI system command (such as clock, SysEx, etc)
     ///
     /// - data:       Array of integers
@@ -181,8 +181,8 @@ open class MIDIInstrument: PolyphonicNode, MIDIListener, NamedNode {
     /// - offset:     the offset in samples that this event occurs in the buffer
     ///
     open func receivedMIDISystemCommand(_ data: [MIDIByte],
-                                          portID: MIDIUniqueID?,
-                                          timeStamp: MIDITimeStamp? = nil) {
+                                        portID: MIDIUniqueID?,
+                                        timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 

--- a/Sources/AudioKit/MIDI/MIDIListener.swift
+++ b/Sources/AudioKit/MIDI/MIDIListener.swift
@@ -31,7 +31,7 @@ public protocol MIDIListener {
                             velocity: MIDIVelocity,
                             channel: MIDIChannel,
                             portID: MIDIUniqueID?,
-                            offset: MIDITimeStamp)
+                            timeStamp: MIDITimeStamp?)
 
     /// Receive the MIDI note off event
     ///
@@ -46,7 +46,7 @@ public protocol MIDIListener {
                              velocity: MIDIVelocity,
                              channel: MIDIChannel,
                              portID: MIDIUniqueID?,
-                             offset: MIDITimeStamp)
+                             timeStamp: MIDITimeStamp?)
 
     /// Receive a generic controller value
     ///
@@ -61,7 +61,7 @@ public protocol MIDIListener {
                                 value: MIDIByte,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp)
+                                timeStamp: MIDITimeStamp?)
 
     /// Receive single note based aftertouch event
     ///
@@ -76,7 +76,7 @@ public protocol MIDIListener {
                                 pressure: MIDIByte,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp)
+                                timeStamp: MIDITimeStamp?)
 
     /// Receive global aftertouch
     ///
@@ -89,7 +89,7 @@ public protocol MIDIListener {
     func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp)
+                                timeStamp: MIDITimeStamp?)
 
     /// Receive pitch wheel value
     ///
@@ -102,7 +102,7 @@ public protocol MIDIListener {
     func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp)
+                                timeStamp: MIDITimeStamp?)
 
     /// Receive program change
     ///
@@ -115,7 +115,7 @@ public protocol MIDIListener {
     func receivedMIDIProgramChange(_ program: MIDIByte,
                                    channel: MIDIChannel,
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp)
+                                   timeStamp: MIDITimeStamp?)
 
     /// Receive a MIDI system command (such as clock, SysEx, etc)
     ///
@@ -125,7 +125,7 @@ public protocol MIDIListener {
     ///
     func receivedMIDISystemCommand(_ data: [MIDIByte],
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp)
+                                   timeStamp: MIDITimeStamp?)
 
     /// MIDI Setup has changed
     func receivedMIDISetupChange()

--- a/Sources/AudioKit/MIDI/MIDINode.swift
+++ b/Sources/AudioKit/MIDI/MIDINode.swift
@@ -88,7 +88,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
                                    velocity: MIDIVelocity,
                                    channel: MIDIChannel,
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp) {
+                                   timeStamp: MIDITimeStamp? = nil) {
         if velocity > 0 {
             internalNode.play(noteNumber: noteNumber, velocity: velocity, channel: channel)
         } else {
@@ -110,7 +110,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
                                     velocity: MIDIVelocity,
                                     channel: MIDIChannel,
                                     portID: MIDIUniqueID?,
-                                    offset: MIDITimeStamp) {
+                                    timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -127,7 +127,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
                                        value: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -144,7 +144,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
                                        pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -159,7 +159,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
     public func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -174,7 +174,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
     public func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                        channel: MIDIChannel,
                                        portID: MIDIUniqueID?,
-                                       offset: MIDITimeStamp) {
+                                       timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -189,7 +189,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
     public func receivedMIDIProgramChange(_ program: MIDIByte,
                                           channel: MIDIChannel,
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 
@@ -201,7 +201,7 @@ open class MIDINode: Node, MIDIListener, NamedNode {
     ///
     public func receivedMIDISystemCommand(_ data: [MIDIByte],
                                           portID: MIDIUniqueID?,
-                                          offset: MIDITimeStamp) {
+                                          timeStamp: MIDITimeStamp? = nil) {
         // Do nothing
     }
 

--- a/Tests/AudioKitTests/MIDI Tests/Support/TestListener.swift
+++ b/Tests/AudioKitTests/MIDI Tests/Support/TestListener.swift
@@ -26,7 +26,7 @@ final class TestListener: MIDIListener {
                             velocity: MIDIVelocity,
                             channel: MIDIChannel,
                             portID: MIDIUniqueID?,
-                            offset: MIDITimeStamp) {
+                            timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.noteOn(channel: channel,
                                          number: noteNumber,
@@ -40,7 +40,7 @@ final class TestListener: MIDIListener {
                              velocity: MIDIVelocity,
                              channel: MIDIChannel,
                              portID: MIDIUniqueID?,
-                             offset: MIDITimeStamp) {
+                             timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.noteOff(channel: channel,
                                           number: noteNumber,
@@ -54,7 +54,7 @@ final class TestListener: MIDIListener {
                                 value: MIDIByte,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp) {
+                                timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.controlChange(channel: channel,
                                                 number: controller,
@@ -68,7 +68,7 @@ final class TestListener: MIDIListener {
                                 pressure: MIDIByte,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp) {
+                                timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.polyPressure(channel: channel,
                                                number: noteNumber,
@@ -81,7 +81,7 @@ final class TestListener: MIDIListener {
     func receivedMIDIAftertouch(_ pressure: MIDIByte,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp) {
+                                timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.channelPressure(channel: channel, value: pressure, portID: portID))
             self.received.fulfill()
@@ -91,7 +91,7 @@ final class TestListener: MIDIListener {
     func receivedMIDIPitchWheel(_ pitchWheelValue: MIDIWord,
                                 channel: MIDIChannel,
                                 portID: MIDIUniqueID?,
-                                offset: MIDITimeStamp) {
+                                timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.pitchBend(channel: channel, value: pitchWheelValue, portID: portID))
             self.received.fulfill()
@@ -101,7 +101,7 @@ final class TestListener: MIDIListener {
     func receivedMIDIProgramChange(_ program: MIDIByte,
                                    channel: MIDIChannel,
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp) {
+                                   timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.programChange(channel: channel, number: program, portID: portID))
             self.received.fulfill()
@@ -111,7 +111,7 @@ final class TestListener: MIDIListener {
 
     func receivedMIDISystemCommand(_ data: [MIDIByte],
                                    portID: MIDIUniqueID?,
-                                   offset: MIDITimeStamp) {
+                                   timeStamp: MIDITimeStamp? = nil) {
         DispatchQueue.main.async {
             self.messages.append(.systemCommand(data: data, portID: portID))
             self.received.fulfill()

--- a/Tests/AudioKitTests/Sequencing and Automation Tests/SequencerEngineTests.swift
+++ b/Tests/AudioKitTests/Sequencing and Automation Tests/SequencerEngineTests.swift
@@ -26,7 +26,8 @@ class SequencerEngineTests: XCTestCase {
             for index in 0 ..< length {
                 bytes.append(midiBytes[index])
             }
-            scheduledEvents.append(MIDIEvent(data: bytes, offset: MIDITimeStamp(sampleTime - AUEventSampleTimeImmediate)))
+            let timeStamp = MIDITimeStamp(sampleTime - AUEventSampleTimeImmediate)
+            scheduledEvents.append(MIDIEvent(data: bytes, timeStamp: timeStamp))
         }
 
         let orderedEvents = sequence.beatTimeOrderedEvents()
@@ -55,7 +56,6 @@ class SequencerEngineTests: XCTestCase {
                        accuracy: 0.0001)
 
         akSequencerEngineDestroy(engine)
-
         return scheduledEvents
     }
 
@@ -70,10 +70,10 @@ class SequencerEngineTests: XCTestCase {
         XCTAssertEqual(events.count, 2)
         XCTAssertEqual(events[0].noteNumber!, 60)
         XCTAssertEqual(events[0].status!.type, .noteOn)
-        XCTAssertEqual(events[0].offset, 11025)
+        XCTAssertEqual(events[0].timeStamp, 11025)
         XCTAssertEqual(events[1].noteNumber!, 60)
         XCTAssertEqual(events[1].status!.type, .noteOff)
-        XCTAssertEqual(events[1].offset, 13230)
+        XCTAssertEqual(events[1].timeStamp, 13230)
     }
 
     func testEmpty() {
@@ -94,7 +94,7 @@ class SequencerEngineTests: XCTestCase {
         XCTAssertEqual(events.count, 6)
 
         XCTAssertEqual(events.map { $0.noteNumber! }, [60, 63, 67, 60, 63, 67])
-        XCTAssertEqual(events.map { $0.offset }, [0, 0, 0, 22050, 22050, 22050])
+        XCTAssertEqual(events.map { $0.timeStamp }, [0, 0, 0, 22050, 22050, 22050])
     }
 
     func testLoop() {
@@ -108,7 +108,7 @@ class SequencerEngineTests: XCTestCase {
 
         XCTAssertEqual(events.map { $0.noteNumber! },
                        [60, 60, 63, 63, 60, 60, 63, 63, 60, 60, 63, 63, 60, 60, 63, 63, 60, 60, 63, 63])
-        XCTAssertEqual(events.map { $0.offset }, [0, 157, 34, 191, 136, 37, 170, 71, 16, 173, 50, 207, 152, 53, 186, 87, 32, 189, 66, 223])
+        XCTAssertEqual(events.map { $0.timeStamp }, [0, 157, 34, 191, 136, 37, 170, 71, 16, 173, 50, 207, 152, 53, 186, 87, 32, 189, 66, 223])
     }
 
     func testOverlap() {
@@ -122,7 +122,7 @@ class SequencerEngineTests: XCTestCase {
         XCTAssertEqual(events.count, 4)
 
         XCTAssertEqual(events.map { $0.noteNumber! }, [60, 63, 63, 60])
-        XCTAssertEqual(events.map { $0.offset }, [0, 2205, 4410, 22050])
+        XCTAssertEqual(events.map { $0.timeStamp }, [0, 2205, 4410, 22050])
     }
     
     func testSameNoteRepeating() {
@@ -137,7 +137,7 @@ class SequencerEngineTests: XCTestCase {
 
         XCTAssertEqual(events.map { $0.noteNumber! }, [60, 60, 60, 60])
         XCTAssertEqual(events.map { $0.status!.type }, [.noteOn, .noteOff, .noteOn, .noteOff])
-        XCTAssertEqual(events.map { $0.offset }, [0, 22050, 22050, 33075])
+        XCTAssertEqual(events.map { $0.timeStamp }, [0, 22050, 22050, 33075])
     }
 
     func testSameNoteRepeatingInChords() {
@@ -157,7 +157,7 @@ class SequencerEngineTests: XCTestCase {
         XCTAssertEqual(events.map { $0.noteNumber! }, [60, 62, 64, 60, 62, 64, 61, 64, 62, 61, 64, 62])
         XCTAssertEqual(events.map { $0.status!.type }, [.noteOn, .noteOn, .noteOn, .noteOff, .noteOff,.noteOff,
                                                         .noteOn, .noteOn, .noteOn, .noteOff, .noteOff,.noteOff])
-        XCTAssertEqual(events.map { $0.offset }, [0, 0, 0, 22050, 22050, 22050, 22050, 22050, 22050, 33075, 33075, 33075])
+        XCTAssertEqual(events.map { $0.timeStamp }, [0, 0, 0, 22050, 22050, 22050, 22050, 22050, 22050, 33075, 33075, 33075])
     }
 
     func testSameNoteRepeatingInChordsAcrossLoop() {
@@ -182,7 +182,7 @@ class SequencerEngineTests: XCTestCase {
                                                                .noteOn, .noteOn, .noteOn, .noteOff, .noteOff,.noteOff,
                                                                .noteOn, .noteOn, .noteOn, .noteOff, .noteOff,.noteOff,
                                                                .noteOn, .noteOn, .noteOn, .noteOff, .noteOff,.noteOff])
-        XCTAssertEqual(events.map { $0.offset }, [0, 0, 0, 34, 34, 34,
+        XCTAssertEqual(events.map { $0.timeStamp }, [0, 0, 0, 34, 34, 34,
                                                   34, 34, 34, 68, 68, 68,
                                                   136, 136, 136, 170, 170, 170,
                                                   170, 170, 170, 204, 204, 204])
@@ -213,7 +213,7 @@ class SequencerEngineTests: XCTestCase {
                                                                .noteOff, .noteOff, .noteOff, .noteOn, .noteOn, .noteOn,
                                                                .noteOn, .noteOn, .noteOn, .noteOff, .noteOff, .noteOff,
                                                                .noteOn, .noteOn, .noteOn])
-        XCTAssertEqual(events.map { $0.offset }, [0, 0, 0, 0, 0, 0,
+        XCTAssertEqual(events.map { $0.timeStamp }, [0, 0, 0, 0, 0, 0,
                                                   43658, 43658, 43658, 0, 0, 0,
                                                   0, 0, 0, 43658, 43658, 43658,
                                                   0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
MIDI hardware receiving is failing because the timestamp is being treated as an offset

This adds a 'timeStamp' property to midievents and uses that where appropriate instead of offset.

Offset is used more in AU event processing and is unrelated, so this separates that

Open to testing / fixes - I'm not entirely sure how or why this was broken.