### PR TITLE
Migrate recordingBufferLength from Settings to NodeRecorder parameter

### DIFF
--- a/Sources/AudioKit/Internals/Settings/Settings.swift
+++ b/Sources/AudioKit/Internals/Settings/Settings.swift
@@ -91,12 +91,6 @@ public class Settings: NSObject {
     /// default is .VeryLong for a buffer set to 2 power 10 = 1024 samples (232 ms)
     public static var bufferLength: BufferLength = .veryLong
 
-    /// AudioKit recording buffer length is set using Settings.BufferLength
-    /// default is .VeryLong for a buffer set to 2 power 10 = 1024 samples (232 ms)
-    /// in Apple's doc : "The requested size of the incoming buffers. The implementation may choose another size."
-    /// So setting this value may have no effect (depending on the hardware device ?)
-    public static var recordingBufferLength: BufferLength = .veryLong
-
     /// If set to true, Recording will stop after some delay to compensate
     /// latency between time recording is stopped and time it is written to file
     /// If set to false (the default value) , stopping record will be immediate,

--- a/Sources/AudioKit/Taps/NodeRecorder.swift
+++ b/Sources/AudioKit/Taps/NodeRecorder.swift
@@ -41,8 +41,8 @@ open class NodeRecorder: NSObject {
     /// Used for fixing recordings being truncated
     private var recordBufferDuration: Double = 16384 / Settings.sampleRate
 
-    /// Buffer length used for chunking audioDataCallback deliveries
-    private var bufferLength: AVAudioFrameCount = Settings.recordingBufferLength.samplesCount
+    /// Buffer length used for the recording tap and chunking audioDataCallback deliveries
+    private let bufferLength: AVAudioFrameCount
 
     /// return the AVAudioFile for reading
     open var audioFile: AVAudioFile? {
@@ -81,24 +81,25 @@ open class NodeRecorder: NSObject {
 
     /// Initialize the node recorder
     ///
-    /// Recording buffer size is Settings.recordingBufferLength
-    ///
     /// - Parameters:
     ///   - node: Node to record from
     ///   - fileDirectoryPath: Directory to write audio files to
     ///   - bus: Integer index of the bus to use
     ///   - shouldCleanupRecordings: Determines if recorded files are deleted upon deinit (default = true)
+    ///   - bufferLength: Size of the recording buffer (default = .veryLong)
     ///   - audioDataCallback: Callback after each buffer processing with raw audio data and time stamp
     ///
     public init(node: Node,
                 fileDirectoryURL: URL? = nil,
                 bus: Int = 0,
                 shouldCleanupRecordings: Bool = true,
+                bufferLength: Settings.BufferLength = .veryLong,
                 audioDataCallback: AudioDataCallback? = nil) throws
     {
         self.node = node
         self.fileDirectoryURL = fileDirectoryURL ?? URL(fileURLWithPath: NSTemporaryDirectory())
         self.shouldCleanupRecordings = shouldCleanupRecordings
+        self.bufferLength = bufferLength.samplesCount
         self.audioDataCallback = audioDataCallback
         super.init()
 
@@ -191,7 +192,6 @@ open class NodeRecorder: NSObject {
             }
         }
 
-        bufferLength = Settings.recordingBufferLength.samplesCount
         isRecording = true
 
         // Note: if you install a tap on a bus that already has a tap it will crash your application.


### PR DESCRIPTION
## Summary
- Remove `Settings.recordingBufferLength` static property and add a `bufferLength` parameter to `NodeRecorder.init` instead (defaults to `.veryLong`, same as before)
- Part of the Swift 6 migration — `Settings` is generally problematic due to its nature of static shared mutable state
- This is a breaking change but simple to resolve at callsites by passing the desired buffer length directly to `NodeRecorder`