### PR TITLE
[AudioEngine] - add `findAudioUnit`

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -239,19 +239,18 @@ public class AudioEngine {
         return buffer
     }
 
-    /// Find an Audio Unit on the system by name and load it
+    /// Find an Audio Unit on the system by name and load it.
+    /// Run this before processing any audio to avoid blocking.
     /// - Parameter named: Display name of the Audio Unit
     /// - Returns: The Audio Unit's AVAudioUnit
     public func findAudioUnit(named: String) -> AVAudioUnit? {
         var foundAU: AVAudioUnit?
-        for component in AVAudioUnitComponentManager().components(matching: AudioComponentDescription()) {
-            if component.name == named {
-                AVAudioUnit.instantiate(with: component.audioComponentDescription) { theAudioUnit, _ in
-                    if let newAU = theAudioUnit {
-                        foundAU = newAU
-                    } else {
-                        Log("🛑 Failed to load Audio Unit named: \(named)")
-                    }
+        for component in AVAudioUnitComponentManager().components(matching: AudioComponentDescription()) where component.name == named {
+            AVAudioUnit.instantiate(with: component.audioComponentDescription) { theAudioUnit, _ in
+                if let newAU = theAudioUnit {
+                    foundAU = newAU
+                } else {
+                    Log("🛑 Failed to load Audio Unit named: \(named)")
                 }
             }
         }

--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -239,6 +239,26 @@ public class AudioEngine {
         return buffer
     }
 
+    /// Find an Audio Unit on the system by name and load it
+    /// - Parameter named: Display name of the Audio Unit
+    /// - Returns: The Audio Unit's AVAudioUnit
+    public func findAudioUnit(named: String) -> AVAudioUnit? {
+        var foundAU: AVAudioUnit?
+        for component in AVAudioUnitComponentManager().components(matching: AudioComponentDescription()) {
+            if component.name == named {
+                AVAudioUnit.instantiate(with: component.audioComponentDescription) { theAudioUnit, _ in
+                    if let newAU = theAudioUnit {
+                        foundAU = newAU
+                    } else {
+                        Log("🛑 Failed to load Audio Unit named: \(named)")
+                    }
+                }
+            }
+        }
+        if foundAU == nil { Log("🛑 Failed to find Audio Unit named: \(named)") }
+        return foundAU
+    }
+
     /// Enumerate the list of available input devices.
     public static var inputDevices: [Device] {
         #if os(macOS)

--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -240,12 +240,13 @@ public class AudioEngine {
     }
 
     /// Find an Audio Unit on the system by name and load it.
-    /// Run this before processing any audio to avoid blocking.
+    /// Make sure to do this before the engine is running to avoid blocking.
     /// - Parameter named: Display name of the Audio Unit
     /// - Returns: The Audio Unit's AVAudioUnit
     public func findAudioUnit(named: String) -> AVAudioUnit? {
         var foundAU: AVAudioUnit?
-        for component in AVAudioUnitComponentManager().components(matching: AudioComponentDescription()) where component.name == named {
+        let allComponents = AVAudioUnitComponentManager().components(matching: AudioComponentDescription())
+        for component in allComponents where component.name == named {
             AVAudioUnit.instantiate(with: component.audioComponentDescription) { theAudioUnit, _ in
                 if let newAU = theAudioUnit {
                     foundAU = newAU

--- a/Tests/AudioKitTests/EngineTests.swift
+++ b/Tests/AudioKitTests/EngineTests.swift
@@ -199,4 +199,12 @@ class EngineTests: XCTestCase {
     func testInputDevices() {
         XCTAssert(AudioEngine.inputDevices.count > 0)
     }
+
+    func testGetAudioUnit() {
+        let engine = AudioEngine()
+        let delayAVAudioUnit = engine.findAudioUnit(named: "AUDelay")
+        XCTAssertNotNil(delayAVAudioUnit)
+        let unknownAVAudioUnit = engine.findAudioUnit(named: "su·per·ca·li·fra·gil·is·tic·ex·pi·a·li·do·cious")
+        XCTAssertNil(unknownAVAudioUnit)
+    }
 }


### PR DESCRIPTION
This function uses the AVFoundation framework to provide an easy way for users to find and instantiate an audio unit on their system.
