### PR TITLE
set AVAudioMixerNode output volume after engine connection

### DIFF
--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -43,7 +43,6 @@ public class Mixer: Node, NamedNode {
     public init(volume: AUValue = 1.0, name: String? = nil) {
         avAudioNode = mixerAU
         self.volume = volume
-        mixerAU.outputVolume = volume
         self.name = name ?? MemoryAddress(of: self).description
     }
 

--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -150,6 +150,9 @@ extension Node {
                 // Mixers will decide which input bus to use.
                 if let mixer = avAudioNode as? AVAudioMixerNode {
                     mixer.connectMixer(input: connection.avAudioNode, format: connection.outputFormat)
+                    if let akMixer = self as? Mixer {
+                        mixer.outputVolume = akMixer.volume
+                    }
                 } else {
                     avAudioNode.connect(input: connection.avAudioNode, bus: bus, format: connection.outputFormat)
                 }


### PR DESCRIPTION
As noted in the closed issue: https://github.com/AudioKit/AudioKit/issues/2372#issuecomment-753094000

The underlying `AVAudioMixerNode` did not retain the output volume of the mixer until the node was connected to the engine. If a Mixer was initialized with a volume, or `mixer.volume` was set before the engine was started, the value was not retained, and the underlying mixer's output volume was its default 1.0.