### PR TITLE
Added ability to set the number of bins returned from FFTTap

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -379,7 +379,6 @@ public func loadAudioSignal(audioURL: URL) -> (signal: [Float], rate: Double, fr
 }
 
 public extension DSPSplitComplex {
-    
     /// Initialize a DSPSplitComplex with repeating values for real and imaginary splits
     ///
     /// - Parameters:
@@ -393,7 +392,7 @@ public extension DSPSplitComplex {
         let imag = [Float](repeating: 0, count: count)
         let imagp = UnsafeMutablePointer<Float>.allocate(capacity: imag.count)
         imagp.assign(from: imag, count: imag.count)
-        
+
         self.init(realp: realp, imagp: imagp)
     }
 }

--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -377,3 +377,23 @@ public func loadAudioSignal(audioURL: URL) -> (signal: [Float], rate: Double, fr
     }
     return nil
 }
+
+public extension DSPSplitComplex {
+    
+    /// Initialize a DSPSplitComplex with repeating values for real and imaginary splits
+    ///
+    /// - Parameters:
+    ///   - repeating: value to set elements to
+    ///   - count: number of real and number of imaginary elements
+    init(repeating: Float, count: Int) {
+        let real = [Float](repeating: repeating, count: count)
+        let realp = UnsafeMutablePointer<Float>.allocate(capacity: real.count)
+        realp.assign(from: real, count: real.count)
+
+        let imag = [Float](repeating: 0, count: count)
+        let imagp = UnsafeMutablePointer<Float>.allocate(capacity: imag.count)
+        imagp.assign(from: imag, count: imag.count)
+        
+        self.init(realp: realp, imagp: imagp)
+    }
+}

