### PR TITLE
Make recorded file URLs public in NodeRecorder.swift

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -63,7 +63,7 @@ open class NodeRecorder: NSObject {
 
     private var recordedFileURL: URL?
 
-    private static var recordedFiles = [URL]()
+    public static var recordedFiles = [URL]()
 
     /// Callback type
     public typealias AudioDataCallback = ([Float], AVAudioTime) -> Void


### PR DESCRIPTION
This allows us to access the recorded files from our main class.