### PR TITLE
Allow non-default filenames in NodeRecorder

### DIFF
--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -133,9 +133,16 @@ open class NodeRecorder: NSObject {
         file = nil
     }
 
-    /// Returns a CAF file in specified directory suitable for writing to via Settings.audioFormat
-    public static func createAudioFile(fileDirectoryURL: URL = URL(fileURLWithPath: NSTemporaryDirectory())) -> AVAudioFile? {
-        let filename = createDateFileName() + ".caf"
+    /// Returns a CAF file in specified directory named using the provided function suitable for writing to via
+    /// Settings.audioFormat
+    /// - Parameters:
+    ///   - fileDirectoryURL: Directory in which to save recorded files. Defaults to Temp.
+    ///   - filenameProvider: Function that returns the filename to use within the fileDirectory. Any sub directorys must already exist. Defaults to String containing a date with format `yyyy-MM-dd HH-mm-ss.SSSS`. A `.caf` extension will be appended.
+    /// - Returns: The configured AVAudioFile
+    public static func createAudioFile(fileDirectoryURL: URL = URL(fileURLWithPath: NSTemporaryDirectory()),
+                                       filenameProvider: (() -> String)? = nil) -> AVAudioFile? {
+        let filenameProvider = filenameProvider ?? NodeRecorder.createDateFileName
+        let filename = filenameProvider() + ".caf"
         let url = fileDirectoryURL.appendingPathComponent(filename)
         var settings = Settings.audioFormat.settings
         settings[AVLinearPCMIsNonInterleaved] = NSNumber(value: false)


### PR DESCRIPTION
I have a use case where I need more-specific control of the names generated by the NodeRecorder. This minor refactor leaves the existing functionality but also allows the customization my project needs.

I'm specifically trying to control the filename at the time I begin recording, so I'm looking to use this functionality like this:

```
func record(withFilename filename: String) throws {

    let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
    
    var audioFile = NodeRecorder.createAudioFile(
        fileDirectoryURL: documentsURL
    ) {
        filename
    }
    
    // Set the internalAudioFile (replacing the default created in /{fileDirectoryURL}/{yyyy-MM-dd HH-mm-ss.SSSS}.caf
    openFile(file: &audioFile)
    
    try record()
    
}
```

I'm definitely open to suggestions on a better way to do this. Thanks for considering!