### PR TITLE
AudioPlayer: improved seek functionality to support non-buffered files

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -74,8 +74,6 @@ extension AudioPlayer {
 
         let time = (0 ... duration).clamp(time)
 
-        Log(wasPlaying, time)
-
         isSeeking = true
 
         if wasPlaying {
@@ -84,7 +82,7 @@ extension AudioPlayer {
             editStartTime = time
             editEndTime = duration
         }
-        
+
         isSeeking = false
     }
 }

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -36,7 +36,7 @@ extension AudioPlayer {
         editStartTime = startTime ?? editStartTime
         editEndTime = endTime ?? editEndTime
 
-        if !isScheduled {
+        if !isScheduled || isSeeking {
             schedule(at: when,
                      completionCallbackType: completionCallbackType)
         }
@@ -62,7 +62,7 @@ extension AudioPlayer {
            let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
             return (Double(playerTime.sampleTime) / playerTime.sampleRate) + editStartTime
         }
-        return pausedTime
+        return editStartTime
     }
 
     /// Sets the player's audio file to a certain time in the track (in seconds)
@@ -80,11 +80,12 @@ extension AudioPlayer {
 
         if wasPlaying {
             play(from: time, to: duration)
-
         } else {
             editStartTime = time
             editEndTime = duration
         }
+        
+        isSeeking = false
     }
 }
 

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -165,14 +165,12 @@ public class AudioPlayer: Node {
     // MARK: - Internal functions
 
     func internalCompletionHandler() {
+        guard !isSeeking else { return }
         guard isPlaying, engine?.isInManualRenderingMode == false else { return }
 
         scheduleTime = nil
-
-        if !isSeeking {
-            completionHandler?()
-            isPlaying = false
-        }
+        completionHandler?()
+        isPlaying = false
 
         if !isBuffered, isLooping, engine?.isRunning == true {
             Log("Playing loop...")

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -173,7 +173,6 @@ public class AudioPlayer: Node {
         isPlaying = false
 
         if !isBuffered, isLooping, engine?.isRunning == true {
-            Log("Playing loop...")
             play()
             return
         }

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class AudioPlayerFileTests: AudioFileTestCase {
     // Bypass tests for automated CI
-    var realtimeEnabled = true
+    var realtimeEnabled = false
 
     func createPlayer(duration: TimeInterval,
                       frequencies: [AUValue]? = nil,


### PR DESCRIPTION
Resolves an issue with the seek method where if it was currently playing, then it wouldn't seek for non-buffered audio files. 

Also, adjustments were made to the completion handler to prevent isPlaying from being set to an incorrect state.