### PR TITLE
Compensate for scheduled play w/ tests

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -80,13 +80,13 @@ extension AudioPlayer {
             if let nodeTime = playerNode.lastRenderTime,
                nodeTime.isSampleTimeValid,
                let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
-               let currTime = Double(playerTime.sampleTime) / playerTime.sampleRate + editStartTime
+               let currTime = Double(playerTime.sampleTime) / playerTime.sampleRate
 
                 // Don't count time before file starts playing
                 if currTime < timeBeforePlay {
                     return editStartTime
                 } else {
-                    return currTime - timeBeforePlay
+                    return currTime + editStartTime - timeBeforePlay
                 }
             } else {
                 return editStartTime

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -28,6 +28,10 @@ extension AudioPlayer {
             return
         }
 
+        if let renderTime = self.playerNode.lastRenderTime, let whenTime = when {
+            timeBeforePlay = whenTime.timeIntervalSince(otherTime: renderTime) ?? 0.0
+        }
+
         switch status {
         case .stopped:
             schedule(at: when,
@@ -71,14 +75,27 @@ extension AudioPlayer {
     /// Gets the accurate playhead time regardless of seeking and pausing
     /// Can't be relied on if playerNode has its playstate modified directly
     public func getCurrentTime() -> TimeInterval {
-        if let nodeTime = playerNode.lastRenderTime,
-           nodeTime.isSampleTimeValid,
-           let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
-            return (Double(playerTime.sampleTime) / playerTime.sampleRate) + editStartTime
-        } else if status == .paused {
+        switch status {
+        case .playing:
+            if let nodeTime = playerNode.lastRenderTime,
+               nodeTime.isSampleTimeValid,
+               let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
+               let currTime = Double(playerTime.sampleTime) / playerTime.sampleRate + editStartTime
+
+                // Don't count time before file starts playing
+                if currTime < timeBeforePlay {
+                    return editStartTime
+                } else {
+                    return currTime - timeBeforePlay
+                }
+            } else {
+                return editStartTime
+            }
+        case .paused:
             return pausedTime
+        default:
+            return editStartTime
         }
-        return editStartTime
     }
 
     /// Sets the player's audio file to a certain time in the track (in seconds)

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -17,6 +17,9 @@ extension AudioPlayer {
 
         editStartTime = startTime ?? editStartTime
         editEndTime = endTime ?? editEndTime
+        if let renderTime = self.playerNode.lastRenderTime, let whenTime = when {
+            timeBeforePlay = whenTime.timeIntervalSince(otherTime: renderTime) ?? 0.0
+        }
 
         guard let engine = playerNode.engine else {
             Log("🛑 Error: AudioPlayer must be attached before playback.", type: .error)
@@ -71,14 +74,27 @@ extension AudioPlayer {
     /// Gets the accurate playhead time regardless of seeking and pausing
     /// Can't be relied on if playerNode has its playstate modified directly
     public func getCurrentTime() -> TimeInterval {
-        if let nodeTime = playerNode.lastRenderTime,
-           nodeTime.isSampleTimeValid,
-           let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
-            return (Double(playerTime.sampleTime) / playerTime.sampleRate) + editStartTime
-        } else if status == .paused {
+        switch status {
+        case .playing:
+            if let nodeTime = playerNode.lastRenderTime,
+               nodeTime.isSampleTimeValid,
+               let playerTime = playerNode.playerTime(forNodeTime: nodeTime) {
+               let currTime = Double(playerTime.sampleTime) / playerTime.sampleRate + editStartTime
+
+                // Don't count time before file starts playing
+                if currTime < timeBeforePlay {
+                    return editStartTime
+                } else {
+                    return currTime - timeBeforePlay
+                }
+            } else {
+                return editStartTime
+            }
+        case .paused:
             return pausedTime
+        default:
+            return editStartTime
         }
-        return editStartTime
     }
 
     /// Sets the player's audio file to a certain time in the track (in seconds)

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -152,9 +152,6 @@ public class AudioPlayer: Node {
         }
     }
 
-    // Internal variable to keep track of how much time before the player is scheduled to play
-    var timeBeforePlay = 0.0
-
     // MARK: - Internal properties
 
     // Time in audio file where track was stopped (allows retrieval of playback time after playerNode is paused)

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -152,6 +152,9 @@ public class AudioPlayer: Node {
         }
     }
 
+    // Internal variable to keep track of how much time before the player is scheduled to play
+    var timeBeforePlay = 0.0
+
     // MARK: - Internal properties
 
     // Time in audio file where track was stopped (allows retrieval of playback time after playerNode is paused)

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
@@ -130,30 +130,15 @@ extension AudioPlayerFileTests {
         }
 
         // test schedule with play
-        let timeBeforePlay = 3.0
-        player.play(at: AVAudioTime.now().offset(seconds: timeBeforePlay))
+        player.play(at: AVAudioTime.now().offset(seconds: 3))
 
-        // Make sure player doesn't count time before file starts playing
-        var playerTime = player.getCurrentTime()
-        XCTAssert(playerTime == 0)
-        wait(for: timeBeforePlay)
-        playerTime = player.getCurrentTime()
-        XCTAssert(playerTime < timeBeforePlay)
-
-        wait(for: player.duration)
+        wait(for: player.duration + 4)
 
         // test schedule separated from play
-        player.schedule(at: AVAudioTime.now().offset(seconds: timeBeforePlay))
+        player.schedule(at: AVAudioTime.now().offset(seconds: 3))
         player.play()
 
-        // Make sure player doesn't count time before file starts playing
-        playerTime = player.getCurrentTime()
-        XCTAssert(playerTime == 0)
-        wait(for: timeBeforePlay)
-        playerTime = player.getCurrentTime()
-        XCTAssert(playerTime < timeBeforePlay)
-
-        wait(for: player.duration)
+        wait(for: player.duration + 4)
 
         XCTAssertEqual(completionCounter, 2, "Completion handler wasn't called on both completions")
     }

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
@@ -130,15 +130,17 @@ extension AudioPlayerFileTests {
         }
 
         // test schedule with play
-        let timeBeforePlay = 3.0
-        player.play(at: AVAudioTime.now().offset(seconds: timeBeforePlay))
+        let timeBeforePlay = 0.6
+        player.play(from: 3.1, at: AVAudioTime.now().offset(seconds: timeBeforePlay))
 
         // Make sure player doesn't count time before file starts playing
-        var playerTime = player.getCurrentTime()
-        XCTAssert(playerTime == 0)
+        // Truncate time to one decimal for precision in comparison
+        var playerTime = Double(floor(pow(10.0, Double(1)) * player.getCurrentTime())/pow(10.0, Double(1)))
+        XCTAssert(playerTime == player.editStartTime)
         wait(for: timeBeforePlay)
-        playerTime = player.getCurrentTime()
-        XCTAssert(playerTime < timeBeforePlay)
+        // Truncate time to one decimal for precision in comparison
+        playerTime = Double(floor(pow(10.0, Double(1)) * player.getCurrentTime())/pow(10.0, Double(1)))
+        XCTAssert(playerTime == player.editStartTime)
 
         wait(for: player.duration)
 
@@ -147,11 +149,13 @@ extension AudioPlayerFileTests {
         player.play()
 
         // Make sure player doesn't count time before file starts playing
-        playerTime = player.getCurrentTime()
-        XCTAssert(playerTime == 0)
+        // Truncate time to one decimal for precision in comparison
+        playerTime = Double(floor(pow(10.0, Double(1)) * player.getCurrentTime())/pow(10.0, Double(1)))
+        XCTAssert(playerTime == player.editStartTime)
         wait(for: timeBeforePlay)
-        playerTime = player.getCurrentTime()
-        XCTAssert(playerTime < timeBeforePlay)
+        // Truncate time to one decimal for precision in comparison
+        playerTime = Double(floor(pow(10.0, Double(1)) * player.getCurrentTime())/pow(10.0, Double(1)))
+        XCTAssert(playerTime == player.editStartTime)
 
         wait(for: player.duration)
 

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
@@ -130,15 +130,30 @@ extension AudioPlayerFileTests {
         }
 
         // test schedule with play
-        player.play(at: AVAudioTime.now().offset(seconds: 3))
+        let timeBeforePlay = 3.0
+        player.play(at: AVAudioTime.now().offset(seconds: timeBeforePlay))
 
-        wait(for: player.duration + 4)
+        // Make sure player doesn't count time before file starts playing
+        var playerTime = player.getCurrentTime()
+        XCTAssert(playerTime == 0)
+        wait(for: timeBeforePlay)
+        playerTime = player.getCurrentTime()
+        XCTAssert(playerTime < timeBeforePlay)
+
+        wait(for: player.duration)
 
         // test schedule separated from play
-        player.schedule(at: AVAudioTime.now().offset(seconds: 3))
+        player.schedule(at: AVAudioTime.now().offset(seconds: timeBeforePlay))
         player.play()
 
-        wait(for: player.duration + 4)
+        // Make sure player doesn't count time before file starts playing
+        playerTime = player.getCurrentTime()
+        XCTAssert(playerTime == 0)
+        wait(for: timeBeforePlay)
+        playerTime = player.getCurrentTime()
+        XCTAssert(playerTime < timeBeforePlay)
+
+        wait(for: player.duration)
 
         XCTAssertEqual(completionCounter, 2, "Completion handler wasn't called on both completions")
     }


### PR DESCRIPTION
This is again to address #2691 and #2708, but this includes the tests for that. I also refactored the `getCurrentTime()` function so it matches the style of the `play()` function now, using the player's `NodeStatus` enums.
