### PR TITLE
Address audio player reset logic

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -43,11 +43,9 @@ extension AudioPlayer {
             return
         case .completed:
             // reset the status and play again if isLooping and not buffered
+            status = .stopped
             if isLooping && !isBuffered {
-                status = .stopped
                 play()
-            } else if !isLooping && !isBuffered {
-                status = .stopped
             }
         }
     }


### PR DESCRIPTION
Allow audio player to be reset to `.stopped` status after `play()` is called again if audio player is still in `.completed` status - AudioKit/AudioKit#2684
