### PR TITLE
NodeRecorder: write to specified directory

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -49,7 +49,7 @@ open class NodeRecorder: NSObject {
             return nil
         }
     }
-    
+
     private var fileDirectoryPath: String
 
     private static var tmpFiles = [URL]()
@@ -62,8 +62,8 @@ open class NodeRecorder: NSObject {
     ///
     /// - Parameters:
     ///   - node: Node to record from
-    ///   - file: Audio file to record to (if not provided: - creates temporary file in NSTemporaryDirectory or a specified fileDirectoryPath)
-    ///   - fileDirectoryPath: Directory to write audio files to (uses NSTemporaryDirectory as default) (ignored if file is provided)
+    ///   - file: Audio file to record to
+    ///   - fileDirectoryPath: Directory to write audio files to
     ///   - bus: Integer index of the bus to use
     ///
     public init(node: Node,
@@ -73,7 +73,7 @@ open class NodeRecorder: NSObject {
         self.node = node
         self.fileDirectoryPath = fileDirectoryPath ?? NSTemporaryDirectory()
         super.init()
-        
+    
         let audioFile = file ?? NodeRecorder.createTempFile(fileDirectoryPath: self.fileDirectoryPath)
 
         guard let audioFile = audioFile else {

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -73,7 +73,7 @@ open class NodeRecorder: NSObject {
         self.node = node
         self.fileDirectoryPath = fileDirectoryPath ?? NSTemporaryDirectory()
         super.init()
-    
+
         let audioFile = file ?? NodeRecorder.createTempFile(fileDirectoryPath: self.fileDirectoryPath)
 
         guard let audioFile = audioFile else {

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -95,8 +95,8 @@ open class NodeRecorder: NSObject {
         return dateFormatter.string(from: Date())
     }
 
-    /// Returns a CAF file in the NSTemporaryDirectory suitable for writing to via Settings.audioFormat
-    public static func createTempFile(fileDirectoryPath: String = NSTemporaryDirectory()) -> AVAudioFile? {
+    /// Returns a CAF file in specified directory suitable for writing to via Settings.audioFormat
+    public static func createAudioFile(fileDirectoryPath: String = NSTemporaryDirectory()) -> AVAudioFile? {
         let filename = createDateFileName() + ".caf"
         let url = URL(fileURLWithPath: fileDirectoryPath).appendingPathComponent(filename)
         var settings = Settings.audioFormat.settings

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -52,7 +52,7 @@ open class NodeRecorder: NSObject {
 
     private var fileDirectoryPath: String
 
-    private static var tmpFiles = [URL]()
+    private static var recordedFiles = [URL]()
 
     // MARK: - Initialization
 
@@ -74,7 +74,7 @@ open class NodeRecorder: NSObject {
         self.fileDirectoryPath = fileDirectoryPath ?? NSTemporaryDirectory()
         super.init()
 
-        let audioFile = file ?? NodeRecorder.createTempFile(fileDirectoryPath: self.fileDirectoryPath)
+        let audioFile = file ?? NodeRecorder.createAudioFile(fileDirectoryPath: self.fileDirectoryPath)
 
         guard let audioFile = audioFile else {
             Log("Error, no file to write to")
@@ -103,22 +103,22 @@ open class NodeRecorder: NSObject {
         settings[AVLinearPCMIsNonInterleaved] = NSNumber(value: false)
 
         Log("Creating temp file at", url)
-        guard let tmpFile = try? AVAudioFile(forWriting: url,
+        guard let audioFile = try? AVAudioFile(forWriting: url,
                                              settings: settings,
                                              commonFormat: Settings.audioFormat.commonFormat,
                                              interleaved: true) else { return nil }
 
-        tmpFiles.append(url)
-        return tmpFile
+        recordedFiles.append(url)
+        return audioFile
     }
 
-    /// When done with this class, remove any temp files that were created with createTempFile()
-    public static func removeTempFiles() {
-        for url in NodeRecorder.tmpFiles {
+    /// When done with this class, remove any audio files that were created with createAudioFile()
+    public static func removeRecordedFiles() {
+        for url in NodeRecorder.recordedFiles {
             try? FileManager.default.removeItem(at: url)
             Log("𝗫 Deleted tmp file at", url)
         }
-        NodeRecorder.tmpFiles.removeAll()
+        NodeRecorder.recordedFiles.removeAll()
     }
 
     /// Start recording
@@ -129,10 +129,10 @@ open class NodeRecorder: NSObject {
         }
 
         if let path = internalAudioFile?.url.path, !FileManager.default.fileExists(atPath: path) {
-            // record to new tmp file
-            if let tmpFile = NodeRecorder.createTempFile(fileDirectoryPath: fileDirectoryPath) {
-                internalAudioFile = try AVAudioFile(forWriting: tmpFile.url,
-                                                    settings: tmpFile.fileFormat.settings)
+            // record to new audio file
+            if let audioFile = NodeRecorder.createAudioFile(fileDirectoryPath: fileDirectoryPath) {
+                internalAudioFile = try AVAudioFile(forWriting: audioFile.url,
+                                                    settings: audioFile.fileFormat.settings)
             }
         }
 


### PR DESCRIPTION
Keeps default functionality unchanged, but when fileDirectoryPath is provided then the NodeRecorder will write its files to this location. 

In other words, tell NodeRecorder "I want the files to get written to this folder - name them whatever" and then the dev can just keep track of the file names after each recording.

Does this sound like a good idea? I'm open to suggestions.

From what I could tell, if you wanted to do something like record audio files to the documents directory then you needed to either:
1) continuously hand off a new AVAudioFile to a new instance of a NodeRecorder
or
2) move/copy each file located in the temporary directory after it was recorded

1 seemed like a hack and 2 seemed like an added overhead with the file move/copy. 