### PR TITLE
AudioPlayer completionHandler #2916 fix

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -94,7 +94,8 @@ public class AudioPlayer: Node {
 
     /// Completion handler to be called when file or buffer is done playing.
     /// This also will be called when looping from disk,
-    /// but no completion is called when looping seamlessly when buffered
+    /// but no completion is called when looping seamlessly when buffered.
+    /// This runs on an asyncronous thread and requires thread-safety practice. See: https://web.mit.edu/6.031/www/fa17/classes/20-thread-safety/.
     public var completionHandler: AVAudioNodeCompletionHandler?
 
     /// The file to use with the player. This can be set while the player is playing.

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -197,18 +197,7 @@ public class AudioPlayer: Node {
     // MARK: - Internal functions
 
     func internalCompletionHandler() {
-        guard status == .playing,
-              !isSeeking,
-              engine?.isInManualRenderingMode == false else { return }
-
         completionHandler?()
-
-        if isLooping, !isBuffered {
-            status = .stopped
-            play()
-        } else {
-            status = .stopped
-        }
     }
 
     // MARK: - Init

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -95,7 +95,8 @@ public class AudioPlayer: Node {
     /// Completion handler to be called when file or buffer is done playing.
     /// This also will be called when looping from disk,
     /// but no completion is called when looping seamlessly when buffered.
-    /// This runs on an asyncronous thread and requires thread-safety practice. See: https://web.mit.edu/6.031/www/fa17/classes/20-thread-safety/.
+    /// This runs on an asyncronous thread and 
+    /// requires thread-safety practice. See: https://web.mit.edu/6.031/www/fa17/classes/20-thread-safety/.
     public var completionHandler: AVAudioNodeCompletionHandler?
 
     /// The file to use with the player. This can be set while the player is playing.

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
@@ -522,4 +522,28 @@ class AudioPlayerTests: XCTestCase {
         XCTAssert(player.status == .stopped)
         testMD5(audio)
     }
+
+    // https://github.com/AudioKit/AudioKit/issues/2916
+    func testCompletionHandler() {
+        guard let counting = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav")
+        else {
+            XCTFail("Couldn't find file")
+            return
+        }
+        guard let drumLoop = Bundle.module.url(forResource: "TestResources/drumloop", withExtension: "wav")
+        else {
+            XCTFail("Couldn't find file")
+            return
+        }
+        let engine = AudioEngine()
+        let player = AudioPlayer()
+        engine.output = player
+        player.completionHandler = {
+            try? player.load(url: drumLoop)
+            player.play()
+        }
+        try? player.load(url: counting)
+        player.play()
+        XCTAssert(player.status != .stopped) // Player should be playing
+    }
 }

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
@@ -543,7 +543,9 @@ class AudioPlayerTests: XCTestCase {
             player.play()
         }
         try? player.load(url: counting)
+        let audio = engine.startTest(totalDuration: 9.0)
         player.play()
-        XCTAssert(player.status != .stopped) // Player should be playing
+        audio.append(engine.render(duration: 9.0))
+        testMD5(audio)
     }
 }

--- a/Tests/AudioKitTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitTests/ValidatedMD5s.swift
@@ -34,6 +34,7 @@ let validatedMD5s: [String: [String]] = [
     "-[AudioPlayerTests testSeekWillStop]": ["84b026cbdf45d9c5f5659f1106fdee6a"],
     "-[AudioPlayerTests testSeekWillContinueLooping]": ["5becbd9530850f217f95ee1142a8db30"],
     "-[AudioPlayerTests testPlaybackWillStopWhenSettingLoopingForBuffer]": ["5becbd9530850f217f95ee1142a8db30"],
+    "-[AudioPlayerTests testCompletionHandler]": ["931361a78333a754a4c357aa82301e94"],
     "-[CompressorTests testAttackTime]": ["f2da585c3e9838c1a41f1a5f34c467d0"],
     "-[CompressorTests testDefault]": ["3064ef82b30c512b2f426562a2ef3448"],
     "-[CompressorTests testHeadRoom]": ["98ac5f20a433ba5a858c461aa090d81f", "db27f010ec481cd02ca73b8652c4f7c1"],


### PR DESCRIPTION
This PR removes some code in the `AudioPlayer` `internalCompletionHandler` to avoid thread-unsafe variables.
#2916