### PR TITLE
stop the playerNode upon completion

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -47,6 +47,7 @@ extension AudioPlayer {
                 status = .stopped
                 play()
             } else if !isLooping && !isBuffered {
+                playerNode.stop()
                 status = .stopped
             }
         }


### PR DESCRIPTION
Without this call the playerNode continues its timeline in the background and subsequent calls to `getCurrentPosition()` are incorrect. 

to reproduce the issue I'm talking about, simply do like:

```
player.play()
... wait for the player to stop naturally, then wait a few seconds

player.seek(0)
player.play()
print(player.getCurrentTime())
```

the call to getCurrentTime() will be off by the amount of seconds you waited (I think).
