### PR TITLE
Fix sample rate for buffered audio player

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -185,7 +185,7 @@ public class AudioPlayer: Node {
             return
         }
         engine.attach(playerNode)
-        engine.connect(playerNode, to: mixerNode, format: nil)
+        engine.connect(playerNode, to: mixerNode, format: file?.processingFormat)
     }
 
     // MARK: - Init


### PR DESCRIPTION
When I use buffered audio player, `playerNode` and audioFile stay with different sample rate and audio file sounds not as It should.
When I try to play, I receive this warning in debug area. My file is 48000, playerNode is 44100 Hz.
```
2021-05-07 11:46:23.486769+0300 AudioKitBugDemo[7339:95802] [general] AudioPlayer+Scheduling.swift:scheduleBuffer(at:completionCallbackType:):68:Format of the buffer doesn't match the player (AudioPlayer+Scheduling.swift:scheduleBuffer(at:completionCallbackType:):68)
2021-05-07 11:46:23.487850+0300 AudioKitBugDemo[7339:95802] [general] AudioPlayer+Scheduling.swift:scheduleBuffer(at:completionCallbackType:):69:Player <AVAudioFormat 0x600000426120:  2 ch,  44100 Hz, Float32, non-inter> Buffer <AVAudioFormat 0x600000425a40:  2 ch,  48000 Hz, Float32, non-inter> (AudioPlayer+Scheduling.swift:scheduleBuffer(at:completionCallbackType:):69)
```

It fix by adding `file?.processingFormat` in `makeAvConnections` function, when connecting playerNode to mixerNode.

I created an example project with buffered and normal player for you to see what I'm talking about.
[example repository](https://github.com/ChaseStas/AudioKitPlayerBug)
