### PR TITLE
Removed engine.input aka AVAudioEngine.inputNode default sample rate adjustment

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -67,15 +67,6 @@ public class AudioEngine {
         var isNotConnected = true
 
         func connect(to engine: AudioEngine) {
-            let sampleRate = engine.avEngine.inputNode.inputFormat(forBus: 0).sampleRate
-
-            // Avoids fatal crash when setting AudioKit's output with a problematic audio configuration
-            // (caused by known AirPlay issue)
-            if sampleRate.isValidSampleRate {
-                Settings.audioFormat = AVAudioFormat(standardFormatWithSampleRate: sampleRate,
-                                                     channels: 2) ?? AVAudioFormat()
-            }
-
             engine.avEngine.attach(avAudioNode)
             engine.avEngine.connect(engine.avEngine.inputNode, to: avAudioNode, format: nil)
         }


### PR DESCRIPTION
It appears that we were changing the default sample rate for all node connections based on the input. Is there some node connection issue that we need to address to avoid this or can we just revert?

Removing this default sample rate based on the input  prevents downsampling the signal when the inputNode has a low sample rate.

For example, before this PR:
If you have a bluetooth input with 16kHz sample rate, then you are using 16kHz for all of your node connections made after accessing engine.input. You can imagine a situation where a player setup after that access could be playing a wav file but downsampling to 16kHz.