### PR TITLE
fix decimator

### DIFF
--- a/Sources/AudioKit/Nodes/Effects/Distortion/Decimator.swift
+++ b/Sources/AudioKit/Nodes/Effects/Distortion/Decimator.swift
@@ -53,6 +53,42 @@ public class Decimator: Node {
     /// Final Mix (Percent) ranges from 0 to 100 (Default: 50)
     @Parameter(finalMixDef) public var finalMix: AUValue
 
+    /// Specification details for polynomialMix
+    private static let polynomialMixDef = NodeParameterDef(
+        identifier: "polynomialMix",
+        name: "Polynomial Mix",
+        address: AUParameterAddress(kDistortionParam_PolynomialMix),
+        defaultValue: 0,
+        range: 0 ... 100,
+        unit: .percent)
+
+    /// Polynomial Mix (Percent) ranges from 0 to 100 (Default: 50). Turned off specifically for decimator
+    @Parameter(polynomialMixDef) private var polynomialMix: AUValue
+
+    /// Specification details for delayMix
+    private static let delayMixDef = NodeParameterDef(
+        identifier: "delayMix",
+        name: "Delay Mix",
+        address: AUParameterAddress(kDistortionParam_DelayMix),
+        defaultValue: 0,
+        range: 0 ... 100,
+        unit: .percent)
+
+    /// Delay Mix (Percent) ranges from 0 to 100 (Default: 50). Turned off specifically for decimator
+    @Parameter(delayMixDef) private var delayMix: AUValue
+
+    /// Specification details for ringModMix
+    private static let ringModMixDef = NodeParameterDef(
+        identifier: "ringModMix",
+        name: "RingMod Mix",
+        address: AUParameterAddress(kDistortionParam_RingModMix),
+        defaultValue: 0,
+        range: 0 ... 100,
+        unit: .percent)
+
+    /// Ring Mod Mix (Percent) ranges from 0 to 100 (Default: 50). Turned off specifically for decimator
+    @Parameter(ringModMixDef) private var ringModMix: AUValue
+
     /// Tells whether the node is processing (ie. started, playing, or active)
     public var isStarted = true
 
@@ -75,6 +111,11 @@ public class Decimator: Node {
         self.decimation = decimation
         self.rounding = rounding
         self.finalMix = finalMix
+        // Since this is the Decimator, mix it to 100% and use the final mix as the mix parameter
+
+        self.ringModMix = 0
+        self.polynomialMix = 0
+        self.delayMix = 0
     }
 
     /// Function to start, play, or activate the node, all do the same thing

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/PeakLimiter.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/PeakLimiter.swift
@@ -7,8 +7,7 @@ import AVFoundation
 ///
 public class PeakLimiter: Node {
 
-    fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_PeakLimiter
-    )
+    fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_PeakLimiter)
 
     let input: Node
 

--- a/Tests/AudioKitTests/Node Tests/GenericNodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/GenericNodeTests.swift
@@ -117,7 +117,7 @@ class GenericNodeTests: XCTestCase {
 
     func testEffects() {
         nodeParameterTest(md5: "d15c926f3da74630f986f7325adf044c", factory: { input in Compressor(input) })
-        nodeParameterTest(md5: "d658edfaaebabcaaeb8a6670d1d60541", factory: { input in Decimator(input) })
+        nodeParameterTest(md5: "e499f2ea0951f830d6dc6ccd5f751b19", factory: { input in Decimator(input) })
         nodeParameterTest(md5: "5955693c964588d2eb571fadb2d744dd", factory: { input in Delay(input) })
         nodeParameterTest(md5: "6df759dd0dae23adb7b5f1c03ca15615", factory: { input in Distortion(input) })
         nodeParameterTest(md5: "0ae9a6b248486f343c55bf0818c3007d", factory: { input in PeakLimiter(input) })


### PR DESCRIPTION
A few of the ak effects are based on singling out a single mode of apples multi-mode-distortion.
At some point, the setup for these nodes got trashed, so the decimator for example was always distorting via the other modes.

This creates private parameters and then uses those to turn the other effects off.

also fixed a weird line break somewhere else.