### PR TITLE
`NodeRecorder` Cleanup

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -216,6 +216,11 @@ open class NodeRecorder: NSObject {
             usleep(delay)
         }
         node.avAudioNode.removeTap(onBus: bus)
+
+        // Unpause if paused
+        if isPaused {
+            isPaused = false
+        }
     }
 
     /// Pause recording
@@ -230,10 +235,6 @@ open class NodeRecorder: NSObject {
 
     /// Reset the AVAudioFile to clear previous recordings
     public func reset() throws {
-        // Unpause if paused
-        if isPaused {
-            isPaused = false
-        }
         // Stop recording
         if isRecording == true {
             stop()

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -80,7 +80,7 @@ open class NodeRecorder: NSObject {
         self.fileDirectoryURL = fileDirectoryURL ?? URL(fileURLWithPath: NSTemporaryDirectory())
         super.init()
 
-        createDefaultFile()
+        createNewFile()
 
         self.bus = bus
     }
@@ -94,15 +94,6 @@ open class NodeRecorder: NSObject {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss.SSSS"
         return dateFormatter.string(from: Date())
-    }
-
-    func createDefaultFile() {
-        let audioFile = NodeRecorder.createAudioFile(fileDirectoryURL: self.fileDirectoryURL)
-        guard audioFile != nil else {
-            Log("Error, no file to write to")
-            return
-        }
-        internalAudioFile = audioFile
     }
 
     /// Open file a for recording
@@ -156,7 +147,7 @@ open class NodeRecorder: NSObject {
         }
 
         if internalAudioFile == nil {
-            createDefaultFile()
+            createNewFile()
         }
 
         if let path = internalAudioFile?.url.path, !FileManager.default.fileExists(atPath: path) {

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -244,19 +244,18 @@ open class NodeRecorder: NSObject {
             stop()
         }
 
-        guard let internalAudioFile = internalAudioFile else { return }
+        guard let audioFile = audioFile else { return }
 
         // Delete the physical recording file
         let fileManager = FileManager.default
-        let settings = internalAudioFile.fileFormat.settings
-        let url = internalAudioFile.url
+        let settings = audioFile.fileFormat.settings
+        let url = audioFile.url
 
         do {
-            if let path = audioFile?.url.path {
-                try fileManager.removeItem(atPath: path)
-            }
+            let path = audioFile.url.path
+            try fileManager.removeItem(atPath: path)
         } catch let error as NSError {
-            Log("Error: Can't delete" + (audioFile?.url.lastPathComponent ?? "nil") + error.localizedDescription)
+            Log("Error: Can't delete" + (audioFile.url.lastPathComponent ?? "nil") + error.localizedDescription)
         }
 
         // Creates a blank new file

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -230,6 +230,10 @@ open class NodeRecorder: NSObject {
 
     /// Reset the AVAudioFile to clear previous recordings
     public func reset() throws {
+        // Unpause if paused
+        if isPaused {
+            isPaused = false
+        }
         // Stop recording
         if isRecording == true {
             stop()

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -187,7 +187,7 @@ class RecordingTests: AudioFileTestCase {
         player.play()
         wait(for: 3)
     }
-    
+
     func testReset() {
         guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
               let file = try? AVAudioFile(forReading: url) else {

--- a/Tests/AudioKitTests/Node Tests/RecordingTests.swift
+++ b/Tests/AudioKitTests/Node Tests/RecordingTests.swift
@@ -187,5 +187,53 @@ class RecordingTests: AudioFileTestCase {
         player.play()
         wait(for: 3)
     }
+    
+    func testReset() {
+        guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
+              let file = try? AVAudioFile(forReading: url) else {
+            XCTFail("Didn't get test file")
+            return
+        }
+
+        let engine = AudioEngine()
+        let player = AudioPlayer(file: file)
+
+        guard let player = player else {
+            XCTFail("Couldn't load input Node.")
+            return
+        }
+
+        let recorder = try? NodeRecorder(node: player)
+        engine.output = player
+        try? engine.start()
+        player.play()
+        try? recorder?.record()
+        wait(for: 1.5)
+
+        // Pause for fun
+        recorder?.pause()
+
+        // Try to reset and record again
+        try? recorder?.reset()
+        try? recorder?.record()
+        wait(for: 1.2)
+
+        recorder?.stop()
+        player.stop()
+        engine.stop()
+        engine.output = player
+
+        guard let recordedFile = recorder?.audioFile else {
+            XCTFail("Couldn't open recorded audio file!")
+            return
+        }
+        wait(for: 1)
+
+        player.file = recordedFile
+        try? engine.start()
+        // 3
+        player.play()
+        wait(for: 3)
+    }
 }
 #endif


### PR DESCRIPTION
Cleaned up the node recorder a bit and added another test. These changes should now work with the Cookbook (when the Cookbook uses `AudioKit:main` or a later version tag).
