### PR TITLE
Check errors after AudioUnit interactions

### DIFF
--- a/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
+++ b/Sources/AudioKit/Internals/Utilities/AudioKitHelpers.swift
@@ -146,13 +146,15 @@ extension Sequence where Iterator.Element: Hashable {
 @inline(__always)
 internal func AudioUnitGetParameter(_ unit: AudioUnit, param: AudioUnitParameterID) -> AUValue {
     var val: AudioUnitParameterValue = 0
-    AudioUnitGetParameter(unit, param, kAudioUnitScope_Global, 0, &val)
+    let status = AudioUnitGetParameter(unit, param, kAudioUnitScope_Global, 0, &val)
+    CheckError(status)
     return val
 }
 
 @inline(__always)
 internal func AudioUnitSetParameter(_ unit: AudioUnit, param: AudioUnitParameterID, to value: AUValue) {
-    AudioUnitSetParameter(unit, param, kAudioUnitScope_Global, 0, AudioUnitParameterValue(value), 0)
+    let status = AudioUnitSetParameter(unit, param, kAudioUnitScope_Global, 0, AudioUnitParameterValue(value), 0)
+    CheckError(status)
 }
 
 extension AVAudioNode {

--- a/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
@@ -55,7 +55,7 @@ public class MatrixMixer: Node {
         // inputs to this mixer.
         var inputCount = UInt32(inputs.count)
         var outputCount = UInt32(1)
-        AudioUnitSetProperty(
+        var status = AudioUnitSetProperty(
             unit.audioUnit,
             kAudioUnitProperty_ElementCount,
             kAudioUnitScope_Input,
@@ -63,7 +63,8 @@ public class MatrixMixer: Node {
             &inputCount,
             UInt32(MemoryLayout<UInt32>.size)
         )
-        AudioUnitSetProperty(
+        CheckError(status)
+        status = AudioUnitSetProperty(
             unit.audioUnit,
             kAudioUnitProperty_ElementCount,
             kAudioUnitScope_Output,
@@ -71,6 +72,7 @@ public class MatrixMixer: Node {
             &outputCount,
             UInt32(MemoryLayout<UInt32>.size)
         )
+        CheckError(status)
     }
 
     private static let masterVolumeElement: AudioUnitElement = 0xFFFFFFFF
@@ -80,17 +82,18 @@ public class MatrixMixer: Node {
     public var masterVolume: Float {
         get {
             var value: AudioUnitParameterValue = 0
-            AudioUnitGetParameter(
+            let status = AudioUnitGetParameter(
                 unit.audioUnit,
                 kMatrixMixerParam_Volume,
                 kAudioUnitScope_Global,
                 Self.masterVolumeElement,
                 &value
             )
+            CheckError(status)
             return value
         }
         set {
-            AudioUnitSetParameter(
+            let status = AudioUnitSetParameter(
                 unit.audioUnit,
                 kMatrixMixerParam_Volume,
                 kAudioUnitScope_Global,
@@ -98,6 +101,7 @@ public class MatrixMixer: Node {
                 newValue,
                 0
             )
+            CheckError(status)
         }
     }
 
@@ -115,7 +119,7 @@ public class MatrixMixer: Node {
     }
 
     public func set(volume: Float, inputChannelIndex: Int) {
-        AudioUnitSetParameter(
+        let status = AudioUnitSetParameter(
             unit.audioUnit,
             kMatrixMixerParam_Volume,
             kAudioUnitScope_Input,
@@ -123,12 +127,13 @@ public class MatrixMixer: Node {
             volume,
             0
         )
+        CheckError(status)
     }
 
     /// Set volume of channel
     /// To map input channel 0 to output channel 1, use (0, 1) crosspoint
     public func set(volume: Float, outputChannelIndex: Int) {
-        AudioUnitSetParameter(
+        let status = AudioUnitSetParameter(
             unit.audioUnit,
             kMatrixMixerParam_Volume,
             kAudioUnitScope_Output,
@@ -136,13 +141,14 @@ public class MatrixMixer: Node {
             volume,
             0
         )
+        CheckError(status)
     }
 
     /// Set volume at crosspoint
     /// To map input channel 0 to output channel 1, use (0, 1) crosspoint
     public func set(volume: Float, atCrosspoints crosspoints: [(Int, Int)]) {
         for crosspoint in crosspoints {
-            AudioUnitSetParameter(
+            let status = AudioUnitSetParameter(
                 unit.audioUnit,
                 kMatrixMixerParam_Volume,
                 kAudioUnitScope_Global,
@@ -150,6 +156,7 @@ public class MatrixMixer: Node {
                 volume,
                 0
             )
+            CheckError(status)
         }
     }
 


### PR DESCRIPTION
I spent quite a bit of time debugging an issue where `AudioUnitSetProperty` was returning error `OSStatus`.

Ideally, all of these would be marked as throws, so that call-site can react appropriatelly to these errors. But I thought this is a good first step to improve the current situation.