### PR TITLE
Compensate for scheduled play

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -17,6 +17,10 @@ extension AudioPlayer {
 
         editStartTime = startTime ?? editStartTime
         editEndTime = endTime ?? editEndTime
+        if let whenTime = when, let renderTime = playerNode.lastRenderTime
+        {
+            scheduledTime = whenTime.timeIntervalSince(otherTime: renderTime) ?? 0.0
+        }
 
         guard let engine = playerNode.engine else {
             Log("🛑 Error: AudioPlayer must be attached before playback.", type: .error)
@@ -74,7 +78,7 @@ extension AudioPlayer {
         if let nodeTime = playerNode.lastRenderTime,
            nodeTime.isSampleTimeValid,
            let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
-            return (Double(playerTime.sampleTime) / playerTime.sampleRate) + editStartTime
+            return (Double(playerTime.sampleTime) / playerTime.sampleRate) + editStartTime - scheduledTime
         } else if status == .paused {
             return pausedTime
         }

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -17,8 +17,7 @@ extension AudioPlayer {
 
         editStartTime = startTime ?? editStartTime
         editEndTime = endTime ?? editEndTime
-        if let whenTime = when, let renderTime = playerNode.lastRenderTime
-        {
+        if let whenTime = when, let renderTime = playerNode.lastRenderTime {
             scheduledTime = whenTime.timeIntervalSince(otherTime: renderTime) ?? 0.0
         }
 

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -175,6 +175,9 @@ public class AudioPlayer: Node {
     var startingFrame: AVAudioFramePosition?
     var endingFrame: AVAudioFramePosition?
 
+    /// Time player is scheduled to play (seconds)
+    var scheduledTime: TimeInterval = 0.0
+
     var engine: AVAudioEngine? { mixerNode.engine }
 
     // MARK: - Internal functions


### PR DESCRIPTION
Addressing #2691 - Allows `getCurrentTime()` to compensate for the scheduled player time