### PR TITLE
Fix retain cycle in BaseTap

### DIFF
--- a/Sources/AudioKit/Taps/BaseTap.swift
+++ b/Sources/AudioKit/Taps/BaseTap.swift
@@ -75,9 +75,9 @@ open class BaseTap {
         }
 
         input.avAudioNode.installTap(onBus: bus,
-                                           bufferSize: bufferSize,
-                                           format: nil,
-                                           block: handleTapBlock(buffer:at:))
+                                     bufferSize: bufferSize,
+                                     format: nil,
+                                     block: { [weak self] in self?.handleTapBlock(buffer: $0, at: $1) })
     }
 
     /// Override this method to handle Tap in derived class

--- a/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
@@ -1,0 +1,22 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import XCTest
+import AudioKit
+
+class BaseTapTests: XCTestCase {
+
+    func testBaseTapDeallocated() throws {
+        let engine = AudioEngine()
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+        engine.output = player
+
+        var tap: BaseTap? = BaseTap(player, bufferSize: 1024)
+        weak var weakTap = tap
+        tap?.start()
+
+        tap = nil
+
+        XCTAssertNil(weakTap)
+    }
+}


### PR DESCRIPTION
Passing instance method of Base Tap to a closure parameter implicitly retains it. 

Break the cycle by capturing self weakly.