### PR TITLE
Change sequencer tempo range in AppleSequencer.swift

### DIFF
--- a/Sources/AudioKit/Sequencing/Apple Sequencer/AppleSequencer.swift
+++ b/Sources/AudioKit/Sequencing/Apple Sequencer/AppleSequencer.swift
@@ -183,7 +183,7 @@ open class AppleSequencer: NSObject {
     /// Clears all existing tempo events and adds single tempo event at start
     /// Will also adjust the tempo immediately if sequence is playing when called
     public func setTempo(_ bpm: Double) {
-        let constrainedTempo = bpm.clamped(to: 10...280)
+        let constrainedTempo = max(1,bpm)
 
         var tempoTrack: MusicTrack?
 
@@ -214,7 +214,7 @@ open class AppleSequencer: NSObject {
     ///   - position: Point in time in beats
     ///
     public func addTempoEventAt(tempo bpm: Double, position: Duration) {
-        let constrainedTempo = bpm.clamped(to: 10...280)
+        let constrainedTempo = max(1,bpm)
 
         var tempoTrack: MusicTrack?
 

--- a/Sources/AudioKit/Sequencing/Apple Sequencer/AppleSequencer.swift
+++ b/Sources/AudioKit/Sequencing/Apple Sequencer/AppleSequencer.swift
@@ -183,7 +183,7 @@ open class AppleSequencer: NSObject {
     /// Clears all existing tempo events and adds single tempo event at start
     /// Will also adjust the tempo immediately if sequence is playing when called
     public func setTempo(_ bpm: Double) {
-        let constrainedTempo = max(1,bpm)
+        let constrainedTempo = max(1, bpm)
 
         var tempoTrack: MusicTrack?
 
@@ -214,7 +214,7 @@ open class AppleSequencer: NSObject {
     ///   - position: Point in time in beats
     ///
     public func addTempoEventAt(tempo bpm: Double, position: Duration) {
-        let constrainedTempo = max(1,bpm)
+        let constrainedTempo = max(1, bpm)
 
         var tempoTrack: MusicTrack?
 


### PR DESCRIPTION
Changed constrainedTempo to be 1 or greater value.

I tested this with MusicToy in the Cookbook and it appears to be working properly in higher ranges. the `max(1,bpm)` is there because the value must be greater than 0 or it stops the player.

#2658