--- a/Sources/AudioKit/Taps/FFTTap.swift
+++ b/Sources/AudioKit/Taps/FFTTap.swift
@@ -28,8 +28,7 @@ open class FFTTap: BaseTap {
     public init(_ input: Node,
                 bufferSize: UInt32 = 4096,
                 fftValidBinCount: FFTValidBinCount? = nil,
-                handler: @escaping Handler)
-    {
+                handler: @escaping Handler) {
         self.handler = handler
         fftData = Array(repeating: 0.0, count: Int(bufferSize))
         if let fftBinCount = fftValidBinCount {
@@ -55,8 +54,7 @@ open class FFTTap: BaseTap {
     static func performFFT(buffer: AVAudioPCMBuffer,
                            isNormalized: Bool = true,
                            zeroPaddingFactor: UInt32 = 0,
-                           fftSetupForBinCount: FFTSetupForBinCount? = nil) -> [Float]
-    {
+                           fftSetupForBinCount: FFTSetupForBinCount? = nil) -> [Float] {
         let frameCount = buffer.frameLength + buffer.frameLength * zeroPaddingFactor
         let log2n = determineLog2n(frameCount: frameCount, fftSetupForBinCount: fftSetupForBinCount)
         let bufferSizePOT = Int(1 << log2n) // 1 << n = 2^n

--- a/Sources/AudioKit/Taps/FFTTap.swift
+++ b/Sources/AudioKit/Taps/FFTTap.swift
@@ -13,6 +13,8 @@ open class FFTTap: BaseTap {
     public var isNormalized: Bool = true
     /// Determines the ratio of zeros padding the input of the FFT (default 0 = no padding)
     public var zeroPaddingFactor: UInt32 = 0
+    /// Sets the number of fft bins return
+    private var fftSetupForBinCount: FFTSetupForBinCount?
 
     private var handler: Handler = { _ in }
 
@@ -21,10 +23,14 @@ open class FFTTap: BaseTap {
     /// - Parameters:
     ///   - input: Node to analyze
     ///   - bufferSize: Size of buffer to analyze
+    ///   - fftValidBinNumber: Valid fft bin count to return
     ///   - handler: Callback to call when FFT is calculated
-    public init(_ input: Node, bufferSize: UInt32 = 4_096, handler: @escaping Handler) {
+    public init(_ input: Node, bufferSize: UInt32 = 4096, fftValidBinCount: FFTValidBinCount? = nil, handler: @escaping Handler) {
         self.handler = handler
-        self.fftData = Array(repeating: 0.0, count: Int(bufferSize))
+        fftData = Array(repeating: 0.0, count: Int(bufferSize))
+        if let fftBinCount = fftValidBinCount {
+            fftSetupForBinCount = FFTSetupForBinCount(binCount: fftBinCount)
+        }
         super.init(input, bufferSize: bufferSize)
     }
 
@@ -35,70 +41,79 @@ open class FFTTap: BaseTap {
     override open func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
         guard buffer.floatChannelData != nil else { return }
 
-        fftData = FFTTap.performFFT(buffer: buffer, isNormalized: isNormalized, zeroPaddingFactor: zeroPaddingFactor)
+        fftData = FFTTap.performFFT(buffer: buffer, isNormalized: isNormalized, zeroPaddingFactor: zeroPaddingFactor, fftSetupForBinCount: fftSetupForBinCount)
         handler(fftData)
     }
 
-    static func performFFT(buffer: AVAudioPCMBuffer, isNormalized: Bool = true, zeroPaddingFactor: UInt32 = 0) -> [Float] {
+    static func performFFT(buffer: AVAudioPCMBuffer, isNormalized: Bool = true, zeroPaddingFactor: UInt32 = 0, fftSetupForBinCount: FFTSetupForBinCount? = nil) -> [Float] {
         let frameCount = buffer.frameLength + buffer.frameLength * zeroPaddingFactor
-        let log2n = UInt(round(log2(Double(frameCount))))
-        let bufferSizePOT = Int(1 << log2n)
-        let inputCount = bufferSizePOT / 2
-        let fftSetup = vDSP_create_fftsetup(log2n, Int32(kFFTRadix2))
 
-        var realp = [Float](repeating: 0, count: inputCount)
-        var imagp = [Float](repeating: 0, count: inputCount)
+        // default to original log2n calculation from frameCount (backwards compatibility and used when we get bad input)
+        var log2n = UInt(round(log2(Double(frameCount))))
 
-        return realp.withUnsafeMutableBufferPointer { realPointer in
-            imagp.withUnsafeMutableBufferPointer { imagPointer in
-                var output = DSPSplitComplex(realp: realPointer.baseAddress!,
-                                             imagp: imagPointer.baseAddress!)
-
-                let windowSize = bufferSizePOT
-                var transferBuffer = [Float](repeating: 0, count: windowSize)
-                var window = [Float](repeating: 0, count: windowSize)
-
-                // Hann windowing to reduce the frequency leakage
-                vDSP_hann_window(&window, vDSP_Length(windowSize), Int32(vDSP_HANN_NORM))
-                vDSP_vmul((buffer.floatChannelData?.pointee)!, 1, window,
-                          1, &transferBuffer, 1, vDSP_Length(windowSize))
-
-                // Transforming the [Float] buffer into a UnsafePointer<Float> object for the vDSP_ctoz method
-                // And then pack the input into the complex buffer (output)
-                transferBuffer.withUnsafeBufferPointer { pointer in
-                    pointer.baseAddress!.withMemoryRebound(to: DSPComplex.self,
-                                                           capacity: transferBuffer.count) {
-                        vDSP_ctoz($0, 2, &output, 1, vDSP_Length(inputCount))
-                    }
-                }
-
-                // Perform the FFT
-                vDSP_fft_zrip(fftSetup!, &output, 1, log2n, FFTDirection(FFT_FORWARD))
-
-                var magnitudes = [Float](repeating: 0.0, count: inputCount)
-                vDSP_zvmags(&output, 1, &magnitudes, 1, vDSP_Length(inputCount))
-
-                var scaledMagnitudes = [Float](repeating: 0.0, count: inputCount)
-
-                // Scale appropriate to the algorithm - results in strictly negative amplitude values (tested against Ableton Live's Spectrum Analyzer)
-                var scaleMultiplier = [Float(1.0 / Double(frameCount))]
-
-                if isNormalized {
-                    // Normalising
-                    scaleMultiplier = [1.0 / (magnitudes.max() ?? 1.0)]
-                }
-
-                vDSP_vsmul(&magnitudes,
-                           1,
-                           &scaleMultiplier,
-                           &scaledMagnitudes,
-                           1,
-                           vDSP_Length(inputCount))
-                
-                vDSP_destroy_fftsetup(fftSetup)
-                return scaledMagnitudes
+        // if a valid amount of bins was requested - use log2n value for number of bins
+        if let setup = fftSetupForBinCount { // do we have a FFTSetupForBinCount object?
+            if frameCount >= setup.binCount { // guard against more bins than buffer size
+                log2n = UInt(setup.log2n + 1) // +1 because we divide bufferSizePOT by two
             }
         }
+
+        let bufferSizePOT = Int(1 << log2n) // 1 << n = 2^n
+        let inputCount = bufferSizePOT / 2 // number of bins returned
+
+        let fftSetup = vDSP_create_fftsetup(log2n, Int32(kFFTRadix2))
+
+        var output = DSPSplitComplex(repeating: 0, count: inputCount)
+
+        let windowSize = bufferSizePOT
+        var transferBuffer = [Float](repeating: 0, count: windowSize)
+        var window = [Float](repeating: 0, count: windowSize)
+
+        // Hann windowing to reduce the frequency leakage
+        vDSP_hann_window(&window, vDSP_Length(windowSize), Int32(vDSP_HANN_NORM))
+        vDSP_vmul((buffer.floatChannelData?.pointee)!, 1, window,
+                  1, &transferBuffer, 1, vDSP_Length(windowSize))
+
+        // Transforming the [Float] buffer into a UnsafePointer<Float> object for the vDSP_ctoz method
+        // And then pack the input into the complex buffer (output)
+        transferBuffer.withUnsafeBufferPointer { pointer in
+            pointer.baseAddress!.withMemoryRebound(to: DSPComplex.self,
+                                                   capacity: transferBuffer.count) {
+                vDSP_ctoz($0, 2, &output, 1, vDSP_Length(inputCount))
+            }
+        }
+
+        // Perform the FFT
+        vDSP_fft_zrip(fftSetup!, &output, 1, log2n, FFTDirection(FFT_FORWARD))
+
+        // Parseval's theorem - Scale with respect to the number of bins
+        var scaledOutput = DSPSplitComplex(repeating: 0, count: inputCount)
+        var scaleMultiplier = DSPSplitComplex(repeating: 1.0 / Float(inputCount), count: 1)
+        vDSP_zvzsml(&output,
+                    1,
+                    &scaleMultiplier,
+                    &scaledOutput,
+                    1,
+                    vDSP_Length(inputCount))
+
+        var magnitudes = [Float](repeating: 0.0, count: inputCount)
+        vDSP_zvmags(&scaledOutput, 1, &magnitudes, 1, vDSP_Length(inputCount))
+        vDSP_destroy_fftsetup(fftSetup)
+
+        if !isNormalized {
+            return magnitudes
+        }
+
+        // normalize according to the momentary maximum value of the fft output bins
+        var normalizationMultiplier: [Float] = [1.0 / (magnitudes.max() ?? 1.0)]
+        var normalizedMagnitudes = [Float](repeating: 0.0, count: inputCount)
+        vDSP_vsmul(&magnitudes,
+                   1,
+                   &normalizationMultiplier,
+                   &normalizedMagnitudes,
+                   1,
+                   vDSP_Length(inputCount))
+        return normalizedMagnitudes
     }
 
     /// Remove the tap on the input
@@ -106,4 +121,40 @@ open class FFTTap: BaseTap {
         super.stop()
         for i in 0 ..< fftData.count { fftData[i] = 0.0 }
     }
+    
+    /// Relevant values for setting the fft bin count
+    struct FFTSetupForBinCount {
+        
+        /// Initialize FFTSetupForBinCount with a valid number of fft bins
+        ///
+        /// - Parameters:
+        ///   - binCount: enum representing a valid 2^n result where n is an integer
+        init(binCount: FFTValidBinCount) {
+            log2n = UInt(log2(binCount.rawValue))
+            self.binCount = Int(binCount.rawValue)
+        }
+
+        /// used to set log2n in fft
+        let log2n: UInt
+
+        /// number of returned fft bins
+        var binCount: Int
+    }
+}
+
+/// Valid results of 2^n where n is an integer
+public enum FFTValidBinCount: Double {
+    case two = 2,
+         four = 4,
+         eight = 8,
+         sixteen = 16,
+         thirtyTwo = 32,
+         sixtyFour = 64,
+         oneHundredTwentyEight = 128,
+         twoHundredFiftySix = 256,
+         fiveHundredAndTwelve = 512,
+         oneThousandAndTwentyFour = 1024,
+         twoThousandAndFortyEight = 2048,
+         fourThousandAndNintySix = 4096,
+         eightThousandOneHundredAndNintyTwo = 8192
 }


### PR DESCRIPTION
- can now set number of bins returned by FFTTap (only accepts valid 2^n bin counts)

- fft bin count input is optional, so the tap will revert log2n to being based on frameCount if no bin count argument is provided

- fft bin scaling is now performed before vDSP_zvmags according to Parseval's theorem which scales with respect to the number of bins instead of the buffer size (this way the scale of the output stays the same at different bin counts)
