### PR TITLE
Refactored two midi send methods into one with timeStamp defaulted to mach_absolute_time()

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -287,11 +287,11 @@ extension MIDI {
     ///   - noteNumber: MIDI Note Number
     ///   - velocity: MIDI Velocity
     ///   - channel: MIDI Channel (default: 0)
-    ///   - time: MIDI Timestamp (default: mach_absolute_time())
+    ///   - time: MIDI Timestamp (default: mach_absolute_time(), note: time should never be 0)
     public func sendNoteOnMessage(noteNumber: MIDINoteNumber,
                                   velocity: MIDIVelocity,
                                   channel: MIDIChannel = 0,
-                                  time: MIDITimeStamp = MIDITimeStamp(mach_absolute_time()),
+                                  time: MIDITimeStamp = mach_absolute_time(),
                                   endpointsUIDs: [MIDIUniqueID]? = nil,
                                   virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOnByte + channel
@@ -303,10 +303,10 @@ extension MIDI {
     /// - Parameters:
     ///   - noteNumber: MIDI Note Number
     ///   - channel: MIDI Channel (default: 0)
-    ///   - time: MIDI Timestamp (default: mach_absolute_time())
+    ///   - time: MIDI Timestamp (default: mach_absolute_time(), note: time should never be 0)
     public func sendNoteOffMessage(noteNumber: MIDINoteNumber,
                                    channel: MIDIChannel = 0,
-                                   time: MIDITimeStamp = MIDITimeStamp(mach_absolute_time()),
+                                   time: MIDITimeStamp = mach_absolute_time(),
                                    endpointsUIDs: [MIDIUniqueID]? = nil,
                                    virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOffByte + channel
@@ -351,9 +351,9 @@ extension MIDI {
     /// Send Message with data with timestamp
     /// - Parameters:
     ///   - data: Array of MIDI Bytes
-    ///   - time: MIDI Timestamp (default mach_absolute_time())
+    ///   - time: MIDI Timestamp (default: mach_absolute_time(), note: time should never be 0)
     public func sendMessage(_ data: [MIDIByte],
-                            time: MIDITimeStamp =  MIDITimeStamp(mach_absolute_time()),
+                            time: MIDITimeStamp = mach_absolute_time(),
                             endpointsUIDs: [MIDIUniqueID]? = nil,
                             virtualOutputPorts: [MIDIPortRef]? = nil) {
         let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -306,7 +306,7 @@ extension MIDI {
     ///   - time: MIDI Timestamp (default: mach_absolute_time())
     public func sendNoteOffMessage(noteNumber: MIDINoteNumber,
                                    channel: MIDIChannel = 0,
-                                   time: MIDITimeStamp = mach_absolute_time(),
+                                   time: MIDITimeStamp = MIDITimeStamp(mach_absolute_time()),
                                    endpointsUIDs: [MIDIUniqueID]? = nil,
                                    virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOffByte + channel

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -269,71 +269,6 @@ extension MIDI {
         }
     }
 
-    /// Send Message with data
-    /// - Parameters:
-    ///   - data: Array of MIDI Bytes
-    ///   - offset: Timestamp offset
-    public func sendMessage(_ data: [MIDIByte],
-                            offset: MIDITimeStamp = 0,
-                            endpointsUIDs: [MIDIUniqueID]? = nil,
-                            virtualOutputPorts: [MIDIPortRef]? = nil) {
-
-        // Create a buffer that is big enough to hold the data to be sent and
-        // all the necessary headers.
-        let bufferSize = data.count + sizeOfMIDICombinedHeaders
-
-        // the discussion section of MIDIPacketListAdd states that "The maximum
-        // size of a packet list is 65536 bytes." Checking for that limit here.
-        if bufferSize > 65_536 {
-            Log("error sending midi : data array is too large, requires a buffer larger than 65536",
-                  log: OSLog.midi,
-                  type: .error)
-            return
-        }
-
-        var buffer = Data(count: bufferSize)
-
-        // Use Data (a.k.a NSData) to create a block where we have access to a
-        // pointer where we can create the packetlist and send it. No need for
-        // explicit alloc and dealloc.
-        buffer.withUnsafeMutableBytes { (ptr: UnsafeMutableRawBufferPointer) -> Void in
-            if let packetListPointer = ptr.bindMemory(to: MIDIPacketList.self).baseAddress {
-
-                let packet = MIDIPacketListInit(packetListPointer)
-                let nextPacket: UnsafeMutablePointer<MIDIPacket>? =
-                    MIDIPacketListAdd(packetListPointer, bufferSize, packet, offset, data.count, data)
-
-                // I would prefer stronger error handling here, perhaps throwing
-                // to force the app developer to handle the error.
-                if nextPacket == nil {
-                    Log("error sending midi: Failed to add packet to packet list.", log: OSLog.midi, type: .error)
-                    return
-                }
-
-                var endpointsRef: [MIDIEndpointRef] = []
-
-                if let endpointsUIDS = endpointsUIDs {
-                    for endpointUID in endpointsUIDS {
-                        if let endpoint = endpoints[endpointUID] {endpointsRef.append(endpoint)}
-                    }
-                } else {
-                    endpointsRef = Array(endpoints.values)
-                }
-
-                for endpoint in endpointsRef {
-                    let result = MIDISend(outputPort, endpoint, packetListPointer)
-                    if result != noErr {
-                        Log("error sending midi: \(result)", log: OSLog.midi, type: .error)
-                    }
-                }
-
-                if virtualOutputs != [0] {
-                    virtualOutputPorts?.forEach {MIDIReceived($0, packetListPointer)}
-                }
-            }
-        }
-    }
-
     /// Clear MIDI destinations
     public func clearEndpoints() {
         endpoints.removeAll()
@@ -352,27 +287,31 @@ extension MIDI {
     ///   - noteNumber: MIDI Note Number
     ///   - velocity: MIDI Velocity
     ///   - channel: MIDI Channel (default: 0)
+    ///   - time: MIDI Timestamp (default: mach_absolute_time())
     public func sendNoteOnMessage(noteNumber: MIDINoteNumber,
                                   velocity: MIDIVelocity,
                                   channel: MIDIChannel = 0,
+                                  time: MIDITimeStamp = MIDITimeStamp(mach_absolute_time()),
                                   endpointsUIDs: [MIDIUniqueID]? = nil,
                                   virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOnByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
+        self.sendMessage(message, time: time, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Note Off Message
     /// - Parameters:
     ///   - noteNumber: MIDI Note Number
     ///   - channel: MIDI Channel (default: 0)
+    ///   - time: MIDI Timestamp (default: mach_absolute_time())
     public func sendNoteOffMessage(noteNumber: MIDINoteNumber,
                                    channel: MIDIChannel = 0,
+                                   time: MIDITimeStamp = mach_absolute_time(),
                                    endpointsUIDs: [MIDIUniqueID]? = nil,
                                    virtualOutputPorts: [MIDIPortRef]? = nil) {
         let noteCommand: MIDIByte = noteOffByte + channel
         let message: [MIDIByte] = [noteCommand, noteNumber, 0]
-        self.sendMessage(message, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
+        self.sendMessage(message, time: time, endpointsUIDs: endpointsUIDs, virtualOutputPorts: virtualOutputPorts)
     }
 
     /// Send a Continuous Controller message
@@ -409,50 +348,14 @@ extension MIDI {
 
     // MARK: - Expand api to include MIDITimeStamp
 
-    /// Send a message with MIDITimeStamp
-    /// - Parameters:
-    ///   - noteNumber: MIDI Note Number
-    ///   - velocity: MIDI Velocity
-    ///   - channel: MIDI Channel (default: 0)
-    ///   - time: MIDI Timestamp (default: 0)
-    public func sendNoteOnMessageWithTime(noteNumber: MIDINoteNumber,
-                                          velocity: MIDIVelocity,
-                                          channel: MIDIChannel = 0,
-                                          time: MIDITimeStamp = 0,
-                                          endpointsUIDs: [MIDIUniqueID]? = nil,
-                                          virtualOutputPorts: [MIDIPortRef]? = nil) {
-        let noteCommand: MIDIByte = noteOnByte + channel
-        let message: [MIDIByte] = [noteCommand, noteNumber, velocity]
-        self.sendMessageWithTime(message, time: time,
-                                 endpointsUIDs: endpointsUIDs,
-                                 virtualOutputPorts: virtualOutputPorts)
-    }
-
-    /// Send a Note Off Message with timestamp
-    /// - Parameters:
-    ///   - noteNumber: MIDI Note Number
-    ///   - channel: MIDI Channel (default: 0)
-    ///   - time: MIDI Timestamp (default: 0)
-    public func sendNoteOffMessageWithTime(noteNumber: MIDINoteNumber,
-                                           channel: MIDIChannel = 0,
-                                           time: MIDITimeStamp = 0,
-                                           endpointsUIDs: [MIDIUniqueID]? = nil,
-                                           virtualOutputPorts: [MIDIPortRef]? = nil) {
-        let noteCommand: MIDIByte = noteOffByte + channel
-        let message: [MIDIByte] = [noteCommand, noteNumber, 0]
-        self.sendMessageWithTime(message, time: time,
-                                 endpointsUIDs: endpointsUIDs,
-                                 virtualOutputPorts: virtualOutputPorts)
-    }
-
     /// Send Message with data with timestamp
     /// - Parameters:
     ///   - data: Array of MIDI Bytes
-    ///   - time: MIDI Timestamp
-    public func sendMessageWithTime(_ data: [MIDIByte],
-                                    time: MIDITimeStamp,
-                                    endpointsUIDs: [MIDIUniqueID]? = nil,
-                                    virtualOutputPorts: [MIDIPortRef]? = nil) {
+    ///   - time: MIDI Timestamp (default mach_absolute_time())
+    public func sendMessage(_ data: [MIDIByte],
+                            time: MIDITimeStamp =  MIDITimeStamp(mach_absolute_time()),
+                            endpointsUIDs: [MIDIUniqueID]? = nil,
+                            virtualOutputPorts: [MIDIPortRef]? = nil) {
         let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)
 
         var packet: UnsafeMutablePointer<MIDIPacket> = MIDIPacketListInit(packetListPointer)


### PR DESCRIPTION
Refactored two midi send methods into one with timeStamp defaulted to mach_absolute_time()

This is a solution to: #2676 
