### PR TITLE
Implement AUNewPitch audio unit node

### DIFF
--- a/Sources/AudioKit/Nodes/Effects/NewPitch.swift
+++ b/Sources/AudioKit/Nodes/Effects/NewPitch.swift
@@ -1,0 +1,33 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import AVFAudio
+
+/// `AUNewPitch` audio unit
+/// This is different to `AUNewTimePitch` (`AVAudioUnitTimePitch`).
+/// `AUNewTimePitch` does both time stretching and pitch shifting.
+/// `AUNewTimePitch` is `AVAudioUnitTimeEffect` and `AUNewPitch` is `AVAudioUnitEffect`
+public class NewPitch: Node {
+    private let input: Node
+    private let pitchUnit = instantiate(
+        componentDescription: AudioComponentDescription(appleEffect: kAudioUnitSubType_NewTimePitch)
+    )
+
+    public var connections: [AudioKit.Node] { [input] }
+    public var avAudioNode: AVAudioNode { pitchUnit }
+
+    /// Initialize the time pitch node
+    ///
+    /// - Parameters:
+    ///   - input: Input node to process
+    public init(_ input: Node) {
+        self.input = input
+    }
+
+    /// Pitch (Cents) ranges from -2400 to 2400 (Default: 0.0)
+    /// NOTE: Base value of pitch is 1.0.
+    /// This means that the value of 1 is the state where no pitch shifing is applied.
+    public var pitch: AUValue {
+        get { AudioUnitGetParameter(pitchUnit.audioUnit, param: kNewTimePitchParam_Pitch) }
+        set { AudioUnitSetParameter(pitchUnit.audioUnit, param: kNewTimePitchParam_Pitch, to: newValue) }
+    }
+}

--- a/Tests/AudioKitTests/Node Tests/Effects Tests/NewPitchTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Effects Tests/NewPitchTests.swift
@@ -1,0 +1,32 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import XCTest
+import AudioKit
+import AVFAudio
+
+final class NewPitchTests: XCTestCase {
+    let engine = AudioEngine()
+    let newPitch = NewPitch(ConstantGenerator(constant: 1))
+
+    override func setUp() {
+        super.setUp()
+        engine.output = newPitch
+    }
+
+    func testSetAndGetPitch() {
+        newPitch.pitch = 200
+        XCTAssertEqual(newPitch.pitch, 200)
+
+        newPitch.pitch = -300
+        XCTAssertEqual(newPitch.pitch, -300)
+
+        newPitch.pitch = 1
+        XCTAssertEqual(newPitch.pitch, 1)
+    }
+
+    // This serves as a smoke test
+    // in case future OS versions change the default.
+    func testDefaultValue() {
+        XCTAssertEqual(newPitch.pitch, 0)
+    }
+}


### PR DESCRIPTION
Apple exposes two audio units behind `kAudioUnitSubType_NewTimePitch`.

One is `AUNewTimePitch` which is available as `AVAudioUnitTimePitch` and is of type `kAudioUnitType_FormatConverter`.

Another one is `AUNewPitch` and this one is not available as a `AVAudioNode`. The type of this unit is `kAudioUnitType_Effect`.
`AUNewPitch` can only perform pitch shifting and not time stretching.

Why you might want this:

- Simple effects can be wired directly to input node where time effects can't.
- Another reason is this bug: http://openradar.appspot.com/radar?id=5525654997041152