### PR TITLE
Draft: Refactoring MIDISampler, AppleSampler and MIDIInstrument

### DIFF
--- a/Sources/AudioKit/MIDI/MIDIConnectable.swift
+++ b/Sources/AudioKit/MIDI/MIDIConnectable.swift
@@ -1,0 +1,27 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+import AVFoundation
+
+#if !os(tvOS)
+
+/// Protocol for a node that can be connected to a MIDI client.
+protocol MIDIConnectable {
+    /// MIDI Input
+    var midiIn: MIDIEndpointRef { get set }
+    
+    /// Enable MIDI input from a given MIDI client
+    ///
+    /// - Parameters:
+    ///   - midiClient: A reference to the midi client
+    ///   - name: Name to connect with
+    ///
+    func enableMIDI(_ midiClient: MIDIClientRef, name: String?)
+    
+    /// Discard all virtual ports
+    func destroyEndpoint()
+    
+    func showVirtualMIDIPort()
+    
+    func hideVirtualMIDIPort()
+}
+
+#endif

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -98,6 +98,8 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable, MIDIP
                                  channel: MIDIChannel,
                                  portID: MIDIUniqueID? = nil,
                                  timeStamp: MIDITimeStamp? = nil) {
+        // TODO: I doubt if this works as expected.
+        // should move to start() and stop() instead
         mpeActiveNotes.append((noteNumber, channel))
         if velocity > 0 {
             start(noteNumber: noteNumber,
@@ -124,6 +126,8 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable, MIDIP
                                   portID: MIDIUniqueID? = nil,
                                   timeStamp: MIDITimeStamp? = nil) {
         stop(noteNumber: noteNumber, channel: channel, timeStamp: timeStamp)
+        // TODO: I doubt if this works as expected.
+        // should move to start() and stop() instead
         mpeActiveNotes.removeAll(where: { $0 == (noteNumber, channel) })
     }
     

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -7,7 +7,7 @@ import CoreAudio
 
 /// A version of Instrument specifically targeted to instruments that
 /// should be triggerable via MIDI or sequenced with the sequencer.
-open class MIDIInstrument: Node, MIDIListener, NamedNode {
+open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
 
     /// Connected nodes
     public var connections: [Node] { [] }
@@ -16,9 +16,6 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode {
     public var avAudioNode: AVAudioNode
 
     // MARK: - Properties
-
-    /// MIDI Input
-    open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
     open var name = "(unset)"
@@ -36,6 +33,11 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode {
         enableMIDI(name: name)
         hideVirtualMIDIPort()
     }
+    
+    // MARK: - MIDIConnectable
+
+    /// MIDI Input
+    open var midiIn = MIDIEndpointRef()
 
     /// Enable MIDI input from a given MIDI client
     ///
@@ -55,6 +57,22 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode {
                 }
             }
         })
+    }
+    
+    /// Discard all virtual ports
+    public func destroyEndpoint() {
+        if midiIn != 0 {
+            MIDIEndpointDispose(midiIn)
+            midiIn = 0
+        }
+    }
+    
+    func showVirtualMIDIPort() {
+        MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 0)
+    }
+    
+    func hideVirtualMIDIPort() {
+        MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 1)
     }
 
     private func handle(event: MIDIEvent) {
@@ -285,14 +303,6 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode {
                                        channel: channel)
             }
         }
-    }
-
-    func showVirtualMIDIPort() {
-        MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 0)
-    }
-
-    func hideVirtualMIDIPort() {
-        MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 1)
     }
 }
 

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -262,18 +262,6 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable, MIDIP
         fatalError("Override in subclass")
     }
 
-    /// Receive program change
-    ///
-    /// - Parameters:
-    ///   - program:  MIDI Program Value (0-127)
-    ///   - channel:  MIDI Channel (1-16)
-    ///
-    open func receivedMIDIProgramChange(_ program: MIDIByte,
-                                        channel: MIDIChannel,
-                                        timeStamp: MIDITimeStamp? = nil) {
-        // Override in subclass
-    }
-
     // MARK: - Private functions
 
     // Send MIDI data to the audio unit

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -7,7 +7,7 @@ import CoreAudio
 
 /// A version of Instrument specifically targeted to instruments that
 /// should be triggerable via MIDI or sequenced with the sequencer.
