### PR TITLE
Public initializer for MultiChannelInputNodeTap.FileChannel

### DIFF
--- a/Sources/AudioKit/Taps/MultiChannelInputNodeTap.swift
+++ b/Sources/AudioKit/Taps/MultiChannelInputNodeTap.swift
@@ -13,7 +13,7 @@ public final class MultiChannelInputNodeTap {
     public struct FileChannel {
         public var name: String
         public var channel: Int32
-        
+
         public init(name: String, channel: Int32) {
             self.name = name
             self.channel = channel

--- a/Sources/AudioKit/Taps/MultiChannelInputNodeTap.swift
+++ b/Sources/AudioKit/Taps/MultiChannelInputNodeTap.swift
@@ -11,8 +11,13 @@ import AVFoundation
 public final class MultiChannelInputNodeTap {
     /// a file name and its associated input channel
     public struct FileChannel {
-        var name: String
-        var channel: Int32
+        public var name: String
+        public var channel: Int32
+        
+        public init(name: String, channel: Int32) {
+            self.name = name
+            self.channel = channel
+        }
     }
 
     /// Receive update events during the lifecycle of this class


### PR DESCRIPTION
`MultiChannelInputNodeTap` has two public methods for its configuration:
```
1. public func prepare(channelMap: [Int32]) { }
2. public func prepare(fileChannels: [FileChannel]) { }
```

However, even though `prepare(fileChannels:)` is public, it's useless because `FileChannel` doesn't have public initializer and thus cannot be created outside the library.

This PR adds public init for `FileChannel`.