### PR TITLE
Use existing track names from midi file instead of overwriting them with "InitializedTrack"

### DIFF
--- a/Sources/AudioKit/Sequencing/Apple Sequencer/AppleSequencer.swift
+++ b/Sources/AudioKit/Sequencing/Apple Sequencer/AppleSequencer.swift
@@ -668,7 +668,7 @@ open class AppleSequencer: NSObject {
                 MusicSequenceGetIndTrack(existingSequence, UInt32(i), &musicTrack)
             }
             if let existingMusicTrack = musicTrack {
-                tracks.append(MusicTrackManager(musicTrack: existingMusicTrack, name: "InitializedTrack"))
+                tracks.append(MusicTrackManager(musicTrack: existingMusicTrack, name: ""))
             }
         }
 

--- a/Sources/AudioKit/Sequencing/Apple Sequencer/MusicTrack.swift
+++ b/Sources/AudioKit/Sequencing/Apple Sequencer/MusicTrack.swift
@@ -96,7 +96,7 @@ open class MusicTrackManager {
         if existingTrackName == nil && name != "" {
             // Add a meta event with track name from parameter
             let data = [MIDIByte](name.utf8)
-            addMetaEvent(metaEventType: 3, data: data, position: Duration(beats: 0))
+            addMetaEvent(metaEventType: 3, data: data)
         }
 
         initSequence()
@@ -586,7 +586,9 @@ open class MusicTrackManager {
     ///   - data: The MIDI data byte array - standard bytes containing the length of the data are added automatically
     ///   - position: Where in the sequence to start the note (expressed in beats)
     ///
-    public func addMetaEvent(metaEventType: MIDIByte, data: [MIDIByte], position: Duration) {
+    public func addMetaEvent(metaEventType: MIDIByte,
+                             data: [MIDIByte],
+                             position: Duration = Duration(beats: 0)) {
         guard let track = internalMusicTrack else {
             Log("internalMusicTrack does not exist")
             return
@@ -594,7 +596,7 @@ open class MusicTrackManager {
         let metaEventPtr = MIDIMetaEvent.allocate(metaEventType: metaEventType, data: data)
         defer { metaEventPtr.deallocate() }
 
-        let result = MusicTrackNewMetaEvent(track, MusicTimeStamp(0), metaEventPtr)
+        let result = MusicTrackNewMetaEvent(track, position.musicTimeStamp, metaEventPtr)
         if result != 0 {
             Log("Unable to write meta event")
         }

--- a/Sources/AudioKit/Sequencing/Apple Sequencer/MusicTrack.swift
+++ b/Sources/AudioKit/Sequencing/Apple Sequencer/MusicTrack.swift
@@ -92,8 +92,7 @@ open class MusicTrackManager {
         if name == "" {
             // Use track name from meta event (or empty name if no meta event found)
             self.name = tryReadTrackNameFromMetaEvent() ?? ""
-        }
-        else {
+        } else {
             // Clear track name meta event if exists
             clearMetaEvent(3)
             // Add meta event with new track name
@@ -110,7 +109,7 @@ open class MusicTrackManager {
     ///
     func tryReadTrackNameFromMetaEvent() -> String? {
         var trackName: String?
-        
+
         eventData?.forEach({ event in
             if event.type == kMusicEventType_Meta {
                 let metaEventPointer = UnsafeMIDIMetaEventPointer(event.data)
@@ -382,7 +381,7 @@ open class MusicTrackManager {
         }
         DisposeMusicEventIterator(iterator)
     }
-    
+
     /// Clear a specific meta event
     public func clearMetaEvent(_ metaEventType: MIDIByte) {
         guard let track = internalMusicTrack else {
@@ -623,7 +622,7 @@ open class MusicTrackManager {
             Log("Unable to insert raw midi data")
         }
     }
-    
+
     /// Add MetaEvent to sequence
     ///
     /// - Parameters:

--- a/Sources/AudioKit/Sequencing/Apple Sequencer/MusicTrack.swift
+++ b/Sources/AudioKit/Sequencing/Apple Sequencer/MusicTrack.swift
@@ -81,7 +81,7 @@ open class MusicTrackManager {
     ///
     /// if the track already contains a track name meta event, that name is used instead of the name parameter.
     ///
-    /// A track name meta event is only added, if it doesn't  yet exist and the name parameter is not an empty string.
+    /// A track name meta event is only added, if it doesn't yet exist and the name parameter is not an empty string.
     ///
     /// - parameter musicTrack: An Apple Music Track
     /// - parameter name: Name for the track


### PR DESCRIPTION
Hi Aure

I tried to use AppleSequencer to read a midi file, find a specific track by name, make some changes on that track and then write the result back to the file with `sequencer.genData()!.write(to: fileUrl!)`.

While doing that, I run into two issues of AppleSequencer midi file handling:

- When reading a file with named tracks (containing TrackName meta events), these names are ignored and all tracks in AudioKit have the same name "InitializedTrack"
- When writing the sequence back into the midi file, additional meta events with track name "InitializedTrack" were added to the midi file.

This pull request fixes these two issues as following:

- function `init(musicTrack: MusicTrack, name: String = "Unnamed")` in `MusicTrackManager` now reads the track name from existing meta event, if the name parameter is an empty string. If no track name meta event is found, no name is set by intention (to not change midi file when writing back).
- function `init(musicTrack: MusicTrack, name: String = "Unnamed")` in `MusicTrackManager` first removes existing track name meta event before adding a new one.
- function `initTracks()` in `AppleSequencer` initializes MusicTrackManager with empty name to request track names from midi file
- Added a new public function `addMetaEvent()` that is also internally used to write the track name meta event
- Added a new public function `clearMetaEvent(_ metaEventType: MIDIByte)` that is also internally used to delete existing track name meta event.

Regards, Matthias