### PR TITLE
MIDIPacket Pre-allocate Bytes

### DIFF
--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -356,7 +356,8 @@ extension MIDI {
                             time: MIDITimeStamp = mach_absolute_time(),
                             endpointsUIDs: [MIDIUniqueID]? = nil,
                             virtualOutputPorts: [MIDIPortRef]? = nil) {
-        let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: data.count)
+        let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(
+            capacity: data.count)
 
         var packet: UnsafeMutablePointer<MIDIPacket> = MIDIPacketListInit(packetListPointer)
         packet = MIDIPacketListAdd(packetListPointer, 1_024, packet, time, data.count, data)

--- a/Sources/AudioKit/MIDI/MIDI+Sending.swift
+++ b/Sources/AudioKit/MIDI/MIDI+Sending.swift
@@ -356,7 +356,7 @@ extension MIDI {
                             time: MIDITimeStamp = mach_absolute_time(),
                             endpointsUIDs: [MIDIUniqueID]? = nil,
                             virtualOutputPorts: [MIDIPortRef]? = nil) {
-        let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: 1)
+        let packetListPointer: UnsafeMutablePointer<MIDIPacketList> = UnsafeMutablePointer.allocate(capacity: data.count)
 
         var packet: UnsafeMutablePointer<MIDIPacket> = MIDIPacketListInit(packetListPointer)
         packet = MIDIPacketListAdd(packetListPointer, 1_024, packet, time, data.count, data)

--- a/Tests/AudioKitTests/MIDI Tests/UMPParsingTests.swift
+++ b/Tests/AudioKitTests/MIDI Tests/UMPParsingTests.swift
@@ -121,6 +121,13 @@ class UMPParsingTests: XCTestCase {
                                                           portID: sender.uniqueID)])
     }
 
+    // Test for heap overflow encountered in https://github.com/AudioKit/AudioKit/issues/2890
+    // will timeout if heap overflow is encountered
+    func testHeapAllocation() {
+        let overflowingMessage: [UInt8] = Array(repeating: 0x01, count: 260)
+        midi.sendMessage(overflowingMessage)
+    }
+
     func testSimultaneousStreams() throws {
         throw XCTSkip("skip test for now: sysex joining is not thread safe")
 


### PR DESCRIPTION
Pre-allocate needed bytes so heap doesn't overflow as demonstrated in #2890