### PR TITLE
Allocate resources w correct formats

### DIFF
--- a/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
+++ b/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
@@ -16,22 +16,23 @@ open class AudioUnitBase: AUAudioUnit {
     override public func allocateRenderResources() throws {
         try super.allocateRenderResources()
 
-        let format = outputBusArray.first!.format
+        let inputFormat = inputBusses[0].format
+        let outputFormat = outputBusses[0].format
 
-        try inputBusArray.forEach { if $0.format != format { try $0.setFormat(format) } }
-        try outputBusArray.forEach { if $0.format != format { try $0.setFormat(format) } }
+        try inputBusArray.forEach { if $0.format != inputFormat { try $0.setFormat(inputFormat) } }
+        try outputBusArray.forEach { if $0.format != outputFormat { try $0.setFormat(outputFormat) } }
 
         // we don't need to allocate a buffer if we can process in place
         if !canProcessInPlace || inputBusArray.count > 1 {
             for i in inputBusArray.indices {
-                if let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: maximumFramesToRender) {
+                if let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: maximumFramesToRender) {
                     setBufferDSP(dsp, buffer.mutableAudioBufferList, i)
                     internalBuffers.append(buffer)
                 }
             }
         }
 
-        allocateRenderResourcesDSP(dsp, format.channelCount, format.sampleRate)
+        allocateRenderResourcesDSP(dsp, outputFormat.channelCount, outputFormat.sampleRate)
     }
 
     /// Delllocate Render Resources

--- a/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
+++ b/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
@@ -16,12 +16,7 @@ open class AudioUnitBase: AUAudioUnit {
     override public func allocateRenderResources() throws {
         try super.allocateRenderResources()
 
-        if inputBusses.count > 0 {
-            let inputFormat = inputBusses[0].format
-
-            try inputBusArray.forEach {
-                if $0.format != inputFormat { try $0.setFormat(inputFormat) }
-            }
+        if let inputFormat = inputBusArray.first?.format {
 
             // we don't need to allocate a buffer if we can process in place
             if !canProcessInPlace || inputBusArray.count > 1 {
@@ -34,10 +29,9 @@ open class AudioUnitBase: AUAudioUnit {
             }
         }
 
-        let outputFormat = outputBusses[0].format
-        try outputBusArray.forEach { if $0.format != outputFormat { try $0.setFormat(outputFormat) } }
-
-        allocateRenderResourcesDSP(dsp, outputFormat.channelCount, outputFormat.sampleRate)
+        if let outputFormat = outputBusArray.first?.format {
+            allocateRenderResourcesDSP(dsp, outputFormat.channelCount, outputFormat.sampleRate)
+        }
     }
 
     /// Delllocate Render Resources

--- a/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
+++ b/Sources/AudioKit/Internals/CoreAudio/AudioUnitBase.swift
@@ -16,21 +16,26 @@ open class AudioUnitBase: AUAudioUnit {
     override public func allocateRenderResources() throws {
         try super.allocateRenderResources()
 
-        let inputFormat = inputBusses[0].format
-        let outputFormat = outputBusses[0].format
+        if inputBusses.count > 0 {
+            let inputFormat = inputBusses[0].format
 
-        try inputBusArray.forEach { if $0.format != inputFormat { try $0.setFormat(inputFormat) } }
-        try outputBusArray.forEach { if $0.format != outputFormat { try $0.setFormat(outputFormat) } }
+            try inputBusArray.forEach {
+                if $0.format != inputFormat { try $0.setFormat(inputFormat) }
+            }
 
-        // we don't need to allocate a buffer if we can process in place
-        if !canProcessInPlace || inputBusArray.count > 1 {
-            for i in inputBusArray.indices {
-                if let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: maximumFramesToRender) {
-                    setBufferDSP(dsp, buffer.mutableAudioBufferList, i)
-                    internalBuffers.append(buffer)
+            // we don't need to allocate a buffer if we can process in place
+            if !canProcessInPlace || inputBusArray.count > 1 {
+                for i in inputBusArray.indices {
+                    if let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: maximumFramesToRender) {
+                        setBufferDSP(dsp, buffer.mutableAudioBufferList, i)
+                        internalBuffers.append(buffer)
+                    }
                 }
             }
         }
+
+        let outputFormat = outputBusses[0].format
+        try outputBusArray.forEach { if $0.format != outputFormat { try $0.setFormat(outputFormat) } }
 
         allocateRenderResourcesDSP(dsp, outputFormat.channelCount, outputFormat.sampleRate)
     }


### PR DESCRIPTION
Previously we were using the output format to set both input and output, setting the busArray format and then allocatingRenderResources using this format.

This treats input format differently than outputFormat, and only does it if the arrays exist (no bang bang).

This also removes the try bufferArray.setFormat calls that don't seem needed.