### PR TITLE
Update to migration guide

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -2,7 +2,11 @@
 
 ## AudioKit 5.1 to 5.2
 
-This version update involves separating AudioKit into separate Sub-AudioKits which are included as separate Swift Packages. This way, developers do not have to compile code that their apps don't require. Most users will probably have to include the SoundpipeAudioKit package since that is the one that contained many of the oscillators, effects, and filters. In addition to including the packages, developers may also have to update their files to import the correct frameworks. 
+This version update involves separating AudioKit into separate Sub-AudioKits which are included as separate Swift Packages. This way, developers do not have to compile code that their apps don't require. Most users will probably have to include the SoundpipeAudioKit package since that is the one that contained many of the oscillators, effects, and filters. In addition to including the packages, developers may also have to update their files to import the correct frameworks.
+
+Also, please note that some types that did not move into a new *package* still moved into a new *module*. For example, `Sequencer` lives in the base AudioKit package, but code that references it will need to import the `AudioKitEX` module that is included in that package.
+
+Here is a list of types that moved into a new package, and where they live now.
 
 | Class                              | New Framework     |
 |------------------------------------|-------------------|


### PR DESCRIPTION
Added a little additional info about types that changed modules while staying in the same package, which can be a little bit non-obvious.