### PR TITLE
Fix crash in AudioPlayer currentTime calculation

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Playback.swift
@@ -140,7 +140,7 @@ public extension AudioPlayer {
         let timeBeforePlay = playerTime >= timeBeforePlay ? timeBeforePlay : 0
         let time = startTime + playerTime - timeBeforePlay
 
-        return time.clamped(to: startTime...duration)
+        return time.clamped(to: startTime...startTime + duration)
     }
 
     /// The time the node has been playing,  in seconds. This is `nil`


### PR DESCRIPTION
`AudioPlayer` crashes when calling it's `currentTime` while looping in some conditions. Even if it doesn't crash it produces wrong result.

This PR fixes it.