### PR TITLE
Fix FormatConverter+Compressed on iOS 18, macOS 15, tvOS 15 and VisionOS 2

### DIFF
--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
@@ -35,7 +35,8 @@ extension FormatConverter {
         session.determineCompatibleFileTypes { list in
             Task.init {
                 guard let outputFileType: AVFileType = list.first else {
-                    let error = Self.createError(message: "Unable to determine a compatible file type from \(inputURL.path)")
+                    let errorMessage = "Unable to determine a compatible file type from \(inputURL.path)"
+                    let error = Self.createError(message: errorMessage)
                     completionHandler?(error)
                     return
                 }


### PR DESCRIPTION
Use export(to:as:) instead.

Remark: 
The old one was fully deprecated on visionOS 2 and Xcode 16. Failed to fallback.
As a workaround, I used ```#if !os(visionOS)...``` to prevent crashes.
<img width="924" alt="Screenshot 2024-06-24 at 2 15 14 PM" src="https://github.com/AudioKit/AudioKit/assets/54872601/8478886c-4e49-4e48-93d9-1d23c3fd2aea">

Ref Doc:
https://developer.apple.com/documentation/avfoundation/avassetexportsession/4354409-export