### PR TITLE
Detach node from the engine on disconnect

### DIFF
--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -94,19 +94,23 @@ public class Mixer: Node, NamedNode {
     }
 
     /// Remove input from the mixer
+    /// If this is last input's connection,
+    /// input will be detached from the engine.
     /// - Parameter node: Node to remove
     public func removeInput(_ node: Node) {
+        guard inputs.contains(where: { $0 === node }) else { return }
         inputs.removeAll(where: { $0 === node })
-        avAudioNode.disconnect(input: node.avAudioNode)
+        disconnectAndDetachIfLast(input: node)
     }
 
     /// Remove all inputs from the mixer
+    /// Inputs where this mixer is their last connection
+    /// will be detached from the engine.
     public func removeAllInputs() {
         guard connections.isNotEmpty else { return }
 
-        let nodes = connections.map { $0.avAudioNode }
-        for input in nodes {
-            avAudioNode.disconnect(input: input)
+        for input in connections {
+            disconnectAndDetachIfLast(input: input)
         }
         inputs.removeAll()
     }

--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -98,6 +98,24 @@ public extension Node {
 
 extension Node {
 
+    func disconnectAndDetachIfLast(input: Node) {
+        if let engine = avAudioNode.engine {
+            let points = engine.outputConnectionPoints(for: input.avAudioNode, outputBus: 0)
+            let otherConnections = points.filter { $0.node != self.avAudioNode }
+            if otherConnections.isEmpty {
+                // It is important to go depth first search.
+                // If we first detach the current node,
+                // upstream nodes will lose the connection to the engine.
+                for connection in input.connections {
+                    input.disconnectAndDetachIfLast(input: connection)
+                }
+                engine.detach(input.avAudioNode)
+            } else {
+                avAudioNode.disconnect(input: input.avAudioNode)
+            }
+        }
+    }
+
     func detach() {
         if let engine = avAudioNode.engine {
             engine.detach(avAudioNode)

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -518,6 +518,27 @@ class NodeTests: XCTestCase {
         XCTAssertTrue(engine.avEngine.attachedNodes.contains(weakDelay!))
         XCTAssertTrue(engine.avEngine.attachedNodes.contains(weakPlayer!))
     }
+
+    @available(iOS 13.0, *)
+    func testInnerNodesThatHaveMultipleInnerConnectionsDeallocated() {
+        let engine = AudioEngine()
+        var chain: Node? = createChain()
+        weak var weakPitch = chain?.avAudioNode
+        weak var weakDelay = chain?.connections.first?.avAudioNode
+        weak var weakPlayer = chain?.connections.first?.connections.first?.avAudioNode
+        var mixer: Mixer? = Mixer(chain!, Mixer(chain!))
+        var outer: Mixer? = Mixer(mixer!)
+        engine.output = outer
+
+        outer!.removeInput(mixer!)
+        outer = nil
+        mixer = nil
+        chain = nil
+
+        XCTAssertNil(weakPitch)
+        XCTAssertNil(weakDelay)
+        XCTAssertNil(weakPlayer)
+    }
 }
 
 private extension NodeTests {

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -457,4 +457,69 @@ class NodeTests: XCTestCase {
         """)
     }
     #endif
+
+    func testAllNodesInChainDeallocatedOnRemove() {
+        let engine = AudioEngine()
+        var chain: Node? = createChain()
+        weak var weakPitch = chain?.avAudioNode
+        weak var weakDelay = chain?.connections.first?.avAudioNode
+        weak var weakPlayer = chain?.connections.first?.connections.first?.avAudioNode
+        let mixer = Mixer(chain!, createChain())
+        engine.output = mixer
+
+        mixer.removeInput(chain!)
+        chain = nil
+
+        XCTAssertNil(weakPitch)
+        XCTAssertNil(weakDelay)
+        XCTAssertNil(weakPlayer)
+    }
+
+    @available(iOS 13.0, *)
+    func testNodesThatHaveOtherConnectionsNotDeallocated() {
+        let engine = AudioEngine()
+        var chain: Node? = createChain()
+        weak var weakPitch = chain?.avAudioNode
+        weak var weakDelay = chain?.connections.first?.avAudioNode
+        weak var weakPlayer = chain?.connections.first?.connections.first?.avAudioNode
+        let mixer1 = Mixer(chain!, createChain())
+        let mixer2 = Mixer(mixer1, chain!)
+        engine.output = mixer2
+
+        mixer1.removeInput(chain!)
+        chain = nil
+
+        XCTAssertNotNil(weakPitch)
+        XCTAssertNotNil(weakDelay)
+        XCTAssertNotNil(weakPlayer)
+        XCTAssertTrue(engine.avEngine.attachedNodes.contains(weakPitch!))
+        XCTAssertTrue(engine.avEngine.attachedNodes.contains(weakDelay!))
+        XCTAssertTrue(engine.avEngine.attachedNodes.contains(weakPlayer!))
+    }
+
+    @available(iOS 13.0, *)
+    func testInnerNodesThatHaveOtherConnectionsNotDeallocated() {
+        let engine = AudioEngine()
+        var chain: Node? = createChain()
+        weak var weakPitch = chain?.avAudioNode
+        weak var weakDelayNode = chain?.connections.first
+        weak var weakDelay = chain?.connections.first?.avAudioNode
+        weak var weakPlayer = chain?.connections.first?.connections.first?.avAudioNode
+        let mixer = Mixer(chain!, createChain(), weakDelayNode!)
+        engine.output = mixer
+
+        mixer.removeInput(chain!)
+        chain = nil
+
+        XCTAssertNil(weakPitch)
+        XCTAssertNotNil(weakDelay)
+        XCTAssertNotNil(weakDelayNode)
+        XCTAssertNotNil(weakPlayer)
+        XCTAssertTrue(engine.avEngine.attachedNodes.contains(weakDelay!))
+        XCTAssertTrue(engine.avEngine.attachedNodes.contains(weakPlayer!))
+    }
+}
+
+private extension NodeTests {
+    func createChain() -> Node { TimePitch(Delay(AudioPlayer())) }
 }


### PR DESCRIPTION
Currently nodes are not detached from the engine if last connection is broken which causes memory leak.