### PR TITLE
Ensure avAudioMixer outputVolume is set on init

### DIFF
--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -43,6 +43,7 @@ public class Mixer: Node, NamedNode {
     public init(volume: AUValue = 1.0, name: String? = nil) {
         avAudioNode = mixerAU
         self.volume = volume
+        mixerAU.outputVolume = volume
         self.name = name ?? MemoryAddress(of: self).description
     }
 


### PR DESCRIPTION
When Mixer is initialized with a volume, the underlying `AVAudioMixerNode`'s output volume is not set because the `didSet` property observer for `Mixer.volume` is not called on init.

A test was started. However, I wasn't sure how to proceed due to the `fileprivate` status of `Mixer.mixerAU`, asked how to proceed with that [here](https://discord.com/channels/105882390357901312/1032334714947776572/1032361093366026241). 