### PR TITLE
Fix another deadlock in BaseTap

### DIFF
--- a/Tests/AudioKitTests/Tap Tests/AmplitudeTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/AmplitudeTapTests.swift
@@ -6,8 +6,6 @@ import AVFAudio
 
 class AmplitudeTapTests: XCTestCase {
 
-    // This sometimes deadlocks.
-    /*
     func testTapDoesntDeadlockOnStop() throws {
         let engine = AudioEngine()
         let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
@@ -22,7 +20,6 @@ class AmplitudeTapTests: XCTestCase {
 
         XCTAssertFalse(tap.isStarted)
     }
-    */
 
     func testDoesntCrashForMoreThenTwoChannels() {
         let channelCount: UInt32 = 4


### PR DESCRIPTION
If we invalidate `handlerBlock` *after* the `lock()` in tap stop,
`handlerBlock`, might get called before being invalidated from internal
engine queue. Since `handlerBlock` acquires the same lock, the
result is a deadlock.
