### PR TITLE
MultiSegmentAudioPlayer - prepare with frame count

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -107,6 +107,8 @@ public class MultiSegmentAudioPlayer: Node {
                                        frameCount: AVAudioFrameCount(totalFrames),
                                        at: whenToPlay,
                                        completionHandler: segment.completionHandler)
+
+            playerNode.prepare(withFrameCount: AVAudioFrameCount(totalFrames))
         }
     }
 }


### PR DESCRIPTION
Added prepare with frame count to MultiSegmentAudioPlayer's schedule segments method

As far as I understand it, this method prepares the player to start playback immediately on play call