-open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
+open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable, MIDIPlayable {
 
     /// Connected nodes
     public var connections: [Node] { [] }
@@ -100,9 +100,14 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
                                  timeStamp: MIDITimeStamp? = nil) {
         mpeActiveNotes.append((noteNumber, channel))
         if velocity > 0 {
-            start(noteNumber: noteNumber, velocity: velocity, channel: channel)
+            start(noteNumber: noteNumber,
+                  velocity: velocity,
+                  channel: channel,
+                  timeStamp: timeStamp)
         } else {
-            stop(noteNumber: noteNumber, channel: channel)
+            stop(noteNumber: noteNumber,
+                 channel: channel,
+                 timeStamp: timeStamp)
         }
     }
     
@@ -118,7 +123,7 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
                                   channel: MIDIChannel,
                                   portID: MIDIUniqueID? = nil,
                                   timeStamp: MIDITimeStamp? = nil) {
-        stop(noteNumber: noteNumber, channel: channel)
+        stop(noteNumber: noteNumber, channel: channel, timeStamp: timeStamp)
         mpeActiveNotes.removeAll(where: { $0 == (noteNumber, channel) })
     }
     
@@ -227,7 +232,7 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
         // Do nothing
     }
 
-    // MARK: - MIDI Note Start/Stop
+    // MARK: - MIDI Note Start/Stop (MIDIPlayable)
 
     /// Start a note
     ///
@@ -240,9 +245,10 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
                     velocity: MIDIVelocity,
                     channel: MIDIChannel,
                     timeStamp: MIDITimeStamp? = nil) {
-        // Override in subclass
+        // MIDIInstrument is useless without overriding in most cases
+        fatalError("Override in subclass")
     }
-
+    
     /// Stop a note
     ///
     /// - Parameters:
@@ -252,7 +258,8 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
     open func stop(noteNumber: MIDINoteNumber,
                    channel: MIDIChannel,
                    timeStamp: MIDITimeStamp? = nil) {
-        // Override in subclass
+        // MIDIInstrument class is useless without overriding in most cases
+        fatalError("Override in subclass")
     }
 
     /// Receive program change

--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -84,7 +84,7 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode, MIDIConnectable {
                         data3: event.data[2])
     }
     
-    // MARK: - Handling MIDI Data
+    // MARK: - Handling MIDI Data (MIDIListener)
     
     /// Handle MIDI commands that come in externally
     /// - Parameters:

--- a/Sources/AudioKit/MIDI/MIDIListener.swift
+++ b/Sources/AudioKit/MIDI/MIDIListener.swift
@@ -151,4 +151,65 @@ func == (lhs: MIDIListener, rhs: MIDIListener) -> Bool {
     return lhs.isEqualTo(rhs)
 }
 
+/// Convience method for handling different types of MIDI events
+public extension MIDIListener {
+    func handleMIDI(event: MIDIEvent) {
+        if let status = event.status, let statusType = status.type {
+            let channel = status.channel
+            let data2 = event.data[1]
+            let data3 = event.data[2]
+
+            switch statusType {
+            case .noteOn:
+                if data3 > 0 {
+                    receivedMIDINoteOn(noteNumber: data2,
+                                       velocity: data3,
+                                       channel: channel,
+                                       portID: 0,
+                                       timeStamp: 0)
+                } else {
+                    receivedMIDINoteOff(noteNumber: data2,
+                                        velocity: data3,
+                                        channel: channel,
+                                        portID: 0,
+                                        timeStamp: 0)
+                }
+            case .noteOff:
+                receivedMIDINoteOff(noteNumber: data2,
+                                    velocity: data3,
+                                    channel: channel,
+                                    portID: 0,
+                                    timeStamp: 0)
+            case .polyphonicAftertouch:
+                receivedMIDIAftertouch(noteNumber: data2,
+                                       pressure: data3,
+                                       channel: channel,
+                                       portID: 0,
+                                       timeStamp: 0)
+            case .channelAftertouch:
+                receivedMIDIAftertouch(data2,
+                                       channel: channel,
+                                       portID: 0,
+                                       timeStamp: 0)
+            case .controllerChange:
+                receivedMIDIController(data2,
+                                       value: data3,
+                                       channel: channel,
+                                       portID: 0,
+                                       timeStamp: 0)
+            case .programChange:
+                receivedMIDIProgramChange(data2,
+                                          channel: channel,
+                                          portID: 0,
+                                          timeStamp: 0)
+            case .pitchWheel:
+                receivedMIDIPitchWheel(MIDIWord(byte1: data2,
+                                                byte2: data3),
+                                                channel: channel,
+                                                portID: 0,
+                                                timeStamp: 0)
+            }
+        }
+    }
+}
 #endif

