### PR TITLE
Add input refs and destination refs properties that filter out virtual ports. Use when opening MIDI IO.

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI+Receiving.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Receiving.swift
@@ -97,6 +97,16 @@ extension MIDI {
         }
         return names
     }
+    
+    /// Array of input source endpoint references
+    public var inputRefs: [MIDIEndpointRef] {
+        var refs = MIDISources().endpointRefs
+        // Remove inputs which are actually virtual outputs from AudioKit
+        for input in self.virtualOutputs {
+            refs.removeAll(where: { $0 == input })
+        }
+        return refs
+    }
 
     /// Lookup a input name from its unique id
     ///
@@ -329,7 +339,11 @@ extension MIDI {
     /// - parameter inputUID: Unique identifier for a MIDI Input
     ///
     public func openInput(uid inputUID: MIDIUniqueID) {
-        for (uid, src) in zip(inputUIDs, MIDISources()) {
+        
+        // Since inputUIDs filters out our own virtual outputs, we need to do the same with the endpoint refs.
+        let sources = inputRefs
+        
+        for (uid, src) in zip(inputUIDs, sources) {
             if inputUID == 0 || inputUID == uid {
                 inputPorts[inputUID] = MIDIPortRef()
 

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -70,6 +70,12 @@ extension Collection where Iterator.Element == MIDIEndpointRef {
             getMIDIObjectIntegerProperty(ref: $0, property: kMIDIPropertyUniqueID)
         }
     }
+    
+    var endpointRefs: [MIDIEndpointRef] {
+        return map {
+            $0
+        }
+    }
 }
 
 internal func getMIDIObjectStringProperty(ref: MIDIObjectRef, property: CFString) -> String {
@@ -111,6 +117,16 @@ extension MIDI {
             names.removeAll(where: { $0 == virtualName})
         }
         return names
+    }
+    
+    /// Array of destination endpoint references
+    public var destinationRefs: [MIDIEndpointRef] {
+        var refs = MIDIDestinations().endpointRefs
+        // Remove outputs which are actually virtual inputs to AudioKit
+        for output in self.virtualInputs {
+            refs.removeAll(where: { $0 == output })
+        }
+        return refs
     }
 
     /// Lookup a destination name from its unique id
@@ -186,7 +202,8 @@ extension MIDI {
             outputPort = tempPort
         }
 
-        let destinations = MIDIDestinations()
+        // Since destinationUIDs filters out our own virtual inputs, we need to do the same with the endpoint refs.
+        let destinations = destinationRefs
 
         // To get all endpoints; and set in endpoints array (mapping without condition)
         if outputUid == 0 {


### PR DESCRIPTION
Hi AudioKit team, I noticed a bug where my app would only properly send/receive MIDI when it was opened after other apps. I took a look at AudioKit and found that the openInput(uid: ...) and openOutput(uid: ...) functions don't filter out virtual ports from the list of MIDI sources/destinations. This means when zip() is called with the uids, they won't be properly matched up whenever virtual ports exist.

I've added computed properties for input refs and destination refs that filter out the app's own virtual ports. Then I use them when opening inputs and outputs.

I'm using these changes in my own app and everything seems to be working. This is my first pull request, so let me know if I need to provide anything else.

Ryan
