### PR TITLE
Fixed crash when ramping delay is longer than 4096 samples

### DIFF
--- a/Sources/AudioKit/Nodes/NodeParameter.swift
+++ b/Sources/AudioKit/Nodes/NodeParameter.swift
@@ -114,7 +114,7 @@ public class NodeParameter {
             Log("Error: can't ramp parameter \(parameter.displayName)", type: .error)
             return
         }
-        assert(delaySamples < 4097)
+        assert(delaySamples <= 4096)
         let paramBlock = avAudioNode.auAudioUnit.scheduleParameterBlock
         paramBlock(AUEventSampleTimeImmediate + Int64(delaySamples),
                    AUAudioFrameCount(duration * Float(Settings.sampleRate)),


### PR DESCRIPTION
If sample count of the delay was longer than 4096, it was capped to 4096, but after that assert() checked for < 4096; so this lead to a crash. Also made the warning log a bit more explanatory including delay length, sample rate and resulting original sample count.