### PR TITLE
Revert macOS Default SamplerRate to 44_100

### DIFF
--- a/Sources/AudioKit/Internals/Settings/Settings.swift
+++ b/Sources/AudioKit/Internals/Settings/Settings.swift
@@ -60,11 +60,6 @@ public class Settings: NSObject {
             }
         }
 
-        if #available(macOS 15.0, *) {
-            /// Default AVAudioFormat for macOS 15 and newer
-            return AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2) ?? AVAudioFormat()
-        }
-
         /// Fallback default
         return AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2) ?? AVAudioFormat()
     }()


### PR DESCRIPTION
Early in macOS 15, 48_000 became the new audio default SampleRate, but at some point they switched it back to 44_100. These changes to the device's sample rate need to be handled when recording or using the DunneSampler.

This PR picks a more probably SampleRate default for most users, but realistically developers need to account for both sample rate possibilities on macOS.