### PR TITLE
AutomationCurve, endTime check

### DIFF
--- a/Sources/AudioKitEX/Automation/AutomationCurve.swift
+++ b/Sources/AudioKitEX/Automation/AutomationCurve.swift
@@ -8,33 +8,32 @@ import Foundation
 /// Includes functions for manipulating automation curves and conversion to linear automation ramps
 /// used by DSP code.
 public struct AutomationCurve {
-    
     /// Shorter name
     public typealias Point = ParameterAutomationPoint
-    
+
     /// Array of points that make up the curve
     public var points: [Point]
-    
+
     /// Initialize with points
     /// - Parameter points: Array of points
     public init(points: [Point]) {
         self.points = points
     }
-    
+
     static func evalRamp(start: Float, segment: Point, time: Float, endTime: Float) -> Float {
         let remain = endTime - time
         let taper = segment.rampTaper
         let goal = segment.targetValue
-        
+
         // x is normalized position in ramp segment
         let x = (segment.rampDuration - remain) / segment.rampDuration
         let taper1 = start + (goal - start) * pow(x, abs(taper))
         let absxm1 = abs((segment.rampDuration - remain) / segment.rampDuration - 1.0)
         let taper2 = start + (goal - start) * (1.0 - pow(absxm1, 1.0 / abs(taper)))
-        
+
         return taper1 * (1.0 - segment.rampSkew) + taper2 * segment.rampSkew
     }
-    
+
     /// Returns a new piecewise-linear automation curve which can be handed off to the audio thread
     /// for efficient processing.
     ///
@@ -44,55 +43,53 @@ public struct AutomationCurve {
     ///
     /// - Returns: A new array of piecewise linear automation points
     public func evaluate(initialValue: AUValue, resolution: Float) -> [AutomationEvent] {
-        
         var result = [AutomationEvent]()
-        
+
         // The last evaluated value
         var value = initialValue
-        
+
         for i in 0 ..< points.count {
             let point = points[i]
-            
+
             if point.isLinear() {
-                
                 result.append(AutomationEvent(targetValue: point.targetValue,
                                               startTime: point.startTime,
                                               rampDuration: point.rampDuration))
                 value = point.targetValue
-                
+
             } else {
-                
                 // Cut off the end if another point comes along.
                 let nextPointStart = i < points.count - 1 ? points[i + 1].startTime
-                                                          : Float.greatestFiniteMagnitude
+                    : Float.greatestFiniteMagnitude
                 let endTime: Float = min(nextPointStart,
                                          point.startTime + point.rampDuration)
-                
+
                 var t = point.startTime
                 let start = value
-                
+
                 // March t along the segment
                 // this is effectively `while t <= endTime - resolution` without potentional for rounding errors
                 for _ in 0 ..< Int(round(endTime / resolution)) {
-                    
                     value = AutomationCurve.evalRamp(start: start,
                                                      segment: point,
                                                      time: t + resolution,
                                                      endTime: point.startTime + point.rampDuration)
-                    
+
                     result.append(AutomationEvent(targetValue: value,
                                                   startTime: t,
                                                   rampDuration: resolution))
-                    
+
                     t += resolution
+
+                    // safety check to not run past the final target value
+                    if t >= endTime { break }
                 }
             }
-            
         }
-        
+
         return result
     }
-    
+
     /// Replaces automation over a time range.
     ///
     /// Use this when calculating a new automation curve after recording automation.
@@ -102,24 +99,21 @@ public struct AutomationCurve {
     ///   - withPoints: new automation events
     /// - Returns: new automation curve
     public func replace(range: ClosedRange<Float>, withPoints newPoints: [(Float, AUValue)]) -> AutomationCurve {
-        
         var result = points
         let startTime = range.lowerBound
         let stopTime = range.upperBound
-        
+
         // Clear existing points in segment range.
         result.removeAll { point in point.startTime >= startTime && point.startTime <= stopTime }
-        
+
         // Append recorded points.
         result.append(contentsOf: newPoints.map { point in
             Point(targetValue: point.1, startTime: point.0, rampDuration: 0.01)
         })
-        
+
         // Sort vector by time.
         result.sort { $0.startTime < $1.startTime }
-        
+
         return AutomationCurve(points: result)
-        
     }
-    
 }


### PR DESCRIPTION
I found this to be a bug, but let me know if I'm wrong. I've finally converted all my stuff to a tiny subset using some of the AK5 things - in particular the automation - and I've found a few problems -- at least for me. 

This is just a clear bug (i think), but will suggest a few changes (or they are bug fixes) to `NodeParameter+Automation` in a different PR. 

For this one what i saw was that the curve generation ran past the endTime like this:

```
// For a 1 point fade out from 1 to 0 with a 0.2 resolution:

Evaluating 1 point(s)
Adding 0.72876936 at 1.1116209 endTime 3.111621
Adding 0.51165694 at 1.311621 endTime 3.111621
Adding 0.3426327 at 1.511621 endTime 3.111621
Adding 0.2156688 at 1.711621 endTime 3.111621
Adding 0.124740005 at 1.9116211 endTime 3.111621
Adding 0.06382406 at 2.1116211 endTime 3.111621
Adding 0.026902497 at 2.3116212 endTime 3.111621
Adding 0.007961392 at 2.5116212 endTime 3.111621
Adding 0.0009931326 at 2.7116213 endTime 3.111621
Adding 0.0 at 2.9116213 endTime 3.111621

// should of ended here but kept going...

Adding 0.0009931326 at 3.1116214 endTime 3.111621
Adding 0.007961452 at 3.3116214 endTime 3.111621
Adding 0.026902616 at 3.5116215 endTime 3.111621
Adding 0.063824296 at 3.7116215 endTime 3.111621
Adding 0.12474024 at 3.9116216 endTime 3.111621
Adding 0.2156691 at 4.1116214 endTime 3.111621
```
