### PR TITLE
Add Docs on Enabling Modules

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -165,7 +165,9 @@ init() {
 ```
 Also, `AKMicrophoneTracker` was removed. Using an `AudioEngine`'s `InputNode` along with a `PitchTap` is a better solution.
 
-9. All of the projects in the Examples for have been moved out of this repository. See the [Examples](Examples.md) documentary for links to the new repositories. 
+9. All of the projects in the Examples for have been moved out of this repository. See the [Examples](Examples.md) documentary for links to the new repositories.
+ 
+10. Using AudioKit as a Swift Package within a C++ or Objective-C project requires you to enable modules to import AudioKit (add `-fcxx-modules` to `OTHER_CXX_FLAGS`).
 
 ## v4-v5 Class Name Changes
 


### PR DESCRIPTION
This adds a line to the migration guide explaining how to enable cxx modules to ensure that `@import AudioKit` will work within Objective-C or C++ targets.