### PR TITLE
Handle case where BaseTap bufferSize exceeds frameCapacity of buffer.

### DIFF
--- a/Sources/AudioKit/Taps/BaseTap.swift
+++ b/Sources/AudioKit/Taps/BaseTap.swift
@@ -107,7 +107,7 @@ open class BaseTap {
             self.unlock()
             return
         }
-        self.doHandleTapBlock(buffer: buffer, at: time)
+        self.doHandleTapBlock(buffer: bufferWithCapacity, at: time)
         self.unlock()
     }
 

--- a/Sources/AudioKit/Taps/BaseTap.swift
+++ b/Sources/AudioKit/Taps/BaseTap.swift
@@ -86,7 +86,21 @@ open class BaseTap {
     ///   - buffer: Buffer to analyze
     ///   - time: Unused in this case
     private func handleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
-        buffer.frameLength = bufferSize
+        var bufferWithCapacity: AVAudioPCMBuffer
+
+        if bufferSize > buffer.frameCapacity {
+            guard let newBuffer = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: bufferSize) else {
+                return
+            }
+
+            newBuffer.append(buffer)
+            bufferWithCapacity = newBuffer
+        } else {
+            bufferWithCapacity = buffer
+        }
+
+        bufferWithCapacity.frameLength = bufferSize
+
         // Create trackers as needed.
         self.lock()
         guard self.isStarted == true else {

--- a/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import AudioKit
 
 class BaseTapTests: XCTestCase {
+
     func testBaseTapDeallocated() throws {
         let engine = AudioEngine()
         let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!

--- a/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
@@ -4,7 +4,6 @@ import XCTest
 import AudioKit
 
 class BaseTapTests: XCTestCase {
-
     func testBaseTapDeallocated() throws {
         let engine = AudioEngine()
         let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
@@ -19,4 +18,16 @@ class BaseTapTests: XCTestCase {
 
         XCTAssertNil(weakTap)
     }
+
+    func testBufferSizeExceedingFrameCapacity() {
+        let engine = AudioEngine()
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+        engine.output = player
+
+        let tap: BaseTap = BaseTap(player, bufferSize: 176400)
+        tap.start()
+        _ = engine.startTest(totalDuration: 1.0)
+        _ = engine.render(duration: 1.0)
+  }
 }


### PR DESCRIPTION
I was using a tap but running into a crash when the `bufferSize` I specified was greater than the `frameCapacity` of the buffer passed to the callback. The crash was:

```
// *** Terminating app due to uncaught exception 'com.apple.coreaudio.avfaudio', reason: 'required condition is false: length <= _imp->_frameCapacity'
```

The test I added will crash without the change here.

I'm still pretty new to AudioKit and programming at this level in general so if this is totally wrong or a bad idea, no worries about closing it.