### PR TITLE
EZAudio optimization

### DIFF
--- a/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.h
+++ b/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.h
@@ -219,6 +219,8 @@ typedef struct _EZPlotHistoryInfo EZPlotHistoryInfo;
 @property (nonatomic, assign) EZPlotHistoryInfo  *historyInfo;
 @property (nonatomic, assign) CGPoint            *points;
 @property (nonatomic, assign) UInt32              pointCount;
+@property (nonatomic, assign) bool                previousPlotIsZero;
+@property (nonatomic, assign) bool                canReusePreviousPlot;
 @property (nonatomic, assign) bool                fadeout;
 #if TARGET_OS_IPHONE
 @property (nonatomic, strong) UIColor            *originalColor;

--- a/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.h
+++ b/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.h
@@ -221,6 +221,7 @@ typedef struct _EZPlotHistoryInfo EZPlotHistoryInfo;
 @property (nonatomic, assign) UInt32              pointCount;
 @property (nonatomic, assign) bool                previousPlotIsZero;
 @property (nonatomic, assign) bool                canReusePreviousPlot;
+@property (nonatomic, assign) bool                isDrawn;
 @property (nonatomic, assign) bool                fadeout;
 #if TARGET_OS_IPHONE
 @property (nonatomic, strong) UIColor            *originalColor;

--- a/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.m
+++ b/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.m
@@ -282,7 +282,9 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
         self.waveformLayer.path = path;
     }
     CGPathRelease(path);
-    self.isDrawn = true;
+    if (frame.size.width > 0 && frame.size.height > 0) {
+        self.isDrawn = true;
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.m
+++ b/AudioKit/Common/User Interface/EZAudio/EZAudioPlot.m
@@ -150,7 +150,7 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
     self.points = calloc(EZAudioPlotDefaultMaxHistoryBufferLength, sizeof(CGPoint));
     self.pointCount = [self initialPointCount];
     
-    self.previousPlotIsZero = self.canReusePreviousPlot = false;
+    self.previousPlotIsZero = self.canReusePreviousPlot = self.isDrawn = false;
     
     [self redraw];
 }
@@ -262,7 +262,7 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
 
 - (void)redraw
 {
-    if (self.canReusePreviousPlot) {
+    if (self.canReusePreviousPlot && self.isDrawn) {
         // No need to redraw, return to reduce CPU consumption
         return;
     }
@@ -282,6 +282,7 @@ UInt32 const EZAudioPlotDefaultMaxHistoryBufferLength = 8192;
         self.waveformLayer.path = path;
     }
     CGPathRelease(path);
+    self.isDrawn = true;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR is an optimization to EZAudioPlot to avoid redrawing the plot unnecessarily if it hasn’t changed, i.e. the plot was zero the last time it was drawn and it’s still zero. If the signal is empty, EZAudioPlot wastes CPU by re-creating and drawing the points of the plot at 60 Hz when the points are all zero and therefore the plot remains the same. I added a condition to the redraw function to not recalculate the plot if the current history buffer is zero and the history buffer at the previous time was also zero.

The performance gain is a reduction of two percentage points in CPU usage in current iPhone models, while the plot is idle.

Caveat: if you’re changing the size of the plot dynamically after the plot has been drawn, this PR might break things. If the size is changed while the signal is empty, the plot will not be redrawn until a signal is received. This means it might happen that the plot will be drawn incorrectly scaled in that circumstance. IMHO this shouldn’t be a big issue, but we don’t know how developers are using EZAudioPlot. There are two solutions to this. The first one would be to save the size of the plot at each invocation of the redraw function, and compare it to the size at the previous invocation. If the size has changed, force a redraw. The other solution would be to instruct the developers to explicitly call the redraw function after they’ve changed the plot size.
