### PR TITLE
MIDI Fix: Adding Multiple Virtual Ports

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -47,7 +47,7 @@ extension MIDI {
         for virtualPortIndex in 0...count - 1 {
             var virtualPortName: String
             var uniqueID: Int32
-            if virtualPortIndex != 0 {virtualInputs.append(0)}
+            if virtualPortIndex != 0 {virtualOutputs.append(0)}
 
             if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
@@ -88,7 +88,7 @@ extension MIDI {
         for virtualPortIndex in 0 ..< count {
             var virtualPortName: String
             var uniqueID: Int32
-            if virtualPortIndex != 0 { virtualOutputs.append(0) }
+            if virtualPortIndex != 0 { virtualInputs.append(0) }
             
             if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName


### PR DESCRIPTION
Possibly addressed one of the MIDI improvements listed in MIDI+VirtualPorts.swift -- having the ability to create more than one virtual port. This works with both the virtual inputs and virtual outputs.

