### PR TITLE
Update actions/checkout to v5 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-15
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Build
       run: xcodebuild -scheme AudioKit -destination "platform=iOS Simulator,name=iPhone 16 Pro" 
     - name: Run tests


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2nd, 2026.