### PR TITLE
Remove assert and replace with conditional check, add channelCapabilities

### DIFF
--- a/Sources/AudioKitEX/AudioKitAU.swift
+++ b/Sources/AudioKitEX/AudioKitAU.swift
@@ -12,6 +12,14 @@ open class AudioKitAU: AUAudioUnit {
     private var inputBusArray: [AUAudioUnitBus] = []
     private var outputBusArray: [AUAudioUnitBus] = []
     private var internalBuffers: [AVAudioPCMBuffer] = []
+
+    // Default supported channel capabilities
+    public var supportedLeftChannelCount: NSNumber = 2
+    public var supportedRightChannelCount: NSNumber = 2
+
+    override public var channelCapabilities: [NSNumber]? {
+        return [supportedLeftChannelCount, supportedRightChannelCount]
+    }
     
     /// Allocate the render resources
     override public func allocateRenderResources() throws {

--- a/Sources/CAudioKitEX/Internals/DSPBase.mm
+++ b/Sources/CAudioKitEX/Internals/DSPBase.mm
@@ -133,22 +133,28 @@ AUInternalRenderBlock DSPBase::internalRenderBlock()
 
 void DSPBase::setParameter(AUParameterAddress address, float value, bool immediate)
 {
-    assert(address < maxParameters);
-    if(auto parameter = parameters[address]) {
-        if (immediate || !isInitialized) {
-            parameter->startRamp(value, 0);
+    if (address < maxParameters) {
+        if(auto parameter = parameters[address]) {
+            if (immediate || !isInitialized) {
+                parameter->startRamp(value, 0);
+            }
+            else {
+                parameter->setUIValue(value);
+            }
         }
-        else {
-            parameter->setUIValue(value);
-        }
+    } else {
+        return;
     }
 }
 
 float DSPBase::getParameter(AUParameterAddress address)
 {
-    assert(address < maxParameters);
-    if(auto parameter = parameters[address]) {
-        return parameter->getUIValue();
+    if (address < maxParameters) {
+        if(auto parameter = parameters[address]) {
+            return parameter->getUIValue();
+        }
+    } else {
+        return;
     }
     return 0.0f;
 }
@@ -267,10 +273,13 @@ void DSPBase::handleOneEvent(AURenderEvent const *event)
 void DSPBase::startRamp(const AUParameterEvent& event)
 {
     auto address = event.parameterAddress;
-    assert(address < maxParameters);
-    auto ramper = parameters[address];
-    if(ramper == nullptr) return;
-    ramper->startRamp(event.value, event.rampDurationSampleFrames);
+    if (address < maxParameters) {
+        auto ramper = parameters[address];
+        if(ramper == nullptr) return;
+        ramper->startRamp(event.value, event.rampDurationSampleFrames);
+    } else {
+        return;
+    }
 }
 
 using DSPFactoryMap = std::map<std::string, DSPBase::CreateFunction>;

--- a/Sources/CAudioKitEX/Internals/DSPBase.mm
+++ b/Sources/CAudioKitEX/Internals/DSPBase.mm
@@ -154,9 +154,8 @@ float DSPBase::getParameter(AUParameterAddress address)
             return parameter->getUIValue();
         }
     } else {
-        return;
+        return 0.0f;
     }
-    return 0.0f;
 }
 
 void DSPBase::init(int channelCount, double sampleRate)

--- a/Sources/CAudioKitEX/Internals/DSPBase.mm
+++ b/Sources/CAudioKitEX/Internals/DSPBase.mm
@@ -156,6 +156,7 @@ float DSPBase::getParameter(AUParameterAddress address)
     } else {
         return 0.0f;
     }
+    return 0.0f;
 }
 
 void DSPBase::init(int channelCount, double sampleRate)


### PR DESCRIPTION
The Plug-In Manager in Logic Pro X doesn't seem to like the assert statement. When auval throws a parameter address at the DSPBase to test the AudioUnitScheduleParameter, it hits the assert immediately, invalidating the plugin.

The auval tool will also fail when it tries to test running DSPBase with one channel. The user can now explicitly state the supportedLeft/supportedRight channel count(which defaults to 2).
