### PR TITLE
Simple NodeRecorder test

### DIFF
--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -56,4 +56,20 @@ class AVAudioPCMBufferTests: XCTestCase {
         XCTAssertTrue(inFile.length > 0)
 
     }
+
+    func testSimpleRecord() {
+        let engine = AudioEngine()
+        let input = PlaygroundOscillator()
+        input.start()
+        let recorder = try! NodeRecorder(node: input)
+        engine.output = input
+        try! recorder.record()
+        try! engine.start()
+        sleep(2)
+        recorder.stop()
+        engine.stop()
+
+        let result = recorder.audioFile!
+        XCTAssertTrue(result.length > 0)
+    }
 }


### PR DESCRIPTION
After https://github.com/AudioKit/AudioKit/commit/9d25f6c1e40975f321786d9b70502b4d74421707, a `NodeRecorder` will fail to record an oscillator (or, it appears, any other node). 

If you run this test before that commit, it will pass. I don't claim to understand the intricacies of why creating a brand new `AVAudioFile` from the one from the args is necessary, but without it, you can see in the logs:

```
2021-12-22 10:47:19.024193-0500 xctest[33203:1134727] [avae]            AVAEInternal.h:109   [AVAudioFile.mm:472:-[AVAudioFile writeFromBuffer:error:]: (ExtAudioFileWrite(_imp->_extAudioFile, buffer.frameLength, buffer.audioBufferList)): error -50
2021-12-22 10:47:19.024429-0500 xctest[33203:1134727] [general] NodeRecorder.swift:process(buffer:time:):170:Write failed: error -> The operation couldn’t be completed. (com.apple.coreaudio.avfaudio error -50.) (NodeRecorder.swift:process(buffer:time:):170)
```

Each time the `process` function in the recorder is called.

Also, please note that if you call `recorder.reset()` after init, it will also work (presumably because it recreates the internal file [here](https://github.com/AudioKit/AudioKit/blob/main/Sources/AudioKit/Taps/NodeRecorder.swift#L213-L220))