### PR TITLE
Fix FFTTap zero padding issue.

### DIFF
--- a/Sources/AudioKit/Taps/FFTTap.swift
+++ b/Sources/AudioKit/Taps/FFTTap.swift
@@ -75,10 +75,10 @@ open class FFTTap: BaseTap {
 
         let windowSize = bufferSizePOT
         var transferBuffer = [Float](repeating: 0, count: windowSize)
-        var window = [Float](repeating: 0, count: windowSize)
+		var window = [Float](repeating: 0, count: Int(buffer.frameLength))
 
         // Hann windowing to reduce the frequency leakage
-        vDSP_hann_window(&window, vDSP_Length(windowSize), Int32(vDSP_HANN_NORM))
+        vDSP_hann_window(&window, vDSP_Length(buffer.frameLength), Int32(vDSP_HANN_NORM))
         vDSP_vmul((buffer.floatChannelData?.pointee)!, 1, window,
                   1, &transferBuffer, 1, vDSP_Length(buffer.frameLength))
         

--- a/Sources/AudioKit/Taps/FFTTap.swift
+++ b/Sources/AudioKit/Taps/FFTTap.swift
@@ -80,8 +80,8 @@ open class FFTTap: BaseTap {
         // Hann windowing to reduce the frequency leakage
         vDSP_hann_window(&window, vDSP_Length(windowSize), Int32(vDSP_HANN_NORM))
         vDSP_vmul((buffer.floatChannelData?.pointee)!, 1, window,
-                  1, &transferBuffer, 1, vDSP_Length(windowSize))
-
+                  1, &transferBuffer, 1, vDSP_Length(buffer.frameLength))
+        
         // Transforming the [Float] buffer into a UnsafePointer<Float> object for the vDSP_ctoz method
         // And then pack the input into the complex buffer (output)
         transferBuffer.withUnsafeBufferPointer { pointer in


### PR DESCRIPTION
Just to give a little bit of context, zero padding append the input time-domain signal by zeros. It is used when more resolution in the output time domain is wanted without increasing the sample size. Although this method does not increase the resolving power of the FFT, it gives an output that is more smooth. 

The problem in AudioKit's FFTTap is that the FFTTap behaves very strangely when zero padding is used (zeroPaddingFactor > 0). Sometimes the FFT outputs positive data (which is odd); sometimes it crashes; sometimes it just straight output Nan. After some digging, I found where the problem is. In _line 82 of FFTTap.swift_, the vDSP_vmul multiples the time-domain audio buffer with the hann window.