### PR TITLE
MultiSegmentAudioPlayer - Prevent Int64 crash

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -94,8 +94,10 @@ public class MultiSegmentAudioPlayer: Node {
                 fileStartTime = segment.fileStartTime + referenceTimeStamp - segment.playbackStartTime
             }
             
+            // skip if invalid sample rate or fileStartTime (prevents crash)
             let sampleRate = segment.audioFile.fileFormat.sampleRate
-            guard sampleRate.isFinite else { continue } // skip if invalid sample rate (prevents crash)
+            guard sampleRate.isFinite else { continue }
+            guard fileStartTime.isFinite else { continue }
 
             let fileLengthInSamples = segment.audioFile.length
             let startFrame = AVAudioFramePosition(fileStartTime * sampleRate)


### PR DESCRIPTION
Added another guard to combat this crash I'm getting on:
`let startFrame = AVAudioFramePosition(fileStartTime * sampleRate)`

<img width="983" alt="Screen Shot 2022-12-13 at 8 36 43 AM" src="https://user-images.githubusercontent.com/15333030/207362023-760043f7-3cd7-4d2b-a00c-fddf6c80a569.png">