--- a/Sources/AudioKit/MIDI/MIDIPlayable.swift
+++ b/Sources/AudioKit/MIDI/MIDIPlayable.swift
@@ -1,0 +1,29 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+import CAudioKit
+
+// TODO: think of a different name. This may be confusing with MIDIPlayer
+/// A protocol for start and stop with MIDI notes
+protocol MIDIPlayable {
+    /// Start a note
+    ///
+    /// - Parameters:
+    ///   - noteNumber: Note number to play
+    ///   - velocity:   Velocity at which to play the note (0 - 127)
+    ///   - channel:    Channel on which to play the note
+    ///
+    func start(noteNumber: MIDINoteNumber,
+               velocity: MIDIVelocity,
+               channel: MIDIChannel,
+               timeStamp: MIDITimeStamp?)
+    
+    /// Stop a note
+    ///
+    /// - Parameters:
+    ///   - noteNumber: Note number to stop
+    ///   - channel:    Channel on which to stop the note
+    ///
+    func stop(noteNumber: MIDINoteNumber,
+              channel: MIDIChannel,
+              timeStamp: MIDITimeStamp?)
+}
+

--- a/Sources/AudioKit/MIDI/MIDIPlayable.swift
+++ b/Sources/AudioKit/MIDI/MIDIPlayable.swift
@@ -27,3 +27,33 @@ protocol MIDIPlayable {
               timeStamp: MIDITimeStamp?)
 }
 
+// TODO: not sure yet, need to think about this.
+//extension Node where Self: MIDIPlayable {
+//    /// Start a note
+//    ///
+//    /// - Parameters:
+//    ///   - noteNumber: Note number to play
+//    ///   - velocity:   Velocity at which to play the note (0 - 127)
+//    ///   - channel:    Channel on which to play the note
+//    ///
+//    func start(noteNumber: MIDINoteNumber,
+//               velocity: MIDIVelocity,
+//               channel: MIDIChannel,
+//               timeStamp: MIDITimeStamp? = nil) {
+//        // TODO: not sure about this
+//        scheduleMIDIEvent(event: MIDIEvent(noteOff: noteNumber, velocity: velocity, channel: channel))
+//    }
+//
+//    /// Stop a note
+//    ///
+//    /// - Parameters:
+//    ///   - noteNumber: Note number to stop
+//    ///   - channel:    Channel on which to stop the note
+//    ///
+//    func stop(noteNumber: MIDINoteNumber,
+//              channel: MIDIChannel,
+//              timeStamp: MIDITimeStamp? = nil) {
+//        // TODO: not sure about this
+//        scheduleMIDIEvent(event: MIDIEvent(noteOff: noteNumber, velocity: 0, channel: channel))
+//    }
+//}

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -6,63 +6,15 @@ import AVFoundation
 import CoreAudio
 import os.log
 
+// TODO: add other deprecation warnings
+
 /// MIDI receiving Sampler
 ///
 /// Be sure to enableMIDI if you want to receive messages
 ///
