### PR TITLE
Call internalCompletionHandler() on main thread as soon as possible

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
@@ -58,8 +58,12 @@ extension AudioPlayer {
                                    at: audioTime,
                                    completionCallbackType: completionCallbackType) { _ in
             if self.isSeeking { return }
-            DispatchQueue.main.async {
+            if Thread.isMainThread {
                 self.internalCompletionHandler()
+            } else {
+                DispatchQueue.main.async {
+                    self.internalCompletionHandler()
+                }
             }
         }
 
@@ -92,8 +96,12 @@ extension AudioPlayer {
                                   options: bufferOptions,
                                   completionCallbackType: completionCallbackType) { _ in
             if self.isSeeking { return }
-            DispatchQueue.main.async {
+            if Thread.isMainThread {
                 self.internalCompletionHandler()
+            } else {
+                DispatchQueue.main.async {
+                    self.internalCompletionHandler()
+                }
             }
         }
 


### PR DESCRIPTION
This prevents the `status` race condition in the Audio Player mentioned here https://github.com/AudioKit/AudioKit/issues/2866 while preserving the rare deadlock of not calling the method on the main thread mentioned here https://github.com/AudioKit/AudioKit/pull/2636.