### PR TITLE
# fix pr #2978 seek regression from stale completion callbacks

### DIFF
--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift
@@ -51,13 +51,14 @@ extension AudioPlayer {
         }
 
         let frameCount = AVAudioFrameCount(totalFrames)
+        let scheduleGeneration = bumpScheduleGeneration()
 
         playerNode.scheduleSegment(file,
                                    startingFrame: startFrame,
                                    frameCount: frameCount,
                                    at: audioTime,
                                    completionCallbackType: completionCallbackType) { [weak self] _ in
-            self?.invokeCompletionHandlerOnMain()
+            self?.invokeCompletionHandlerOnMain(generation: scheduleGeneration)
         }
 
         playerNode.prepare(withFrameCount: frameCount)
@@ -83,12 +84,13 @@ extension AudioPlayer {
         if isLooping {
             bufferOptions = [.loops, .interrupts]
         }
+        let scheduleGeneration = bumpScheduleGeneration()
 
         playerNode.scheduleBuffer(buffer,
                                   at: audioTime,
                                   options: bufferOptions,
                                   completionCallbackType: completionCallbackType) { [weak self] _ in
-            self?.invokeCompletionHandlerOnMain()
+            self?.invokeCompletionHandlerOnMain(generation: scheduleGeneration)
         }
 
         playerNode.prepare(withFrameCount: buffer.frameLength)

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -89,6 +89,17 @@ public class AudioPlayer: NamedNode {
     /// Indicates the player is in the midst of a seek operation
     public internal(set) var isSeeking: Bool = false
 
+    /// Monotonic counter incremented for every scheduled playback segment.
+    /// Completion closures capture the generation current at scheduling time so
+    /// callbacks from older schedules can be ignored after seek/reschedule.
+    private var scheduleGeneration: UInt64 = 0
+
+    @discardableResult
+    func bumpScheduleGeneration() -> UInt64 {
+        scheduleGeneration &+= 1
+        return scheduleGeneration
+    }
+
     /// Length of the audio file in seconds
     public var duration: TimeInterval {
         file?.duration ?? bufferDuration
@@ -205,7 +216,8 @@ public class AudioPlayer: NamedNode {
 
     // MARK: - Internal functions
 
-    func internalCompletionHandler() {
+    func internalCompletionHandler(generation: UInt64) {
+        guard generation == scheduleGeneration else { return }
         guard !isSeeking, status == .playing else { return }
 
         if !isLooping {
@@ -225,12 +237,12 @@ public class AudioPlayer: NamedNode {
         }
     }
 
-    func invokeCompletionHandlerOnMain() {
+    func invokeCompletionHandlerOnMain(generation: UInt64) {
         if Thread.isMainThread {
-            internalCompletionHandler()
+            internalCompletionHandler(generation: generation)
         } else {
             DispatchQueue.main.async { [weak self] in
-                self?.internalCompletionHandler()
+                self?.internalCompletionHandler(generation: generation)
             }
         }
     }

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -100,6 +100,10 @@ public class AudioPlayer: NamedNode {
         return scheduleGeneration
     }
 
+    var currentScheduleGeneration: UInt64 {
+        scheduleGeneration
+    }
+
     /// Length of the audio file in seconds
     public var duration: TimeInterval {
         file?.duration ?? bufferDuration

--- a/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
+++ b/Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift
@@ -89,7 +89,7 @@ public class AudioPlayer: NamedNode {
     /// Indicates the player is in the midst of a seek operation
     public internal(set) var isSeeking: Bool = false
 
-    /// Monotonic counter incremented for every scheduled playback segment.
+    /// Generation counter incremented for every scheduled playback segment.
     /// Completion closures capture the generation current at scheduling time so
     /// callbacks from older schedules can be ignored after seek/reschedule.
     private var scheduleGeneration: UInt64 = 0

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
@@ -1,6 +1,7 @@
-import AudioKit
 import AVFoundation
 import XCTest
+
+@testable import AudioKit
 
 class AudioPlayerTests: XCTestCase {
 
@@ -543,6 +544,92 @@ class AudioPlayerTests: XCTestCase {
         let currentTime2 = player.currentTime
         XCTAssertEqual(currentTime2, 2)
         testMD5(audio)
+    }
+
+    /// Regression test for the stale-completion race introduced by PR #2978.
+    /// A completion from an older scheduled segment must not affect the newer
+    /// playback that replaced it after seek/reschedule.
+    func testStaleCompletionDoesNotStompPlaybackOrInvokeHandler() {
+        guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav") else {
+            XCTFail("Didn't get test file")
+            return
+        }
+
+        let engine = AudioEngine()
+        let player = AudioPlayer()
+        engine.output = player
+        player.isLooping = false
+
+        var completionCount = 0
+        player.completionHandler = {
+            completionCount += 1
+        }
+
+        do {
+            try player.load(url: url)
+        } catch let error as NSError {
+            Log(error, type: .error)
+            XCTFail(error.description)
+        }
+
+        let staleGeneration = player.bumpScheduleGeneration()
+
+        let audio = engine.startTest(totalDuration: 1.0)
+        player.play()
+        audio.append(engine.render(duration: 0.1))
+        XCTAssertEqual(player.status, .playing)
+
+        let staleCompletionIgnored = expectation(description: "stale completion ignored")
+        DispatchQueue.global().async {
+            player.invokeCompletionHandlerOnMain(generation: staleGeneration)
+            DispatchQueue.main.async {
+                staleCompletionIgnored.fulfill()
+            }
+        }
+        wait(for: [staleCompletionIgnored], timeout: 1.0)
+
+        XCTAssertEqual(player.status, .playing,
+                       "stale completion must not stomp status to .stopped")
+        XCTAssertEqual(completionCount, 0,
+                       "stale completion must not invoke the user-supplied handler")
+    }
+
+    /// `stop()` promises not to generate a callback event, even if the retired
+    /// schedule later reports completion.
+    func testStopDoesNotInvokeCompletionHandler() {
+        guard let url = Bundle.module.url(forResource: "TestResources/12345", withExtension: "wav") else {
+            XCTFail("Didn't get test file")
+            return
+        }
+
+        let engine = AudioEngine()
+        let player = AudioPlayer()
+        engine.output = player
+        player.isLooping = false
+
+        var completionCount = 0
+        player.completionHandler = {
+            completionCount += 1
+        }
+
+        do {
+            try player.load(url: url)
+        } catch let error as NSError {
+            Log(error, type: .error)
+            XCTFail(error.description)
+        }
+
+        let audio = engine.startTest(totalDuration: 1.0)
+        player.play()
+        audio.append(engine.render(duration: 0.1))
+        let stoppedGeneration = player.bumpScheduleGeneration()
+        player.stop()
+
+        player.internalCompletionHandler(generation: stoppedGeneration)
+
+        XCTAssertEqual(player.status, .stopped)
+        XCTAssertEqual(completionCount, 0,
+                       "stop() must not produce a user completion callback")
     }
 
     func testSeekWillStop() {

--- a/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
+++ b/Tests/AudioKitTests/Node Tests/Player Tests/AudioPlayerTests.swift
@@ -622,7 +622,7 @@ class AudioPlayerTests: XCTestCase {
         let audio = engine.startTest(totalDuration: 1.0)
         player.play()
         audio.append(engine.render(duration: 0.1))
-        let stoppedGeneration = player.bumpScheduleGeneration()
+        let stoppedGeneration = player.currentScheduleGeneration
         player.stop()
 
         player.internalCompletionHandler(generation: stoppedGeneration)


### PR DESCRIPTION
After upgrading my app to v5.6.6 and above, scrubbing the timeline during playback causes playback to get stuck or stop. I tracked this back to a regression introduced by PR #2978 . I tried a simpler fix in #3009 but decided to reject that after I realized it fixed the seek race but accidentally broke `stop()` when looping.

## The Bug

`seek(time:)` calls `playerNode.stop()`, then reschedules and resumes. The stopped segment's completion can arrive asynchronously on main after `seek()` has already cleared `isSeeking` and restored `status` to `.playing`. PR #2978's guard (`guard !isSeeking, status == .playing`) then accepts that stale callback, and the non-looping cleanup branch stomps the new playback state.

Same pattern applies to the `file =` and `buffer =` replacement paths.

## The fix

Each `scheduleSegment` / `scheduleBuffer` call bumps a monotonic UInt64 `scheduleGeneration` and captures it by value in the completion closure. `internalCompletionHandler(generation:)` ignores any callback whose captured generation no longer matches — the schedule's identity rides in by value, so no shared state needs to be consulted on the audio thread.

The pre-existing `!isSeeking, status == .playing` guard is preserved. With the generation check added on top, all three invariants hold simultaneously:

- stale seek/reschedule completions are dropped (generation mismatch)
- explicit `stop()` honors its "won't generate a callback event" contract
  (`status` is `.stopped` after `stop()`, status-side guard drops the call)
- natural end-of-track still runs cleanup and invokes the user handler
  (generation matches, both guards pass)

Touched files:

- `Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer.swift` — adds
  the counter + bump helper, threads `generation:` through
  `internalCompletionHandler` and `invokeCompletionHandlerOnMain`.
- `Sources/AudioKit/Nodes/Playback/AudioPlayer/AudioPlayer+Scheduling.swift`
  — captures the generation at both schedule sites and passes it to the
  completion closure.

## tests

Two new regression tests in `AudioPlayerTests`:

- `testStaleCompletionDoesNotStompPlaybackOrInvokeHandler` — dispatches a
  stale-generation invocation via `DispatchQueue.global().async` to exercise
  the real audio-thread → main path, then asserts `status` stays `.playing`
  and the user handler is not called.
- `testStopDoesNotInvokeCompletionHandler` — calls `stop()` followed by a
  hand-invoked completion at the current generation, asserts the user
  handler is not called.