### PR TITLE
[`NodeRecorder`] - Pause recording feature

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -12,6 +12,9 @@ open class NodeRecorder: NSObject {
     /// True if we are recording.
     public private(set) var isRecording = false
 
+    /// True if we are paused
+    public private(set) var isPaused = false
+
     /// An optional duration for the recording to auto-stop when reached
     open var durationToRecord: Double = 0
 
@@ -201,14 +204,15 @@ open class NodeRecorder: NSObject {
         guard let internalAudioFile = internalAudioFile else { return }
 
         do {
-            recordBufferDuration = Double(buffer.frameLength) / Settings.sampleRate
-            try internalAudioFile.write(from: buffer)
+            if !isPaused {
+                recordBufferDuration = Double(buffer.frameLength) / Settings.sampleRate
+                try internalAudioFile.write(from: buffer)
 
-            // allow an optional timed stop
-            if durationToRecord != 0 && internalAudioFile.duration >= durationToRecord {
-                stop()
+                // allow an optional timed stop
+                if durationToRecord != 0 && internalAudioFile.duration >= durationToRecord {
+                    stop()
+                }
             }
-
         } catch let error as NSError {
             Log("Write failed: error -> \(error.localizedDescription)")
         }
@@ -229,6 +233,16 @@ open class NodeRecorder: NSObject {
             usleep(delay)
         }
         node.avAudioNode.removeTap(onBus: bus)
+    }
+
+    /// Pause recording
+    public func pause() {
+        isPaused = true
+    }
+
+    /// Resume recording
+    public func resume() {
+        isPaused = false
     }
 
     /// Reset the AVAudioFile to clear previous recordings

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -67,14 +67,14 @@ class RecordingTests: AudioFileTestCase {
 
         engine.stop()
     }
-    
+
     func createFileURL() -> URL {
         let fileManager = FileManager.default
         let filename = UUID().uuidString + ".m4a"
         let fileUrl = fileManager.temporaryDirectory.appendingPathComponent(filename)
         return fileUrl
     }
-    
+
     func getSettings() -> [String: Any] {
         var settings = Settings.audioFormat.settings
         settings[AVFormatIDKey] = kAudioFormatMPEG4AAC
@@ -131,7 +131,7 @@ class RecordingTests: AudioFileTestCase {
         player.play()
         wait(for: 2)
     }
-    
+
     func testPauseRecording() {
         guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
               let file = try? AVAudioFile(forReading: url) else {

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -67,6 +67,20 @@ class RecordingTests: AudioFileTestCase {
 
         engine.stop()
     }
+    
+    func createFileURL() -> URL {
+        let fileManager = FileManager.default
+        let filename = UUID().uuidString + ".m4a"
+        let fileUrl = fileManager.temporaryDirectory.appendingPathComponent(filename)
+        return fileUrl
+    }
+    
+    func getSettings() -> [String: Any] {
+        var settings = Settings.audioFormat.settings
+        settings[AVFormatIDKey] = kAudioFormatMPEG4AAC
+        settings[AVLinearPCMIsNonInterleaved] = NSNumber(value: false)
+        return settings
+    }
 
     func testOpenCloseFile() {
         guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
@@ -74,16 +88,12 @@ class RecordingTests: AudioFileTestCase {
             XCTFail("Didn't get test file")
             return
         }
-        let fileManager = FileManager.default
-        let filename = UUID().uuidString + ".m4a"
-        let fileUrl = fileManager.temporaryDirectory.appendingPathComponent(filename)
 
-        var settings = Settings.audioFormat.settings
-        settings[AVFormatIDKey] = kAudioFormatMPEG4AAC
-        settings[AVLinearPCMIsNonInterleaved] = NSNumber(value: false)
+        let fileURL = createFileURL()
+        let settings = getSettings()
 
         var outFile = try? AVAudioFile(
-            forWriting: fileUrl,
+            forWriting: fileURL,
             settings: settings)
 
         let engine = AudioEngine()
@@ -92,6 +102,7 @@ class RecordingTests: AudioFileTestCase {
             XCTFail("Couldn't load input Node.")
             return
         }
+
         let recorder = try? NodeRecorder(node: input)
         recorder?.openFile(file: &outFile)
         let player = AudioPlayer()
@@ -101,11 +112,14 @@ class RecordingTests: AudioFileTestCase {
         input.start()
         try? recorder?.record()
         wait(for: 2)
+
         recorder?.stop()
         input.stop()
         engine.stop()
+
         engine.output = player
         recorder?.closeFile(file: &outFile)
+
         guard let recordedFile = recorder?.audioFile else {
             XCTFail("Couldn't open recorded audio file!")
             return
@@ -116,6 +130,62 @@ class RecordingTests: AudioFileTestCase {
         try? engine.start()
         player.play()
         wait(for: 2)
+    }
+    
+    func testPauseRecording() {
+        guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
+              let file = try? AVAudioFile(forReading: url) else {
+            XCTFail("Didn't get test file")
+            return
+        }
+
+        let fileURL = createFileURL()
+        let settings = getSettings()
+
+        var outFile = try? AVAudioFile(
+            forWriting: fileURL,
+            settings: settings)
+
+        let engine = AudioEngine()
+        let player = AudioPlayer(file: file)
+        guard let player = player else {
+            XCTFail("Couldn't load input Node.")
+            return
+        }
+
+        let recorder = try? NodeRecorder(node: player)
+        recorder?.openFile(file: &outFile)
+        engine.output = player
+
+        try? engine.start()
+        player.play()
+        try? recorder?.record()
+        wait(for: 1.5)
+
+        recorder?.pause()
+        wait(for: 1.2)
+
+        recorder?.resume()
+        wait(for: 1.2)
+
+        recorder?.stop()
+        player.stop()
+        engine.stop()
+        engine.output = player
+
+        recorder?.closeFile(file: &outFile)
+
+        guard let recordedFile = recorder?.audioFile else {
+            XCTFail("Couldn't open recorded audio file!")
+            return
+        }
+        wait(for: 1)
+
+        player.file = recordedFile
+        try? engine.start()
+        // 1, 2, 4
+        player.play()
+        wait(for: 3)
     }
 }
 #endif


### PR DESCRIPTION
Changes:

1. Add `isPaused` property to `NodeRecorder`
2. Don't write to buffer if `isPaused`
3. Add `pause()` function
4. Add `resume()` function
5. Add tests for this functionality in `RecordingTests`

Also reverted a previous PR because it didn't do much other than break the Cookbook. Sorry 😣. But it works now 🙃!