### PR TITLE
set .stopped status before stopping

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -111,7 +111,7 @@ extension AudioPlayer {
     public func stop() {
         guard status == .playing else { return }
         pausedTime = getCurrentTime()
-        playerNode.stop()
         status = .stopped
+        playerNode.stop()
     }
 }


### PR DESCRIPTION
If we don't do this, we can race with the completion handler, which says "ah, I'm stopping and the status is still `.playing`.  let's fire."  

we could also introduce an intermediate `.stopping` state, but I don't think it's necessary.