### PR TITLE
Adopt NamedNode for all Node conformers

### DIFF
--- a/Sources/AudioKit/MIDI/MIDIInstrument.swift
+++ b/Sources/AudioKit/MIDI/MIDIInstrument.swift
@@ -21,7 +21,7 @@ open class MIDIInstrument: Node, MIDIListener, NamedNode {
     open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
-    open var name = "(unset)"
+    open var name = "MIDIInstrument"
 
     /// Active MPE notes
     open var mpeActiveNotes: [(note: MIDINoteNumber, channel: MIDIChannel)] = []

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -10,14 +10,17 @@ import os.log
 ///
 /// Similar to ``AppleSampler`` but with added MIDI capabilities
 ///
-open class MIDISampler: AppleSampler, NamedNode {
+open class MIDISampler: AppleSampler {
     // MARK: - Properties
 
     /// MIDI Input
     open var midiIn = MIDIEndpointRef()
 
     /// Name of the instrument
-    open var name = "(unset)"
+    open override var name: String {
+        get { super.name }
+        set { super.name = newValue }
+    }
 
     /// Initialize the MIDI Sampler
     ///
@@ -25,7 +28,7 @@ open class MIDISampler: AppleSampler, NamedNode {
     ///
     public init(name midiOutputName: String? = nil) {
         super.init()
-        name = midiOutputName ?? MemoryAddress(of: self).description
+        name = midiOutputName ?? "MIDISampler"
         enableMIDI(name: name)
         hideVirtualMIDIPort()
     }

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -16,12 +16,6 @@ open class MIDISampler: AppleSampler {
     /// MIDI Input
     open var midiIn = MIDIEndpointRef()
 
-    /// Name of the instrument
-    open override var name: String {
-        get { super.name }
-        set { super.name = newValue }
-    }
-
     /// Initialize the MIDI Sampler
     ///
     /// - Parameter midiOutputName: Name of the instrument's MIDI output

--- a/Sources/AudioKit/Nodes/Effects/Delay.swift
+++ b/Sources/AudioKit/Nodes/Effects/Delay.swift
@@ -4,7 +4,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's Delay Audio Unit
 ///
-public class Delay: Node {
+public class Delay: NamedNode {
     let delayAU = AVAudioUnitDelay()
 
     let input: Node
@@ -14,6 +14,8 @@ public class Delay: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { return delayAU }
+
+    public var name = "Delay"
 
     /// Specification details for dry wet mix
     public static let dryWetMixDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Distortion/AppleDistortion.swift
+++ b/Sources/AudioKit/Nodes/Effects/Distortion/AppleDistortion.swift
@@ -5,7 +5,7 @@ import AVFoundation
 /// AudioKit version of Apple's Distortion Audio Unit
 ///
 @available(iOS 8.0, *)
-public class AppleDistortion: Node {
+public class AppleDistortion: NamedNode {
     fileprivate let distAU = AVAudioUnitDistortion()
 
     let input: Node
@@ -15,6 +15,8 @@ public class AppleDistortion: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode
+
+    public var name = "AppleDistortion"
 
     /// Dry/Wet Mix (Default 50)
     public var dryWetMix: AUValue = 50 {

--- a/Sources/AudioKit/Nodes/Effects/Distortion/Decimator.swift
+++ b/Sources/AudioKit/Nodes/Effects/Distortion/Decimator.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's Decimator Audio Unit
 ///
-public class Decimator: Node {
+public class Decimator: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_Distortion)
 
     let input: Node
@@ -15,6 +15,8 @@ public class Decimator: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "Decimator"
 
     /// Specification details for decimation
     public static let decimationDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Distortion/Distortion.swift
+++ b/Sources/AudioKit/Nodes/Effects/Distortion/Distortion.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's Distortion Audio Unit
 ///
-public class Distortion: Node {
+public class Distortion: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_Distortion)
 
     let input: Node
@@ -15,6 +15,8 @@ public class Distortion: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "Distortion"
 
     /// Specification details for delay
     public static let delayDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Distortion/RingModulator.swift
+++ b/Sources/AudioKit/Nodes/Effects/Distortion/RingModulator.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's RingModulator Audio Unit
 ///
-public class RingModulator: Node {
+public class RingModulator: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_Distortion)
 
     let input: Node
@@ -15,6 +15,8 @@ public class RingModulator: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "RingModulator"
 
     /// Specification details for ringModFreq1
     public static let ringModFreq1Def = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/Compressor.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/Compressor.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's Compressor Audio Unit
 ///
-public class Compressor: Node {
+public class Compressor: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_DynamicsProcessor)
 
     let input: Node
@@ -15,6 +15,8 @@ public class Compressor: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "Compressor"
 
     /// Specification details for threshold
     public static let thresholdDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/DynamicsProcessor.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/DynamicsProcessor.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's DynamicsProcessor Audio Unit
 ///
-public class DynamicsProcessor: Node {
+public class DynamicsProcessor: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_DynamicsProcessor)
 
     let input: Node
@@ -15,6 +15,8 @@ public class DynamicsProcessor: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "DynamicsProcessor"
 
     /// Specification details for threshold
     public static let thresholdDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/Expander.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/Expander.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's Expander Audio Unit
 ///
-public class Expander: Node {
+public class Expander: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_DynamicsProcessor)
 
     let input: Node
@@ -15,6 +15,8 @@ public class Expander: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "Expander"
 
     /// Specification details for expansionRatio
     public static let expansionRatioDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/PeakLimiter.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/PeakLimiter.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's PeakLimiter Audio Unit
 ///
-public class PeakLimiter: Node {
+public class PeakLimiter: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_PeakLimiter)
 
     let input: Node
@@ -15,6 +15,8 @@ public class PeakLimiter: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "PeakLimiter"
 
     /// Specification details for attackTime
     public static let attackTimeDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Filters/BandPassFilter.swift
+++ b/Sources/AudioKit/Nodes/Effects/Filters/BandPassFilter.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's BandPassFilter Audio Unit
 ///
-public class BandPassFilter: Node {
+public class BandPassFilter: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_BandPassFilter)
 
     let input: Node
@@ -15,6 +15,8 @@ public class BandPassFilter: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "BandPassFilter"
 
     /// Specification details for centerFrequency
     public static let centerFrequencyDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Filters/HighPassFilter.swift
+++ b/Sources/AudioKit/Nodes/Effects/Filters/HighPassFilter.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's HighPassFilter Audio Unit
 ///
-public class HighPassFilter: Node {
+public class HighPassFilter: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_HighPassFilter)
 
     let input: Node
@@ -15,6 +15,8 @@ public class HighPassFilter: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "HighPassFilter"
 
     /// Specification details for cutoffFrequency
     public static let cutoffFrequencyDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Filters/HighShelfFilter.swift
+++ b/Sources/AudioKit/Nodes/Effects/Filters/HighShelfFilter.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's HighShelfFilter Audio Unit
 ///
-public class HighShelfFilter: Node {
+public class HighShelfFilter: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_HighShelfFilter)
 
     let input: Node
@@ -15,6 +15,8 @@ public class HighShelfFilter: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "HighShelfFilter"
 
     /// Specification details for cutOffFrequency
     public static let cutOffFrequencyDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Filters/LowPassFilter.swift
+++ b/Sources/AudioKit/Nodes/Effects/Filters/LowPassFilter.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's LowPassFilter Audio Unit
 ///
-public class LowPassFilter: Node {
+public class LowPassFilter: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_LowPassFilter)
 
     let input: Node
@@ -15,6 +15,8 @@ public class LowPassFilter: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "LowPassFilter"
 
     /// Specification details for cutoffFrequency
     public static let cutoffFrequencyDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Filters/LowShelfFilter.swift
+++ b/Sources/AudioKit/Nodes/Effects/Filters/LowShelfFilter.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's LowShelfFilter Audio Unit
 ///
-public class LowShelfFilter: Node {
+public class LowShelfFilter: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_LowShelfFilter)
 
     let input: Node
@@ -15,6 +15,8 @@ public class LowShelfFilter: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "LowShelfFilter"
 
     /// Specification details for cutoffFrequency
     public static let cutoffFrequencyDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/Filters/ParametricEQ.swift
+++ b/Sources/AudioKit/Nodes/Effects/Filters/ParametricEQ.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's ParametricEQ Audio Unit
 ///
-public class ParametricEQ: Node {
+public class ParametricEQ: NamedNode {
     fileprivate let effectAU = AVAudioUnitEffect(appleEffect: kAudioUnitSubType_ParametricEQ)
 
     let input: Node
@@ -15,6 +15,8 @@ public class ParametricEQ: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { effectAU }
+
+    public var name = "ParametricEQ"
 
     /// Specification details for centerFreq
     public static let centerFreqDef = NodeParameterDef(

--- a/Sources/AudioKit/Nodes/Effects/NewPitch.swift
+++ b/Sources/AudioKit/Nodes/Effects/NewPitch.swift
@@ -6,7 +6,7 @@ import AVFAudio
 /// This is different to `AUNewTimePitch` (`AVAudioUnitTimePitch`).
 /// `AUNewTimePitch` does both time stretching and pitch shifting.
 /// `AUNewTimePitch` is `AVAudioUnitTimeEffect` and `AUNewPitch` is `AVAudioUnitEffect`
-public class NewPitch: Node {
+public class NewPitch: NamedNode {
     private let input: Node
     private let pitchUnit = instantiate(
         componentDescription: AudioComponentDescription(appleEffect: kAudioUnitSubType_NewTimePitch)
@@ -14,6 +14,7 @@ public class NewPitch: Node {
 
     public var connections: [AudioKit.Node] { [input] }
     public var avAudioNode: AVAudioNode { pitchUnit }
+    public var name = "NewPitch"
 
     /// Initialize the time pitch node
     ///

--- a/Sources/AudioKit/Nodes/Effects/Reverb.swift
+++ b/Sources/AudioKit/Nodes/Effects/Reverb.swift
@@ -4,7 +4,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's Reverb Audio Unit
 ///
-public class Reverb: Node {
+public class Reverb: NamedNode {
     fileprivate let reverbAU = AVAudioUnitReverb()
 
     let input: Node
@@ -14,6 +14,8 @@ public class Reverb: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode
+
+    public var name = "Reverb"
 
     // Hacking start, stop, play, and bypass to use dryWetMix because reverbAU's bypass results in no sound
 

--- a/Sources/AudioKit/Nodes/Generators/PlaygroundNoiseGenerator.swift
+++ b/Sources/AudioKit/Nodes/Generators/PlaygroundNoiseGenerator.swift
@@ -5,7 +5,7 @@ import CoreAudio // for UnsafeMutableAudioBufferListPointer
 
 /// Pure Swift Noise Generator
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-public class PlaygroundNoiseGenerator: Node {
+public class PlaygroundNoiseGenerator: NamedNode {
     fileprivate lazy var sourceNode = AVAudioSourceNode { [self] _, _, frameCount, audioBufferList in
         let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
 
@@ -36,6 +36,8 @@ public class PlaygroundNoiseGenerator: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { sourceNode }
+
+    public var name = "PlaygroundNoiseGenerator"
 
     /// Volume usually 0-1
     public var amplitude: AUValue = 1

--- a/Sources/AudioKit/Nodes/Generators/PlaygroundOscillator.swift
+++ b/Sources/AudioKit/Nodes/Generators/PlaygroundOscillator.swift
@@ -7,7 +7,7 @@ let twoPi = 2 * Float.pi
 
 /// Pure Swift oscillator
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-public class PlaygroundOscillator: Node {
+public class PlaygroundOscillator: NamedNode {
     fileprivate lazy var sourceNode = AVAudioSourceNode { [self] _, _, frameCount, audioBufferList in
         let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
 
@@ -44,6 +44,8 @@ public class PlaygroundOscillator: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode { sourceNode }
+
+    public var name = "PlaygroundOscillator"
 
     private var currentPhase: Float = 0
 

--- a/Sources/AudioKit/Nodes/Mixing/EnvironmentalNode.swift
+++ b/Sources/AudioKit/Nodes/Mixing/EnvironmentalNode.swift
@@ -45,7 +45,7 @@ public class EnvironmentalNode: Node, NamedNode {
     public var avAudioNode: AVAudioNode {
         avAudioEnvironmentNode
     }
-    open var name = "(unset)"
+    open var name = "EnvironmentalNode"
     /// The listener’s position in the 3D environment.
     public var listenerPosition: AVAudio3DPoint {
         get {

--- a/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/MatrixMixer.swift
@@ -27,11 +27,13 @@
 
 import AVFAudio
 
-public class MatrixMixer: Node {
+public class MatrixMixer: NamedNode {
     private let inputs: [Node]
 
     public var connections: [Node] { inputs }
     public var avAudioNode: AVAudioNode { unit }
+
+    public var name = "MatrixMixer"
 
     /// Output format to be used when making connections from this node
     public var outputFormat = Settings.audioFormat

--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -19,7 +19,7 @@ public class Mixer: Node, NamedNode {
     public var outputFormat = Settings.audioFormat
 
     /// Name of the node
-    open var name = "(unset)"
+    open var name = "Mixer"
 
     /// Output Volume (Default 1), values above 1 will have gain applied
     public var volume: AUValue = 1.0 {

--- a/Sources/AudioKit/Nodes/Node+Graphviz.swift
+++ b/Sources/AudioKit/Nodes/Node+Graphviz.swift
@@ -8,15 +8,24 @@ extension ObjectIdentifier {
     }
 }
 
+#if !Swift6
 fileprivate var labels: [ObjectIdentifier: String] = [:]
+#endif
 
 extension Node {
 
     /// A label for to use when printing the dot.
+    #if Swift6
+    public var label: String {
+        get { (self as? NamedNode)?.name ?? "" }
+        set { (self as? NamedNode)?.name = newValue }
+    }
+    #else
     public var label: String {
         get { labels[ObjectIdentifier(self)] ?? "" }
         set { labels[ObjectIdentifier(self)] = newValue }
     }
+    #endif
     
     /// Generates Graphviz (.dot) format for a chain of AudioKit nodes.
     ///

--- a/Sources/AudioKit/Nodes/Node+connectionTreeDescription.swift
+++ b/Sources/AudioKit/Nodes/Node+connectionTreeDescription.swift
@@ -11,9 +11,10 @@ extension Node {
     }
 
     private func createConnectionTreeDescription(paddedWith indentation: String = "") -> String {
-        var nodeDescription = String(describing: self).components(separatedBy: ".").last ?? "Unknown"
+        let typeName = String(describing: type(of: self))
+        var nodeDescription = typeName
 
-        if let namedSelf = self as? NamedNode {
+        if let namedSelf = self as? NamedNode, namedSelf.name != typeName {
             nodeDescription += "(\"\(namedSelf.name)\")"
         }
 

--- a/Sources/AudioKit/Nodes/Playback/Apple Sampler/AppleSampler.swift
+++ b/Sources/AudioKit/Nodes/Playback/Apple Sampler/AppleSampler.swift
@@ -9,11 +9,13 @@ import AVFoundation
 /// 3. connect to the engine: engine.output = sampler
 /// 4. start the engine engine.start()
 ///
-open class AppleSampler: Node {
+open class AppleSampler: NamedNode {
     // MARK: - Properties
 
     /// Internal audio unit
     public private(set) var internalAU: AUAudioUnit?
+
+    open var name = "AppleSampler"
 
     private var _audioFiles: [AVAudioFile] = []
 

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -7,7 +7,7 @@ import AVFoundation
 /// played from disk. If you want seamless looping then buffer it. You can still loop from disk, but the
 /// loop will not be totally seamless.
 
-public class AudioPlayer: Node {
+public class AudioPlayer: NamedNode {
     /// Nodes providing input to this node.
     public var connections: [Node] { [] }
 
@@ -19,6 +19,8 @@ public class AudioPlayer: Node {
 
     /// The internal AVAudioEngine AVAudioNode
     public var avAudioNode: AVAudioNode { return mixerNode }
+
+    public var name = "AudioPlayer"
 
     /// Just the playerNode's property, values above 1 will have gain applied
     public var volume: AUValue {

--- a/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/MultiSegmentAudioPlayer/MultiSegmentAudioPlayer.swift
@@ -3,18 +3,20 @@
 import AVFoundation
 
 /// audio player that can schedule many file segments
-public class MultiSegmentAudioPlayer: Node {
+public class MultiSegmentAudioPlayer: NamedNode {
     /// Nodes providing input to this node.
     public var connections: [Node] { [] }
-    
+
     /// The underlying player node
     public private(set) var playerNode = AVAudioPlayerNode()
 
     /// The output of the AudioPlayer and provides sample rate conversion if needed
     public private(set) var mixerNode = AVAudioMixerNode()
-    
+
     /// The internal AVAudioEngine AVAudioNode
     public var avAudioNode: AVAudioNode { return mixerNode }
+
+    public var name = "MultiSegmentAudioPlayer"
     
     /// Just the playerNode's property, values above 1 will have gain applied
     public var volume: AUValue {

--- a/Sources/AudioKit/Nodes/Playback/TimePitch.swift
+++ b/Sources/AudioKit/Nodes/Playback/TimePitch.swift
@@ -4,7 +4,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's TimePitch Audio Unit
 ///
-public class TimePitch: Node {
+public class TimePitch: NamedNode {
     fileprivate let timePitchAU = AVAudioUnitTimePitch()
 
     let input: Node
@@ -14,6 +14,8 @@ public class TimePitch: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode
+
+    public var name = "TimePitch"
 
     /// Rate (rate) ranges from 0.03125 to 32.0 (Default: 1.0)
     public var rate: AUValue = 1.0 {

--- a/Sources/AudioKit/Nodes/Playback/VariSpeed.swift
+++ b/Sources/AudioKit/Nodes/Playback/VariSpeed.swift
@@ -4,7 +4,7 @@ import AVFoundation
 
 /// AudioKit version of Apple's VariSpeed Audio Unit
 ///
-public class VariSpeed: Node {
+public class VariSpeed: NamedNode {
     fileprivate let variSpeedAU = AVAudioUnitVarispeed()
 
     let input: Node
@@ -14,6 +14,8 @@ public class VariSpeed: Node {
 
     /// Underlying AVAudioNode
     public var avAudioNode: AVAudioNode
+
+    public var name = "VariSpeed"
 
     /// Rate (rate) ranges form 0.25 to 4.0 (Default: 1.0)
     public var rate: AUValue = 1.0 {


### PR DESCRIPTION
## Summary
While addressing Swift 6 warnings around the `label` property in `Node+Graphviz.swift`, I noticed significant overlap between the `label` (Graphviz) and `name` (NamedNode) concepts. To unify them:

- All `Node` subclasses now conform to `NamedNode` with a default `name` matching the class name
- Existing `NamedNode` conformers (`Mixer`, `EnvironmentalNode`, `MIDIInstrument`) updated from `"(unset)"` to their class name
- `MIDISampler` removes redundant `NamedNode` conformance (inherited from `AppleSampler`) and defaults name to `"MIDISampler"`
- Connection tree description only appends the name when it differs from the type name, keeping output clean