### PR TITLE
Fixed imaginary array value in DSPSplitComplex initializer

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -389,7 +389,7 @@ public extension DSPSplitComplex {
         let realp = UnsafeMutablePointer<Float>.allocate(capacity: real.count)
         realp.assign(from: real, count: real.count)
 
-        let imag = [Float](repeating: 0, count: count)
+        let imag = [Float](repeating: repeating, count: count)
         let imagp = UnsafeMutablePointer<Float>.allocate(capacity: imag.count)
         imagp.assign(from: imag, count: imag.count)
 


### PR DESCRIPTION
Fixed imaginary array value in DSPSplitComplex initializer. This was an accident on my part.

This does slightly change the scaling for the FFTView. We may want to tweak our reference value to something even higher.