### PR TITLE
Fix spelling in Reverb preset name

### DIFF
--- a/Sources/AudioKit/Nodes/Effects/Reverb.swift
+++ b/Sources/AudioKit/Nodes/Effects/Reverb.swift
@@ -84,7 +84,7 @@ public extension AVAudioUnitReverbPreset {
         case .mediumRoom:
             return "Medium Room"
         case .largeRoom:
-            return "Larg Room"
+            return "Large Room"
         case .mediumHall:
             return "Medium Hall"
         case .largeHall:


### PR DESCRIPTION
"Larg Room" -> "Large Room"
