### PR TITLE
Create RawBufferTap to expose AVAudioPCMBuffer

### DIFF
--- a/Sources/AudioKit/Taps/RawBufferTap.swift
+++ b/Sources/AudioKit/Taps/RawBufferTap.swift
@@ -3,7 +3,7 @@
 import AVFoundation
 
 /// Get the raw buffer from any node
-final public class RawBufferTap: BaseTap {
+open class RawBufferTap: BaseTap {
     /// Callback type
     public typealias Handler = (AVAudioPCMBuffer, AVAudioTime) -> Void
 

--- a/Sources/AudioKit/Taps/RawBufferTap.swift
+++ b/Sources/AudioKit/Taps/RawBufferTap.swift
@@ -1,0 +1,26 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import AVFoundation
+
+/// Get the raw buffer from any node
+final public class RawBufferTap: BaseTap {
+    /// Callback type
+    public typealias Handler = (AVAudioPCMBuffer, AVAudioTime) -> Void
+
+    private let handler: Handler
+
+    /// Initialize the raw buffer tap
+    ///
+    /// - Parameters:
+    ///   - input: Node to analyze
+    ///   - bufferSize: Size of buffer
+    ///   - handler: Callback to call on each pcm buffer received
+    public init(_ input: Node, bufferSize: UInt32 = 4096, handler: @escaping Handler) {
+        self.handler = handler
+        super.init(input, bufferSize: bufferSize)
+    }
+
+    override public func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {
+        handler(buffer, time)
+    }
+}

--- a/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
@@ -1,0 +1,31 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import XCTest
+import AudioKit
+import AVFoundation
+
+final class RawBufferTapTests: XCTestCase {
+
+    func testRawBufferTap() throws {
+
+        let engine = AudioEngine()
+        let osc = PlaygroundOscillator()
+        engine.output = osc
+
+        let dataExpectation = XCTestExpectation(description: "dataExpectation")
+        var allBuffers: [(AVAudioPCMBuffer, AVAudioTime)] = []
+        let tap = RawBufferTap(osc) { buffer, time in
+            dataExpectation.fulfill()
+            allBuffers.append((buffer, time))
+        }
+
+        tap.start()
+        osc.start()
+        try engine.start()
+
+        wait(for: [dataExpectation], timeout: 1)
+
+        XCTAssertGreaterThan(allBuffers.count, 0)
+    }
+
+}


### PR DESCRIPTION
Disclaimer: maybe there is another way already built in.
Also, could not be worth it to add to the project

The motivation was to expose the `AVAudioPCMBuffer` to use AudioKit with `SFSpeechAudioBufferRecognitionRequest`