### PR TITLE
Fixes two control-flow typos in `func convertToPCM()`

### DIFF
--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
@@ -169,7 +169,7 @@ extension FormatConverter {
                 {
                     completionProxy(error: Self.createError(message: "Error reading from the input file."),
                                     completionHandler: completionHandler)
-                    didErrorWhileIteratingSRCBUffer = true
+                    didErrorWhileIteratingSRCBuffer = true
                     return
                 }
                 // EOF
@@ -183,13 +183,13 @@ extension FormatConverter {
                 {
                     completionProxy(error: Self.createError(message: "Error reading from the output file."),
                                     completionHandler: completionHandler)
-                    didErrorWhileIteratingSRCBUffer = true
+                    didErrorWhileIteratingSRCBuffer = true
                     return
                 }
             }
         }
 
-        if !didErrorWhileIteratingSRCBUffer {
+        if !didErrorWhileIteratingSRCBuffer {
             // no errors
             completionHandler?(nil)
         }

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
@@ -185,9 +185,6 @@ extension FormatConverter {
                 }
             }
         }
-
-        closeFiles()
-
         // no errors
         completionHandler?(nil)
     }

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
@@ -148,6 +148,7 @@ extension FormatConverter {
         var srcBuffer = [UInt8](repeating: 0, count: Int(bufferByteSize))
         var sourceFrameOffset: UInt32 = 0
 
+        var didErrorWhileIteratingSRCBuffer = false
         srcBuffer.withUnsafeMutableBytes { body in
             while true {
                 let mBuffer = AudioBuffer(mNumberChannels: inputDescription.mChannelsPerFrame,
@@ -168,6 +169,7 @@ extension FormatConverter {
                 {
                     completionProxy(error: Self.createError(message: "Error reading from the input file."),
                                     completionHandler: completionHandler)
+                    didErrorWhileIteratingSRCBUffer = true
                     return
                 }
                 // EOF
@@ -181,12 +183,16 @@ extension FormatConverter {
                 {
                     completionProxy(error: Self.createError(message: "Error reading from the output file."),
                                     completionHandler: completionHandler)
+                    didErrorWhileIteratingSRCBUffer = true
                     return
                 }
             }
         }
-        // no errors
-        completionHandler?(nil)
+
+        if !didErrorWhileIteratingSRCBUffer {
+            // no errors
+            completionHandler?(nil)
+        }
     }
 
     func createOutputDescription(options: Options,


### PR DESCRIPTION
## Two fixes in `func convertToPCM(){}` 
[file here](https://github.com/AudioKit/AudioKit/blob/618df54cf5a31ae267d3957cf8a2f03a137f16cf/Sources/AudioKit/Audio%20Files/Format%20Converter/FormatConverter%2BPCM.swift#L8C29-L8C29)


#### Fix 1: 
There is a `defer{}` which calls `closeFiles()`, but later it's called again further down the function - so executes twice.

![CleanShot 2023-06-30 at 12 19 07@2x](https://github.com/AudioKit/AudioKit/assets/1131967/65135b73-dcaf-4075-a2cb-5283e507b15f)

![CleanShot 2023-06-30 at 12 19 53@2x](https://github.com/AudioKit/AudioKit/assets/1131967/c6c5340a-4fe5-438b-9483-7a1bcad4b1a5)

#### Fix 2: 
This one is a bit serious: when there's an error (_see below_), the `completionHandler` is first called with the error, but then later executes the "no errors" path and calls `completionHandler?(nil)`, so both paths execute in the client code:

![CleanShot 2023-06-30 at 12 22 39@2x](https://github.com/AudioKit/AudioKit/assets/1131967/e2ed48ff-7ef5-47c5-b0d8-2fc121ad1d45)

