### PR TITLE
failing test for getCurrentTime after pause, and seek

### DIFF
--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
@@ -196,6 +196,36 @@ class AudioPlayerTests: XCTestCase {
         testMD5(audio)
     }
 
+    // If we play for 1 second and pause, and then seek 1 more second forward, we
+    // should be given the current time of 2 seconds
+    func testGetCurrentTimeAfterPauseAndSeek() {
+      guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav") else {
+        XCTFail("Didn't get test file")
+        return
+      }
+      let engine = AudioEngine()
+      let player = AudioPlayer()
+      engine.output = player
+
+      let audio = engine.startTest(totalDuration: 3.0)
+
+      do {
+        try player.load(url: url, buffered: true)
+      } catch let error as NSError {
+        Log(error, type: .error)
+        XCTFail(error.description)
+      }
+
+      player.play()
+      audio.append(engine.render(duration: 1.0))
+
+      player.pause()
+      player.seek(time: 2.0)
+
+      let currentTime = player.getCurrentTime()
+      XCTAssertEqual(currentTime, 2.0)
+    }
+
     func testToggleEditTime() {
         guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav") else {
             XCTFail("Didn't get test file")


### PR DESCRIPTION
This is a failing test showing that `AudioPlayer.getCurrentTime` does not report the correct time if the player is `seek`ed while it's paused. It appears to have to do with the `pauseTime` value held in the player.

It may also illustrate a failure of understanding on my part how the interplay of seeking a paused player is expected to work. To me, if a paused player is seeked, `getCurrentTime` should report the time that the play head is at _after_ the seek.

The test below shows that if you play for `1.0` second, pause the player, and then attempt to seek to `2.0` seconds, `getCurrentTime` will still report `1.0`.