### PR TITLE
Player - fix currentTime for looping buffer

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -132,14 +132,15 @@ public extension AudioPlayer {
         let startTime = editStartTime
         let duration = editEndTime - startTime
 
-        guard let playerTime = isBuffered
+        guard let playerTime = isBuffered && isLooping
                 ? playerTime?.truncatingRemainder(dividingBy: duration)
                 : playerTime
         else { return startTime }
 
-        guard playerTime > timeBeforePlay else { return startTime + playerTime }
+        let timeBeforePlay = playerTime >= timeBeforePlay ? timeBeforePlay : 0
+        let time = startTime + playerTime - timeBeforePlay
 
-        return startTime + playerTime - timeBeforePlay
+        return time.clamped(to: startTime...duration)
     }
 
     /// The time the node has been playing,  in seconds. This is `nil`

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -68,6 +68,19 @@ public class AudioPlayer: Node {
     public var isLooping: Bool = false {
         didSet {
             bufferOptions = isLooping ? .loops : .interrupts
+
+            if isBuffered {
+                // The playerNode needs to be stopped for the buffer options to
+                // take effect. The playerNode does not stop once a buffer has
+                // completed playback (even though the player is 'stopped' as it
+                // is no longer playing the file).
+                if status == .stopped { playerNode.stop() }
+
+                if isPlaying {
+                    Log("For buffers, 'isLooping' should only be set when the player is stopped.", type: .debug)
+                    stop()
+                }
+            }
         }
     }
 

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
@@ -337,7 +337,7 @@ class AudioPlayerTests: XCTestCase {
         let player = AudioPlayer()
         engine.output = player
 
-        let audio = engine.startTest(totalDuration: 3.0)
+        let audio = engine.startTest(totalDuration: 2.0)
 
         do {
             try player.load(url: url)
@@ -349,9 +349,6 @@ class AudioPlayerTests: XCTestCase {
         player.play()
         player.seek(time: 1.0)
         audio.append(engine.render(duration: 1.0))
-
-        player.seek(time: 1.0)
-        audio.append(engine.render(duration: 1.0))
         XCTAssertEqual(player.status, .playing)
 
         player.pause()
@@ -361,7 +358,7 @@ class AudioPlayerTests: XCTestCase {
         player.seek(time: 1.0)
         audio.append(engine.render(duration: 1.0))
         let currentTime = player.currentTime
-        XCTAssertEqual(currentTime, 6.0)
+        XCTAssertEqual(currentTime, 4.0)
         testMD5(audio)
     }
 

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
@@ -495,4 +495,31 @@ class AudioPlayerTests: XCTestCase {
         XCTAssert(player.status == .playing)
         testMD5(audio)
     }
+
+    func testPlaybackWillStopWhenSettingLoopingForBuffer() {
+        guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav"),
+              let buffer = try? AVAudioPCMBuffer(url: url)
+        else {
+            XCTFail("Couldn't create buffer")
+            return
+        }
+
+        let engine = AudioEngine()
+        let player = AudioPlayer()
+        engine.output = player
+        player.buffer = buffer
+        player.isLooping = false
+
+        let audio = engine.startTest(totalDuration: 4.0)
+        player.play()
+
+        player.play()
+        audio.append(engine.render(duration: 2.0))
+        XCTAssert(player.status == .playing)
+
+        player.isLooping = false
+        audio.append(engine.render(duration: 2.0))
+        XCTAssert(player.status == .stopped)
+        testMD5(audio)
+    }
 }

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -33,6 +33,7 @@ let validatedMD5s: [String: String] = [
     "-[AudioPlayerTests testSeekForwardsAndBackwards]": "31d6c565efa462738ac32e9438ccfed0",
     "-[AudioPlayerTests testSeekWillStop]": "84b026cbdf45d9c5f5659f1106fdee6a",
     "-[AudioPlayerTests testSeekWillContinueLooping]": "5becbd9530850f217f95ee1142a8db30",
+    "-[AudioPlayerTests testPlaybackWillStopWhenSettingLoopingForBuffer]": "5becbd9530850f217f95ee1142a8db30",
     "-[CompressorTests testAttackTime]": "f2da585c3e9838c1a41f1a5f34c467d0",
     "-[CompressorTests testDefault]": "3064ef82b30c512b2f426562a2ef3448",
     "-[CompressorTests testHeadRoom]": "98ac5f20a433ba5a858c461aa090d81f",

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -28,7 +28,7 @@ let validatedMD5s: [String: String] = [
     "-[AudioPlayerTests testSwitchFilesDuringPlayback]": "5bd0d50c56837bfdac4d9881734d0f8e",
     "-[AudioPlayerTests testCanStopPausedPlayback]": "7076f63dc5c70f6bd006a7d4ff891aa3",
     "-[AudioPlayerTests testCurrentPosition]": "8c5c55d9f59f471ca1abb53672e3ffbf",
-    "-[AudioPlayerTests testSeekAfterPause]": "01fcf60fa30105e062c00db97de501e7",
+    "-[AudioPlayerTests testSeekAfterPause]": "271add78c1dc38d54b261d240dab100f",
     "-[AudioPlayerTests testSeekAfterStop]": "90a31285a6ce11a3609a2c52f0b3ec66",
     "-[AudioPlayerTests testSeekForwardsAndBackwards]": "31d6c565efa462738ac32e9438ccfed0",
     "-[AudioPlayerTests testSeekWillStop]": "84b026cbdf45d9c5f5659f1106fdee6a",


### PR DESCRIPTION
- Fix currentTime for looping buffers (missed an 'isLooping' condition)
- Also noticed currentTime needs to be clamped.
- Prevent isLooping being set whilst the node is playing and add test for this (details in comments and commit)

currentTime should be accurate now!