### PR TITLE
Player always respects new startTime and endTime

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -14,6 +14,10 @@ extension AudioPlayer {
                      to endTime: TimeInterval? = nil,
                      at when: AVAudioTime? = nil,
                      completionCallbackType: AVAudioPlayerNodeCompletionCallbackType = .dataPlayedBack) {
+
+        editStartTime = startTime ?? editStartTime
+        editEndTime = endTime ?? editEndTime
+
         guard let engine = playerNode.engine else {
             Log("🛑 Error: AudioPlayer must be attached before playback.", type: .error)
             return
@@ -23,11 +27,9 @@ extension AudioPlayer {
             Log("🛑 Error: AudioPlayer's engine must be running before playback.", type: .error)
             return
         }
+
         switch status {
         case .stopped:
-            editStartTime = startTime ?? editStartTime
-            editEndTime = endTime ?? editEndTime
-
             schedule(at: when,
                      completionCallbackType: completionCallbackType)
 


### PR DESCRIPTION
Address #2672
The player was ignoring the new `editStartTime` and `editEndTime` unless it was in a stopped state. The code is now changed so the player always respects these two parameters and updates them whenever `play()` is called with the corresponding `startTime` and `endTime` arguments. Otherwise, these two parameters will remain the same as the last scheduled segment. Please test and leave any feedback here. I tested myself, but a second pair of eyes and ears always helps :) !