-open class MIDISampler: AppleSampler, NamedNode {
-    // MARK: - Properties
-
-    /// MIDI Input
-    open var midiIn = MIDIEndpointRef()
-
-    /// Name of the instrument
-    open var name = "(unset)"
-
-    /// Initialize the MIDI Sampler
-    ///
-    /// - Parameter midiOutputName: Name of the instrument's MIDI output
-    ///
-    public init(name midiOutputName: String? = nil) {
-        super.init()
-        name = midiOutputName ?? MemoryAddress(of: self).description
-        enableMIDI(name: name)
-        hideVirtualMIDIPort()
-    }
-
-    /// Enable MIDI input from a given MIDI client
-    /// This is not in the init function because it must be called AFTER you start AudioKit
-    ///
-    /// - Parameters:
-    ///   - midiClient: A reference to the MIDI client
-    ///   - name: Name to connect with
-    ///
-    public func enableMIDI(_ midiClient: MIDIClientRef = MIDI.sharedInstance.client,
-                           name: String? = nil) {
-        let cfName = (name ?? self.name) as CFString
-        guard let midiBlock = avAudioNode.auAudioUnit.scheduleMIDIEventBlock else {
-            fatalError("Expected AU to respond to MIDI.")
-        }
-        CheckError(MIDIDestinationCreateWithBlock(midiClient, cfName, &midiIn) { packetList, _ in
-            for e in packetList.pointee {
-                e.forEach { event in
-                    event.data.withUnsafeBufferPointer { ptr in
-                        guard let ptr = ptr.baseAddress else { return }
-                        midiBlock(AUEventSampleTimeImmediate, 0, event.data.count, ptr)
-                    }
-                }
-            }
-        })
-    }
-
-    private func handle(event: MIDIEvent) throws {
-        try self.handleMIDI(data1: event.data[0],
-                            data2: event.data[1],
-                            data3: event.data[2])
-    }
-
+open class MIDISampler: AppleSampler {
     // MARK: - Handling MIDI Data
-
+    
     // Send MIDI data to the audio unit
     func handleMIDI(data1: MIDIByte, data2: MIDIByte, data3: MIDIByte) throws {
         if let status = MIDIStatus(byte: data1) {
@@ -78,24 +30,7 @@ open class MIDISampler: AppleSampler, NamedNode {
             }
         }
     }
-
-    /// Handle MIDI commands that come in externally
-    ///
-    /// - Parameters:
-    ///   - noteNumber: MIDI Note number
-    ///   - velocity:   MIDI velocity
-    ///   - channel:    MIDI channel
-    ///
-    public func receivedMIDINoteOn(noteNumber: MIDINoteNumber,
-                                   velocity: MIDIVelocity,
-                                   channel: MIDIChannel) throws {
-        if velocity > 0 {
-            play(noteNumber: noteNumber, velocity: velocity, channel: channel)
-        } else {
-            stop(noteNumber: noteNumber, channel: channel)
-        }
-    }
-
+    
     /// Handle MIDI CC that come in externally
     ///
     /// - Parameters:
@@ -103,58 +38,9 @@ open class MIDISampler: AppleSampler, NamedNode {
     ///   - value: MIDI CC value
     ///   - channel: MIDI CC channel
     ///
+    @available(*, deprecated, message: "midiCC(controller:, value:, channel:) is depreated. Use receivedMIDIController(controller, value: channel:) instead.")
     public func midiCC(_ controller: MIDIByte, value: MIDIByte, channel: MIDIChannel) {
         samplerUnit.sendController(controller, withValue: value, onChannel: channel)
-    }
-
-    // MARK: - MIDI Note Start/Stop
-
-    /// Start a note or trigger a sample
-    ///
-    /// - Parameters:
-    ///   - noteNumber: MIDI note number
-    ///   - velocity: MIDI velocity
-    ///   - channel: MIDI channel
-    ///
-    /// NB: when using an audio file, noteNumber 60 will play back the file at normal
-    /// speed, 72 will play back at double speed (1 octave higher), 48 will play back at
-    /// half speed (1 octave lower) and so on
-    open override func play(noteNumber: MIDINoteNumber,
-                            velocity: MIDIVelocity,
-                            channel: MIDIChannel) {
-        do {
-            try ExceptionCatcher {
-                self.samplerUnit.startNote(noteNumber, withVelocity: velocity, onChannel: channel)
-            }
-        } catch {
-            Log("Could not play MIDISampler note: \(error.localizedDescription)", type: .error)
-        }
-    }
-
-    /// Stop a note
-    open override func stop(noteNumber: MIDINoteNumber, channel: MIDIChannel) {
-        do {
-            try ExceptionCatcher {
-                self.samplerUnit.stopNote(noteNumber, onChannel: channel)
-            }
-        } catch {
-            Log("Could not stop MIDISampler note: \(error.localizedDescription)", type: .error)
-        }
-    }
-
-    /// Discard all virtual ports
-    public func destroyEndpoint() {
-        if midiIn != 0 {
-            MIDIEndpointDispose(midiIn)
-            midiIn = 0
-        }
-    }
-
-    func showVirtualMIDIPort() {
-        MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 0)
-    }
-    func hideVirtualMIDIPort() {
-        MIDIObjectSetIntegerProperty(midiIn, kMIDIPropertyPrivate, 1)
     }
 }
 

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -40,7 +40,7 @@ open class MIDISampler: AppleSampler {
     ///
     @available(*, deprecated, message: "midiCC(controller:, value:, channel:) is depreated. Use receivedMIDIController(controller, value: channel:) instead.")
     public func midiCC(_ controller: MIDIByte, value: MIDIByte, channel: MIDIChannel) {
-        samplerUnit.sendController(controller, withValue: value, onChannel: channel)
+        receivedMIDIController(controller, value: value, channel: channel)
     }
 }
 

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -13,24 +13,6 @@ import os.log
 /// Be sure to enableMIDI if you want to receive messages
 ///
 open class MIDISampler: AppleSampler {
-    // MARK: - Handling MIDI Data
-    
-    // Send MIDI data to the audio unit
-    func handleMIDI(data1: MIDIByte, data2: MIDIByte, data3: MIDIByte) throws {
-        if let status = MIDIStatus(byte: data1) {
-            let channel = status.channel
-            if status.type == .noteOn && data3 > 0 {
-                play(noteNumber: data2,
-                     velocity: data3,
-                     channel: channel)
-            } else if status.type == .noteOn && data3 == 0 {
-                stop(noteNumber: data2, channel: channel)
-            } else if status.type == .controllerChange {
-                midiCC(data2, value: data3, channel: channel)
-            }
-        }
-    }
-    
     /// Handle MIDI CC that come in externally
     ///
     /// - Parameters:

--- a/Sources/AudioKit/Nodes/Generators/Physical Models/DrumSynths.swift
+++ b/Sources/AudioKit/Nodes/Generators/Physical Models/DrumSynths.swift
@@ -6,7 +6,7 @@ import CAudioKit
 #if !os(tvOS)
 
 /// Kick Drum Synthesizer Instrument
-public class SynthKick: MIDIInstrument {
+open class SynthKick: MIDIInstrument {
 
     var generator: OperationGenerator
 
@@ -42,7 +42,7 @@ public class SynthKick: MIDIInstrument {
 }
 
 /// Snare Drum Synthesizer Instrument
-public class SynthSnare: MIDIInstrument {
+open class SynthSnare: MIDIInstrument {
 
     var generator: OperationGenerator
     var duration = 0.143

--- a/Sources/AudioKit/Nodes/Generators/Synth/Synth.swift
+++ b/Sources/AudioKit/Nodes/Generators/Synth/Synth.swift
@@ -6,7 +6,7 @@ import CAudioKit
 
 /// Synth
 ///
-public class Synth: Node {
+public class Synth: Node, MIDIPlayable {
 
     /// Connected nodes
     public var connections: [Node] { [] }
@@ -243,15 +243,18 @@ public class Synth: Node {
         self.filterReleaseDuration = filterReleaseDuration
         
     }
-
+    
+    // MARK: - MIDIPlayable
+    
     /// Play a note on the synth
     /// - Parameters:
     ///   - noteNumber: MIDI Note Number
     ///   - velocity: MIDI Velocity
     ///   - channel: MIDI Channel
-    public func play(noteNumber: MIDINoteNumber,
-                     velocity: MIDIVelocity,
-                     channel: MIDIChannel = 0) {
+    public func start(noteNumber: MIDINoteNumber,
+               velocity: MIDIVelocity,
+               channel: MIDIChannel,
+               timeStamp: MIDITimeStamp? = nil) {
         scheduleMIDIEvent(event: MIDIEvent(noteOn: noteNumber, velocity: velocity, channel: channel))
     }
 
@@ -259,7 +262,9 @@ public class Synth: Node {
     /// - Parameters:
     ///   - noteNumber: MIDI Note Number
     ///   - channel: MIDI Channel
-    public func stop(noteNumber: MIDINoteNumber, channel: MIDIChannel = 0) {
+    public func stop(noteNumber: MIDINoteNumber,
+              channel: MIDIChannel,
+              timeStamp: MIDITimeStamp? = nil) {
         scheduleMIDIEvent(event: MIDIEvent(noteOff: noteNumber, velocity: 0, channel: channel))
     }
 }

--- a/Sources/AudioKit/Nodes/Playback/Samplers/Apple Sampler/AppleSampler.swift
+++ b/Sources/AudioKit/Nodes/Playback/Samplers/Apple Sampler/AppleSampler.swift
@@ -344,4 +344,14 @@ open class AppleSampler: MIDIInstrument {
     public func resetSampler() {
         samplerUnit.reset()
     }
+    
+    // MARK: - MIDIListener
+    
+    open override func receivedMIDIController(_ controller: MIDIByte,
+                                              value: MIDIByte,
+                                              channel: MIDIChannel,
+                                              portID: MIDIUniqueID? = nil,
+                                              timeStamp: MIDITimeStamp? = nil) {
+        samplerUnit.sendController(controller, withValue: value, onChannel: channel)
+    }
 }


### PR DESCRIPTION
Hi,

The 5.1 AudioKit release broke quite a few components of my app. It was specifically this change that was an issue for me: https://github.com/AudioKit/AudioKit/commit/b38069b7965ccc9242c6f78d0cbf9a10ae106bf1#diff-fb7560882c334efaa2772be40163bacf6bb652b87b83151ee492a2fbc033fc03  

What I'm missing now is a uniform way to identify and interact with Nodes that respond to MIDI playback events (play a MIDI note, stop a MIDI note). I understand that MIDINode wasn't used by AudioKit internally, but that doesn't mean that someone using AudioKit wasn't using it. ;)

One of the things that I find a bit problematic when using AudioKit is that different classes use different method signatures for starting and stopping MIDI notes. There is no clearly defined protocol for that. Also, I believe that having two classes for MIDISampler and AppleSampler is not necessary. And I didn't understand why they did not inherit from MIDIInstrument. Why can't a sampler be a midi instrument?

So I tried to fix all of this! 

I haven't tested all of these changes yet! But I wanted to share it with you to make sure I'm not doing some work that somebody else is already doing.

There are a few things I still need to do:
- Add tests, of course! I will work on that.
- Have another look at `handleMIDI`, with respect to a race condition mentioned by Tayler and these commits: 02c7b3e763b85720bb7c6131775b9b89f1ce0705 and 830cb6240340f6596582a5520c3b67c8d3c9aa26. I might have removed something important so will double check that
- I'm not sure about the name of the new `MIDIPlayable` protocol I introduced. Might be confusing because there's also a MIDIPlayer that represents something very different. Maybe I should name it something like `MIDINotePlayable`? 
- I'm not always sure when to use public vs open. I subclass some AudioKit classes in my own app, which doesn't always work when the parent (AudioKit) class is public. I notices some classes in AudioKit are public while others are open.
