### PR TITLE
Add File Open/Close Functions for `NodeRecorder`

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -112,18 +112,7 @@ open class NodeRecorder: NSObject {
             // Keep track of file URL before closing
             recordedFileURL = fileURL
         }
-        guard let engine = self.node.avAudioNode.engine else {
-            Log("Error: Can't close file because NodeRecorder has no engine!")
-            return
-        }
-        // Need to pause rendering because closing the file can interfere with audio thread
-        engine.pause()
         file = nil
-        do {
-            try engine.start()
-        } catch let err {
-            Log(err.localizedDescription, type: .error)
-        }
     }
 
     /// Returns a CAF file in specified directory suitable for writing to via Settings.audioFormat

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -41,7 +41,7 @@ open class NodeRecorder: NSObject {
     /// return the AVAudioFile for reading
     open var audioFile: AVAudioFile? {
         do {
-            guard let url = internalAudioFile?.url else { return nil }
+            guard let url = recordedFileURL else { return nil }
             return try AVAudioFile(forReading: url)
 
         } catch let error as NSError {
@@ -51,6 +51,8 @@ open class NodeRecorder: NSObject {
     }
 
     private var fileDirectoryURL: URL
+
+    private var recordedFileURL: URL?
 
     private static var recordedFiles = [URL]()
 
@@ -62,19 +64,17 @@ open class NodeRecorder: NSObject {
     ///
     /// - Parameters:
     ///   - node: Node to record from
-    ///   - file: Audio file to record to
     ///   - fileDirectoryPath: Directory to write audio files to
     ///   - bus: Integer index of the bus to use
     ///
     public init(node: Node,
-                file: AVAudioFile? = nil,
                 fileDirectoryURL: URL? = nil,
                 bus: Int = 0) throws {
         self.node = node
         self.fileDirectoryURL = fileDirectoryURL ?? URL(fileURLWithPath: NSTemporaryDirectory())
         super.init()
 
-        let audioFile = file ?? NodeRecorder.createAudioFile(fileDirectoryURL: self.fileDirectoryURL)
+        let audioFile = NodeRecorder.createAudioFile(fileDirectoryURL: self.fileDirectoryURL)
 
         guard audioFile != nil else {
             Log("Error, no file to write to")
@@ -86,6 +86,8 @@ open class NodeRecorder: NSObject {
         self.bus = bus
     }
 
+    deinit { NodeRecorder.removeRecordedFiles() }
+
     // MARK: - Methods
 
     /// Use Date and Time as Filename
@@ -93,6 +95,24 @@ open class NodeRecorder: NSObject {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss.SSSS"
         return dateFormatter.string(from: Date())
+    }
+    
+    /// Open file a for recording
+    /// - Parameter file: Reference to the file you want to record to
+    public func openFile(file: inout AVAudioFile?) {
+        internalAudioFile = file
+        // Close the file object passed in, try returning another one for reading after
+        closeFile(file: &file)
+    }
+
+    /// Close file after recording
+    /// - Parameter file: Reference to the file you want to close
+    public func closeFile(file: inout AVAudioFile?) {
+        if let fileURL = file?.url {
+            // Keep track of file URL before closing
+            recordedFileURL = fileURL
+        }
+        file = nil
     }
 
     /// Returns a CAF file in specified directory suitable for writing to via Settings.audioFormat
@@ -191,6 +211,7 @@ open class NodeRecorder: NSObject {
             usleep(delay)
         }
         node.avAudioNode.removeTap(onBus: bus)
+        closeFile(file: &internalAudioFile)
     }
 
     /// Reset the AVAudioFile to clear previous recordings

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -96,7 +96,7 @@ open class NodeRecorder: NSObject {
         dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss.SSSS"
         return dateFormatter.string(from: Date())
     }
-    
+
     /// Open file a for recording
     /// - Parameter file: Reference to the file you want to record to
     public func openFile(file: inout AVAudioFile?) {

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -112,7 +112,18 @@ open class NodeRecorder: NSObject {
             // Keep track of file URL before closing
             recordedFileURL = fileURL
         }
+        guard let engine = self.node.avAudioNode.engine else {
+            Log("Error: Can't close file because NodeRecorder has no engine!")
+            return
+        }
+        // Need to pause rendering because closing the file can interfere with audio thread
+        engine.pause()
         file = nil
+        do {
+            try engine.start()
+        } catch let err {
+            Log(err.localizedDescription, type: .error)
+        }
     }
 
     /// Returns a CAF file in specified directory suitable for writing to via Settings.audioFormat

--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -32,7 +32,7 @@ class AVAudioPCMBufferTests: XCTestCase {
             let recorder = try? NodeRecorder(node: osc)
             recorder?.openFile(file: &outFile)
             engine.output = osc
-            try! recorder?.record()
+            try? recorder?.record()
             try! engine.start()
             sleep(2)
             recorder?.stop()

--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -29,13 +29,13 @@ class AVAudioPCMBufferTests: XCTestCase {
         if #available(iOS 13.0, *) {
             let osc = PlaygroundOscillator()
             osc.start()
-            let recorder = try! NodeRecorder(node: osc)
-            recorder.openFile(file: &outFile)
+            let recorder = try? NodeRecorder(node: osc)
+            recorder?.openFile(file: &outFile)
             engine.output = osc
-            try! recorder.record()
+            try! recorder?.record()
             try! engine.start()
             sleep(2)
-            recorder.stop()
+            recorder?.stop()
             engine.stop()
         } else {
             // Fallback on earlier versions

--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -21,7 +21,7 @@ class AVAudioPCMBufferTests: XCTestCase {
         settings[AVFormatIDKey] = kAudioFormatMPEG4AAC
         settings[AVLinearPCMIsNonInterleaved] = NSNumber(value: false)
 
-        let outFile = try! AVAudioFile(
+        var outFile = try? AVAudioFile(
             forWriting: url,
             settings: settings)
 
@@ -29,7 +29,8 @@ class AVAudioPCMBufferTests: XCTestCase {
         if #available(iOS 13.0, *) {
             let osc = PlaygroundOscillator()
             osc.start()
-            let recorder = try! NodeRecorder(node: osc, file: outFile)
+            let recorder = try! NodeRecorder(node: osc)
+            recorder.openFile(file: &outFile)
             engine.output = osc
             try! recorder.record()
             try! engine.start()

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -85,6 +85,7 @@ class RecordingTests: AudioFileTestCase {
         let osc = PlaygroundOscillator()
         let recorder = try? NodeRecorder(node: osc)
         recorder?.openFile(file: &outFile)
+        let player = AudioPlayer()
         engine.output = osc
 
         try? engine.start()
@@ -94,12 +95,18 @@ class RecordingTests: AudioFileTestCase {
         recorder?.stop()
         osc.stop()
         engine.stop()
+        engine.output = player
         recorder?.closeFile(file: &outFile)
         guard let recordedFile = recorder?.audioFile else {
             XCTFail("Couldn't open recorded audio file!")
             return
         }
-        XCTAssert(recordedFile.length > 0)
+        wait(for: 2)
+
+        player.file = recordedFile
+        try? engine.start()
+        player.play()
+        wait(for: 2)
     }
 }
 #endif

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -67,11 +67,11 @@ class RecordingTests: AudioFileTestCase {
 
         engine.stop()
     }
-    
+
     func testOpenCloseFile() {
-        let fm = FileManager.default
+        let fileManager = FileManager.default
         let filename = UUID().uuidString + ".m4a"
-        let fileUrl = fm.temporaryDirectory.appendingPathComponent(filename)
+        let fileUrl = fileManager.temporaryDirectory.appendingPathComponent(filename)
 
         var settings = Settings.audioFormat.settings
         settings[AVFormatIDKey] = kAudioFormatMPEG4AAC
@@ -83,28 +83,28 @@ class RecordingTests: AudioFileTestCase {
 
         let engine = AudioEngine()
         let osc = PlaygroundOscillator()
-        let recorder = try! NodeRecorder(node: osc)
-        recorder.openFile(file: &outFile)
+        let recorder = try? NodeRecorder(node: osc)
+        recorder?.openFile(file: &outFile)
         let player = AudioPlayer()
         engine.output = osc
 
-        try! engine.start()
+        try? engine.start()
         osc.start()
-        try! recorder.record()
+        try? recorder?.record()
         wait(for: 2)
-        recorder.stop()
+        recorder?.stop()
         osc.stop()
         engine.stop()
         engine.output = player
-        recorder.closeFile(file: &outFile)
-        guard let recordedFile = recorder.audioFile else {
+        recorder?.closeFile(file: &outFile)
+        guard let recordedFile = recorder?.audioFile else {
             XCTFail("Couldn't open recorded audio file!")
             return
         }
         wait(for: 2)
 
         player.file = recordedFile
-        try! engine.start()
+        try? engine.start()
         player.play()
         wait(for: 2)
     }

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -85,7 +85,6 @@ class RecordingTests: AudioFileTestCase {
         let osc = PlaygroundOscillator()
         let recorder = try? NodeRecorder(node: osc)
         recorder?.openFile(file: &outFile)
-        let player = AudioPlayer()
         engine.output = osc
 
         try? engine.start()
@@ -95,18 +94,12 @@ class RecordingTests: AudioFileTestCase {
         recorder?.stop()
         osc.stop()
         engine.stop()
-        engine.output = player
         recorder?.closeFile(file: &outFile)
         guard let recordedFile = recorder?.audioFile else {
             XCTFail("Couldn't open recorded audio file!")
             return
         }
-        wait(for: 2)
-
-        player.file = recordedFile
-        try? engine.start()
-        player.play()
-        wait(for: 2)
+        XCTAssert(recordedFile.length > 0)
     }
 }
 #endif


### PR DESCRIPTION
Changes:

1. Removed `file` parameter from initialization - this passes the value without a reference, leaving the user with the possible mistake of forgetting to close the file outside the scope of `NodeRecorder`

2. Added `deinit` so temp files can be deleted after the recorder is done being used

3. Added `openFile` function

4. Added `closeFile` function

5. Added a `recordedFileURL` to keep track of the url of the most recently closed file

6. Modified `audioFile` computed variable to return a file for reading based on the `recordedFileURL`

7. Changed the `AVAudioPCMBufferTests` to work with the new `NodeRecorder`

8. Added `NodeRecorder` tests which use `openFile` and `closeFile`

This should now make the test demonstrated in #2634 pass if the new `NodeRecorder` is used accordingly
