### PR TITLE
Reset player's edit times when needed

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -62,7 +62,9 @@ extension AudioPlayer {
     /// Resumes audio player from paused time
     public func resume() {
         isPaused = false
-        seek(time: pausedTime)
+        if !isBuffered {
+            seek(time: pausedTime)
+        }
         playerNode.play()
     }
 

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -206,6 +206,10 @@ public class AudioPlayer: Node {
         completionHandler?()
 
         if !isBuffered, isLooping, engine?.isRunning == true {
+            if !isEditTimeEnabled {
+                editStartTime = 0
+                editEndTime = 0
+            }
             play()
             return
         }


### PR DESCRIPTION
Put some changes in `AudioPlayer` to address #2576. The `editStartTime` and `editEndTime` were never reset when the file loops, which plays back the file from the player's pause time at each new loop. These changes will address that issue, but I'll keep working on fixing things up in here.

I was thinking it may be a good idea to decouple the `editStartTime` and `editEndTime` properties of the player from its playhead. That way, the playhead won't rely on the `editStartTime` if the editing region doesn't need to be enabled.