### PR TITLE
Added callback handler to node recorder

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -177,7 +177,7 @@ open class NodeRecorder: NSObject {
         do {
             recordBufferDuration = Double(buffer.frameLength) / Settings.sampleRate
             try internalAudioFile.write(from: buffer)
-            
+
             if rawDataTapHandler != nil {
                 doHandleTapBlock(buffer: buffer)
             }

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -54,10 +54,10 @@ open class NodeRecorder: NSObject {
     private var fileDirectoryURL: URL
 
     private static var recordedFiles = [URL]()
-    
+
     /// Callback type
     public typealias RawAudioDataHandler = ([Float]) -> Void
-    
+
     /// Callback of incoming audio floating point values for monitoring purposes
     public var rawDataTapHandler: RawAudioDataHandler?
 
@@ -191,7 +191,7 @@ open class NodeRecorder: NSObject {
             Log("Write failed: error -> \(error.localizedDescription)")
         }
     }
-    
+
     /// When a raw data tap handler is provided, we call it back with the recorded float values
     private func doHandleTapBlock(buffer: AVAudioPCMBuffer) {
         guard buffer.floatChannelData != nil else { return }

--- a/Tests/AudioKitTests/Node Tests/NodeRecorderTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeRecorderTests.swift
@@ -1,0 +1,68 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+@testable import AudioKit
+import AVFoundation
+import XCTest
+
+class NodeRecorderTests: XCTestCase {
+    func testBasicRecord() throws {
+        let engine = AudioEngine()
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+        engine.output = player
+        let recorder = try NodeRecorder(node: player)
+
+        // record a little audio
+        try engine.start()
+        player.play()
+        try recorder.reset()
+        try recorder.record()
+        sleep(1)
+
+        // stop recording and load it into a player
+        recorder.stop()
+        let audioFileURL = recorder.audioFile!.url
+        engine.stop()
+        player.stop()
+        try player.load(url: audioFileURL)
+
+        // test the result
+        let audio = engine.startTest(totalDuration: 1.0)
+        player.play()
+        audio.append(engine.render(duration: 1.0))
+        testMD5(audio)
+    }
+
+    func testCallback() throws {
+        let engine = AudioEngine()
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+        engine.output = player
+        let recorder = try NodeRecorder(node: player)
+
+        // attach the callback handler
+        var values = [Float]()
+        recorder.rawDataTapHandler = { audioData in
+            values.append(contentsOf: audioData)
+        }
+
+        // record a little audio
+        try engine.start()
+        player.play()
+        try recorder.reset()
+        try recorder.record()
+        sleep(1)
+
+        // stop recording and load it into a player
+        recorder.stop()
+        let audioFileURL = recorder.audioFile!.url
+        engine.stop()
+        player.stop()
+        try player.load(url: audioFileURL)
+
+        // test the result
+        let audio = engine.startTest(totalDuration: 1.0)
+        player.play()
+        audio.append(engine.render(duration: 1.0))
+        XCTAssertEqual(values[5000], -0.027038574)
+    }
+}

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -37,6 +37,7 @@ let validatedMD5s: [String: String] = [
     "-[MultiSegmentPlayerTests testPlaySegmentInTheFuture]": "feb1367cee8917a890088b8967b8d422",
     "-[MultiSegmentPlayerTests testPlayMultipleSegments]": "feb1367cee8917a890088b8967b8d422",
     "-[MultiSegmentPlayerTests testPlayWithinSegment]": "adc3d1fef36f68e1f12dbb471eb4069b",
+    "-[NodeRecorderTests testBasicRecord]": "f98d952748c408b1e38325f2bfe2ce81",
     "-[NodeTests testDisconnect]": "8c5c55d9f59f471ca1abb53672e3ffbf",
     "-[NodeTests testDynamicConnection]": "c61c69779df208d80f371881346635ce",
     "-[NodeTests testDynamicConnection2]": "8c5c55d9f59f471ca1abb53672e3ffbf",


### PR DESCRIPTION
Added callback handler to node recorder. 

This is useful if you'd like to show the ongoing recording's audio waveform on the UI in realtime.

When no handler is provided, no extra work is done - same as before.