### PR TITLE
Do not run tap on main queue

### DIFF
--- a/Sources/AudioKit/Taps/BaseTap.swift
+++ b/Sources/AudioKit/Taps/BaseTap.swift
@@ -85,19 +85,15 @@ open class BaseTap {
     ///   - buffer: Buffer to analyze
     ///   - time: Unused in this case
     private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
-        // Call on the main thread so the client doesn't have to worry
-        // about thread safety.
         buffer.frameLength = bufferSize
-        DispatchQueue.main.async {
-            // Create trackers as needed.
-            self.lock()
-            guard self.isStarted == true else {
-                self.unlock()
-                return
-            }
-            self.doHandleTapBlock(buffer: buffer, at: time)
+        // Create trackers as needed.
+        self.lock()
+        guard self.isStarted == true else {
             self.unlock()
+            return
         }
+        self.doHandleTapBlock(buffer: buffer, at: time)
+        self.unlock()
     }
 
     /// Override this method to handle Tap in derived class


### PR DESCRIPTION
This code is taking locks and doing calculations.
It is called many times per second and it shouldn't
run on the main queue.

If callsite needs to run it on the main queue, it should
be easy enough to add it on top of the tap. On another hand,
if we run it on the main queue internally, callsite cannot decide to
run it on the background queue.
