### PR TITLE
Update defaultAudioFormat for iOS 18 to 48_000

### DIFF
--- a/Sources/AudioKit/Internals/Settings/Settings.swift
+++ b/Sources/AudioKit/Internals/Settings/Settings.swift
@@ -52,8 +52,22 @@ public class Settings: NSObject {
     }
 
     /// Default audio format
-    public static let defaultAudioFormat = AVAudioFormat(standardFormatWithSampleRate: 44_100,
-                                                         channels: 2) ?? AVAudioFormat()
+    public static let defaultAudioFormat: AVAudioFormat = {
+        if #available(iOS 14.0, *) {
+            if ProcessInfo.processInfo.isMacCatalystApp || ProcessInfo.processInfo.isiOSAppOnMac {
+                // iOS app on Mac
+                return AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2) ?? AVAudioFormat()
+            }
+        }
+
+        // iOS 18 handling
+        if #available(iOS 18.0, *) {
+            return AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2) ?? AVAudioFormat()
+        } else {
+            // Fallback default
+            return AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2) ?? AVAudioFormat()
+        }
+    }()
 
     /// The sample rate in Hertz, default is 44100 kHz. Set a new audioFormat if you want to change this value.
     /// See audioFormat. This is the format that is used for node connections.


### PR DESCRIPTION
This PR sets a better defaultAudioFormat for Settings.sampleRate on iOS 18 and newer. Tests have shown that the current sampleRate of 44_100 causes audio glitches when recording from the mic input. This PR changes the default in iOS 18 to `AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2) ?? AVAudioFormat()` while keeping earlier versions, Mac, and iOS on Mac unchanged.

Tests show the following:

iOS Simulator
**48_000** & **44_100** both work

Sequoia macOS Catalyst 
**44_100** works

iOS 17 iPad 
**48_000** & **44_100** both work

iOS 18 iPad
**48_000** & **44_100** both work

iOS 17 iPhone
**44_100** works

iOS 18 iPhone
**48_000** works