### PR TITLE
MultiSegmentAudioPlayer - offline rendering timing

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -409,3 +409,12 @@ public extension DSPSplitComplex {
         imagp.deallocate()
     }
 }
+
+public extension AVAudioTime {
+    /// Returns an AVAudioTime set to sampleTime of zero at the default sample rate
+    static func sampleTimeZero() -> AVAudioTime {
+        let sampleRate = Double(Settings.sampleRate)
+        let sampleTime = AVAudioFramePosition(Double(0))
+        return AVAudioTime(sampleTime: sampleTime, atRate: sampleRate)
+    }
+}

--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -44,7 +44,7 @@ public class MultiSegmentAudioPlayer: Node {
     ///     - processingDelay: used to allow many players to process the scheduling of segments and then play in sync
     public func playSegments(audioSegments: [StreamableAudioSegment],
                              referenceTimeStamp: TimeInterval = 0,
-                             referenceNowTime: AVAudioTime = AVAudioTime.now(),
+                             referenceNowTime: AVAudioTime = AVAudioTime.sampleTimeZero(),
                              processingDelay: TimeInterval = 0) {
         scheduleSegments(audioSegments: audioSegments,
                          referenceTimeStamp: referenceTimeStamp,
@@ -64,7 +64,7 @@ public class MultiSegmentAudioPlayer: Node {
     ///     - this has not been tested on overlapped segments (any most likely does not work for this use case)
     public func scheduleSegments(audioSegments: [StreamableAudioSegment],
                                  referenceTimeStamp: TimeInterval = 0,
-                                 referenceNowTime: AVAudioTime = AVAudioTime.now(),
+                                 referenceNowTime: AVAudioTime = AVAudioTime.sampleTimeZero(),
                                  processingDelay: TimeInterval = 0) {
         for segment in audioSegments {
             

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -34,7 +34,7 @@ let validatedMD5s: [String: String] = [
     "-[CompressorTests testThreshold]": "e1133fc525a256a72db31453d293c47c",
     "-[MixerTests testSplitConnection]": "6b2d34e86130813c7e7d9f1cf7a2a87c",
     "-[MultiSegmentPlayerTests testPlaySegment]": "feb1367cee8917a890088b8967b8d422",
-    "-[MultiSegmentPlayerTests testPlaySegmentInTheFuture]": "feb1367cee8917a890088b8967b8d422",
+    "-[MultiSegmentPlayerTests testPlaySegmentInTheFuture]": "00545f274477d014dcc51822d97f1705",
     "-[MultiSegmentPlayerTests testPlayMultipleSegments]": "feb1367cee8917a890088b8967b8d422",
     "-[MultiSegmentPlayerTests testPlayMultiplePlayersInSync]": "d405ff00ef9dd3c890486163b7499a52",
     "-[MultiSegmentPlayerTests testPlayWithinSegment]": "adc3d1fef36f68e1f12dbb471eb4069b",


### PR DESCRIPTION
Added zero sample time as default reference time now argument to support offline rendering while respecting scheduled segment playback timing.

Why this change (host time vs. sample time):
AVAudioTime.now() creates a host time not a sample time. We can see from Apple's documentation on "Scheduling Playback Time" that host time is ignored during rendering (I discovered this the hard way as all of my "to be played in the future" segments were rendered beginning at time zero to my surprise). 
https://developer.apple.com/documentation/avfaudio/avaudioplayernode

<img width="639" alt="Screen Shot 2022-06-30 at 7 15 45 AM" src="https://user-images.githubusercontent.com/15333030/176674811-727aaef9-cf6f-4363-b15a-9fd0648dcdbd.png">

I now use this sample time of zero as my reference now time and everything works as expected for both real time scheduling and manual offline rendering.

*NOTE - had to swap out the test result for scheduling a segment in the future
