### PR TITLE
Optimized tests.yml workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   swift_test:
-    strategy:
-      matrix:
-        xcode_version: ['13.1']
     runs-on: macos-12
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
       - name: Check out AudioKit
         uses: actions/checkout@v2
+      - name: Setup Xcode
+        # Documentation: https://github.com/marketplace/actions/setup-xcode-version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '13.2'
       - name: Build AudioKit
         run: |
           set -euo pipefail


### PR DESCRIPTION
- Use the latest Xcode version for a given Swift version. The latest for 5.5.2 is 13.2.
- Uses the `setup-xcode` action instead of going through the environment variable. Will produce a better error in the event of a configuration problem, and properly installs command line tools and other necessities that get missed by just using the environment variable.