### PR TITLE
Implement matrix mixer

### DIFF
--- a/Sources/AudioKit/Internals/Audio Unit/AVAudioUnit+Helpers.swift
+++ b/Sources/AudioKit/Internals/Audio Unit/AVAudioUnit+Helpers.swift
@@ -1,0 +1,15 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import AVFAudio
+
+func instantiate(componentDescription: AudioComponentDescription) -> AVAudioUnit {
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: AVAudioUnit!
+    AVAudioUnit.instantiate(with: componentDescription) { avAudioUnit, _ in
+        guard let au = avAudioUnit else { fatalError("Unable to instantiate AVAudioUnit") }
+        result = au
+        semaphore.signal()
+    }
+    _ = semaphore.wait(wallTimeout: .distantFuture)
+    return result
+}

--- a/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
@@ -1,0 +1,185 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+/// Matrix Mixer allows you to map X input channels to Y output channels
+/// There is almost no documentation about how matrix mixer audio unit works.
+/// This implementation is a result of consolidating various online resources:
+/// - https://stackoverflow.com/questions/48059405/how-should-an-aumatrixmixer-be-configured-in-an-avaudioengine-graph
+/// - https://stackoverflow.com/questions/16754037/how-to-use-aumatrixmixer
+/// - https://lists.apple.com/archives/coreaudio-api/2008/Apr/msg00169.html
+/// - https://lists.apple.com/archives/coreaudio-api/2006/Jul/msg00047.html
+/// - https://lists.apple.com/archives/coreaudio-api/2008/Jun/msg00116.html
+///
+/// In order to be able to use Matrix Mixer upstream connections will need to have
+/// different format then downstream. Downstream connections are determined by
+/// output node's channel count. But for matrix mixer to be able to count input channels
+/// correctly, upstream connections need to preserve source number of channels.
+/// This can be done using `Node.outputFormat`.
+
+import AVFAudio
+
+public class MatrixMixer: Node {
+    private let inputs: [Node]
+
+    public var connections: [Node] { inputs }
+    public var avAudioNode: AVAudioNode { unit }
+
+    public let unit = instantiate(
+        componentDescription:
+            AudioComponentDescription(
+                componentType: kAudioUnitType_Mixer,
+                componentSubType: kAudioUnitSubType_MatrixMixer,
+                componentManufacturer: kAudioUnitManufacturer_Apple,
+                componentFlags: 0,
+                componentFlagsMask: 0
+            )
+        )
+
+    public init(_ inputs: [Node]) {
+        self.inputs = inputs
+        // It is required to set element counts.
+        // If we don't do it, running engine will throw
+        // an exception when trying to dynamically connect
+        // inputs to this mixer.
+        var inputCount = UInt32(inputs.count)
+        var outputCount = UInt32(1)
+        AudioUnitSetProperty(
+            unit.audioUnit,
+            kAudioUnitProperty_ElementCount,
+            kAudioUnitScope_Input,
+            0,
+            &inputCount,
+            UInt32(MemoryLayout<UInt32>.size)
+        )
+        AudioUnitSetProperty(
+            unit.audioUnit,
+            kAudioUnitProperty_ElementCount,
+            kAudioUnitScope_Output,
+            0,
+            &outputCount,
+            UInt32(MemoryLayout<UInt32>.size)
+        )
+    }
+
+    private static let masterVolumeElement: AudioUnitElement = 0xFFFFFFFF
+
+    /// Matrix Mixer master volume
+    /// This is by default set to 0
+    public var masterVolume: Float {
+        get {
+            var value: AudioUnitParameterValue = 0
+            AudioUnitGetParameter(
+                unit.audioUnit,
+                kMatrixMixerParam_Volume,
+                kAudioUnitScope_Global,
+                Self.masterVolumeElement,
+                &value
+            )
+            return value
+        }
+        set {
+            AudioUnitSetParameter(
+                unit.audioUnit,
+                kMatrixMixerParam_Volume,
+                kAudioUnitScope_Global,
+                Self.masterVolumeElement,
+                newValue,
+                0
+            )
+        }
+    }
+
+    /// Matrix Mixer by default starts with all volumes set to 0
+    /// Convenience method to unmute all inputs and outputs
+    /// It is important to do this after the engine has started
+    /// and node was connected. Otherwise, it will have no effect.
+    public func unmuteAllInputsAndOutputs() {
+        for i in 0..<inputChannelCount {
+            set(volume: 1, inputChannelIndex: Int(i))
+        }
+        for i in 0..<outputChannelCount {
+            set(volume: 1, outputChannelIndex: Int(i))
+        }
+    }
+
+    public func set(volume: Float, inputChannelIndex: Int) {
+        AudioUnitSetParameter(
+            unit.audioUnit,
+            kMatrixMixerParam_Volume,
+            kAudioUnitScope_Input,
+            UInt32(inputChannelIndex),
+            volume,
+            0
+        )
+    }
+
+    /// Set volume of channel
+    /// To map input channel 0 to output channel 1, use (0, 1) crosspoint
+    public func set(volume: Float, outputChannelIndex: Int) {
+        AudioUnitSetParameter(
+            unit.audioUnit,
+            kMatrixMixerParam_Volume,
+            kAudioUnitScope_Output,
+            UInt32(outputChannelIndex),
+            volume,
+            0
+        )
+    }
+
+    /// Set volume at crosspoint
+    /// To map input channel 0 to output channel 1, use (0, 1) crosspoint
+    public func set(volume: Float, atCrosspoints crosspoints: [(Int, Int)]) {
+        for crosspoint in crosspoints {
+            AudioUnitSetParameter(
+                unit.audioUnit,
+                kMatrixMixerParam_Volume,
+                kAudioUnitScope_Global,
+                (UInt32(crosspoint.0) << 16) | (UInt32(crosspoint.1) & 0x0000FFFF),
+                volume,
+                0
+            )
+        }
+    }
+
+    /// Returns number of input channels in matrix mixer
+    public var inputChannelCount: AVAudioChannelCount {
+        inputs
+            .map { $0.avAudioNode.outputFormat(forBus: 0).channelCount }
+            .reduce(0, +)
+    }
+
+    /// Returns number of output channels in matrix mixer
+    public var outputChannelCount: AVAudioChannelCount {
+        unit.outputFormat(forBus: 0).channelCount
+    }
+
+    /// Returns matrix mixer levels 2 dimensional array.
+    /// For more info about the format, see `kAudioUnitProperty_MatrixLevels` documentation.
+    public var matrixLevels: [[Float32]] {
+        let count = (inputChannelCount + 1) * (outputChannelCount + 1)
+        var size = count * UInt32(MemoryLayout<Float32>.size)
+        var volumes: [Float32] = Array(repeating: Float32(0), count: Int(count))
+
+        AudioUnitGetProperty(
+            unit.audioUnit,
+            kAudioUnitProperty_MatrixLevels,
+            kAudioUnitScope_Global,
+            0,
+            &volumes,
+            &size
+        )
+        let chunkSize = Int(outputChannelCount + 1)
+        return stride(from: 0, to: count, by: chunkSize).map {
+            Array(volumes[Int($0)..<min(Int($0) + chunkSize, volumes.count)])
+        }
+    }
+
+    /// It might be tricky to configure matrix mixer properly.
+    /// Convenience method to print matrix levels and help you debugging.
+    public func printMatrixLevels() {
+        for (channel, chunk) in matrixLevels[0..<matrixLevels.count - 1].enumerated() {
+            print("Input Channel \(channel) - \(chunk[0..<chunk.count - 1]), Input Volume \(chunk[chunk.count - 1])")
+        }
+        let last = matrixLevels[matrixLevels.count - 1]
+        print("Output Volumes - \(last[0..<last.count - 1]), Master Volume \(last[last.count - 1])")
+    }
+}

