### PR TITLE
Added test case for Mixer volume check

### DIFF
--- a/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
@@ -53,4 +53,36 @@ extension MixerTests {
         }
         wait(for: [delayExpectation], timeout: interval + 1)
     }
+    
+    func testMixerVolume() {
+        
+        let engine = AudioEngine()
+        let engineMixer = Mixer()
+        engine.output = engineMixer
+        
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+        
+        let mixerA = Mixer(volume: 0.5, name: "mixerA")
+        mixerA.addInput(player)
+        engineMixer.addInput(mixerA)
+        
+        let mixerB = Mixer(player, name: "mixerB")
+        mixerB.volume = 0.5
+        engineMixer.addInput(mixerB)
+        
+        try? engine.start()
+        
+        if let mixerANode = mixerA.avAudioNode as? AVAudioMixerNode {
+            XCTAssertEqual(mixerANode.outputVolume, mixerA.volume)
+        }
+        
+        if let mixerBNode = mixerB.avAudioNode as? AVAudioMixerNode {
+            XCTAssertEqual(mixerBNode.outputVolume, mixerA.volume)
+        }
+        
+        engine.stop()
+        
+    }
+    
 }

--- a/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
@@ -53,36 +53,33 @@ extension MixerTests {
         }
         wait(for: [delayExpectation], timeout: interval + 1)
     }
-    
+
     func testMixerVolume() {
-        
         let engine = AudioEngine()
         let engineMixer = Mixer()
         engine.output = engineMixer
-        
+
         let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
         let player = AudioPlayer(url: url)!
-        
+
         let mixerA = Mixer(volume: 0.5, name: "mixerA")
         mixerA.addInput(player)
         engineMixer.addInput(mixerA)
-        
+
         let mixerB = Mixer(player, name: "mixerB")
         mixerB.volume = 0.5
         engineMixer.addInput(mixerB)
-        
+
         try? engine.start()
-        
+
         if let mixerANode = mixerA.avAudioNode as? AVAudioMixerNode {
             XCTAssertEqual(mixerANode.outputVolume, mixerA.volume)
         }
-        
+
         if let mixerBNode = mixerB.avAudioNode as? AVAudioMixerNode {
             XCTAssertEqual(mixerBNode.outputVolume, mixerA.volume)
         }
-        
+
         engine.stop()
-        
     }
-    
 }


### PR DESCRIPTION
Test to ensure that the underlying `AVAudioMixerNode`'s `outputVolume` stays in sync with the `Mixer` when the property is set, on initialization or with property change, but before the engine has started.

I would have included this before, but I had a brain fart and was trying to access the `fileprivate` `mixerAU` property instead of just using `Nodes`'s `avAudioNode` property :neutral_face:. 
