### PR TITLE
Add a test for start and pause with empty mixer

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AVAudioEngine+Extensions.swift
+++ b/Sources/AudioKit/Internals/Engine/AVAudioEngine+Extensions.swift
@@ -123,6 +123,7 @@ extension AVAudioEngine {
     /// on the mixer, subsequent connections made to the mixer will silently fail.  A workaround is to connect a dummy
     /// node to the mixer prior to making a connection, then removing the dummy node after the connection has been made.
     /// This is still a bug as of macOS 11.4 (2021). A place in ADD where this would happen is the Importer editor
+    /// http://openradar.appspot.com/radar?id=5588189343383552
     func initializeMixer(_ node: AVAudioNode) -> AVAudioNode? {
         // Only an issue if engine is running, node is a mixer, and mixer has no inputs
         guard isRunning,

--- a/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
@@ -23,6 +23,9 @@ class MixerTests: XCTestCase {
 }
 
 extension MixerTests {
+
+    // Tests workaround for:
+    // http://openradar.appspot.com/radar?id=5588189343383552
     func testWiringAfterEngineStart() {
         let engine = AudioEngine()
         let engineMixer = Mixer()
@@ -45,6 +48,37 @@ extension MixerTests {
         engine.stop()
     }
 
+    @available(iOS 16.0, *)
+    // This is the same bug as the test above.
+    // However, there is no easy way to detect that engine is paused.
+    // There is currently no workaround for this in AudioKit.
+    // Apps will need to manually insert empty nodes
+    // http://openradar.appspot.com/radar?id=5588189343383552
+    func testWiringAfterEngineStartedAndPaused() async throws {
+        try XCTSkipIf(true, "Enable if we find a way to workaround this")
+        let engine = AudioEngine()
+        let engineMixer = Mixer()
+
+        engine.output = engineMixer
+        try engine.start()
+        try await Task.sleep(for: .milliseconds(1000))
+        engine.pause()
+
+        let subtreeMixer = Mixer()
+        engineMixer.addInput(subtreeMixer)
+
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+        subtreeMixer.addInput(player)
+
+        try? engine.start()
+        print(engine.connectionTreeDescription)
+        player.play()
+
+        // only for auditioning
+        // wait(for: player.duration)
+        engine.stop()
+    }
     // for waiting in the background for realtime testing
     private func wait(for interval: TimeInterval) {
         let delayExpectation = XCTestExpectation(description: "delayExpectation")


### PR DESCRIPTION
- This currently fails so it is skipped
- Add a reference to bug report

I don't have clear idea in mind on how to fix this.
I was thinking about possibly maintaining separate state within AudioEngine, but we don't have a reference to it from Mixer. Adding associated object to `AVAudioEngine` would probably work, but I am not sure if it is worth it. It is not that difficult to workaround at the callsite.