### PR TITLE
MultiSegmentAudioPlayer sample time fix

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -412,8 +412,7 @@ public extension DSPSplitComplex {
 
 public extension AVAudioTime {
     /// Returns an AVAudioTime set to sampleTime of zero at the default sample rate
-    static func sampleTimeZero() -> AVAudioTime {
-        let sampleRate = Double(Settings.sampleRate)
+    static func sampleTimeZero(sampleRate: Double = Settings.sampleRate) -> AVAudioTime {
         let sampleTime = AVAudioFramePosition(Double(0))
         return AVAudioTime(sampleTime: sampleTime, atRate: sampleRate)
     }

--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -66,8 +66,10 @@ public class MultiSegmentAudioPlayer: Node {
                                  referenceTimeStamp: TimeInterval = 0,
                                  referenceNowTime: AVAudioTime? = nil,
                                  processingDelay: TimeInterval = 0) {
+        // will not schedule if the engine is not running or if the node is disconnected
+        guard let lastRenderTime = playerNode.lastRenderTime else { return }
+
         for segment in audioSegments {
-            guard let lastRenderTime = playerNode.lastRenderTime else { return }
             let sampleTime = referenceNowTime ?? AVAudioTime.sampleTimeZero(sampleRate: lastRenderTime.sampleRate)
 
             // how long the file will be playing back for in seconds

--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -44,7 +44,7 @@ public class MultiSegmentAudioPlayer: Node {
     ///     - processingDelay: used to allow many players to process the scheduling of segments and then play in sync
     public func playSegments(audioSegments: [StreamableAudioSegment],
                              referenceTimeStamp: TimeInterval = 0,
-                             referenceNowTime: AVAudioTime = AVAudioTime.sampleTimeZero(),
+                             referenceNowTime: AVAudioTime? = nil,
                              processingDelay: TimeInterval = 0) {
         scheduleSegments(audioSegments: audioSegments,
                          referenceTimeStamp: referenceTimeStamp,
@@ -64,10 +64,12 @@ public class MultiSegmentAudioPlayer: Node {
     ///     - this has not been tested on overlapped segments (any most likely does not work for this use case)
     public func scheduleSegments(audioSegments: [StreamableAudioSegment],
                                  referenceTimeStamp: TimeInterval = 0,
-                                 referenceNowTime: AVAudioTime = AVAudioTime.sampleTimeZero(),
+                                 referenceNowTime: AVAudioTime? = nil,
                                  processingDelay: TimeInterval = 0) {
         for segment in audioSegments {
-            
+            guard let lastRenderTime = playerNode.lastRenderTime else { return }
+            let sampleTime = referenceNowTime ?? AVAudioTime.sampleTimeZero(sampleRate: lastRenderTime.sampleRate)
+
             // how long the file will be playing back for in seconds
             let durationToSchedule = segment.fileEndTime - segment.fileStartTime
             
@@ -76,7 +78,7 @@ public class MultiSegmentAudioPlayer: Node {
             if endTimeWithRespectToReference <= referenceTimeStamp { continue } // skip the clip if it's already past
 
             // either play right away or schedule for a future time to begin playback
-            var whenToPlay = referenceNowTime.offset(seconds: processingDelay)
+            var whenToPlay = sampleTime.offset(seconds: processingDelay)
             
             // the specific location in the audio file we will start playing from
             var fileStartTime = segment.fileStartTime


### PR DESCRIPTION
Fixed default sample time used for segment scheduling so that segments will no longer play late when no referenceNowTime argument is provided

Long story short - when testing on hardware the sample rate was incorrect when calculating the sample time.
