### PR TITLE
Addresses #2540

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -72,6 +72,8 @@ extension AudioPlayer {
            nodeTime.isSampleTimeValid,
            let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
             return (Double(playerTime.sampleTime) / playerTime.sampleRate) + editStartTime
+        } else if isPaused {
+            return pausedTime
         }
         return editStartTime
     }


### PR DESCRIPTION
Have the AudioPlayer return `pauseTime` if it is paused instead of returning 0.0. `playerTime` is `nil` when the player isn't playing (issue #2540).
