### PR TITLE
Update NodeRecorder's audio file name

### DIFF
--- a/Sources/AudioKit/Nodes/Effects/Delay.swift
+++ b/Sources/AudioKit/Nodes/Effects/Delay.swift
@@ -20,7 +20,7 @@ public class Delay: Node {
         identifier: "dryWetMix",
         name: "Dry-Wet Mix",
         address: 0,
-        defaultValue: 1,
+        defaultValue: 50,
         range: 0.0 ... 1.0,
         unit: .generic)
 

--- a/Sources/AudioKit/Nodes/Effects/Delay.swift
+++ b/Sources/AudioKit/Nodes/Effects/Delay.swift
@@ -20,7 +20,7 @@ public class Delay: Node {
         identifier: "dryWetMix",
         name: "Dry-Wet Mix",
         address: 0,
-        defaultValue: 50,
+        defaultValue: 1,
         range: 0.0 ... 1.0,
         unit: .generic)
 

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -88,9 +88,16 @@ open class NodeRecorder: NSObject {
 
     // MARK: - Methods
 
+    /// Use Date and Time as Filename
+    private static func createDateFileName() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss"
+        return dateFormatter.string(from:Date())
+    }
+
     /// Returns a CAF file in the NSTemporaryDirectory suitable for writing to via Settings.audioFormat
     public static func createTempFile() -> AVAudioFile? {
-        let filename = UUID().uuidString + ".caf"
+        let filename = createDateFileName() + ".caf"
         let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(filename)
         var settings = Settings.audioFormat.settings
         settings[AVLinearPCMIsNonInterleaved] = NSNumber(value: false)


### PR DESCRIPTION
This sets the formatted date as the recorded file's name like in Synth One. It just looks a little nicer when sharing the audio file. 

Optionally it might be cool to have the file name accessible as a public var but this could run into issues if each recording needs a new file name.

Thanks,
Nick
