### PR TITLE
Add async FormatConverter APIs under Swift6 trait

### DIFF
--- a/Sources/AudioKit/Audio Files/AVAudioFile+Utilities.swift
+++ b/Sources/AudioKit/Audio Files/AVAudioFile+Utilities.swift
@@ -152,6 +152,7 @@ public extension AVAudioFile {
             return NSError(domain: "io.audiokit.FormatConverter.error", code: code, userInfo: userInfo)
         }
 
+        // if options are nil, create them to match the input file
         let options = options ?? FormatConverter.Options(audioFile: self)
 
         let format = options?.format ?? AudioFileFormat(rawValue: url.pathExtension) ?? .unknown
@@ -160,6 +161,7 @@ public extension AVAudioFile {
         let tempFile = directory.appendingPathComponent(filename + "_temp").appendingPathExtension("caf")
         let outputURL = directory.appendingPathComponent(filename).appendingPathExtension(format.rawValue)
 
+        // first print CAF file
         guard extract(to: tempFile,
                       from: startTime,
                       to: endTime,
@@ -170,6 +172,7 @@ public extension AVAudioFile {
             return
         }
 
+        // then convert to desired format here:
         guard FileManager.default.isReadableFile(atPath: tempFile.path) else {
             completionHandler?(createError(message: "File wasn't created correctly"))
             return

--- a/Sources/AudioKit/Audio Files/AVAudioFile+Utilities.swift
+++ b/Sources/AudioKit/Audio Files/AVAudioFile+Utilities.swift
@@ -94,6 +94,51 @@ public extension AVAudioFile {
     }
 
     /// - Returns: An extracted section of this file of the passed in conversion options
+    #if Swift6
+    func extract(to url: URL,
+                 from startTime: TimeInterval,
+                 to endTime: TimeInterval,
+                 fadeInTime: TimeInterval = 0,
+                 fadeOutTime: TimeInterval = 0,
+                 options: FormatConverter.Options? = nil) async throws
+    {
+        func createError(message: String, code: Int = 1) -> NSError {
+            let userInfo: [String: Any] = [NSLocalizedDescriptionKey: message]
+            return NSError(domain: "io.audiokit.FormatConverter.error", code: code, userInfo: userInfo)
+        }
+
+        let options = options ?? FormatConverter.Options(audioFile: self)
+
+        let format = options?.format ?? AudioFileFormat(rawValue: url.pathExtension) ?? .unknown
+        let directory = url.deletingLastPathComponent()
+        let filename = url.deletingPathExtension().lastPathComponent
+        let tempFile = directory.appendingPathComponent(filename + "_temp").appendingPathExtension("caf")
+        let outputURL = directory.appendingPathComponent(filename).appendingPathExtension(format.rawValue)
+
+        let extracted: AVAudioFile? = extract(to: tempFile,
+                                              from: startTime,
+                                              to: endTime,
+                                              fadeInTime: fadeInTime,
+                                              fadeOutTime: fadeOutTime)
+        guard extracted != nil else {
+            throw createError(message: "Failed to create new file")
+        }
+
+        guard FileManager.default.isReadableFile(atPath: tempFile.path) else {
+            throw createError(message: "File wasn't created correctly")
+        }
+
+        let converter = FormatConverter(inputURL: tempFile, outputURL: outputURL, options: options)
+        do {
+            try await converter.start()
+        } catch {
+            Log("Done, error", error, type: .error)
+            try? FileManager.default.removeItem(at: tempFile)
+            throw error
+        }
+        try? FileManager.default.removeItem(at: tempFile)
+    }
+    #else
     func extract(to url: URL,
                  from startTime: TimeInterval,
                  to endTime: TimeInterval,
@@ -107,7 +152,6 @@ public extension AVAudioFile {
             return NSError(domain: "io.audiokit.FormatConverter.error", code: code, userInfo: userInfo)
         }
 
-        // if options are nil, create them to match the input file
         let options = options ?? FormatConverter.Options(audioFile: self)
 
         let format = options?.format ?? AudioFileFormat(rawValue: url.pathExtension) ?? .unknown
@@ -116,7 +160,6 @@ public extension AVAudioFile {
         let tempFile = directory.appendingPathComponent(filename + "_temp").appendingPathExtension("caf")
         let outputURL = directory.appendingPathComponent(filename).appendingPathExtension(format.rawValue)
 
-        // first print CAF file
         guard extract(to: tempFile,
                       from: startTime,
                       to: endTime,
@@ -127,7 +170,6 @@ public extension AVAudioFile {
             return
         }
 
-        // then convert to desired format here:
         guard FileManager.default.isReadableFile(atPath: tempFile.path) else {
             completionHandler?(createError(message: "File wasn't created correctly"))
             return
@@ -150,6 +192,7 @@ public extension AVAudioFile {
             }
         }
     }
+    #endif
 }
 
 public extension AVURLAsset {

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
@@ -18,6 +18,30 @@ extension FormatConverter {
     ///
     /// This is no longer used in this class as it's not possible to convert sample rate or other
     /// required options. It will use the next function instead
+    #if Swift6
+    @available(macOS 15, iOS 18, tvOS 18, visionOS 2.0, *)
+    func convertCompressed(presetName: String) async throws {
+        guard let inputURL = inputURL else {
+            throw Self.createError(message: "Input file can't be nil.")
+        }
+        guard let outputURL = outputURL else {
+            throw Self.createError(message: "Output file can't be nil.")
+        }
+
+        let asset = AVURLAsset(url: inputURL)
+        guard let session = AVAssetExportSession(asset: asset,
+                                                 presetName: presetName) else {
+            throw Self.createError(message: "session can't be nil.")
+        }
+
+        let list = await session.compatibleFileTypes
+        guard let outputFileType: AVFileType = list.first else {
+            throw Self.createError(message: "Unable to determine a compatible file type from \(inputURL.path)")
+        }
+
+        try await session.export(to: outputURL, as: outputFileType)
+    }
+    #else
     @available(visionOS, unavailable, message: "This method is not supported on visionOS")
     func convertCompressed(presetName: String, completionHandler: FormatConverterCallback? = nil) {
         guard let inputURL = inputURL else {
@@ -49,47 +73,54 @@ extension FormatConverter {
             }
         }
     }
+    #endif
 
-    /// Example of the most simplistic AVFoundation conversion.
-    /// With this approach you can't really specify any settings other than the limited presets.
-    /// No sample rate conversion in this. This isn't used in the public methods but is here
-    /// for example.
-    ///
-    /// see `AVAssetExportSession`:
-    /// *Prior to initializing an instance of AVAssetExportSession, you can invoke
-    /// +allExportPresets to obtain the complete list of presets available. Use
-    /// +exportPresetsCompatibleWithAsset: to obtain a list of presets that are compatible
-    /// with a specific AVAsset.*
-    ///
-    /// This is no longer used in this class as it's not possible to convert sample rate or other
-    /// required options. It will use the next function instead
-    #if swift(>=6.0) // Swift 6.0 corresponds to Xcode 16+
-    @available(macOS 15, iOS 18, tvOS 18, visionOS 2.0, *)
-    func convertCompressed(presetName: String) async throws {
+    /// Convert to compressed first creating a tmp file to PCM to allow more flexible conversion
+    /// options to work.
+    #if Swift6
+    func convertCompressed() async throws {
         guard let inputURL = inputURL else {
             throw Self.createError(message: "Input file can't be nil.")
         }
         guard let outputURL = outputURL else {
             throw Self.createError(message: "Output file can't be nil.")
         }
-
-        let asset = AVURLAsset(url: inputURL)
-        guard let session = AVAssetExportSession(asset: asset,
-                                                 presetName: presetName) else {
-            throw Self.createError(message: "session can't be nil.")
+        guard let options = options else {
+            throw Self.createError(message: "Options can't be nil.")
         }
 
-        let list = await session.compatibleFileTypes
-        guard let outputFileType: AVFileType = list.first else {
-            throw Self.createError(message: "Unable to determine a compatible file type from \(inputURL.path)")
+        let tempName = outputURL.deletingPathExtension().lastPathComponent + "_TEMP.wav"
+        let tempFile = outputURL.deletingLastPathComponent().appendingPathComponent(tempName)
+
+        var tempOptions = FormatConverter.Options()
+        tempOptions.bitDepthRule = .lessThanOrEqual
+        tempOptions.bitDepth = 24
+        tempOptions.sampleRate = options.sampleRate
+        tempOptions.channels = options.channels
+        tempOptions.format = .wav
+
+        let tempConverter = FormatConverter(inputURL: inputURL,
+                                            outputURL: tempFile,
+                                            options: tempOptions)
+
+        do {
+            try await tempConverter.start()
+        } catch {
+            try? FileManager.default.removeItem(at: tempFile)
+            throw Self.createError(message: "Failed to convert input to PCM: \(error.localizedDescription)")
         }
 
-        try await session.export(to: outputURL, as: outputFileType)
+        self.inputURL = tempFile
+
+        do {
+            try await self.convertPCMToCompressed()
+        } catch {
+            try? FileManager.default.removeItem(at: tempFile)
+            throw error
+        }
+        try? FileManager.default.removeItem(at: tempFile)
     }
-    #endif
-
-    /// Convert to compressed first creating a tmp file to PCM to allow more flexible conversion
-    /// options to work.
+    #else
     func convertCompressed(completionHandler: FormatConverterCallback? = nil) {
         guard let inputURL = inputURL else {
             completionHandler?(Self.createError(message: "Input file can't be nil."))
@@ -133,9 +164,25 @@ extension FormatConverter {
             }
         }
     }
+    #endif
 
     /// The AVFoundation way. *This doesn't currently handle compressed input - only compressed output.*
+    #if Swift6
+    func convertPCMToCompressed() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            self.convertPCMToCompressedImpl { error in
+                if let error { continuation.resume(throwing: error) }
+                else { continuation.resume() }
+            }
+        }
+    }
+    #else
     func convertPCMToCompressed(completionHandler: FormatConverterCallback? = nil) {
+        convertPCMToCompressedImpl(completionHandler: completionHandler)
+    }
+    #endif
+
+    private func convertPCMToCompressedImpl(completionHandler: FormatConverterCallback? = nil) {
         guard let inputURL = inputURL else {
             completionHandler?(Self.createError(message: "Input file can't be nil."))
             return
@@ -193,6 +240,7 @@ extension FormatConverter {
             formatKey = kAudioFormatLinearPCM
         default:
             Log("Unsupported output format: \(outputFormat)")
+            completionHandler?(Self.createError(message: "Unsupported output format: \(outputFormat)"))
             return
         }
 

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
@@ -18,30 +18,6 @@ extension FormatConverter {
     ///
     /// This is no longer used in this class as it's not possible to convert sample rate or other
     /// required options. It will use the next function instead
-    #if Swift6
-    @available(macOS 15, iOS 18, tvOS 18, visionOS 2.0, *)
-    func convertCompressed(presetName: String) async throws {
-        guard let inputURL = inputURL else {
-            throw Self.createError(message: "Input file can't be nil.")
-        }
-        guard let outputURL = outputURL else {
-            throw Self.createError(message: "Output file can't be nil.")
-        }
-
-        let asset = AVURLAsset(url: inputURL)
-        guard let session = AVAssetExportSession(asset: asset,
-                                                 presetName: presetName) else {
-            throw Self.createError(message: "session can't be nil.")
-        }
-
-        let list = await session.compatibleFileTypes
-        guard let outputFileType: AVFileType = list.first else {
-            throw Self.createError(message: "Unable to determine a compatible file type from \(inputURL.path)")
-        }
-
-        try await session.export(to: outputURL, as: outputFileType)
-    }
-    #else
     @available(visionOS, unavailable, message: "This method is not supported on visionOS")
     func convertCompressed(presetName: String, completionHandler: FormatConverterCallback? = nil) {
         guard let inputURL = inputURL else {
@@ -72,6 +48,43 @@ extension FormatConverter {
                 completionHandler?(session.error)
             }
         }
+    }
+
+    /// Example of the most simplistic AVFoundation conversion.
+    /// With this approach you can't really specify any settings other than the limited presets.
+    /// No sample rate conversion in this. This isn't used in the public methods but is here
+    /// for example.
+    ///
+    /// see `AVAssetExportSession`:
+    /// *Prior to initializing an instance of AVAssetExportSession, you can invoke
+    /// +allExportPresets to obtain the complete list of presets available. Use
+    /// +exportPresetsCompatibleWithAsset: to obtain a list of presets that are compatible
+    /// with a specific AVAsset.*
+    ///
+    /// This is no longer used in this class as it's not possible to convert sample rate or other
+    /// required options. It will use the next function instead
+    #if swift(>=6.0) // Swift 6.0 corresponds to Xcode 16+
+    @available(macOS 15, iOS 18, tvOS 18, visionOS 2.0, *)
+    func convertCompressed(presetName: String) async throws {
+        guard let inputURL = inputURL else {
+            throw Self.createError(message: "Input file can't be nil.")
+        }
+        guard let outputURL = outputURL else {
+            throw Self.createError(message: "Output file can't be nil.")
+        }
+
+        let asset = AVURLAsset(url: inputURL)
+        guard let session = AVAssetExportSession(asset: asset,
+                                                 presetName: presetName) else {
+            throw Self.createError(message: "session can't be nil.")
+        }
+
+        let list = await session.compatibleFileTypes
+        guard let outputFileType: AVFileType = list.first else {
+            throw Self.createError(message: "Unable to determine a compatible file type from \(inputURL.path)")
+        }
+
+        try await session.export(to: outputURL, as: outputFileType)
     }
     #endif
 

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+Compressed.swift
@@ -170,19 +170,15 @@ extension FormatConverter {
     #if Swift6
     func convertPCMToCompressed() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            self.convertPCMToCompressedImpl { error in
+            self.convertPCMToCompressed { error in
                 if let error { continuation.resume(throwing: error) }
                 else { continuation.resume() }
             }
         }
     }
-    #else
-    func convertPCMToCompressed(completionHandler: FormatConverterCallback? = nil) {
-        convertPCMToCompressedImpl(completionHandler: completionHandler)
-    }
     #endif
 
-    private func convertPCMToCompressedImpl(completionHandler: FormatConverterCallback? = nil) {
+    func convertPCMToCompressed(completionHandler: FormatConverterCallback? = nil) {
         guard let inputURL = inputURL else {
             completionHandler?(Self.createError(message: "Input file can't be nil."))
             return

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter+PCM.swift
@@ -98,6 +98,7 @@ extension FormatConverter {
                 completionHandler?(nil)
             } catch let err as NSError {
                 Log(err)
+                completionHandler?(err)
             }
             return
         }
@@ -142,7 +143,7 @@ extension FormatConverter {
             readDescription.mBytesPerPacket = readDescription.mBytesPerFrame
         }
 
-        var readDescriptionSize = UInt32(MemoryLayout.stride(ofValue: readDescription))
+        let readDescriptionSize = UInt32(MemoryLayout.stride(ofValue: readDescription))
 
         if noErr != ExtAudioFileSetProperty(strongInputFile,
                                             kExtAudioFileProperty_ClientDataFormat,

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
@@ -72,6 +72,7 @@ public class FormatConverter {
         }
 
         let inputFormat = AudioFileFormat(rawValue: inputURL.pathExtension.lowercased()) ?? .unknown
+        // verify inputFormat, only allow files with path extensions for speed?
         guard FormatConverter.inputFormats.contains(inputFormat) else {
             throw Self.createError(message: "The input file format is in an incompatible format: \(inputFormat)")
         }
@@ -117,6 +118,7 @@ public class FormatConverter {
         }
     }
     #else
+    /// - Parameter completionHandler: the callback that will be triggered when process has completed.
     public func start(completionHandler: FormatConverterCallback? = nil) {
         guard let inputURL = inputURL else {
             completionHandler?(Self.createError(message: "Input file can't be nil."))

--- a/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
+++ b/Sources/AudioKit/Audio Files/Format Converter/FormatConverter.swift
@@ -61,7 +61,62 @@ public class FormatConverter {
     // MARK: - functions
 
     /// The entry point for file conversion
-    /// - Parameter completionHandler: the callback that will be triggered when process has completed.
+    #if Swift6
+    public func start() async throws {
+        guard let inputURL = inputURL else {
+            throw Self.createError(message: "Input file can't be nil.")
+        }
+
+        guard let outputURL = outputURL else {
+            throw Self.createError(message: "Output file can't be nil.")
+        }
+
+        let inputFormat = AudioFileFormat(rawValue: inputURL.pathExtension.lowercased()) ?? .unknown
+        guard FormatConverter.inputFormats.contains(inputFormat) else {
+            throw Self.createError(message: "The input file format is in an incompatible format: \(inputFormat)")
+        }
+
+        if FileManager.default.fileExists(atPath: outputURL.path) {
+            if options?.eraseFile == true {
+                Log("Warning: removing existing file at", outputURL.path)
+                try? FileManager.default.removeItem(at: outputURL)
+            } else {
+                throw Self.createError(message: "The output file exists already. You need to choose a unique URL or delete the file.")
+            }
+        }
+
+        if options?.format == nil {
+            options?.format = AudioFileFormat(rawValue: outputURL.pathExtension.lowercased()) ?? .unknown
+        }
+
+        // Format checks are necessary as AVAssetReader has opinions about compressed
+
+        // PCM output, any supported input
+        if Self.isPCM(url: outputURL) == true {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                convertToPCM { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
+                }
+            }
+
+            // PCM input, compressed output
+        } else if Self.isPCM(url: inputURL) == true,
+                  Self.isCompressed(url: outputURL) == true
+        {
+            try await convertPCMToCompressed()
+
+            // Compressed input and output, won't do sample rate
+        } else if Self.isCompressed(url: inputURL) == true,
+                  Self.isCompressed(url: outputURL) == true
+        {
+            try await convertCompressed()
+
+        } else {
+            throw Self.createError(message: "Unable to determine formats for conversion")
+        }
+    }
+    #else
     public func start(completionHandler: FormatConverterCallback? = nil) {
         guard let inputURL = inputURL else {
             completionHandler?(Self.createError(message: "Input file can't be nil."))
@@ -118,6 +173,7 @@ public class FormatConverter {
             completionHandler?(Self.createError(message: "Unable to determine formats for conversion"))
         }
     }
+    #endif
 }
 
 // MARK: - Definitions

--- a/Tests/AudioKitTests/File Tests/FormatConverterChannelTests.swift
+++ b/Tests/AudioKitTests/File Tests/FormatConverterChannelTests.swift
@@ -11,11 +11,11 @@ class FormatConverterChannelTests: XCTestCase {
 
     /// Verifies that converting a stereo file with audio only in the RIGHT channel
     /// to mono produces non-silent output. This is the core bug from issue #2900.
-    func testStereoToMonoPreservesRightChannel() throws {
+    func testStereoToMonoPreservesRightChannel() async throws {
         let stereoBuffer = createStereoBuffer(leftValue: 0.0, rightValue: 0.5)
         let inputURL = try writeTempFile(buffer: stereoBuffer, name: "rightOnly")
 
-        let monoBuffer = try convertToMono(inputURL: inputURL)
+        let monoBuffer = try await convertToMono(inputURL: inputURL)
 
         XCTAssertEqual(monoBuffer.format.channelCount, 1, "Output should be mono")
         XCTAssertGreaterThan(monoBuffer.frameLength, 0, "Output should have frames")
@@ -27,11 +27,11 @@ class FormatConverterChannelTests: XCTestCase {
 
     /// Verifies that converting a stereo file with audio only in the LEFT channel
     /// to mono also produces non-silent output.
-    func testStereoToMonoPreservesLeftChannel() throws {
+    func testStereoToMonoPreservesLeftChannel() async throws {
         let stereoBuffer = createStereoBuffer(leftValue: 0.5, rightValue: 0.0)
         let inputURL = try writeTempFile(buffer: stereoBuffer, name: "leftOnly")
 
-        let monoBuffer = try convertToMono(inputURL: inputURL)
+        let monoBuffer = try await convertToMono(inputURL: inputURL)
 
         XCTAssertEqual(monoBuffer.format.channelCount, 1)
 
@@ -42,11 +42,11 @@ class FormatConverterChannelTests: XCTestCase {
 
     /// Verifies that both channels are summed when converting stereo to mono.
     /// Left=0.25 and Right=0.25 should produce mono samples of 0.5 (sum of both).
-    func testStereoToMonoMixesBothChannels() throws {
+    func testStereoToMonoMixesBothChannels() async throws {
         let stereoBuffer = createStereoBuffer(leftValue: 0.25, rightValue: 0.25)
         let inputURL = try writeTempFile(buffer: stereoBuffer, name: "bothChannels")
 
-        let monoBuffer = try convertToMono(inputURL: inputURL)
+        let monoBuffer = try await convertToMono(inputURL: inputURL)
 
         XCTAssertEqual(monoBuffer.format.channelCount, 1)
 
@@ -87,7 +87,7 @@ class FormatConverterChannelTests: XCTestCase {
         return url
     }
 
-    private func convertToMono(inputURL: URL) throws -> AVAudioPCMBuffer {
+    private func convertToMono(inputURL: URL) async throws -> AVAudioPCMBuffer {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("FormatConverterChannelTests")
         let outputURL = tmp.appendingPathComponent("output_mono.wav")
@@ -107,6 +107,9 @@ class FormatConverterChannelTests: XCTestCase {
 
         let converter = FormatConverter(inputURL: inputURL, outputURL: outputURL, options: options)
 
+        #if Swift6
+        try await converter.start()
+        #else
         let expectation = XCTestExpectation(description: "conversion")
         var conversionError: Error?
 
@@ -115,11 +118,12 @@ class FormatConverterChannelTests: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 30)
+        await fulfillment(of: [expectation], timeout: 30)
 
         if let error = conversionError {
             throw error
         }
+        #endif
 
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw NSError(domain: "FormatConverterChannelTests", code: 1,

--- a/Tests/AudioKitTests/File Tests/FormatConverterTests.swift
+++ b/Tests/AudioKitTests/File Tests/FormatConverterTests.swift
@@ -101,6 +101,7 @@ class FormatConverterTests: AudioFileTestCase {
         let outputURL = tmp.appendingPathComponent(name).appendingPathExtension(format.rawValue)
 
         defer {
+            // Log("🗑 Deleting:", tmp.lastPathComponent)
             try? FileManager.default.removeItem(at: tmp)
         }
 

--- a/Tests/AudioKitTests/File Tests/FormatConverterTests.swift
+++ b/Tests/AudioKitTests/File Tests/FormatConverterTests.swift
@@ -15,7 +15,7 @@ class FormatConverterTests: AudioFileTestCase {
         Bundle.module.url(forResource: "12345", withExtension: "wav", subdirectory: "TestResources")
     }
 
-    func testbitDepthRule() throws {
+    func testbitDepthRule() async throws {
         var options = FormatConverter.Options()
         options.sampleRate = 48000
         options.bitDepth = UInt32(24)
@@ -23,10 +23,15 @@ class FormatConverterTests: AudioFileTestCase {
         options.eraseFile = true
         options.bitDepthRule = .lessThanOrEqual
 
-        XCTAssertThrowsError(try convert(with: options, input: stereoWAVE44k16Bit))
+        do {
+            try await convert(with: options, input: stereoWAVE44k16Bit)
+            XCTFail("Expected error for bit depth rule violation")
+        } catch {
+            // expected
+        }
     }
 
-    func testConvertAIFF44k16bit() throws {
+    func testConvertAIFF44k16bit() async throws {
         var options = FormatConverter.Options()
         options.sampleRate = 44100
         options.bitDepth = UInt32(16)
@@ -34,10 +39,10 @@ class FormatConverterTests: AudioFileTestCase {
         options.eraseFile = true
         options.bitDepthRule = .any
 
-        try convert(with: options)
+        try await convert(with: options)
     }
 
-    func testConvertCAF96k32bit() throws {
+    func testConvertCAF96k32bit() async throws {
         var options = FormatConverter.Options()
         options.sampleRate = 96000
         options.bitDepth = UInt32(32)
@@ -45,10 +50,10 @@ class FormatConverterTests: AudioFileTestCase {
         options.eraseFile = true
         options.bitDepthRule = .any
 
-        try convert(with: options)
+        try await convert(with: options)
     }
 
-    func testConvertM4A24Bit() throws {
+    func testConvertM4A24Bit() async throws {
         var options = FormatConverter.Options()
         options.sampleRate = 44100
         options.bitRate = 256000
@@ -56,10 +61,10 @@ class FormatConverterTests: AudioFileTestCase {
         options.eraseFile = true
         options.bitDepthRule = .any
 
-        try convert(with: options)
+        try await convert(with: options)
     }
 
-    func testConvertMonoM4A24Bit() throws {
+    func testConvertMonoM4A24Bit() async throws {
         var options = FormatConverter.Options()
         options.sampleRate = 48000
         options.bitRate = 320000
@@ -67,13 +72,13 @@ class FormatConverterTests: AudioFileTestCase {
         options.eraseFile = true
         options.bitDepthRule = .any
 
-        try convert(with: options, input: monoWAVE44k24Bit)
+        try await convert(with: options, input: monoWAVE44k24Bit)
     }
 
     // MARK: helpers
 
     private func convert(with options: FormatConverter.Options,
-                         input: URL? = nil) throws
+                         input: URL? = nil) async throws
     {
         guard let format = options.format,
               let sampleRate = options.sampleRate
@@ -96,12 +101,15 @@ class FormatConverterTests: AudioFileTestCase {
         let outputURL = tmp.appendingPathComponent(name).appendingPathExtension(format.rawValue)
 
         defer {
-            // Log("🗑 Deleting:", tmp.lastPathComponent)
             try? FileManager.default.removeItem(at: tmp)
         }
 
-        let expectation = XCTestExpectation(description: outputURL.path)
         let converter = FormatConverter(inputURL: inputFile, outputURL: outputURL, options: options)
+
+        #if Swift6
+        try await converter.start()
+        #else
+        let expectation = XCTestExpectation(description: outputURL.path)
 
         converter.start { error in
             if let error = error {
@@ -110,7 +118,8 @@ class FormatConverterTests: AudioFileTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 30)
+        await fulfillment(of: [expectation], timeout: 30)
+        #endif
 
         guard FileManager.default.fileExists(atPath: outputURL.path) else {
             throw createError(message: "File is missing at \(outputURL.path)")

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+Realtime.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+Realtime.swift
@@ -46,14 +46,14 @@ extension AudioPlayerFileTests {
         realtimeTestEdited(buffered: true)
     }
 
-    func testMixedSampleRates() {
+    func testMixedSampleRates() async {
         guard realtimeEnabled else { return }
-        realtimeTestMixedSampleRates(buffered: true)
+        await realtimeTestMixedSampleRates(buffered: true)
     }
 
-    func testBufferedMixedSampleRates() {
+    func testBufferedMixedSampleRates() async {
         guard realtimeEnabled else { return }
-        realtimeTestMixedSampleRates(buffered: true)
+        await realtimeTestMixedSampleRates(buffered: true)
     }
 
     // testSeek and testSeekBuffered should effectively sound the same

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerFileTests+RealtimeContent.swift
@@ -430,7 +430,7 @@ extension AudioPlayerFileTests {
 
 extension AudioPlayerFileTests {
     /// Files should play back at normal pitch for both buffered and streamed
-    func realtimeTestMixedSampleRates(buffered: Bool = false) {
+    func realtimeTestMixedSampleRates(buffered: Bool = false) async {
         // this file is 44.1k
         guard let countingURL = countingURL else {
             XCTFail("Didn't find the 12345.wav")
@@ -453,15 +453,27 @@ extension AudioPlayerFileTests {
                                         outputURL: countingURL48k,
                                         options: wav48k)
 
+        #if Swift6
+        do {
+            try await converter.start()
+        } catch {
+            XCTFail(error.localizedDescription)
+            return
+        }
+        #else
+        let expectation = XCTestExpectation(description: "conversion")
         converter.start { error in
             if let error = error {
                 XCTFail(error.localizedDescription)
-                return
             }
-            self.processMixedSampleRates(urls: [countingURL, countingURL48k],
-                                         audioFormat: audioFormat,
-                                         buffered: buffered)
+            expectation.fulfill()
         }
+        await fulfillment(of: [expectation], timeout: 30)
+        #endif
+
+        processMixedSampleRates(urls: [countingURL, countingURL48k],
+                                audioFormat: audioFormat,
+                                buffered: buffered)
     }
 
     private func processMixedSampleRates(urls: [URL],

--- a/Tests/AudioKitTests/Tap Tests/RawDataTapTests.swift
+++ b/Tests/AudioKitTests/Tap Tests/RawDataTapTests.swift
@@ -60,6 +60,7 @@ class RawDataTapTests: XCTestCase {
         // the background Task.
         wait(for: [dataExpectation], timeout: 0)
 
+        engine.stop()
     }
 
 }


### PR DESCRIPTION
## Summary

- Part of the Swift 6 migration. To keep the existing library unchanged, async versions of the FormatConverter methods are introduced behind the `Swift6` package trait (`#if Swift6` / `#else`).
- Each async function is structurally identical to its non-async counterpart — same validation, same error messages, same control flow — with `throw` replacing completion-handler error delivery and `await` replacing callback chaining.
- `convertPCMToCompressed` uses a shared private `convertPCMToCompressedImpl` to avoid duplicating its ~200-line body; async and callback versions are thin wrappers around it.
- Fixes two pre-existing bugs where completion handlers were not called on error paths (`convertToPCM` copy-failure, and `convertPCMToCompressedImpl` unsupported-format default case), which would have caused leaked continuations in the async wrappers.
- Tests updated to use `async/await` under the Swift6 trait.

### Methods converted

| Method | Pattern |
|--------|---------|
| `FormatConverter.start()` | `#if Swift6` / `#else` with complete functions |
| `convertCompressed(presetName:)` | `#if Swift6` / `#else` (different platform APIs) |
| `convertCompressed()` | `#if Swift6` / `#else` with complete functions |
| `convertPCMToCompressed()` | Shared `Impl` + async wrapper / callback wrapper |
| `AVAudioFile.extract(to:...)` | `#if Swift6` / `#else` with complete functions |