### PR TITLE
Enabling multiple output formats to be used at the same time

### DIFF
--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -68,7 +68,7 @@ public class AudioEngine {
 
     /// Main mixer at the end of the signal chain
     public private(set) var mainMixerNode: Mixer?
-    
+
     /// Output format to be used when making connections to the output
     public var outputFormat = Settings.audioFormat
 

--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -68,6 +68,9 @@ public class AudioEngine {
 
     /// Main mixer at the end of the signal chain
     public private(set) var mainMixerNode: Mixer?
+    
+    /// Output format to be used when making connections to the output
+    public var outputFormat = Settings.audioFormat
 
     /// Input node mixer
     public class InputNode: Mixer {
@@ -122,7 +125,8 @@ public class AudioEngine {
 
                 // has the sample rate changed?
                 if let currentSampleRate = mainMixerNode?.avAudioNode.outputFormat(forBus: 0).sampleRate,
-                   currentSampleRate != Settings.sampleRate
+                   let currentChannelCount = mainMixerNode?.avAudioNode.outputFormat(forBus: 0).channelCount,
+                   (currentSampleRate != outputFormat.sampleRate || currentChannelCount != outputFormat.channelCount)
                 {
                     Log("Sample Rate has changed, creating new mainMixerNode at", Settings.sampleRate)
                     removeEngineMixer()
@@ -139,15 +143,16 @@ public class AudioEngine {
     }
 
     // simulate the AVAudioEngine.mainMixerNode, but create it ourselves to ensure the
-    // correct sample rate is used from Settings.audioFormat
+    // correct sample rate is used from outputFormat (default: Settings.audioFormat)
 	private func createEngineMixer() {
 		guard mainMixerNode == nil else { return }
 
 		let mixer = Mixer(name: "AudioKit Engine Mixer")
+        mixer.outputFormat = outputFormat
 		avEngine.attach(mixer.avAudioNode)
 		avEngine.connect(mixer.avAudioNode,
 						 to: avEngine.outputNode,
-						 format: Settings.audioFormat)
+						 format: outputFormat)
 
 		mainMixerNode = mixer
 	}
@@ -201,7 +206,7 @@ public class AudioEngine {
         do {
             avEngine.reset()
             try avEngine.enableManualRenderingMode(.offline,
-                                                   format: Settings.audioFormat,
+                                                   format: outputFormat,
                                                    maximumFrameCount: maximumFrameCount)
             try start()
         } catch let err {

--- a/Sources/AudioKit/Internals/Engine/AudioEngine.swift
+++ b/Sources/AudioKit/Internals/Engine/AudioEngine.swift
@@ -70,7 +70,8 @@ public class AudioEngine {
     public private(set) var mainMixerNode: Mixer?
 
     /// Output format to be used when making connections to the output
-    public var outputFormat = Settings.audioFormat
+    public var outputAudioFormat: AVAudioFormat?
+    private var outputFormat: AVAudioFormat { outputAudioFormat ?? Settings.audioFormat }
 
     /// Input node mixer
     public class InputNode: Mixer {

--- a/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
@@ -33,6 +33,9 @@ public class MatrixMixer: Node {
     public var connections: [Node] { inputs }
     public var avAudioNode: AVAudioNode { unit }
 
+    /// Output format to be used when making connections from this node
+    public var outputFormat = Settings.audioFormat
+
     public let unit = instantiate(
         componentDescription:
             AudioComponentDescription(

--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -15,6 +15,9 @@ public class Mixer: Node, NamedNode {
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode
 
+    /// Output format to be used when making connections from this node
+    public var outputFormat = Settings.audioFormat
+
     /// Name of the node
     open var name = "(unset)"
 

--- a/Sources/AudioKit/Nodes/Mixing/Mixer3D.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer3D.swift
@@ -19,14 +19,14 @@ public class Mixer3D: Mixer {
 
 	fileprivate let mixerAU = AVAudioMixerNode()
 
-	public var outputFormat: AVAudioFormat {
-		guard let monoFormat = AVAudioFormat(
+	override init(volume: AUValue = 1.0, name: String? = nil) {
+        super.init(volume: volume, name: name)
+
+		outputFormat = AVAudioFormat(
 			standardFormatWithSampleRate: Settings.audioFormat.sampleRate,
-			channels: 1) else {
-			return Settings.audioFormat
-		}
-		return monoFormat
-	}
+			channels: 1
+		) ?? Settings.audioFormat
+    }
 
 	// MARK: - 3D Mixing Properties
 


### PR DESCRIPTION
A lot of effects don't support more than 2 output channels. This will result in a crash if `Settings.audioFormat` is set to have more than 2 outputs.
To support having more than 2 outputs, and no crashes, we need to split audio chain in two parts.
First part - general audio processing part on single audio track (Sampler / Player) using format with 2 outputs.
Second part - `MatrixMixer` for routing multiple audio tracks to different outputs. This part of the chain will need to use format with N outputs.
