### PR TITLE
Add an ability to specify node's output format

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -5,7 +5,7 @@ import AVFoundation
 extension AVAudioNode {
 
     /// Disconnect without breaking other connections.
-    func disconnect(input: AVAudioNode) {
+    func disconnect(input: AVAudioNode, format: AVAudioFormat) {
 
         if let engine = engine {
 
@@ -23,14 +23,14 @@ extension AVAudioNode {
                 if connections.isEmpty {
                     engine.disconnectNodeOutput(node)
                 } else {
-                    engine.connect(node, to: connections, fromBus: 0, format: Settings.audioFormat)
+                    engine.connect(node, to: connections, fromBus: 0, format: format)
                 }
             }
         }
     }
 
     /// Make a connection without breaking other connections.
-    func connect(input: AVAudioNode, bus: Int, format: AVAudioFormat? = Settings.audioFormat) {
+    func connect(input: AVAudioNode, bus: Int, format: AVAudioFormat) {
         if let engine = engine {
             var points = engine.outputConnectionPoints(for: input, outputBus: 0)
             if points.contains(where: {
@@ -44,7 +44,7 @@ extension AVAudioNode {
 
 extension AVAudioMixerNode {
     /// Make a connection without breaking other connections.
-    public func connectMixer(input: AVAudioNode, format: AVAudioFormat? = Settings.audioFormat) {
+    public func connectMixer(input: AVAudioNode, format: AVAudioFormat) {
         if let engine = engine {
             var points = engine.outputConnectionPoints(for: input, outputBus: 0)
             if points.contains(where: { $0.node === self }) { return }
@@ -112,7 +112,7 @@ public class AudioEngine {
             if let node = oldValue {
                 mainMixerNode?.removeInput(node)
                 node.detach()
-                avEngine.outputNode.disconnect(input: node.avAudioNode)
+                avEngine.outputNode.disconnect(input: node.avAudioNode, format: node.outputFormat)
             }
 
             // if non nil, set the main output now
@@ -149,7 +149,7 @@ public class AudioEngine {
 
     private func removeEngineMixer() {
         guard let mixer = mainMixerNode else { return }
-        avEngine.outputNode.disconnect(input: mixer.avAudioNode)
+        avEngine.outputNode.disconnect(input: mixer.avAudioNode, format: mixer.outputFormat)
         mixer.removeAllInputs()
         mixer.detach()
         mainMixerNode = nil

--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -23,6 +23,10 @@ public protocol Node: AnyObject {
     /// Tells whether the node is processing (ie. started, playing, or active)
     var isStarted: Bool { get }
 
+    /// Audio format to use when connecting this node.
+    /// Defaults to `Settings.audioFormat`.
+    var outputFormat: AVAudioFormat { get }
+
 }
 
 public extension Node {
@@ -56,6 +60,7 @@ public extension Node {
     func stop() { bypassed = true }
     func play() { bypassed = false }
     func bypass() { bypassed = true }
+    var outputFormat: AVAudioFormat { Settings.audioFormat }
 
     /// All parameters on the Node
     var parameters: [NodeParameter] {
@@ -111,7 +116,7 @@ extension Node {
                 }
                 engine.detach(input.avAudioNode)
             } else {
-                avAudioNode.disconnect(input: input.avAudioNode)
+                avAudioNode.disconnect(input: input.avAudioNode, format: input.outputFormat)
             }
         }
     }
@@ -175,9 +180,9 @@ extension Node {
 
                 // Mixers will decide which input bus to use.
                 if let mixer = avAudioNode as? AVAudioMixerNode {
-                    mixer.connectMixer(input: connection.avAudioNode)
+                    mixer.connectMixer(input: connection.avAudioNode, format: connection.outputFormat)
                 } else {
-                    avAudioNode.connect(input: connection.avAudioNode, bus: bus)
+                    avAudioNode.connect(input: connection.avAudioNode, bus: bus, format: connection.outputFormat)
                 }
 
                 connection.makeAVConnections()

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -6,8 +6,7 @@ import XCTest
 class NodeTests: XCTestCase {
     func testNodeBasic() {
         let engine = AudioEngine()
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         XCTAssertNil(player.avAudioNode.engine)
         engine.output = player
         XCTAssertNotNil(player.avAudioNode.engine)
@@ -19,8 +18,7 @@ class NodeTests: XCTestCase {
     
     func testNodeConnection() {
         let engine = AudioEngine()
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         let verb = Reverb(player)
         engine.output = verb
         let audio = engine.startTest(totalDuration: 0.1)
@@ -29,10 +27,30 @@ class NodeTests: XCTestCase {
         XCTAssertFalse(audio.isSilent)
         testMD5(audio)
     }
+
+    static let reverbFormat = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 2)!
+    func testNodeOutputFormatRespected() {
+        class TestReverb: Node {
+            private let reverb: Reverb
+            var avAudioNode: AVAudioNode { reverb.avAudioNode }
+            var connections: [Node] { reverb.connections }
+            var outputFormat: AVAudioFormat { NodeTests.reverbFormat }
+
+            init(_ input: Node) {
+                self.reverb = Reverb(input)
+            }
+        }
+        let engine = AudioEngine()
+        let player = AudioPlayer(testFile: "12345")
+        let verb = TestReverb(player)
+        engine.output = verb
+
+        XCTAssertEqual(engine.mainMixerNode!.avAudioNode.inputFormat(forBus: 0), Self.reverbFormat)
+        XCTAssertEqual(verb.avAudioNode.inputFormat(forBus: 0), Settings.audioFormat)
+    }
     
     func testRedundantConnection() {
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         let mixer = Mixer()
         mixer.addInput(player)
         mixer.addInput(player)
@@ -41,18 +59,16 @@ class NodeTests: XCTestCase {
     
     func testDynamicOutput() {
         let engine = AudioEngine()
-        
-        let url1 = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player1 = AudioPlayer(url: url1)!
+
+        let player1 = AudioPlayer(testFile: "12345")
         engine.output = player1
         
         let audio = engine.startTest(totalDuration: 2.0)
         player1.play()
         let newAudio = engine.render(duration: 1.0)
         audio.append(newAudio)
-        
-        let url2 = Bundle.module.url(forResource: "drumloop", withExtension: "wav", subdirectory: "TestResources")!
-        let player2 = AudioPlayer(url: url2)!
+
+        let player2 = AudioPlayer(testFile: "drumloop")
         engine.output = player2
         player2.play()
         
@@ -96,8 +112,7 @@ class NodeTests: XCTestCase {
 
         let engine = AudioEngine()
 
-        let url1 = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player1 = AudioPlayer(url: url1)!
+        let player1 = AudioPlayer(testFile: "12345")
         let mixer = Mixer(player1)
 
         engine.output = mixer
@@ -107,8 +122,7 @@ class NodeTests: XCTestCase {
 
         audio.append(engine.render(duration: 1.0))
 
-        let url2 = Bundle.module.url(forResource: "drumloop", withExtension: "wav", subdirectory: "TestResources")!
-        let player2 = AudioPlayer(url: url2)!
+        let player2 = AudioPlayer(testFile: "drumloop")
         let verb = Reverb(player2)
         player2.play()
         mixer.addInput(verb)
@@ -123,8 +137,7 @@ class NodeTests: XCTestCase {
 
         let engine = AudioEngine()
 
-        let url1 = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player1 = AudioPlayer(url: url1)!
+        let player1 = AudioPlayer(testFile: "12345")
         let mixer = Mixer(player1)
         engine.output = mixer
 
@@ -133,8 +146,7 @@ class NodeTests: XCTestCase {
         
         audio.append(engine.render(duration: 1.0))
 
-        let url2 = Bundle.module.url(forResource: "drumloop", withExtension: "wav", subdirectory: "TestResources")!
-        let player2 = AudioPlayer(url: url2)!
+        let player2 = AudioPlayer(testFile: "drumloop")
         mixer.addInput(player2)
 
         player2.play()
@@ -152,8 +164,7 @@ class NodeTests: XCTestCase {
         try XCTSkipIf(true, "TODO Skipped test")
         let engine = AudioEngine()
         let outputMixer = Mixer()
-        let url1 = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player1 = AudioPlayer(url: url1)!
+        let player1 = AudioPlayer(testFile: "12345")
         outputMixer.addInput(player1)
         engine.output = outputMixer
         let audio = engine.startTest(totalDuration: 2.0)
@@ -162,8 +173,7 @@ class NodeTests: XCTestCase {
         
         audio.append(engine.render(duration: 1.0))
 
-        let url2 = Bundle.module.url(forResource: "drumloop", withExtension: "wav", subdirectory: "TestResources")!
-        let player2 = AudioPlayer(url: url2)!
+        let player2 = AudioPlayer(testFile: "drumloop")
 
         let localMixer = Mixer()
         localMixer.addInput(player2)
@@ -182,8 +192,7 @@ class NodeTests: XCTestCase {
         engine.output = outputMixer
         let audio = engine.startTest(totalDuration: 1.0)
 
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         
         let mixer = Mixer()
         mixer.addInput(player)
@@ -199,9 +208,8 @@ class NodeTests: XCTestCase {
 
     func testDisconnect() {
         let engine = AudioEngine()
-        
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+
+        let player = AudioPlayer(testFile: "12345")
         
         let mixer = Mixer(player)
         engine.output = mixer
@@ -222,8 +230,7 @@ class NodeTests: XCTestCase {
     func testNodeDetach() {
         let engine = AudioEngine()
         
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         
         let mixer = Mixer(player)
         engine.output = mixer
@@ -270,8 +277,7 @@ class NodeTests: XCTestCase {
         let engine = AudioEngine()
         let engine2 = AudioEngine()
         
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         
         engine2.output = player
         
@@ -313,8 +319,7 @@ class NodeTests: XCTestCase {
     
     func testFanout() {
         let engine = AudioEngine()
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         
         let verb = Reverb(player)
         let mixer = Mixer(player, verb)
@@ -327,8 +332,8 @@ class NodeTests: XCTestCase {
     func testMixerRedundantUpstreamConnection() {
         let engine = AudioEngine()
         
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+
+        let player = AudioPlayer(testFile: "12345")
         
         let mixer1 = Mixer(player)
         let mixer2 = Mixer(mixer1)
@@ -346,8 +351,7 @@ class NodeTests: XCTestCase {
         try XCTSkipIf(true, "TODO Skipped test")
 
         let engine = AudioEngine()
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         func exampleStart() {
             engine.output = player
             try! engine.start()
@@ -371,8 +375,7 @@ class NodeTests: XCTestCase {
     // of mixers in testMixerPerformance.
     func testChainPerformance() {
         let engine = AudioEngine()
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         
         let rev = Reverb(player)
         
@@ -395,8 +398,7 @@ class NodeTests: XCTestCase {
     // Measure the overhead of mixers.
     func testMixerPerformance() {
         let engine = AudioEngine()
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         
         let mix1 = Mixer(player)
         let rev = Reverb(mix1)
@@ -419,14 +421,12 @@ class NodeTests: XCTestCase {
     }
     
     func testConnectionTreeDescriptionForStandaloneNode() {
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         XCTAssertEqual(player.connectionTreeDescription, "\(connectionTreeLinePrefix)↳AudioPlayer")
     }
     
     func testConnectionTreeDescriptionForConnectedNode() {
-        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
-        let player = AudioPlayer(url: url)!
+        let player = AudioPlayer(testFile: "12345")
         
         let verb = Reverb(player)
         let mixer = Mixer(player, verb)
@@ -543,4 +543,11 @@ class NodeTests: XCTestCase {
 
 private extension NodeTests {
     func createChain() -> Node { TimePitch(Delay(AudioPlayer())) }
+}
+
+extension AudioPlayer {
+    convenience init(testFile: String) {
+        let url = Bundle.module.url(forResource: testFile, withExtension: "wav", subdirectory: "TestResources")!
+        self.init(url: url)!
+    }
 }

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -331,7 +331,6 @@ class NodeTests: XCTestCase {
     
     func testMixerRedundantUpstreamConnection() {
         let engine = AudioEngine()
-        
 
         let player = AudioPlayer(testFile: "12345")
         


### PR DESCRIPTION
There is currently no way to override `Settings.audioFormat` in part of the chain. This may be desirable if input format and output format are different and you want to preserve input format up until some mixer in the chain.