### PR TITLE
Ensure internalCompletionHandler runs on main thread

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
@@ -56,7 +56,9 @@ extension AudioPlayer {
                                    frameCount: frameCount,
                                    at: audioTime,
                                    completionCallbackType: completionCallbackType) { callbackType in
-            self.internalCompletionHandler()
+            DispatchQueue.main.async {
+                self.internalCompletionHandler()
+            }
         }
 
         playerNode.prepare(withFrameCount: frameCount)
@@ -85,7 +87,9 @@ extension AudioPlayer {
                                   at: audioTime,
                                   options: bufferOptions,
                                   completionCallbackType: completionCallbackType) { callbackType in
-            self.internalCompletionHandler()
+            DispatchQueue.main.async {
+                self.internalCompletionHandler()
+            }
         }
 
         playerNode.prepare(withFrameCount: buffer.frameLength)


### PR DESCRIPTION
I was getting rare but show-stopping mutex deadlocks on `AudioPlayer.stop()` when it just so happened that AudioPlayer's `internalCompletionHandler` was running on another thread:

![image](https://user-images.githubusercontent.com/15148/145720650-ae287d71-1ea0-4b96-ae36-c2550a8b6f91.png)

⬆️  In this example, there are also 20+ threads off-screen that are stuck in `internalCompletionHandler` as well.

I would expect most people would never run into this issue, but I've got dozens of AudioPlayers running simultaneously, starting and stopping many times a second, so it would inevitably happen after a short time (a few minutes at most). 

With this change, I was able to leave my app running for hours with no deadlocks. 🎉

I'm not sure if this is the best approach – I'm relatively new to Swift and learning as I go – but I submit it for your consideration!