### PR TITLE
Fix crash after reading a MIDICustomMetaEvent with payload size > 127 bytes

### DIFF
--- a/Sources/AudioKit/MIDI/Enums/MIDICustomMetaEvent.swift
+++ b/Sources/AudioKit/MIDI/Enums/MIDICustomMetaEvent.swift
@@ -125,7 +125,7 @@ public struct MIDICustomMetaEvent: MIDIMessage {
             let type = MIDICustomMetaEventType(rawValue: data[1]),
             let vlqLength = MIDIVariableLengthQuantity(fromBytes: Array(data.suffix(from: 2))) {
             self.length = Int(vlqLength.quantity)
-            self.data = Array(data.prefix(2 + vlqLength.length + length)) //drop excess data
+            self.data = Array(data.prefix(2 + vlqLength.length + length)) // drop excess data
             self.type = type
         } else {
             return nil

--- a/Sources/AudioKit/MIDI/Enums/MIDICustomMetaEvent.swift
+++ b/Sources/AudioKit/MIDI/Enums/MIDICustomMetaEvent.swift
@@ -125,7 +125,7 @@ public struct MIDICustomMetaEvent: MIDIMessage {
             let type = MIDICustomMetaEventType(rawValue: data[1]),
             let vlqLength = MIDIVariableLengthQuantity(fromBytes: Array(data.suffix(from: 2))) {
             self.length = Int(vlqLength.quantity)
-            self.data = Array(data.prefix(3 + length)) //drop excess data
+            self.data = Array(data.prefix(2 + vlqLength.length + length)) //drop excess data
             self.type = type
         } else {
             return nil


### PR DESCRIPTION
When a MIDI file contains a Meta event with payload longer than 127 bytes, reading until that event works fine, but then the offset to jump to the next event is calculated wrong.
MIDIVariableLengthQuantity() is correctly used to calculate the length of the payload, but not for the amount to bytes used to encode payload length.

Meta events start with a byte with value FF, then a byte containing the meta event type, then a variable count of n bytes containing the encoded length of payload and finally the payload. The old code assumes the value 1 instead of n for the count of bytes containing the length of payload. My change uses the count of bytes from vlqLength.length.

Please ignore the name of my (old) fork containing an old AudioKit version. I was not able to delete it and create a new one.
The PR is for current version 6.5.2.

Best regards,
Matthias