--- a/Tests/AudioKitTests/Node Tests/Effects Tests/BypassTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Effects Tests/BypassTests.swift
@@ -5,25 +5,6 @@ import XCTest
 import AVFAudio
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-public class ConstantGenerator: Node {
-    public var connections: [Node] { [] }
-    public private(set) var avAudioNode: AVAudioNode
-
-    init(constant: Float) {
-        avAudioNode = AVAudioSourceNode { _, _, frameCount, audioBufferList in
-            let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
-            for frame in 0..<Int(frameCount) {
-                for buffer in ablPointer {
-                    let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
-                    buf[frame] = constant
-                }
-            }
-            return noErr
-        }
-    }
-}
-
-@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
 class BypassTests: XCTestCase {
     let duration = 0.1
     let source = ConstantGenerator(constant: 1)

--- a/Tests/AudioKitTests/Node Tests/Mixing Tests/MatrixMixerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Mixing Tests/MatrixMixerTests.swift
@@ -1,0 +1,83 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import XCTest
+import AudioKit
+import AVFAudio
+
+@available(iOS 13.0, *)
+class MatrixMixerTests: XCTestCase {
+    let engine = AudioEngine()
+    let mixer = MatrixMixer([ConstantGenerator(constant: 1), ConstantGenerator(constant: 2)])
+    var data: AVAudioPCMBuffer!
+
+    var output0: [Float] { data.toFloatChannelData()!.first! }
+    var output1: [Float] { data.toFloatChannelData()!.last! }
+
+    override func setUp() {
+        super.setUp()
+        engine.output = mixer
+        data = engine.startTest(totalDuration: 1)
+        mixer.unmuteAllInputsAndOutputs()
+        mixer.masterVolume = 1
+    }
+
+    func testMapChannel0ToChannel0() {
+        mixer.set(volume: 1, atCrosspoints: [(0, 0)])
+        data.append(engine.render(duration: 1))
+
+        XCTAssertTrue(output0.allSatisfy { $0 == 1 })
+        XCTAssertTrue(output1.allSatisfy { $0 == 0 })
+    }
+
+    func testMapChannel0ToChannel1() {
+        mixer.set(volume: 1, atCrosspoints: [(0, 1)])
+        data.append(engine.render(duration: 1))
+
+        XCTAssertTrue(output0.allSatisfy { $0 == 0 })
+        XCTAssertTrue(output1.allSatisfy { $0 == 1 })
+    }
+
+    func testMapChannel2ToChannel0() {
+        mixer.set(volume: 1, atCrosspoints: [(2, 0)])
+        data.append(engine.render(duration: 1))
+
+        XCTAssertTrue(output0.allSatisfy { $0 == 2 })
+        XCTAssertTrue(output1.allSatisfy { $0 == 0 })
+    }
+
+    func testMapChannel0And2ToChannel0() {
+        mixer.set(volume: 1, atCrosspoints: [(0, 0)])
+        mixer.set(volume: 1, atCrosspoints: [(2, 0)])
+        data.append(engine.render(duration: 1))
+
+        XCTAssertTrue(output0.allSatisfy { $0 == 3 })
+        XCTAssertTrue(output1.allSatisfy { $0 == 0 })
+    }
+
+    func testMapChannel2ToChannel0MasterVolume0() {
+        mixer.masterVolume = 0
+        mixer.set(volume: 1, atCrosspoints: [(2, 0)])
+        data.append(engine.render(duration: 1))
+
+        XCTAssertTrue(output0.allSatisfy { $0 == 0 })
+        XCTAssertTrue(output1.allSatisfy { $0 == 0 })
+    }
+
+    func testMapChannel2ToChannel0Channel0Output0Volume0() {
+        mixer.set(volume: 0, outputChannelIndex: 0)
+        mixer.set(volume: 1, atCrosspoints: [(2, 0)])
+        data.append(engine.render(duration: 1))
+
+        XCTAssertTrue(output0.allSatisfy { $0 == 0 })
+        XCTAssertTrue(output1.allSatisfy { $0 == 0 })
+    }
+
+    func testMapChannel2ToChannel0Channel0Input2Volume0() {
+        mixer.set(volume: 0, inputChannelIndex: 2)
+        mixer.set(volume: 1, atCrosspoints: [(2, 0)])
+        data.append(engine.render(duration: 1))
+
+        XCTAssertTrue(output0.allSatisfy { $0 == 0 })
+        XCTAssertTrue(output1.allSatisfy { $0 == 0 })
+    }
+}

--- a/Tests/AudioKitTests/Test Helpers/ConstantGenerator.swift
+++ b/Tests/AudioKitTests/Test Helpers/ConstantGenerator.swift
@@ -1,0 +1,23 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import AudioKit
+import AVFAudio
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
+public class ConstantGenerator: Node {
+    public var connections: [Node] { [] }
+    public private(set) var avAudioNode: AVAudioNode
+
+    init(constant: Float) {
+        avAudioNode = AVAudioSourceNode { _, _, frameCount, audioBufferList in
+            let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
+            for frame in 0..<Int(frameCount) {
+                for buffer in ablPointer {
+                    let buf: UnsafeMutableBufferPointer<Float> = UnsafeMutableBufferPointer(buffer)
+                    buf[frame] = constant
+                }
+            }
+            return noErr
+        }
+    }
+}


### PR DESCRIPTION
NOTE 1:

In order to use matrix mixer, it is required to use different connection format in the part of the chain. This ability was implemented in https://github.com/AudioKit/AudioKit/pull/2741. 
It was the simplest way to get the functionality but it is not very elegant on the use site. You need to create custom node and override `outputFormat`, which leads to boilerplate code.

I am not sure if there is better way around it apart from providing `outputFormat` on each of node implementations.

NOTE 2:

This is probably in some ways specific to our use case. But it should be in place where it might be useful for other people too.