### PR TITLE
Make `MIDIEvent(command:byte1:byte2:)` public.

### DIFF
--- a/Sources/AudioKit/MIDI/MIDIEvent.swift
+++ b/Sources/AudioKit/MIDI/MIDIEvent.swift
@@ -215,7 +215,7 @@ public struct MIDIEvent: MIDIMessage, Equatable {
     ///   - byte1:   First data byte
     ///   - byte2:   Second data byte
     ///
-    init(command: MIDISystemCommand, byte1: MIDIByte, byte2: MIDIByte? = nil) {
+    public init(command: MIDISystemCommand, byte1: MIDIByte, byte2: MIDIByte? = nil) {
         var data = [byte1]
         if let byte2 = byte2 {
             data.append(byte2)


### PR DESCRIPTION
Very small change to make `MIDIEvent(command:byte1:byte2:)` public rather than internal. Please feel free to close if I'm missing a reason why this initializer shouldn't be public 🙂