### PR TITLE
 Make Separate MIDI Port Collection for Virtual Inputs and Outputs

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI+Receiving.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Receiving.swift
@@ -78,12 +78,24 @@ extension MIDI {
 
     /// Array of input source unique ids
     public var inputUIDs: [MIDIUniqueID] {
-        return MIDISources().uniqueIds
+        var ids = MIDISources().uniqueIds
+        // Remove inputs which are actually virtual outputs from AudioKit
+        for input in self.virtualOutputs {
+            let virtualId = getMIDIObjectIntegerProperty(ref: input, property: kMIDIPropertyUniqueID)
+            ids.removeAll(where: { $0 == virtualId})
+        }
+        return ids
     }
 
     /// Array of input source names
     public var inputNames: [String] {
-        return MIDISources().names
+        var names = MIDISources().names
+        // Remove inputs which are actually virtual outputs from AudioKit
+        for input in self.virtualOutputs {
+            let virtualName = getMIDIObjectStringProperty(ref: input, property: kMIDIPropertyName)
+            names.removeAll(where: { $0 == virtualName})
+        }
+        return names
     }
 
     /// Lookup a input name from its unique id

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -246,7 +246,7 @@ extension MIDI {
     public func sendMessage(_ data: [MIDIByte],
                             offset: MIDITimeStamp = 0,
                             endpointsUIDs: [MIDIUniqueID]? = nil,
-                            virtualInputPorts: [MIDIPortRef]? = nil) {
+                            virtualOutputPorts: [MIDIPortRef]? = nil) {
 
         // Create a buffer that is big enough to hold the data to be sent and
         // all the necessary headers.
@@ -297,8 +297,8 @@ extension MIDI {
                     }
                 }
 
-                if virtualInputs != [0] {
-                    virtualInputPorts?.forEach {MIDIReceived($0, packetListPointer)}
+                if virtualOutputs != [0] {
+                    virtualOutputPorts?.forEach {MIDIReceived($0, packetListPointer)}
                 }
             }
         }
@@ -313,8 +313,8 @@ extension MIDI {
     /// - Parameter event: Event so send
     public func sendEvent(_ event: MIDIEvent,
                           endpointsUIDs: [MIDIUniqueID]? = nil,
-                          virtualInputPorts: [MIDIPortRef]? = nil) {
-        sendMessage(event.data, endpointsUIDs: endpointsUIDs, virtualInputPorts: virtualInputPorts)
+                          virtualOutputPorts: [MIDIPortRef]? = nil) {
+        sendMessage(event.data, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note On Message
@@ -326,10 +326,10 @@ extension MIDI {
                                   velocity: MIDIVelocity,
                                   channel: MIDIChannel = 0,
                                   endpointsUIDs: [MIDIUniqueID]? = nil,
-                                  virtualInputPorts: [MIDIPortRef]? = nil) {
+                                  virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOnByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualInputPorts: virtualInputPorts)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note Off Message
@@ -341,10 +341,10 @@ extension MIDI {
                                    velocity: MIDIVelocity,
                                    channel: MIDIChannel = 0,
                                    endpointsUIDs: [MIDIUniqueID]? = nil,
-                                   virtualInputPorts: [MIDIPortRef]? = nil) {
+                                   virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOffByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualInputPorts: virtualInputPorts)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Continuous Controller message
@@ -356,10 +356,10 @@ extension MIDI {
                                       value: MIDIByte,
                                       channel: MIDIChannel = 0,
                                       endpointsUIDs: [MIDIUniqueID]? = nil,
-                                      virtualInputPorts: [MIDIPortRef]? = nil) {
+                                      virtualOutputPorts: [MIDIPortRef]? = nil) {
         let controlCommand: MIDIByte = MIDIByte(0xB0) + channel
         let message: [MIDIByte] = [controlCommand, control, value]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualInputPorts: virtualInputPorts)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a pitch bend message.
@@ -370,13 +370,13 @@ extension MIDI {
     public func sendPitchBendMessage(value: UInt16,
                                      channel: MIDIChannel = 0,
                                      endpointsUIDs: [MIDIUniqueID]? = nil,
-                                     virtualInputPorts: [MIDIPortRef]? = nil) {
+                                     virtualOutputPorts: [MIDIPortRef]? = nil) {
         let pitchCommand = MIDIByte(0xE0) + channel
         let mask: UInt16 = 0x007F
         let byte1 = MIDIByte(value & mask) // MSB, bit shift right 7
         let byte2 = MIDIByte((value & (mask << 7)) >> 7) // LSB, mask of 127
         let message: [MIDIByte] = [pitchCommand, byte1, byte2]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualInputPorts: virtualInputPorts)
+        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     // MARK: - Expand api to include MIDITimeStamp
@@ -392,12 +392,12 @@ extension MIDI {
                                           channel: MIDIChannel = 0,
                                           time: MIDITimeStamp = 0,
                                           endpointsUIDs: [MIDIUniqueID]? = nil,
-                                          virtualInputPorts: [MIDIPortRef]? = nil) {
+                                          virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOnByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
         self.sendMessageWithTime(message, time: time,
                                  endpointsUIDs: endpointsUIDs,
-                                 virtualInputPorts: virtualInputPorts)
+                                 virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note Off Message with timestamp
@@ -411,12 +411,12 @@ extension MIDI {
                                            channel: MIDIChannel = 0,
                                            time: MIDITimeStamp = 0,
                                            endpointsUIDs: [MIDIUniqueID]? = nil,
-                                           virtualInputPorts: [MIDIPortRef]? = nil) {
+                                           virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOffByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
         self.sendMessageWithTime(message, time: time,
                                  endpointsUIDs: endpointsUIDs,
-                                 virtualInputPorts: virtualInputPorts)
+                                 virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send Message with data with timestamp
@@ -426,7 +426,7 @@ extension MIDI {
     public func sendMessageWithTime(_ data: [MIDIByte],
                                     time: MIDITimeStamp,
                                     endpointsUIDs: [MIDIUniqueID]? = nil,
-                                    virtualInputPorts: [MIDIPortRef]? = nil) {
+                                    virtualOutputPorts: [MIDIPortRef]? = nil) {
         let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)
 
         var packet: UnsafeMutablePointer<MIDIPacket> = MIDIPacketListInit(packetListPointer)
@@ -449,8 +449,8 @@ extension MIDI {
             }
         }
 
-        if virtualInputs != [0] {
-            virtualInputPorts?.forEach {MIDIReceived($0, packetListPointer)}
+        if virtualOutputs != [0] {
+            virtualOutputPorts?.forEach {MIDIReceived($0, packetListPointer)}
         }
     }
 }

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -92,12 +92,25 @@ extension MIDI {
 
     /// Array of destination unique ids
     public var destinationUIDs: [MIDIUniqueID] {
-        return MIDIDestinations().uniqueIds
+        var ids = MIDIDestinations().uniqueIds
+        // Remove outputs which are actually virtual inputs to AudioKit
+        for output in self.virtualInputs {
+            let virtualId = getMIDIObjectIntegerProperty(ref: output, property: kMIDIPropertyUniqueID)
+            ids.removeAll(where: { $0 == virtualId})
+            // Add this UID to the inputUIDs
+        }
+        return ids
     }
 
     /// Array of destination names
     public var destinationNames: [String] {
-        return MIDIDestinations().names
+        var names = MIDIDestinations().names
+        // Remove outputs which are actually virtual inputs to AudioKit
+        for output in self.virtualInputs {
+            let virtualName = getMIDIObjectStringProperty(ref: output, property: kMIDIPropertyName)
+            names.removeAll(where: { $0 == virtualName})
+        }
+        return names
     }
 
     /// Lookup a destination name from its unique id

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -18,6 +18,50 @@ extension MIDI {
     //      * Support hidden uuid generation so the caller can worry about less (completed)
     //
 
+    /// Array of virtual input ids
+    public var virtualInputUIDs: [MIDIUniqueID] {
+        var ids = [MIDIUniqueID]()
+        for input in self.virtualInputs {
+            ids.append(getMIDIObjectIntegerProperty(ref: input, property: kMIDIPropertyUniqueID))
+            // Remove uninitialized ports
+            ids.removeAll(where: {$0 == 0})
+        }
+        return ids
+    }
+
+    /// Array of virtual input names
+    public var virtualInputNames: [String] {
+        var names = [String]()
+        for input in self.virtualInputs {
+            names.append(getMIDIObjectStringProperty(ref: input, property: kMIDIPropertyName))
+            // Remove uninitialized ports
+            names.removeAll(where: {$0 == ""})
+        }
+        return names
+    }
+
+    /// Array of virtual output ids
+    public var virtualOutputUIDs: [MIDIUniqueID] {
+        var ids = [MIDIUniqueID]()
+        for output in self.virtualOutputs {
+            ids.append(getMIDIObjectIntegerProperty(ref: output, property: kMIDIPropertyUniqueID))
+            // Remove uninitialized ports
+            ids.removeAll(where: {$0 == 0})
+        }
+        return ids
+    }
+
+    /// Array of virtual output names
+    public var virtualOutputNames: [String] {
+        var names = [String]()
+        for output in self.virtualOutputs {
+            names.append(getMIDIObjectStringProperty(ref: output, property: kMIDIPropertyName))
+            // Remove uninitialized ports
+            names.removeAll(where: {$0 == ""})
+        }
+        return names
+    }
+
     /// Create set of virtual input and output MIDI ports
     /// - Parameters:
     ///   - count: Number of ports to create (default: 1 Virtual Input and 1 Virtual Output)
@@ -39,7 +83,7 @@ extension MIDI {
         createVirtualOutputPorts(count: count, uniqueIDs: outputPortIDs, names: outputPortNames)
     }
 
-    /// Create virtual MIDI input ports (ports sending from AudioKit)
+    /// Create virtual MIDI input ports (ports sending to AudioKit)
     /// - Parameters:
     ///   - count: Number of ports to create (default: 1)
     ///   - uniqueIDs: Optional list of IDs (otherwise they are automatically generated)
@@ -60,7 +104,7 @@ extension MIDI {
             if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
             } else {
-                virtualPortName = String("From \(clientName) \(unnamedPortIndex)")
+                virtualPortName = String("\(clientName) Input \(unnamedPortIndex)")
                 unnamedPortIndex += 1
             }
 
@@ -97,7 +141,7 @@ extension MIDI {
         }
     }
 
-    /// Create virtual MIDI output ports (ports sending to AudioKit)
+    /// Create virtual MIDI output ports (ports sending from AudioKit)
     /// - Parameters:
     ///   - count: Number of ports to create (default: 1)
     ///   - uniqueIDs: Optional list of IDs (otherwise they are automatically generated)
@@ -118,7 +162,7 @@ extension MIDI {
             if names?.count ?? 0 > virtualPortIndex, let portName = names?[virtualPortIndex] {
                 virtualPortName = portName
             } else {
-                virtualPortName = String("To \(clientName) \(unnamedPortIndex)")
+                virtualPortName = String("\(clientName) Output \(unnamedPortIndex)")
                 unnamedPortIndex += 1
             }
 

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -69,8 +69,18 @@ extension MIDI {
             } else {
                 uniqueID = 2_000_000 + unIDPortIndex
                 unIDPortIndex += 2
+
+            let result = MIDIDestinationCreateWithBlock(
+            client,
+            virtualPortName as CFString,
+            &virtualInputs[virtualPortIndex]) { packetList, _ in
+                for packet in packetList.pointee {
+                    // a Core MIDI packet may contain multiple MIDI events
+                    for event in packet {
+                        self.handleMIDIMessage(event, fromInput: uniqueID)
+                    }
+                }
             }
-            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualInputs[virtualPortIndex])
             if result == noErr {
                 MIDIObjectSetIntegerProperty(virtualInputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {
@@ -118,18 +128,8 @@ extension MIDI {
                 uniqueID = 2_000_001 + unIDPortIndex
                 unIDPortIndex += 2
             }
-
-            let result = MIDIDestinationCreateWithBlock(
-                client,
-                virtualPortName as CFString,
-                &virtualOutputs[virtualPortIndex]) { packetList, _ in
-                for packet in packetList.pointee {
-                    // a Core MIDI packet may contain multiple MIDI events
-                    for event in packet {
-                        self.handleMIDIMessage(event, fromInput: uniqueID)
-                    }
-                }
-            }
+           }
+           let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
                 MIDIObjectSetIntegerProperty(virtualOutputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -69,7 +69,6 @@ extension MIDI {
             } else {
                 uniqueID = 2_000_000 + unIDPortIndex
                 unIDPortIndex += 2
-           }
 
             let result = MIDIDestinationCreateWithBlock(
             client,

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -69,6 +69,7 @@ extension MIDI {
             } else {
                 uniqueID = 2_000_000 + unIDPortIndex
                 unIDPortIndex += 2
+           }
 
             let result = MIDIDestinationCreateWithBlock(
             client,

--- a/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
+++ b/Sources/AudioKit/MIDI/MIDI+VirtualPorts.swift
@@ -69,7 +69,7 @@ extension MIDI {
             } else {
                 uniqueID = 2_000_000 + unIDPortIndex
                 unIDPortIndex += 2
-
+            }
             let result = MIDIDestinationCreateWithBlock(
             client,
             virtualPortName as CFString,
@@ -128,8 +128,8 @@ extension MIDI {
                 uniqueID = 2_000_001 + unIDPortIndex
                 unIDPortIndex += 2
             }
-           }
-           let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
+
+            let result = MIDISourceCreate(client, virtualPortName as CFString, &virtualOutputs[virtualPortIndex])
             if result == noErr {
                 MIDIObjectSetIntegerProperty(virtualOutputs[virtualPortIndex], kMIDIPropertyUniqueID, uniqueID)
             } else {

--- a/Sources/AudioKit/MIDI/MIDIEndpointInfo.swift
+++ b/Sources/AudioKit/MIDI/MIDIEndpointInfo.swift
@@ -118,6 +118,16 @@ extension MIDI {
     public var inputInfos: [EndpointInfo] {
         return MIDISources().endpointInfos
     }
+
+    /// Virtual Outputs
+    public var virtualOutputInfos: [EndpointInfo] {
+        return virtualOutputs.endpointInfos
+    }
+
+    /// Virtual Inputs
+    public var virtualInputInfos: [EndpointInfo] {
+        return virtualInputs.endpointInfos
+    }
 }
 
 #endif


### PR DESCRIPTION
Retrieving `MIDISources()` and `MIDIDestinations()` in MIDI+Receiving.swift and MIDI+Sending.swift respectively was causing some problems. This is because `createVirtualInputPorts()` and `createVirtualOutputPorts()` in MIDI+VirtualPorts.swift create their own "MIDIDestinations" and "MIDISources" to receive and send from respectively. However, these destination and source ports should not be mixed up with the destination and source ports from the system. This is because the AudioKit MIDI Client is to use the virtual MIDIDestinations for receiving and the virtual MIDISources for sending.

This will make more sense in the updated, wonderful MIDI example created by @ShowtimeSoft:
[MIDI Port Test.zip](https://github.com/AudioKit/AudioKit/files/6555605/MIDI.Port.Test.zip)

More PR's on the way. The `openInput()` and `openOutput()` functions aren't built to handle the virtual ports right now. I will make sure they do.
