### PR TITLE
Moved isPlaying

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -202,8 +202,8 @@ public class AudioPlayer: Node {
               engine?.isInManualRenderingMode == false else { return }
 
         scheduleTime = nil
-        completionHandler?()
         isPlaying = false
+        completionHandler?()
 
         if !isBuffered, isLooping, engine?.isRunning == true {
             play()


### PR DESCRIPTION
This needed to be above the completionHandler to prevent the player from trying to stop itself inside the completionHandler.

In order for AudioKit/Cookbook#53 to run successfully, this version of AudioKit should be used.
