### PR TITLE
Remove seek() in resume() 

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -19,9 +19,10 @@ extension AudioPlayer {
             resume()
             return
         }
-
+        
+        // Do nothing if player is already playing
         if isPlaying {
-            stop()
+            return
         }
 
         guard let engine = playerNode.engine else {
@@ -62,9 +63,6 @@ extension AudioPlayer {
     /// Resumes audio player from paused time
     public func resume() {
         isPaused = false
-        if !isBuffered {
-            seek(time: pausedTime)
-        }
         playerNode.play()
     }
 

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -19,7 +19,7 @@ extension AudioPlayer {
             resume()
             return
         }
-        
+
         // Do nothing if player is already playing
         if isPlaying {
             return

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -202,7 +202,11 @@ public class AudioPlayer: Node {
               engine?.isInManualRenderingMode == false else { return }
 
         scheduleTime = nil
-        isPlaying = false
+
+        if !isLooping {
+            isPlaying = false
+        }
+
         completionHandler?()
 
         if !isBuffered, isLooping, engine?.isRunning == true {

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -202,11 +202,7 @@ public class AudioPlayer: Node {
               engine?.isInManualRenderingMode == false else { return }
 
         scheduleTime = nil
-
-        if !isLooping {
-            isPlaying = false
-        }
-
+        isPlaying = false
         completionHandler?()
 
         if !isBuffered, isLooping, engine?.isRunning == true {


### PR DESCRIPTION
#2646
Do nothing if player is already playing inside `play()` and remove `seek()` in resume() -- doesn't seem to be needed