### PR TITLE
Fix: Stop accessing non-existing MIDIPacket's pointee

### DIFF
--- a/Sources/AudioKit/MIDI/Packets/MIDIPacketList+SequenceType.swift
+++ b/Sources/AudioKit/MIDI/Packets/MIDIPacketList+SequenceType.swift
@@ -22,10 +22,12 @@ extension MIDIPacketList: Sequence {
             guard idx < self.numPackets else {
                 return nil
             }
-            defer {
+
+            if idx != 0 {
                 p = MIDIPacketNext(&p).pointee
-                idx += 1
             }
+            idx += 1
+            
             return p
         }
     }


### PR DESCRIPTION
Address sanitizer catches a bug on `p = MIDIPacketNext(&p).pointee` line: 
`heap-buffer-overflow (App:x86_64+0x10618c206) in $defer #1 () in closure #1 in MIDIPacketList.makeIterator()+0x5d46`

After the last return statement, there are no more packets in the packet list, but defer block still calls `MIDIPacketNext` and accesses `pointee` causing invalid memory access and potentially a crash.