### PR TITLE
Add flag to allow bypass of MIDI enabling on sampler

### DIFF
--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -22,10 +22,12 @@ open class MIDISampler: AppleSampler, NamedNode {
     /// Initialize the MIDI Sampler
     ///
     /// - Parameter midiOutputName: Name of the instrument's MIDI output
+    /// - Parameter shouldEnableMIDI: Should automatically enable MIDI input for this sampler. Defaults to false
     ///
-    public init(name midiOutputName: String? = nil) {
+    public init(name midiOutputName: String? = nil, shouldEnableMIDI: Bool = true) {
         super.init()
         name = midiOutputName ?? MemoryAddress(of: self).description
+        guard shouldEnableMIDI else { return }
         enableMIDI(name: name)
         hideVirtualMIDIPort()
     }


### PR DESCRIPTION
Enabling midi on sampler instance is not always desirable. If you have MIDI chain with MIDI effects, the sampler should receive transformed events and not the original ones.

This preserves backwards compatibility by defaulting to `shouldEnableMIDI` to `true`