### PR TITLE
Implement incremental connection to Mixer

### DIFF
--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -69,7 +69,7 @@ public class Mixer: Node, NamedNode {
 
     /// Add input to the mixer
     /// - Parameter node: Node to add
-    public func addInput(_ node: Node) {
+    public func addInput(_ node: Node, strategy: ConnectStrategy = .complete) {
         guard !hasInput(node) else {
             Log("🛑 Error: Node is already connected to Mixer.")
             return
@@ -84,7 +84,12 @@ public class Mixer: Node, NamedNode {
             mixerAU.engine?.detach(mixerReset)
         }
 
-        makeAVConnections()
+        switch strategy {
+        case .complete:
+            makeAVConnections()
+        case .incremental:
+            makeAVConnections(for: [node])
+        }
     }
 
     /// Is this node already connected?

--- a/Sources/AudioKit/Nodes/Node+ConnectStrategy.swift
+++ b/Sources/AudioKit/Nodes/Node+ConnectStrategy.swift
@@ -1,0 +1,11 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import AVFAudio
+
+/// Describes a way to connect a node to another node
+public enum ConnectStrategy {
+    /// Traverses all existing connections of target node
+    case complete
+    /// Traverses only newly added node and connects it
+    case incremental
+}

--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -130,7 +130,8 @@ extension Node {
         }
     }
 
-    func makeAVConnections() {
+    func makeAVConnections(for subset: [Node]? = nil) {
+        let connections = subset ?? connections
         if let node = self as? HasInternalConnections {
             node.makeInternalConnections()
         }

--- a/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Mixing Tests/MixerTests.swift
@@ -67,18 +67,43 @@ extension MixerTests {
         engineMixer.addInput(mixerA)
 
         let mixerB = Mixer(player, name: "mixerB")
-        mixerB.volume = 0.5
+        mixerB.volume = 0.3
         engineMixer.addInput(mixerB)
 
         try? engine.start()
 
-        if let mixerANode = mixerA.avAudioNode as? AVAudioMixerNode {
-            XCTAssertEqual(mixerANode.outputVolume, mixerA.volume)
-        }
+        let mixerANode = mixerA.avAudioNode as! AVAudioMixerNode
+        XCTAssertEqual(mixerANode.outputVolume, mixerA.volume)
 
-        if let mixerBNode = mixerB.avAudioNode as? AVAudioMixerNode {
-            XCTAssertEqual(mixerBNode.outputVolume, mixerA.volume)
-        }
+        let mixerBNode = mixerB.avAudioNode as! AVAudioMixerNode
+        XCTAssertEqual(mixerBNode.outputVolume, mixerB.volume)
+
+        engine.stop()
+    }
+
+    func testMixerVolumeWhenAddingIncrementally() {
+        let engine = AudioEngine()
+        let engineMixer = Mixer()
+        engine.output = engineMixer
+
+        let url = Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")!
+        let player = AudioPlayer(url: url)!
+
+        let mixerA = Mixer(volume: 0.5, name: "mixerA")
+        mixerA.addInput(player, strategy: .incremental)
+        engineMixer.addInput(mixerA)
+
+        let mixerB = Mixer(player, name: "mixerB")
+        mixerB.volume = 0.3
+        engineMixer.addInput(mixerB, strategy: .incremental)
+
+        try? engine.start()
+
+        let mixerANode = mixerA.avAudioNode as! AVAudioMixerNode
+        XCTAssertEqual(mixerANode.outputVolume, mixerA.volume)
+
+        let mixerBNode = mixerB.avAudioNode as! AVAudioMixerNode
+        XCTAssertEqual(mixerBNode.outputVolume, mixerB.volume)
 
         engine.stop()
     }

--- a/Tests/AudioKitTests/Node Tests/NodeTests.swift
+++ b/Tests/AudioKitTests/Node Tests/NodeTests.swift
@@ -46,6 +46,7 @@ class NodeTests: XCTestCase {
         let mixer = Mixer()
         mixer.addInput(player)
         mixer.addInput(player)
+        mixer.addInput(player, strategy: .incremental)
         XCTAssertEqual(mixer.connections.count, 1)
     }
     


### PR DESCRIPTION
Existing `addInput` strategy traverses existing connections and reestablishes them.

This might not be always desirable.

The specific problem that I had was that I was adding a node while having parameter automation on another node that was already in the mixer.

Since we [reset mixer volume](https://github.com/AudioKit/AudioKit/pull/2791) while doing connections, parameter automation was not working as expected.

We default to existing strategy so this is not a breaking change.