### PR TITLE
NodeRecorder: naming collisions and createNewFile

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -91,7 +91,7 @@ open class NodeRecorder: NSObject {
     /// Use Date and Time as Filename
     private static func createDateFileName() -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss"
+        dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss.SSSS"
         return dateFormatter.string(from: Date())
     }
 
@@ -225,5 +225,14 @@ open class NodeRecorder: NSObject {
             Log("Error: Can't record to" + url.lastPathComponent)
             throw error
         }
+    }
+
+    /// Creates a new audio file for recording
+    public func createNewFile() {
+        if isRecording == true {
+            stop()
+        }
+
+        self.internalAudioFile = NodeRecorder.createAudioFile(fileDirectoryPath: self.fileDirectoryPath)
     }
 }


### PR DESCRIPTION
Two things:
- Added milliseconds to file names to avoid naming collisions from files created in the same second
- Added method to update the internalAudioFile to a new AVAudioFile named based on the current time

My scenario:
- Initialize NodeRecorder with a directory to write the files to
- After each recording, grab the audio file's url to keep track of recorded files
- Run createNewFile to prepare for the next recording

There may be some way that this was possible before, but this was the only obvious way I got it to work.