### PR TITLE
Added methods required to chop an audio file into an array of type Table

### DIFF
--- a/Sources/AudioKit/Internals/Table/Table+AdditiveSynthesis.swift
+++ b/Sources/AudioKit/Internals/Table/Table+AdditiveSynthesis.swift
@@ -333,7 +333,7 @@ extension Table {
         let filter = [Float](repeating: 1 / Float(filterLength), count: Int(filterLength))
 
         let decimationFactor = numberOfInputSamples / numberOfOutputSamples
-        let n = vDSP_Length((inputLength - filterLength) / vDSP_Length(decimationFactor))
+        let outputLength = vDSP_Length((inputLength - filterLength) / vDSP_Length(decimationFactor))
 
         var outputTables: [Table] = []
         for inputTable in inputTables {
@@ -342,7 +342,7 @@ extension Table {
                         decimationFactor,
                         filter,
                         &outputSignal,
-                        n,
+                        outputLength,
                         filterLength)
             outputTables.append(Table(outputSignal))
         }
@@ -350,7 +350,8 @@ extension Table {
     }
 
     /// Takes a large array of floating point values and splits them up into an array of Tables.
-    /// Returns an array of tables (if there are extra samples at the end of the signal that are less than tableLength - they are ommitted)
+    /// Returns an array of tables
+    /// If there are extra samples at the end of the signal that are less than tableLength, they are ommitted.
     ///
     /// Parameters:
     ///   - signal: large array of floating point values
@@ -359,8 +360,8 @@ extension Table {
         let numberOfSamples = signal.count
         let numberOfOutputTables = numberOfSamples / tableLength
         var outputTables: [Table] = []
-        for i in 0..<numberOfOutputTables {
-            let startIndex = i * tableLength
+        for index in 0..<numberOfOutputTables {
+            let startIndex = index * tableLength
             let endIndex = startIndex + tableLength
             outputTables.append(Table(Array(signal[startIndex..<endIndex])))
         }

--- a/Sources/AudioKit/Internals/Table/Table+AdditiveSynthesis.swift
+++ b/Sources/AudioKit/Internals/Table/Table+AdditiveSynthesis.swift
@@ -324,20 +324,20 @@ extension Table {
     ///
     /// Parameters:
     ///   - inputTables: array of tables - which we can assume have a large sample count
-    ///   - numberOfOutputSamples: the number of floating point values to which we will downsample each Table array count
-    public class func downSampleTables(inputTables: [Table], numberOfOutputSamples: Int = 64) -> [Table] {
+    ///   - sampleCount: the number of floating point values to which we will downsample each Table array count
+    public class func downSampleTables(inputTables: [Table], to sampleCount: Int = 64) -> [Table] {
         let numberOfInputSamples = inputTables[0].content.count
         let inputLength = vDSP_Length(numberOfInputSamples)
 
         let filterLength: vDSP_Length = 2
         let filter = [Float](repeating: 1 / Float(filterLength), count: Int(filterLength))
 
-        let decimationFactor = numberOfInputSamples / numberOfOutputSamples
+        let decimationFactor = numberOfInputSamples / sampleCount
         let outputLength = vDSP_Length((inputLength - filterLength) / vDSP_Length(decimationFactor))
 
         var outputTables: [Table] = []
         for inputTable in inputTables {
-            var outputSignal = [Float](repeating: 0, count: Int(n))
+            var outputSignal = [Float](repeating: 0, count: Int(outputLength))
             vDSP_desamp(inputTable.content,
                         decimationFactor,
                         filter,

--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -378,19 +378,18 @@ public extension Array where Element == Float {
     /// Returns an array of downsampled floating point values
     ///
     /// Parameters:
-    ///   - inputTables: array of type Float - which is assumed have a large sample count
-    ///   - numberOfOutputSamples: the number of samples we will downsample the array to
-    func downSample(numberOfOutputSamples: Int = 128) -> [Element] {
+    ///   - sampleCount: the number of samples we will downsample the array to
+    func downSample(to sampleCount: Int = 128) -> [Element] {
         let numberOfInputSamples = self.count
         let inputLength = vDSP_Length(numberOfInputSamples)
 
         let filterLength: vDSP_Length = 2
         let filter = [Float](repeating: 1 / Float(filterLength), count: Int(filterLength))
 
-        let decimationFactor = numberOfInputSamples / numberOfOutputSamples
+        let decimationFactor = numberOfInputSamples / sampleCount
         let outputLength = vDSP_Length((inputLength - filterLength) / vDSP_Length(decimationFactor))
 
-        var outputFloats = [Float](repeating: 0, count: Int(n))
+        var outputFloats = [Float](repeating: 0, count: Int(outputLength))
         vDSP_desamp(self,
                     decimationFactor,
                     filter,


### PR DESCRIPTION
Added the following functionality:

- Table class method for downsampling an array of type Table (downSampleTables)
- Array extension method for downsampling an array of type Float (downSample)
- Table class method to take a large float array and segment it into many arrays of type Table (chopAudioToTables)
- Table class method to take a URL to an audio file and create an array of type Table (createWavetableArray)
- Helper method to take a URL to an audio file and return it's audio information (loadAudioSignal)

These were all added to be able to chop an audio file into an array of type Table (follow the logic in createWavetableArray to get an idea of the workflow)

Happy to rename / rework things - let me know what you think