### PR TITLE
Fixed imaginary number for scaling by split complex in FFTTap

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -395,7 +395,7 @@ public extension DSPSplitComplex {
 
         self.init(realp: realp, imagp: imagp)
     }
-    
+
     /// Initialize a DSPSplitComplex with repeating values for real and imaginary splits
     ///
     /// - Parameters:

--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -395,4 +395,22 @@ public extension DSPSplitComplex {
 
         self.init(realp: realp, imagp: imagp)
     }
+    
+    /// Initialize a DSPSplitComplex with repeating values for real and imaginary splits
+    ///
+    /// - Parameters:
+    ///   - repeatingReal: value to set real elements to
+    ///   - repeatingImag: value to set imaginary elements to
+    ///   - count: number of real and number of imaginary elements
+    init(repeatingReal: Float, repeatingImag: Float, count: Int) {
+        let real = [Float](repeating: repeatingReal, count: count)
+        let realp = UnsafeMutablePointer<Float>.allocate(capacity: real.count)
+        realp.assign(from: real, count: real.count)
+
+        let imag = [Float](repeating: repeatingImag, count: count)
+        let imagp = UnsafeMutablePointer<Float>.allocate(capacity: imag.count)
+        imagp.assign(from: imag, count: imag.count)
+
+        self.init(realp: realp, imagp: imagp)
+    }
 }

--- a/Sources/AudioKit/Taps/FFTTap.swift
+++ b/Sources/AudioKit/Taps/FFTTap.swift
@@ -30,10 +30,17 @@ open class FFTTap: BaseTap {
                 fftValidBinCount: FFTValidBinCount? = nil,
                 handler: @escaping Handler) {
         self.handler = handler
-        fftData = Array(repeating: 0.0, count: Int(bufferSize))
         if let fftBinCount = fftValidBinCount {
             fftSetupForBinCount = FFTSetupForBinCount(binCount: fftBinCount)
+            
         }
+        
+        if let binCount = fftSetupForBinCount?.binCount {
+            fftData = Array(repeating: 0.0, count: binCount)
+        } else {
+            fftData = Array(repeating: 0.0, count: Int(bufferSize))
+        }
+        
         super.init(input, bufferSize: bufferSize)
     }
 
@@ -58,11 +65,11 @@ open class FFTTap: BaseTap {
         let frameCount = buffer.frameLength + buffer.frameLength * zeroPaddingFactor
         let log2n = determineLog2n(frameCount: frameCount, fftSetupForBinCount: fftSetupForBinCount)
         let bufferSizePOT = Int(1 << log2n) // 1 << n = 2^n
-        let inputCount = bufferSizePOT / 2 // number of bins returned
+        let binCount = bufferSizePOT / 2
 
         let fftSetup = vDSP_create_fftsetup(log2n, Int32(kFFTRadix2))
 
-        var output = DSPSplitComplex(repeating: 0, count: inputCount)
+        var output = DSPSplitComplex(repeating: 0, count: binCount)
 
         let windowSize = bufferSizePOT
         var transferBuffer = [Float](repeating: 0, count: windowSize)
@@ -78,7 +85,7 @@ open class FFTTap: BaseTap {
         transferBuffer.withUnsafeBufferPointer { pointer in
             pointer.baseAddress!.withMemoryRebound(to: DSPComplex.self,
                                                    capacity: transferBuffer.count) {
-                vDSP_ctoz($0, 2, &output, 1, vDSP_Length(inputCount))
+                vDSP_ctoz($0, 2, &output, 1, vDSP_Length(binCount))
             }
         }
 
@@ -86,17 +93,17 @@ open class FFTTap: BaseTap {
         vDSP_fft_zrip(fftSetup!, &output, 1, log2n, FFTDirection(FFT_FORWARD))
 
         // Parseval's theorem - Scale with respect to the number of bins
-        var scaledOutput = DSPSplitComplex(repeating: 0, count: inputCount)
-        var scaleMultiplier = DSPSplitComplex(repeating: 1.0 / Float(inputCount), count: 1)
+        var scaledOutput = DSPSplitComplex(repeating: 0, count: binCount)
+        var scaleMultiplier = DSPSplitComplex(repeatingReal: 1.0 / Float(binCount), repeatingImag: 0, count: 1)
         vDSP_zvzsml(&output,
                     1,
                     &scaleMultiplier,
                     &scaledOutput,
                     1,
-                    vDSP_Length(inputCount))
+                    vDSP_Length(binCount))
 
-        var magnitudes = [Float](repeating: 0.0, count: inputCount)
-        vDSP_zvmags(&scaledOutput, 1, &magnitudes, 1, vDSP_Length(inputCount))
+        var magnitudes = [Float](repeating: 0.0, count: binCount)
+        vDSP_zvmags(&scaledOutput, 1, &magnitudes, 1, vDSP_Length(binCount))
         vDSP_destroy_fftsetup(fftSetup)
 
         if !isNormalized {
@@ -105,13 +112,13 @@ open class FFTTap: BaseTap {
 
         // normalize according to the momentary maximum value of the fft output bins
         var normalizationMultiplier: [Float] = [1.0 / (magnitudes.max() ?? 1.0)]
-        var normalizedMagnitudes = [Float](repeating: 0.0, count: inputCount)
+        var normalizedMagnitudes = [Float](repeating: 0.0, count: binCount)
         vDSP_vsmul(&magnitudes,
                    1,
                    &normalizationMultiplier,
                    &normalizedMagnitudes,
                    1,
-                   vDSP_Length(inputCount))
+                   vDSP_Length(binCount))
         return normalizedMagnitudes
     }
 

--- a/Sources/AudioKit/Taps/FFTTap.swift
+++ b/Sources/AudioKit/Taps/FFTTap.swift
@@ -32,15 +32,14 @@ open class FFTTap: BaseTap {
         self.handler = handler
         if let fftBinCount = fftValidBinCount {
             fftSetupForBinCount = FFTSetupForBinCount(binCount: fftBinCount)
-            
         }
-        
+
         if let binCount = fftSetupForBinCount?.binCount {
             fftData = Array(repeating: 0.0, count: binCount)
         } else {
             fftData = Array(repeating: 0.0, count: Int(bufferSize))
         }
-        
+
         super.init(input, bufferSize: bufferSize)
     }
 


### PR DESCRIPTION
Addresses comments made in: https://github.com/AudioKit/AudioKit/pull/2581 by @aburgel

Set the imaginary element of complex split to zero for scaling

Renamed inputCount to binCount

Set initial array length of fftData to the bin count