### PR TITLE
tempBuffer must have the same format as the source buffer.

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Buffering.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Buffering.swift
@@ -67,7 +67,9 @@ extension AudioPlayer {
         if pcmBuffer.format.channelCount < playerChannelCount {
             Log("Copying mono data to 2 channel buffer...", pcmBuffer.format)
 
-            guard let tmpBuffer = AVAudioPCMBuffer(pcmFormat: processingFormat,
+            let newProcessingFormat = AVAudioFormat(commonFormat: processingFormat.commonFormat, sampleRate: processingFormat.sampleRate, channels: playerChannelCount, interleaved: processingFormat.isInterleaved)!
+            
+            guard let tmpBuffer = AVAudioPCMBuffer(pcmFormat: newProcessingFormat,
                                                    frameCapacity: frameCount),
                 let monoData = pcmBuffer.floatChannelData
             else {


### PR DESCRIPTION
When copying mono content to two channels the target buffer must have the same sample rate as the source buffer. If not the audio content is altered.
The processing format of the source file must not be the processing format of the engine.