### PR TITLE
Prevent problematic audio configuration crash

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -68,12 +68,12 @@ public class AudioEngine {
 
         func connect(to engine: AudioEngine) {
             let sampleRate = engine.avEngine.inputNode.inputFormat(forBus: 0).sampleRate
-            
+
             // Avoids fatal crash inside AudioKit when setting the output with a problematic audio configuration (known AirPlay issue)
             if sampleRate.isValidSampleRate {
                 Settings.audioFormat = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2) ?? AVAudioFormat()
             }
-            
+
             engine.avEngine.attach(avAudioNode)
             engine.avEngine.connect(engine.avEngine.inputNode, to: avAudioNode, format: nil)
         }

--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -69,9 +69,11 @@ public class AudioEngine {
         func connect(to engine: AudioEngine) {
             let sampleRate = engine.avEngine.inputNode.inputFormat(forBus: 0).sampleRate
 
-            // Avoids fatal crash inside AudioKit when setting the output with a problematic audio configuration (known AirPlay issue)
+            // Avoids fatal crash when setting AudioKit's output with a problematic audio configuration
+            // (caused by known AirPlay issue)
             if sampleRate.isValidSampleRate {
-                Settings.audioFormat = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2) ?? AVAudioFormat()
+                Settings.audioFormat = AVAudioFormat(standardFormatWithSampleRate: sampleRate,
+                                                     channels: 2) ?? AVAudioFormat()
             }
 
             engine.avEngine.attach(avAudioNode)

--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -67,9 +67,13 @@ public class AudioEngine {
         var isNotConnected = true
 
         func connect(to engine: AudioEngine) {
-            Settings.audioFormat = AVAudioFormat(standardFormatWithSampleRate:
-                engine.avEngine.inputNode.inputFormat(forBus: 0)
-                    .sampleRate, channels: 2) ?? AVAudioFormat()
+            let sampleRate = engine.avEngine.inputNode.inputFormat(forBus: 0).sampleRate
+            
+            // Avoids fatal crash inside AudioKit when setting the output with a problematic audio configuration (known AirPlay issue)
+            if sampleRate.isValidSampleRate {
+                Settings.audioFormat = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 2) ?? AVAudioFormat()
+            }
+            
             engine.avEngine.attach(avAudioNode)
             engine.avEngine.connect(engine.avEngine.inputNode, to: avAudioNode, format: nil)
         }

--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -241,6 +241,12 @@ public extension Double {
     func mapped(from source: ClosedRange<Double> = 0 ... 1.0, to target: ClosedRange<Double> = 0 ... 1.0) -> Double {
         return ((self - source.lowerBound) / (source.upperBound - source.lowerBound)) * (target.upperBound - target.lowerBound) + target.lowerBound
     }
+    
+    /// Returns false if the value is not positive
+    var isValidSampleRate : Bool {
+        // Could expand on this to check the valid sample rate range for the device (typically from 8000 through 48000 hertz.)
+        return self > 0
+    }
 }
 
 public extension CGFloat {
@@ -295,6 +301,7 @@ public extension CGFloat {
         return exp(logStart2 + scale * (self - source.lowerBound))
     }
 }
+
 
 public extension Int {
     /// Map the value to a new range

--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -244,7 +244,8 @@ public extension Double {
 
     /// Returns false if the value is not positive
     var isValidSampleRate: Bool {
-        // Could expand on this to check the valid sample rate range for the device (typically from 8000 through 48000 hertz.)
+        // Could expand on this to check the valid sample rate range for the device
+        // (typically from 8000 through 48000 hertz.)
         return self > 0
     }
 }

--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -241,9 +241,9 @@ public extension Double {
     func mapped(from source: ClosedRange<Double> = 0 ... 1.0, to target: ClosedRange<Double> = 0 ... 1.0) -> Double {
         return ((self - source.lowerBound) / (source.upperBound - source.lowerBound)) * (target.upperBound - target.lowerBound) + target.lowerBound
     }
-    
+
     /// Returns false if the value is not positive
-    var isValidSampleRate : Bool {
+    var isValidSampleRate: Bool {
         // Could expand on this to check the valid sample rate range for the device (typically from 8000 through 48000 hertz.)
         return self > 0
     }


### PR DESCRIPTION
Under certain conditions where AirPlay is set as the output, the input device's sampleRate can show up as zero. 

In this problematic situation, setting AudioKit's audioFormat to a sample rate of zero causes a fatal crash when setting the engine output - from this method inside of createEngineMixer:
`avEngine.connect(mixer.avAudioNode, to: avEngine.outputNode, format: Settings.audioFormat)`

By guarding against this using the provided code change, the problematic audio configuration will cause an error to get thrown instead when starting the engine - this gives developers the opportunity to handle the error, unlike the fatal crash.

See this issue which is I believe is the same as what I have encountered:
https://stackoverflow.com/questions/70141192/ios-audio-inputs-not-working-if-app-is-launched-while-airplay-is-connected

Also gathered from our app's analytics right before the crash (we've seen many of these):
<img width="461" alt="Screen Shot 2022-09-17 at 5 16 26 PM" src="https://user-images.githubusercontent.com/15333030/191145480-30506223-8eb9-4420-b751-edcc0a099f13.png">
            