### PR TITLE
FormatConverter update

### DIFF
--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
@@ -150,26 +150,26 @@ extension FormatConverter {
 
                 var fillBufList = AudioBufferList(mNumberBuffers: 1,
                                                   mBuffers: mBuffer)
-                var numFrames: UInt32 = 0
+                var frameCount: UInt32 = 0
 
                 if outputDescription.mBytesPerFrame > 0 {
-                    numFrames = bufferByteSize / outputDescription.mBytesPerFrame
+                    frameCount = bufferByteSize / outputDescription.mBytesPerFrame
                 }
 
                 if noErr != ExtAudioFileRead(strongInputFile,
-                                             &numFrames,
+                                             &frameCount,
                                              &fillBufList) {
                     completionProxy(error: Self.createError(message: "Error reading from the input file."),
                                     completionHandler: completionHandler)
                     return
                 }
                 // EOF
-                if numFrames == 0 { break }
+                if frameCount == 0 { break }
 
-                sourceFrameOffset += numFrames
+                sourceFrameOffset += frameCount
 
                 if noErr != ExtAudioFileWrite(strongOutputFile,
-                                              numFrames,
+                                              frameCount,
                                               &fillBufList) {
                     completionProxy(error: Self.createError(message: "Error reading from the output file."),
                                     completionHandler: completionHandler)

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
@@ -19,8 +19,6 @@ extension FormatConverter {
             completionHandler?(Self.createError(message: "Options can't be nil."))
             return
         }
-        // Log("converting to", outputURL)
-
         var format: AudioFileTypeID
 
         switch outputFormat {
@@ -40,7 +38,6 @@ extension FormatConverter {
 
         func closeFiles() {
             if let strongFile = inputFile {
-                // Log("🗑 Disposing input", inputURL.path)
                 if noErr != ExtAudioFileDispose(strongFile) {
                     Log("Error disposing input file, could have a memory leak")
                 }
@@ -48,7 +45,6 @@ extension FormatConverter {
             inputFile = nil
 
             if let strongFile = outputFile {
-                // Log("🗑 Disposing output", outputURL.path)
                 if noErr != ExtAudioFileDispose(strongFile) {
                     Log("Error disposing output file, could have a memory leak")
                 }
@@ -121,10 +117,10 @@ extension FormatConverter {
             return
         }
 
-//        The format must be linear PCM (kAudioFormatLinearPCM).
-//        You must set this in order to encode or decode a non-PCM file data format.
-//        You may set this on PCM files to specify the data format used in your calls
-//        to read/write.
+        // The format must be linear PCM (kAudioFormatLinearPCM).
+        // You must set this in order to encode or decode a non-PCM file data format.
+        // You may set this on PCM files to specify the data format used in your calls
+        // to read/write.
         if noErr != ExtAudioFileSetProperty(strongInputFile,
                                             kExtAudioFileProperty_ClientDataFormat,
                                             inputDescriptionSize,
@@ -163,7 +159,7 @@ extension FormatConverter {
                 if noErr != ExtAudioFileRead(strongInputFile,
                                              &numFrames,
                                              &fillBufList) {
-                    completionProxy(error: Self.createError(message: "Unable to read input file."),
+                    completionProxy(error: Self.createError(message: "Error reading from the input file."),
                                     completionHandler: completionHandler)
                     return
                 }
@@ -172,8 +168,10 @@ extension FormatConverter {
 
                 sourceFrameOffset += numFrames
 
-                if noErr != ExtAudioFileWrite(strongOutputFile, numFrames, &fillBufList) {
-                    completionProxy(error: Self.createError(message: "Unable to write output file."),
+                if noErr != ExtAudioFileWrite(strongOutputFile,
+                                              numFrames,
+                                              &fillBufList) {
+                    completionProxy(error: Self.createError(message: "Error reading from the output file."),
                                     completionHandler: completionHandler)
                     return
                 }

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Utilities.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Utilities.swift
@@ -5,7 +5,7 @@ import AVFoundation
 extension FormatConverter {
     class func createError(message: String, code: Int = 1) -> NSError {
         let userInfo = [NSLocalizedDescriptionKey: message]
-        return NSError(domain: "io.audiokit.FormatConverter.error",
+        return NSError(domain: "com.audiodesigndesk.FormatConverter.error",
                        code: code,
                        userInfo: userInfo)
     }
@@ -88,5 +88,16 @@ extension FormatConverter {
             // basically all other format IDs are compressed
             return true
         }
+    }
+}
+
+extension Comparable {
+    // ie: 5.clamped(to: 7...10)
+    // ie: 5.0.clamped(to: 7.0...10.0)
+    // ie: "a".clamped(to: "b"..."h")
+    /// **OTCore:**
+    /// Returns the value clamped to the passed range.
+    @inlinable internal func clamped(to limits: ClosedRange<Self>) -> Self {
+        min(max(self, limits.lowerBound), limits.upperBound)
     }
 }

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
@@ -150,7 +150,9 @@ extension FormatConverter {
     /// The conversion options, leave any property nil to adopt the value of the input file
     /// bitRate assumes a stereo bit rate and the converter will half it for mono
     public struct Options {
+        /// Audio Format as a string
         public var format: String?
+        /// Sample Rate in Hertz
         public var sampleRate: Double?
         /// used only with PCM data
         public var bitDepth: UInt32?

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
@@ -6,6 +6,7 @@ import AVFoundation
  FormatConverter wraps the more complex AVFoundation and CoreAudio audio conversions in an easy to use format.
  ```swift
  let options = FormatConverter.Options()
+
  // any options left nil will adopt the value of the input file
  options.format = "wav"
  options.sampleRate = 48000
@@ -14,7 +15,7 @@ import AVFoundation
  let converter = FormatConverter(inputURL: oldURL, outputURL: newURL, options: options)
 
  converter.start { error in
-    // check to see if error isn't nil, otherwise you're good
+    // the error will be nil on success
  }
  ```
  */
@@ -139,7 +140,7 @@ extension FormatConverter {
     /// An option to block upsampling to a higher bit depth than the source.
     /// For example, converting to 24bit from 16 doesn't have much benefit
     public enum BitDepthRule {
-        /// For example: don't allow upsampling to 24bit if the src is 16
+        /// Don't allow upsampling to 24bit if the src is 16
         case lessThanOrEqual
 
         /// allow any conversaion

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
@@ -218,7 +218,7 @@ extension FormatConverter {
     func completionProxy(error: Error?,
                          deleteOutputOnError: Bool = true,
                          completionHandler: FormatConverterCallback? = nil) {
-        guard let error = error,
+        guard error != nil,
               deleteOutputOnError,
               let outputURL = outputURL,
               FileManager.default.fileExists(atPath: outputURL.path) else {

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
@@ -148,6 +148,7 @@ extension FormatConverter {
     }
 
     /// The conversion options, leave any property nil to adopt the value of the input file
+    /// bitRate assumes a stereo bit rate and the converter will half it for mono
     public struct Options {
         public var format: String?
         public var sampleRate: Double?


### PR DESCRIPTION
handle bitRate conversion for stereo vs mono given that the mono file is effectively 1/2 the bitrate of the stereo.
I've chosen to handle this by keeping one bit rate range and dividing by 2 if mono input.
This conversion previously failed if the bit rate was above the bounds allowed by m4a mono.

So, if bitrate is 320 (highest supported) : 320 bitrate for stereo and 160 for mono.

