### PR TITLE
[AudioPlayer] - Fixing `internalAudioFile` so pointers are more safe - helping workflows and CI

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -101,9 +101,11 @@ open class NodeRecorder: NSObject {
     }
 
     /// Open file a for recording
-    /// - Parameter file: Reference to the file you want to record to
+    /// - Parameter file: Reference to the file you want to record to.
+    /// Has to be optional because this file will be set to `nil` when the recorder is done using it.
     public func openFile(file: inout AVAudioFile?) {
         // Close the file object passed in, try returning another one for reading after
+        openFile(file: &file)
         closeFile(file: &file)
     }
 

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -105,7 +105,6 @@ open class NodeRecorder: NSObject {
     /// Has to be optional because this file will be set to `nil` when the recorder is done using it.
     public func openFile(file: inout AVAudioFile?) {
         // Close the file object passed in, try returning another one for reading after
-        openFile(file: &file)
         closeFile(file: &file)
     }
 

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -40,6 +40,7 @@ open class NodeRecorder: NSObject {
 
     /// return the AVAudioFile for reading
     open var audioFile: AVAudioFile? {
+        // Close the writing file locally before trying to read
         if internalAudioFile != nil { internalAudioFile = nil }
         do {
             guard let url = recordedFileURL else { return nil }

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -55,8 +55,8 @@ open class NodeRecorder: NSObject {
     private var fileDirectoryURL: URL
 
     private var recordedFileURL: URL?
-    
-    private var recordedFileSettings: [String : Any]?
+
+    private var recordedFileSettings: [String:Any]?
 
     private static var recordedFiles = [URL]()
 

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -56,7 +56,7 @@ open class NodeRecorder: NSObject {
 
     private var recordedFileURL: URL?
 
-    private var recordedFileSettings: [String:Any]?
+    private var recordedFileSettings: [String: Any]?
 
     private static var recordedFiles = [URL]()
 

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -103,7 +103,6 @@ open class NodeRecorder: NSObject {
     /// Open file a for recording
     /// - Parameter file: Reference to the file you want to record to
     public func openFile(file: inout AVAudioFile?) {
-        //internalAudioFile = file
         // Close the file object passed in, try returning another one for reading after
         closeFile(file: &file)
     }
@@ -112,7 +111,7 @@ open class NodeRecorder: NSObject {
     /// - Parameter file: Reference to the file you want to close
     public func closeFile(file: inout AVAudioFile?) {
         if let inFile = file {
-            // Keep track of file URL before closing
+            // Keep track of file URL/settings before closing
             recordedFileURL = inFile.url
             recordedFileSettings = inFile.fileFormat.settings
         }
@@ -176,16 +175,18 @@ open class NodeRecorder: NSObject {
             isRecording = false
             return
         }
-        
+
         guard let writeToURL = recordedFileURL, let writeToSettings = recordedFileSettings else {
             Log("🛑 Error: No file URL/settings to record to", type: .error)
             return
         }
-        
+
         do {
-            internalAudioFile = try AVAudioFile(forWriting: writeToURL, settings: writeToSettings)
+            internalAudioFile = try AVAudioFile(forWriting: writeToURL,
+                                                settings: writeToSettings)
         } catch let err {
-            Log("🛑 Error: Couldn't create internal file because of this error: \(err.localizedDescription)", type: .error)
+            Log("🛑 Error: Couldn't create internal file error: \(err.localizedDescription)",
+                type: .error)
         }
 
         node.avAudioNode.installTap(onBus: bus,

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -40,6 +40,7 @@ open class NodeRecorder: NSObject {
 
     /// return the AVAudioFile for reading
     open var audioFile: AVAudioFile? {
+        if internalAudioFile != nil { internalAudioFile = nil }
         do {
             guard let url = recordedFileURL else { return nil }
             return try AVAudioFile(forReading: url)
@@ -211,7 +212,6 @@ open class NodeRecorder: NSObject {
             usleep(delay)
         }
         node.avAudioNode.removeTap(onBus: bus)
-        closeFile(file: &internalAudioFile)
     }
 
     /// Reset the AVAudioFile to clear previous recordings

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -151,6 +151,19 @@ open class NodeRecorder: NSObject {
             return
         }
 
+        guard let writeToURL = recordedFileURL, let writeToSettings = recordedFileSettings else {
+            Log("🛑 Error: No file URL/settings to record to", type: .error)
+            return
+        }
+
+        do {
+            internalAudioFile = try AVAudioFile(forWriting: writeToURL,
+                                                settings: writeToSettings)
+        } catch let err {
+            Log("🛑 Error: Couldn't create internal file error: \(err.localizedDescription)",
+                type: .error)
+        }
+
         if let path = internalAudioFile?.url.path, !FileManager.default.fileExists(atPath: path) {
             // record to new audio file
             if let audioFile = NodeRecorder.createAudioFile(fileDirectoryURL: fileDirectoryURL) {
@@ -176,19 +189,6 @@ open class NodeRecorder: NSObject {
             Log("🛑 Error: Error recording. Input node '\(node)' has no engine.")
             isRecording = false
             return
-        }
-
-        guard let writeToURL = recordedFileURL, let writeToSettings = recordedFileSettings else {
-            Log("🛑 Error: No file URL/settings to record to", type: .error)
-            return
-        }
-
-        do {
-            internalAudioFile = try AVAudioFile(forWriting: writeToURL,
-                                                settings: writeToSettings)
-        } catch let err {
-            Log("🛑 Error: Couldn't create internal file error: \(err.localizedDescription)",
-                type: .error)
         }
 
         node.avAudioNode.installTap(onBus: bus,


### PR DESCRIPTION
I noticed more of the workflows were running successfully, both on my machine and with `build.yml` when I pushed these commits and made adjustments to the `internalAudioFile`. There's still a run every once in a while when it freezes up, but the probability is smaller now. 

Tomorrow I'm going to check out [`XCTestExpectation`](https://developer.apple.com/documentation/xctest/asynchronous_tests_and_expectations). It seems like it would be useful to add in another PR. I would add it here, but there's a lot of commits, and my brain is fried for the day. I thought it would be best to start with a clean slate tomorrow.