### PR TITLE
MultiSegmentAudioPlayer - Added guard to prevent invalid number of frames scheduled crash

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -100,6 +100,8 @@ public class MultiSegmentAudioPlayer: Node {
             let endFrame = AVAudioFramePosition(segment.fileEndTime * sampleRate)
             let totalFrames = (fileLengthInSamples - startFrame) - (fileLengthInSamples - endFrame)
             
+            guard totalFrames > 0 else { continue } // skip if zero frames (prevents zero frames crash)
+            
             playerNode.scheduleSegment(segment.audioFile,
                                        startingFrame: startFrame,
                                        frameCount: AVAudioFrameCount(totalFrames),

--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -99,9 +99,9 @@ public class MultiSegmentAudioPlayer: Node {
             let startFrame = AVAudioFramePosition(fileStartTime * sampleRate)
             let endFrame = AVAudioFramePosition(segment.fileEndTime * sampleRate)
             let totalFrames = (fileLengthInSamples - startFrame) - (fileLengthInSamples - endFrame)
-            
+
             guard totalFrames > 0 else { continue } // skip if zero frames (prevents zero frames crash)
-            
+
             playerNode.scheduleSegment(segment.audioFile,
                                        startingFrame: startFrame,
                                        frameCount: AVAudioFrameCount(totalFrames),

--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -100,7 +100,7 @@ public class MultiSegmentAudioPlayer: Node {
             let endFrame = AVAudioFramePosition(segment.fileEndTime * sampleRate)
             let totalFrames = (fileLengthInSamples - startFrame) - (fileLengthInSamples - endFrame)
 
-            guard totalFrames > 0 else { continue } // skip if zero frames (prevents zero frames crash)
+            guard totalFrames > 0 else { continue } // skip if invalid number of frames (prevents crash)
 
             playerNode.scheduleSegment(segment.audioFile,
                                        startingFrame: startFrame,

--- a/Tests/AudioKitTests/Node Tests/Multi-Segment Player Tests/MultiSegmentPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Multi-Segment Player Tests/MultiSegmentPlayerTests.swift
@@ -150,7 +150,10 @@ class MultiSegmentPlayerTests: XCTestCase {
         let engine = AudioEngine()
         let player = MultiSegmentAudioPlayer()
         let segmentNormal = ExampleSegment(audioFile: file)
-        let segmentZeroFrames = ExampleSegment(audioFile: file, playbackStartTime: 1.0, fileStartTime: 1.0, fileEndTime: 1.0)
+        let segmentZeroFrames = ExampleSegment(audioFile: file,
+                                               playbackStartTime: 1.0,
+                                               fileStartTime: 1.0,
+                                               fileEndTime: 1.0)
         engine.output = player
 
         let audio = engine.startTest(totalDuration: 5.0)
@@ -199,8 +202,9 @@ private class ExampleSegment: StreamableAudioSegment {
         self.fileStartTime = fileStartTime
         self.fileEndTime = audioFile.duration
     }
-    
-    /// Segment starts some time into the file with an offset on the playback time (plays in future when reference time is 0) and completes playback before the end of file
+
+    /// Segment starts some time into the file with an offset on the playback time (plays in future when reference time is 0)
+    /// and completes playback before the end of file
     init(audioFile: AVAudioFile, playbackStartTime: TimeInterval, fileStartTime: TimeInterval, fileEndTime: TimeInterval) {
         self.audioFile = audioFile
         self.playbackStartTime = playbackStartTime

--- a/Tests/AudioKitTests/Node Tests/Multi-Segment Player Tests/MultiSegmentPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Multi-Segment Player Tests/MultiSegmentPlayerTests.swift
@@ -137,6 +137,31 @@ class MultiSegmentPlayerTests: XCTestCase {
         
         testMD5(audio)
     }
+    
+    // tests that we prevent this crash: required condition is false: numberFrames > 0 (com.apple.coreaudio.avfaudio)
+    func testAttemptToPlayZeroFrames() {
+        guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
+              let file = try? AVAudioFile(forReading: url)
+        else {
+            XCTFail("Didn't get test file")
+            return
+        }
+        
+        let engine = AudioEngine()
+        let player = MultiSegmentAudioPlayer()
+        let segmentNormal = ExampleSegment(audioFile: file)
+        let segmentZeroFrames = ExampleSegment(audioFile: file, playbackStartTime: 1.0, fileStartTime: 1.0, fileEndTime: 1.0)
+        engine.output = player
+        
+        let audio = engine.startTest(totalDuration: 5.0)
+        
+        player.playSegments(audioSegments: [segmentNormal, segmentZeroFrames], referenceTimeStamp: 0.0)
+        
+        player.play()
+        audio.append(engine.render(duration: 5.0))
+        
+        testMD5(audio)
+    }
 }
 
 /// NOT INTENDED FOR PRODUCTION - Test Class Adopting StreamableAudioSegment for MultiSegmentPlayerTests
@@ -173,5 +198,13 @@ private class ExampleSegment: StreamableAudioSegment {
         self.playbackStartTime = playbackStartTime
         self.fileStartTime = fileStartTime
         self.fileEndTime = audioFile.duration
+    }
+    
+    /// Segment starts some time into the file with an offset on the playback time (plays in future when reference time is 0) and ends before the end of file
+    init(audioFile: AVAudioFile, playbackStartTime: TimeInterval, fileStartTime: TimeInterval, fileEndTime: TimeInterval) {
+        self.audioFile = audioFile
+        self.playbackStartTime = playbackStartTime
+        self.fileStartTime = fileStartTime
+        self.fileEndTime = fileEndTime
     }
 }

--- a/Tests/AudioKitTests/Node Tests/Multi-Segment Player Tests/MultiSegmentPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Multi-Segment Player Tests/MultiSegmentPlayerTests.swift
@@ -137,7 +137,7 @@ class MultiSegmentPlayerTests: XCTestCase {
         
         testMD5(audio)
     }
-    
+
     // tests that we prevent this crash: required condition is false: numberFrames > 0 (com.apple.coreaudio.avfaudio)
     func testAttemptToPlayZeroFrames() {
         guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
@@ -146,20 +146,20 @@ class MultiSegmentPlayerTests: XCTestCase {
             XCTFail("Didn't get test file")
             return
         }
-        
+
         let engine = AudioEngine()
         let player = MultiSegmentAudioPlayer()
         let segmentNormal = ExampleSegment(audioFile: file)
         let segmentZeroFrames = ExampleSegment(audioFile: file, playbackStartTime: 1.0, fileStartTime: 1.0, fileEndTime: 1.0)
         engine.output = player
-        
+
         let audio = engine.startTest(totalDuration: 5.0)
-        
+
         player.playSegments(audioSegments: [segmentNormal, segmentZeroFrames], referenceTimeStamp: 0.0)
-        
+
         player.play()
         audio.append(engine.render(duration: 5.0))
-        
+
         testMD5(audio)
     }
 }
@@ -200,7 +200,7 @@ private class ExampleSegment: StreamableAudioSegment {
         self.fileEndTime = audioFile.duration
     }
     
-    /// Segment starts some time into the file with an offset on the playback time (plays in future when reference time is 0) and ends before the end of file
+    /// Segment starts some time into the file with an offset on the playback time (plays in future when reference time is 0) and completes playback before the end of file
     init(audioFile: AVAudioFile, playbackStartTime: TimeInterval, fileStartTime: TimeInterval, fileEndTime: TimeInterval) {
         self.audioFile = audioFile
         self.playbackStartTime = playbackStartTime

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -33,6 +33,7 @@ let validatedMD5s: [String: String] = [
     "-[CompressorTests testParameters]": "6b99deb194dd53e8ceb6428924d6666b",
     "-[CompressorTests testThreshold]": "e1133fc525a256a72db31453d293c47c",
     "-[MixerTests testSplitConnection]": "6b2d34e86130813c7e7d9f1cf7a2a87c",
+    "-[MultiSegmentPlayerTests testAttemptToPlayZeroFrames]": "feb1367cee8917a890088b8967b8d422",
     "-[MultiSegmentPlayerTests testPlaySegment]": "feb1367cee8917a890088b8967b8d422",
     "-[MultiSegmentPlayerTests testPlaySegmentInTheFuture]": "00545f274477d014dcc51822d97f1705",
     "-[MultiSegmentPlayerTests testPlayMultipleSegments]": "feb1367cee8917a890088b8967b8d422",


### PR DESCRIPTION
I have gotten a lot of crashes due to: required condition is false: numberFrames > 0 (com.apple.coreaudio.avfaudio)

The player now just ignores a segment with an invalid number of frames

Before ☹️
<img width="1701" alt="Screen Shot 2022-07-26 at 6 58 50 AM" src="https://user-images.githubusercontent.com/15333030/181001166-4f82a0de-4894-4185-a76e-3b0934766922.png">

After 🙂
<img width="1287" alt="Screen Shot 2022-07-26 at 6 59 14 AM" src="https://user-images.githubusercontent.com/15333030/181001297-89d129ff-7f04-491a-9fb6-2d2470fb1779.png">

