### PR TITLE
[Realtime AudioPlayer Tests] - Fix Scheduling Test

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
@@ -62,6 +62,7 @@ extension AudioPlayer {
         }
 
         playerNode.prepare(withFrameCount: frameCount)
+        self.status = .stopped
     }
 
     private func scheduleBuffer(at audioTime: AVAudioTime?,

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
@@ -115,7 +115,7 @@ extension AudioPlayerFileTests {
     }
 
     func realtimeScheduleFile() {
-        guard let player = createPlayer(duration: 2) else {
+        guard let player = createPlayer(duration: 5) else {
             XCTFail("Failed to create AudioPlayer")
             return
         }


### PR DESCRIPTION
This test was failing for a couple reasons:

1. No file exists for the specified duration of 2 seconds. However, there is a file which exists for the duration of 5 seconds.

2. The player get's stuck in the `scheduling` status when manually scheduling. To fix this, the player is set to a `stopped` status before the scheduling function returns.
