### PR TITLE
AUPreset helper method

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/Apple Sampler/AppleSampler.swift
+++ b/Sources/AudioKit/Nodes/Playback/Apple Sampler/AppleSampler.swift
@@ -114,6 +114,14 @@ open class AppleSampler: Node {
         try loadInstrument(file, type: "exs")
     }
 
+    /// Load an AUPreset file
+    ///
+    /// - parameter file: Name of the AUPreset file without the .aupreset extension
+    ///
+    public func loadAUPreset(_ file: String) throws {
+        try loadInstrument(file, type: "aupreset")
+    }
+
     /// Load an AVAudioFile
     ///
     /// - parameter file: an AVAudioFile


### PR DESCRIPTION
This update makes it more convenient to load AUPreset files in AppleSampler without needing to include the "bundle.main" information in the link like the `loadEXS24` method. I tested with the Cookbook and it works properly.

`public func loadAUPreset(_ file: String) throws {
        try loadInstrument(file, type: "aupreset")
    }`


