### PR TITLE
Tap buffer length fix

### DIFF
--- a/Sources/AudioKit/Taps/BaseTap.swift
+++ b/Sources/AudioKit/Taps/BaseTap.swift
@@ -82,9 +82,7 @@ open class BaseTap {
             bufferSize: bufferSize,
             format: nil,
             block: { [weak self] buffer, time in
-                self?.callbackQueue.async {
-                    self?.handleBlock?(buffer, time)
-                }
+                self?.handleBlock?(buffer, time)
             }
         )
     }
@@ -108,15 +106,18 @@ open class BaseTap {
         }
 
         bufferWithCapacity.frameLength = bufferSize
-
-        // Create trackers as needed.
-        self.lock()
-        guard self.isStarted == true else {
+        
+        self.callbackQueue.async {
+            
+            // Create trackers as needed.
+            self.lock()
+            guard self.isStarted == true else {
+                self.unlock()
+                return
+            }
+            self.doHandleTapBlock(buffer: bufferWithCapacity, at: time)
             self.unlock()
-            return
         }
-        self.doHandleTapBlock(buffer: bufferWithCapacity, at: time)
-        self.unlock()
     }
 
     /// Override this method to handle Tap in derived class

--- a/Sources/AudioKit/Taps/BaseTap.swift
+++ b/Sources/AudioKit/Taps/BaseTap.swift
@@ -106,9 +106,9 @@ open class BaseTap {
         }
 
         bufferWithCapacity.frameLength = bufferSize
-        
+
         self.callbackQueue.async {
-            
+
             // Create trackers as needed.
             self.lock()
             guard self.isStarted == true else {

--- a/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
@@ -27,5 +27,32 @@ final class RawBufferTapTests: XCTestCase {
 
         XCTAssertGreaterThan(allBuffers.count, 0)
     }
+    
+    func testRawBufferTapCount() throws {
+        let duration = 1.5
+        let bufferSize = 1024
+        let rounding = 0.9
+        
+        let engine = AudioEngine()
+        let osc = PlaygroundOscillator()
+        engine.output = osc
+
+        let durationExpectation = XCTestExpectation(description: "durationExpectation")
+        var allBuffers: [(AVAudioPCMBuffer, AVAudioTime)] = []
+        let tap = RawBufferTap(osc, bufferSize: UInt32(bufferSize), callbackQueue: .main) { buffer, time in
+            allBuffers.append((buffer, time))
+        }
+        
+        tap.start()
+        osc.start()
+        try engine.start()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+            durationExpectation.fulfill()
+        }
+        wait(for: [durationExpectation], timeout: duration + 0.5)
+
+        XCTAssertGreaterThan(allBuffers.count, Int(Settings.sampleRate / Double(bufferSize) * duration * rounding))
+    }
 
 }

--- a/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/RawBufferTapTests.swift
@@ -27,12 +27,12 @@ final class RawBufferTapTests: XCTestCase {
 
         XCTAssertGreaterThan(allBuffers.count, 0)
     }
-    
+
     func testRawBufferTapCount() throws {
         let duration = 1.5
         let bufferSize = 1024
         let rounding = 0.9
-        
+
         let engine = AudioEngine()
         let osc = PlaygroundOscillator()
         engine.output = osc
@@ -42,7 +42,7 @@ final class RawBufferTapTests: XCTestCase {
         let tap = RawBufferTap(osc, bufferSize: UInt32(bufferSize), callbackQueue: .main) { buffer, time in
             allBuffers.append((buffer, time))
         }
-        
+
         tap.start()
         osc.start()
         try engine.start()


### PR DESCRIPTION
Fixes a bug where the number of `doHandleTapBlock` calls is not correctly proportional to buffer size parameter.
Includes both the fix, and a test that fails without the fix.

Background:
In my own project, we've recently upgraded AudioKit from version 5.2.2 to 5.6.0. Afterwards, we saw a drastic reduction in the number of calls to `doHandleTapBlock` when recording the microphone, leading to reduced responsivity. After debugging the issue, I believe the change that caused it was moving the call to `bufferWithCapacity.frameLength = bufferSize` to be asynchronous with respect to the `block` parameter in `installTap`. I've also managed to recreate the issue and its fix using only AVFAudio code, if such an example is necessary.

Many thanks