### PR TITLE
Fix deadlock on tap stop

### DIFF
--- a/Tests/AudioKitTests/Tap Tests/AmplitudeTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/AmplitudeTapTests.swift
@@ -1,0 +1,22 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import XCTest
+import AudioKit
+
+class AmplitudeTapTests: XCTestCase {
+
+    func testTapDoesntDeadlockOnStop() throws {
+        let engine = AudioEngine()
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+        engine.output = player
+        let tap = AmplitudeTap(player)
+
+        _ = engine.startTest(totalDuration: 1)
+        tap.start()
+        _ = engine.render(duration: 1)
+        tap.stop()
+
+        XCTAssertFalse(tap.isStarted)
+    }
+}


### PR DESCRIPTION
On removal, tap internally flushes callbacks,
which calls another handle block synchronously.
This causes deadlock as we are locking inside of another lock.

https://github.com/AudioKit/AudioKit/issues/2730