### PR TITLE
restore behavior that stops calling CompletionHandler on seek

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -87,8 +87,10 @@ extension AudioPlayer {
         let time = time.clamped(to: 0...duration)
 
         if status == .playing {
+            isSeeking = true
             stop()
             play(from: time, to: duration)
+            isSeeking = false
         } else {
             editStartTime = time
             editEndTime = duration

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
@@ -55,6 +55,7 @@ extension AudioPlayer {
                                    frameCount: frameCount,
                                    at: audioTime,
                                    completionCallbackType: completionCallbackType) { callbackType in
+            if self.isSeeking { return }
             DispatchQueue.main.async {
                 self.internalCompletionHandler()
             }
@@ -86,6 +87,7 @@ extension AudioPlayer {
                                   at: audioTime,
                                   options: bufferOptions,
                                   completionCallbackType: completionCallbackType) { callbackType in
+            if self.isSeeking { return }
             DispatchQueue.main.async {
                 self.internalCompletionHandler()
             }


### PR DESCRIPTION
https://github.com/AudioKit/AudioKit/issues/2683

FYI I had to move the `isSeeking` guard out of the `internalCompletionHandler`, with the (more correct) approach of calling it on the main dispatch thread it now has a data race with the `isSeeking` guard.

