### PR TITLE
[AudioPlayer] - Tests for player status

### DIFF
--- a/Sources/AudioKit/Nodes/NodeStatus.swift
+++ b/Sources/AudioKit/Nodes/NodeStatus.swift
@@ -12,7 +12,5 @@ public enum NodeStatus {
         case paused
         /// The player node is scheduling.
         case scheduling
-        /// The player node completed playback.
-        case completed
     }
 }

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -47,20 +47,12 @@ extension AudioPlayer {
         case .scheduling:
             // player is already scheduling
             return
-        case .completed:
-            // reset the status and play again if isLooping and not buffered
-            status = .stopped
-            if isLooping && !isBuffered {
-                play()
-            } else {
-                playerNode.stop()
-            }
         }
     }
 
     /// Pauses audio player. Calling play() will resume from the paused time.
     public func pause() {
-        guard status == .playing || status == .completed else { return }
+        guard status == .playing else { return }
         pausedTime = getCurrentTime()
         playerNode.pause()
         status = .paused

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -186,10 +186,13 @@ public class AudioPlayer: Node {
         guard status == .playing,
                 engine?.isInManualRenderingMode == false else { return }
 
-        status = .completed
+        status = .stopped
 
         completionHandler?()
-        play()
+
+        if isLooping && !isBuffered {
+            play()
+        }
     }
 
     // MARK: - Init

--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -42,8 +42,8 @@ class AVAudioPCMBufferTests: XCTestCase {
         }
     }
 
+    // This get's stuck in CI sometimes
     func testM4A() {
-
         let fm = FileManager.default
 
         let filename = UUID().uuidString + ".m4a"

--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -42,8 +42,8 @@ class AVAudioPCMBufferTests: XCTestCase {
         }
     }
 
-    // This get's stuck in CI sometimes
     func testM4A() {
+
         let fm = FileManager.default
 
         let filename = UUID().uuidString + ".m4a"

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+Realtime.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+Realtime.swift
@@ -23,7 +23,7 @@ extension AudioPlayerFileTests {
 
     func testFileLooping() {
         guard realtimeEnabled else { return }
-        realtimeLoop(buffered: false, duration: 2)
+        realtimeLoop(buffered: false, duration: 5)
     }
 
     func testBufferLooping() {
@@ -70,5 +70,10 @@ extension AudioPlayerFileTests {
     func testReversed() {
         guard realtimeEnabled else { return }
         realtimeTestReversed(from: 1, to: 3)
+    }
+    
+    func testPlayerStatus() {
+        guard realtimeEnabled else { return }
+        realtimeTestPlayerStatus()
     }
 }

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+Realtime.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+Realtime.swift
@@ -71,7 +71,7 @@ extension AudioPlayerFileTests {
         guard realtimeEnabled else { return }
         realtimeTestReversed(from: 1, to: 3)
     }
-    
+
     func testPlayerStatus() {
         guard realtimeEnabled else { return }
         realtimeTestPlayerStatus()

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
@@ -329,7 +329,7 @@ extension AudioPlayerFileTests {
         }
         player.stop()
     }
-    
+
     func realtimeTestPlayerStatus() {
         guard let countingURL = countingURL else {
             XCTFail("Didn't find the 12345.wav")

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
@@ -185,7 +185,7 @@ extension AudioPlayerFileTests {
         player.isLooping = true
         player.play()
 
-        wait(for: 5)
+        wait(for: 10)
         player.stop()
     }
 
@@ -328,6 +328,40 @@ extension AudioPlayerFileTests {
             wait(for: 1)
         }
         player.stop()
+    }
+    
+    func realtimeTestPlayerStatus() {
+        guard let countingURL = countingURL else {
+            XCTFail("Didn't find the 12345.wav")
+            return
+        }
+        guard let drumloopURL = drumloopURL else {
+            XCTFail("Didn't find the 12345.wav")
+            return
+        }
+        guard let countingFile = try? AVAudioFile(forReading: countingURL) else {
+            XCTFail("Failed to open file URL \(countingURL) for reading")
+            return
+        }
+        guard let drumloopFile = try? AVAudioFile(forReading: drumloopURL) else {
+            XCTFail("Failed to open file URL \(drumloopURL) for reading")
+            return
+        }
+
+        let engine = AudioEngine()
+        let player = AudioPlayer()
+        engine.output = player
+        try? engine.start()
+
+        player.file = countingFile
+        player.play()
+        wait(for: 1)
+        player.stop()
+        player.file = drumloopFile
+        player.play()
+        XCTAssert(player.status == .playing)
+        wait(for: 4)
+        XCTAssert(player.status == .stopped)
     }
 }
 

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -68,6 +68,7 @@ class RecordingTests: AudioFileTestCase {
         engine.stop()
     }
 
+    // This gets stuck in CI sometimes
     func testOpenCloseFile() {
         guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
               let file = try? AVAudioFile(forReading: url) else {


### PR DESCRIPTION
There weren't any tests for the `AudioPlayer` status after two different files are loaded, so I added one.

Changes:
1.  Removed `completed` status.
2. Move looping check inside `completionHandler`
3. Fix `testFileLooping` to use a file which exists.
4. Add tests for AudioKit/Cookbook#97
