### PR TITLE
One more edge case for #2536

### DIFF
--- a/Sources/CAudioKitEX/Sequencing/SequencerEngine.mm
+++ b/Sources/CAudioKitEX/Sequencing/SequencerEngine.mm
@@ -174,12 +174,12 @@ struct SequencerEngineImpl {
             for (auto& event : events) {
                 // go through every event
                 int triggerTime = beatToSamples(event.beat);
+                int triggerTimeInLoop = triggerTime % lengthInSamples();
 
                 if (currentEndSample > lengthInSamples() && data->settings.loopEnabled) {
                     // this buffer extends beyond the length of the loop and looping is on
                     int loopRestartInBuffer = (int)(lengthInSamples() - currentStartSample);
                     int samplesOfBufferForNewLoop = frameCount - loopRestartInBuffer;
-                    int triggerTimeInLoop = triggerTime % lengthInSamples();
                     if (triggerTimeInLoop < samplesOfBufferForNewLoop) {
                         // this event would trigger early enough in the next loop that it should happen in this buffer
                         // ie. this buffer contains events from the previous loop, and the next loop
@@ -187,7 +187,7 @@ struct SequencerEngineImpl {
                         sendMidiData(event.status, event.data1, event.data2,
                                      offset, event.beat);
                     }
-                } else if (currentStartSample <= triggerTime && triggerTime < currentEndSample) {
+                } else if (currentStartSample <= triggerTimeInLoop && triggerTimeInLoop < currentEndSample) {
                     // this event is supposed to trigger between currentStartSample and currentEndSample
                     int offset = (int)(triggerTime - currentStartSample);
                     sendMidiData(event.status, event.data1, event.data2,


### PR DESCRIPTION
* Dealing with scenario: `currentEndSample` == `lengthInSamples()` == `triggerTime`
