### PR TITLE
Added convertCompressed for visionOS 2.0

### DIFF
--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
@@ -63,6 +63,7 @@ extension FormatConverter {
     ///
     /// This is no longer used in this class as it's not possible to convert sample rate or other
     /// required options. It will use the next function instead
+    #if swift(>=6.0) // Swift 6.0 corresponds to Xcode 16+
     @available(macOS 15, iOS 18, tvOS 18, visionOS 2.0, *)
     func convertCompressed(presetName: String) async throws {
         guard let inputURL = inputURL else {
@@ -85,6 +86,7 @@ extension FormatConverter {
 
         try await session.export(to: outputURL, as: outputFileType)
     }
+    #endif
 
     /// Convert to compressed first creating a tmp file to PCM to allow more flexible conversion
     /// options to work.

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
@@ -50,6 +50,19 @@ extension FormatConverter {
         }
     }
 
+    /// Example of the most simplistic AVFoundation conversion.
+    /// With this approach you can't really specify any settings other than the limited presets.
+    /// No sample rate conversion in this. This isn't used in the public methods but is here
+    /// for example.
+    ///
+    /// see `AVAssetExportSession`:
+    /// *Prior to initializing an instance of AVAssetExportSession, you can invoke
+    /// +allExportPresets to obtain the complete list of presets available. Use
+    /// +exportPresetsCompatibleWithAsset: to obtain a list of presets that are compatible
+    /// with a specific AVAsset.*
+    ///
+    /// This is no longer used in this class as it's not possible to convert sample rate or other
+    /// required options. It will use the next function instead
     @available(macOS 15, iOS 18, tvOS 18, visionOS 2.0, *)
     func convertCompressed(presetName: String) async throws {
         guard let inputURL = inputURL else {


### PR DESCRIPTION
Hides existing convertCompressed from visionOS since it does not compile on the platform and adds a modern concurrency version of convertCompressed which works with visionOS 2.0

Related:
https://github.com/AudioKit/AudioKit/issues/2921
https://github.com/AudioKit/AudioKit/pull/2923