### PR TITLE
Access the pointee of AUValue

### DIFF
--- a/Sources/AudioKitEX/AudioKitAU.swift
+++ b/Sources/AudioKitEX/AudioKitAU.swift
@@ -88,7 +88,7 @@ open class AudioKitAU: AUAudioUnit {
             
             _parameterTree?.implementorStringFromValueCallback = { parameter, value in
                 if let value = value {
-                    return String(format: "%.f", value)
+                    return String(format: "%.2f", value.pointee)
                 } else {
                     return "Invalid"
                 }


### PR DESCRIPTION
For some reason, the String can't read the pointer alone. It needs to read the pointee for parameter changes to be visible to the observer.
