### PR TITLE
Midi: remove velocity from sendNoteOffMessage

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -365,15 +365,13 @@ extension MIDI {
     /// Send a Note Off Message
     /// - Parameters:
     ///   - noteNumber: MIDI Note Number
-    ///   - velocity: MIDI Velocity
     ///   - channel: MIDI Channel (default: 0)
     public func sendNoteOffMessage(noteNumber: MIDINoteNumber,
-                                   velocity: MIDIVelocity,
                                    channel: MIDIChannel = 0,
                                    endpointsUIDs: [MIDIUniqueID]? = nil,
                                    virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOffByte + channel
-        let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
+        let message: [MIDIByte] = [noteCommand, noteNumber, 0]
         self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 


### PR DESCRIPTION
I think it is confusing to have an inconsequential velocity value included for a note off message, but I could see leaving the argument and defaulting it to zero for backwards compatibility...

Unless there's some situation where note off has a velocity that I'm not aware of??