### PR TITLE
append failing test reproduction

### DIFF
--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import AVFoundation
+import AudioKit
+import XCTest
+
+class AVAudioPCMBufferTests: XCTestCase {
+  func testAppend() {
+    let path = Bundle.module.url(forResource: "TestResources/drumloop", withExtension: "wav")
+    let file = try? AVAudioFile(forReading: path!)
+    let loopBuffer = file!.toAVAudioPCMBuffer()!
+    XCTAssertNoThrow(loopBuffer.append(file!.toAVAudioPCMBuffer()!))
+  }
+}


### PR DESCRIPTION
*Failing test for #2584*

Simplified example from #2584, converting a file to a AVAudioPCMBuffer, and trying to append to the file, throws the same error I was seeing in my app. Added a failing test per request.