### PR TITLE
Make HasInternalConnections a public protocol

### DIFF
--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -168,7 +168,7 @@ extension Node {
 
 }
 
-protocol HasInternalConnections: AnyObject {
+public protocol HasInternalConnections: AnyObject {
     /// Override point for any connections internal to the node.
     func makeInternalConnections()
 }


### PR DESCRIPTION
Make HasInternalConnections a public protocol so that AK nodes outside the framework can make use of it.