### PR TITLE
[`AVAudioSourceNode`] - Fix semaphore wait trap

### DIFF
--- a/Sources/AudioKit/Nodes/Generators/PlaygroundNoiseGenerator.swift
+++ b/Sources/AudioKit/Nodes/Generators/PlaygroundNoiseGenerator.swift
@@ -9,16 +9,25 @@ public class PlaygroundNoiseGenerator: Node {
     fileprivate lazy var sourceNode = AVAudioSourceNode { [self] _, _, frameCount, audioBufferList in
         let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
         
-        for frame in 0..<Int(frameCount) {
-            // Get signal value for this frame at time.
-            let value = self.amplitude * Float.random(in: -1 ... 1)
-            
-            // Set the same value on all channels (due to the inputFormat we have only 1 channel though).
-            for buffer in ablPointer {
-                let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
-                buf[frame] = self.isStarted ? value : 0
+        if isStarted {
+            for frame in 0..<Int(frameCount) {
+                // Get signal value for this frame at time.
+                let value = self.amplitude * Float.random(in: -1 ... 1)
+
+                // Set the same value on all channels (due to the inputFormat we have only 1 channel though).
+                for buffer in ablPointer {
+                    let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
+                    buf[frame] = value
+                }
+
             }
-            
+        } else {
+            for frame in 0..<Int(frameCount) {
+                for buffer in ablPointer {
+                    let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
+                    buf[frame] = 0
+                }
+            }
         }
         return noErr
     }

--- a/Sources/AudioKit/Nodes/Generators/PlaygroundOscillator.swift
+++ b/Sources/AudioKit/Nodes/Generators/PlaygroundOscillator.swift
@@ -11,20 +11,29 @@ public class PlaygroundOscillator: Node {
     fileprivate lazy var sourceNode = AVAudioSourceNode { [self] _, _, frameCount, audioBufferList in
         let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
         
-        let phaseIncrement = (twoPi / Float(Settings.sampleRate)) * self.frequency
-        for frame in 0..<Int(frameCount) {
-            // Get signal value for this frame at time.
-            let index = Int(self.currentPhase / twoPi * Float(self.waveform!.count))
-            let value = self.waveform![index] * self.amplitude
+        if isStarted {
+            let phaseIncrement = (twoPi / Float(Settings.sampleRate)) * self.frequency
+            for frame in 0..<Int(frameCount) {
+                // Get signal value for this frame at time.
+                let index = Int(self.currentPhase / twoPi * Float(self.waveform!.count))
+                let value = self.waveform![index] * self.amplitude
 
-            // Advance the phase for the next frame.
-            self.currentPhase += phaseIncrement
-            if self.currentPhase >= twoPi { self.currentPhase -= twoPi }
-            if self.currentPhase < 0.0 { self.currentPhase += twoPi }
-            // Set the same value on all channels (due to the inputFormat we have only 1 channel though).
-            for buffer in ablPointer {
-                let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
-                buf[frame] = self.isStarted ? value : 0
+                // Advance the phase for the next frame.
+                self.currentPhase += phaseIncrement
+                if self.currentPhase >= twoPi { self.currentPhase -= twoPi }
+                if self.currentPhase < 0.0 { self.currentPhase += twoPi }
+                // Set the same value on all channels (due to the inputFormat we have only 1 channel though).
+                for buffer in ablPointer {
+                    let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
+                    buf[frame] = value
+                }
+            }
+        } else {
+            for frame in 0..<Int(frameCount) {
+                for buffer in ablPointer {
+                    let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
+                    buf[frame] = 0
+                }
             }
         }
         return noErr

--- a/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
+++ b/Tests/AudioKitTests/Extension Tests/AVAudioPCMBufferTests.swift
@@ -36,6 +36,7 @@ class AVAudioPCMBufferTests: XCTestCase {
             try! engine.start()
             sleep(2)
             recorder?.stop()
+            osc.stop()
             engine.stop()
         } else {
             // Fallback on earlier versions


### PR DESCRIPTION
Fix a weird bug which happens when removing the `NodeRecorder` tap:

<img width="1390" alt="Screen Shot 2022-05-19 at 10 53 56 PM" src="https://user-images.githubusercontent.com/15041342/169466037-69da20b4-0660-40fe-b4b1-2fc8e3b45c79.png">

