### PR TITLE
Introduce a callback queue on a tap

### DIFF
--- a/Sources/AudioKit/Taps/AmplitudeTap.swift
+++ b/Sources/AudioKit/Taps/AmplitudeTap.swift
@@ -44,13 +44,14 @@ public class AmplitudeTap: BaseTap {
                 bufferSize: UInt32 = 1_024,
                 stereoMode: StereoMode = .center,
                 analysisMode: AnalysisMode = .rms,
+                callbackQueue: DispatchQueue,
                 handler: @escaping (Float) -> Void = { _ in }) {
         self.handler = handler
         self.stereoMode = stereoMode
         self.analysisMode = analysisMode
         self.channelCount = Int(input.outputFormat.channelCount)
         self.amp = Array(repeating: 0, count: channelCount)
-        super.init(input, bufferSize: bufferSize)
+        super.init(input, bufferSize: bufferSize, callbackQueue: callbackQueue)
     }
 
     /// Override this method to handle Tap in derived class

--- a/Sources/AudioKit/Taps/FFTTap.swift
+++ b/Sources/AudioKit/Taps/FFTTap.swift
@@ -28,6 +28,7 @@ open class FFTTap: BaseTap {
     public init(_ input: Node,
                 bufferSize: UInt32 = 4096,
                 fftValidBinCount: FFTValidBinCount? = nil,
+                callbackQueue: DispatchQueue,
                 handler: @escaping Handler) {
         self.handler = handler
         if let fftBinCount = fftValidBinCount {
@@ -40,7 +41,7 @@ open class FFTTap: BaseTap {
             fftData = Array(repeating: 0.0, count: Int(bufferSize))
         }
 
-        super.init(input, bufferSize: bufferSize)
+        super.init(input, bufferSize: bufferSize, callbackQueue: callbackQueue)
     }
 
     /// Override this method to handle Tap in derived class

--- a/Sources/AudioKit/Taps/RawBufferTap.swift
+++ b/Sources/AudioKit/Taps/RawBufferTap.swift
@@ -15,9 +15,9 @@ open class RawBufferTap: BaseTap {
     ///   - input: Node to analyze
     ///   - bufferSize: Size of buffer
     ///   - handler: Callback to call on each pcm buffer received
-    public init(_ input: Node, bufferSize: UInt32 = 4096, handler: @escaping Handler) {
+    public init(_ input: Node, bufferSize: UInt32 = 4096, callbackQueue: DispatchQueue, handler: @escaping Handler) {
         self.handler = handler
-        super.init(input, bufferSize: bufferSize)
+        super.init(input, bufferSize: bufferSize, callbackQueue: callbackQueue)
     }
 
     override public func doHandleTapBlock(buffer: AVAudioPCMBuffer, at time: AVAudioTime) {

--- a/Sources/AudioKit/Taps/RawDataTap.swift
+++ b/Sources/AudioKit/Taps/RawDataTap.swift
@@ -18,10 +18,10 @@ open class RawDataTap: BaseTap {
     ///   - input: Node to analyze
     ///   - bufferSize: Size of buffer to analyze
     ///   - handler: Callback to call when results are available
-    public init(_ input: Node, bufferSize: UInt32 = 1_024, handler: @escaping Handler = { _ in }) {
+    public init(_ input: Node, bufferSize: UInt32 = 1_024, callbackQueue: DispatchQueue, handler: @escaping Handler = { _ in }) {
         self.data = Array(repeating: 0.0, count: Int(bufferSize))
         self.handler = handler
-        super.init(input, bufferSize: bufferSize)
+        super.init(input, bufferSize: bufferSize, callbackQueue: callbackQueue)
     }
 
     /// Override this method to handle Tap in derived class

--- a/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/BaseTapTests.swift
@@ -10,7 +10,7 @@ class BaseTapTests: XCTestCase {
         let player = AudioPlayer(url: url)!
         engine.output = player
 
-        var tap: BaseTap? = BaseTap(player, bufferSize: 1024)
+        var tap: BaseTap? = BaseTap(player, bufferSize: 1024, callbackQueue: .main)
         weak var weakTap = tap
         tap?.start()
 
@@ -25,7 +25,7 @@ class BaseTapTests: XCTestCase {
         let player = AudioPlayer(url: url)!
         engine.output = player
 
-        let tap: BaseTap = BaseTap(player, bufferSize: 176400)
+        let tap: BaseTap = BaseTap(player, bufferSize: 176400, callbackQueue: .main)
         tap.start()
         _ = engine.startTest(totalDuration: 1.0)
         _ = engine.render(duration: 1.0)

--- a/Tests/AudioKitTests/Tap Tests/FFTTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/FFTTapTests.swift
@@ -29,7 +29,7 @@ class FFTTapTests: XCTestCase {
         let targetFrequencies: [Float] = [88, 258, 433, 605, 777, 949, 1122, 1294, 1467, 1639]
         let expectedBuckets: [Int] = [8, 24, 40, 56, 72, 88, 104, 120, 136, 152]
 
-        let tap = FFTTap(mixer) { fft in
+        let tap = FFTTap(mixer, callbackQueue: .main) { fft in
             let max: Float = fft.max() ?? 0.0
             let index = Int(fft.firstIndex(of: max) ?? 0)
             if !fftData.contains(index) {
@@ -84,7 +84,7 @@ class FFTTapTests: XCTestCase {
         let targetFrequencies: [Float] = [88, 258, 433, 605, 777, 949, 1122, 1294, 1467, 1639]
         let expectedBuckets: [Int] = [8, 24, 40, 56, 72, 88, 104, 120, 136, 152]
 
-        let tap = FFTTap(oscillator) { fft in
+        let tap = FFTTap(oscillator, callbackQueue: .main) { fft in
             let max: Float = fft.max() ?? 0.0
             let index = Int(fft.firstIndex(of: max) ?? 0) / (paddingFactor + 1)
             if !fftData.contains(index) {

--- a/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
@@ -14,7 +14,7 @@ final class RawBufferTapTests: XCTestCase {
 
         let dataExpectation = XCTestExpectation(description: "dataExpectation")
         var allBuffers: [(AVAudioPCMBuffer, AVAudioTime)] = []
-        let tap = RawBufferTap(osc) { buffer, time in
+        let tap = RawBufferTap(osc, callbackQueue: .main) { buffer, time in
             dataExpectation.fulfill()
             allBuffers.append((buffer, time))
         }


### PR DESCRIPTION
Fixes #2814, but it feels clumsy as we have two syncronisation mechanisms - locks and queue.

We should probably rewrite a tap to work on one dispatch queue and remove all the locks.