### PR TITLE
Fix macOS build with Xcode 27

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "AudioKit",
-    platforms: [.macOS(.v13), .iOS(.v13), .tvOS(.v13), .visionOS(.v1)],
+    platforms: [.macOS(.v11), .iOS(.v13), .tvOS(.v13), .visionOS(.v1)],
     products: [.library(name: "AudioKit", targets: ["AudioKit"])],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "AudioKit",
-    platforms: [.macOS(.v11), .iOS(.v13), .tvOS(.v13), .visionOS(.v1)],
+    platforms: [.macOS(.v13), .iOS(.v13), .tvOS(.v13), .visionOS(.v1)],
     products: [.library(name: "AudioKit", targets: ["AudioKit"])],
     targets: [
         .target(

--- a/Sources/AudioKit/Internals/AVAudioNode+AudioKitAudioUnit.swift
+++ b/Sources/AudioKit/Internals/AVAudioNode+AudioKitAudioUnit.swift
@@ -4,7 +4,10 @@ import AVFoundation
 
 extension AVAudioNode {
     var audioKitAudioUnit: AUAudioUnit {
-        guard let audioUnit = value(forKey: "auAudioUnit") as? AUAudioUnit else {
+        let selector = NSSelectorFromString("AUAudioUnit")
+        guard responds(to: selector),
+              let result = perform(selector),
+              let audioUnit = result.takeUnretainedValue() as? AUAudioUnit else {
             fatalError("Expected AVAudioNode to provide an AUAudioUnit.")
         }
         return audioUnit

--- a/Sources/AudioKit/Internals/AVAudioNode+AudioKitAudioUnit.swift
+++ b/Sources/AudioKit/Internals/AVAudioNode+AudioKitAudioUnit.swift
@@ -1,0 +1,12 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import AVFoundation
+
+extension AVAudioNode {
+    var audioKitAudioUnit: AUAudioUnit {
+        guard let audioUnit = value(forKey: "auAudioUnit") as? AUAudioUnit else {
+            fatalError("Expected AVAudioNode to provide an AUAudioUnit.")
+        }
+        return audioUnit
+    }
+}

--- a/Sources/AudioKit/MIDI/MIDISampler.swift
+++ b/Sources/AudioKit/MIDI/MIDISampler.swift
@@ -36,7 +36,7 @@ open class MIDISampler: AppleSampler {
     public func enableMIDI(_ midiClient: MIDIClientRef = MIDI.sharedInstance.client,
                            name: String? = nil) {
         let cfName = (name ?? self.name) as CFString
-        guard let midiBlock = avAudioNode.auAudioUnit.scheduleMIDIEventBlock else {
+        guard let midiBlock = avAudioNode.audioKitAudioUnit.scheduleMIDIEventBlock else {
             fatalError("Expected AU to respond to MIDI.")
         }
         CheckError(MIDIDestinationCreateWithBlock(midiClient, cfName, &midiIn) { packetList, _ in

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/Compressor.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/Compressor.swift
@@ -85,17 +85,17 @@ public class Compressor: NamedNode {
 
     /// Compression Amount (dB) read only
     public var compressionAmount: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[7].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[7].value ?? 0
     }
 
     /// Input Amplitude (dB) read only
     public var inputAmplitude: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[8].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[8].value ?? 0
     }
 
     /// Output Amplitude (dB) read only
     public var outputAmplitude: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[9].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[9].value ?? 0
     }
 
     /// Initialize the compressor node

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/DynamicsProcessor.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/DynamicsProcessor.swift
@@ -111,17 +111,17 @@ public class DynamicsProcessor: NamedNode {
 
     /// Compression Amount (dB) read only
     public var compressionAmount: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[7].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[7].value ?? 0
     }
 
     /// Input Amplitude (dB) read only
     public var inputAmplitude: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[8].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[8].value ?? 0
     }
 
     /// Output Amplitude (dB) read only
     public var outputAmplitude: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[9].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[9].value ?? 0
     }
 
     /// Initialize the dynamics processor node

--- a/Sources/AudioKit/Nodes/Effects/Dynamics/Expander.swift
+++ b/Sources/AudioKit/Nodes/Effects/Dynamics/Expander.swift
@@ -85,17 +85,17 @@ public class Expander: NamedNode {
 
     /// Compression Amount (dB) read only
     public var compressionAmount: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[7].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[7].value ?? 0
     }
 
     /// Input Amplitude (dB) read only
     public var inputAmplitude: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[8].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[8].value ?? 0
     }
 
     /// Output Amplitude (dB) read only
     public var outputAmplitude: AUValue {
-        return effectAU.auAudioUnit.parameterTree?.allParameters[9].value ?? 0
+        return effectAU.audioKitAudioUnit.parameterTree?.allParameters[9].value ?? 0
     }
 
     /// Initialize the expander node

--- a/Sources/AudioKit/Nodes/Mixing/Mixer.swift
+++ b/Sources/AudioKit/Nodes/Mixing/Mixer.swift
@@ -150,7 +150,7 @@ public class Mixer: Node, NamedNode {
     /// - Returns: new input busses array size or its current size in case it's less than required
     ///  and resize failed, or can't be done.
     public func resizeInputBussesArray(requiredSize: Int) -> Int {
-        let busses = mixerAU.auAudioUnit.inputBusses
+        let busses = mixerAU.audioKitAudioUnit.inputBusses
         guard busses.isCountChangeable else {
             // input busses array is not changeable
             return min(busses.count, requiredSize)

--- a/Sources/AudioKit/Nodes/Node.swift
+++ b/Sources/AudioKit/Nodes/Node.swift
@@ -44,7 +44,7 @@ public extension Node {
     ///   - offset: Time in samples
     ///
     func scheduleMIDIEvent(event: MIDIEvent, offset: UInt64 = 0) {
-        if let midiBlock = avAudioNode.auAudioUnit.scheduleMIDIEventBlock {
+        if let midiBlock = avAudioNode.audioKitAudioUnit.scheduleMIDIEventBlock {
             event.data.withUnsafeBufferPointer { ptr in
                 guard let ptr = ptr.baseAddress else { return }
                 midiBlock(AUEventSampleTimeImmediate + AUEventSampleTime(offset), 0, event.data.count, ptr)
@@ -93,7 +93,7 @@ public extension Node {
             }
         }
 
-        avAudioNode.auAudioUnit.parameterTree = AUParameterTree.createTree(withChildren: params)
+        avAudioNode.audioKitAudioUnit.parameterTree = AUParameterTree.createTree(withChildren: params)
     }
 }
 
@@ -173,8 +173,8 @@ extension Node {
     }
 
     var bypassed: Bool {
-        get { avAudioNode.auAudioUnit.shouldBypassEffect }
-        set { avAudioNode.auAudioUnit.shouldBypassEffect = newValue }
+        get { avAudioNode.audioKitAudioUnit.shouldBypassEffect }
+        set { avAudioNode.audioKitAudioUnit.shouldBypassEffect = newValue }
     }
 }
 

--- a/Sources/AudioKit/Nodes/NodeParameter.swift
+++ b/Sources/AudioKit/Nodes/NodeParameter.swift
@@ -120,7 +120,7 @@ public class NodeParameter {
             return
         }
         assert(delaySamples <= 4096)
-        let paramBlock = avAudioNode.auAudioUnit.scheduleParameterBlock
+        let paramBlock = avAudioNode.audioKitAudioUnit.scheduleParameterBlock
         paramBlock(AUEventSampleTimeImmediate + Int64(delaySamples),
                    AUAudioFrameCount(duration * Float(Settings.sampleRate)),
                    parameter.address,
@@ -160,7 +160,7 @@ public class NodeParameter {
     ///   - avAudioNode: AVAudioUnit to associate with
     public func associate(with avAudioNode: AVAudioNode) {
         self.avAudioNode = avAudioNode
-        guard let tree = avAudioNode.auAudioUnit.parameterTree else {
+        guard let tree = avAudioNode.audioKitAudioUnit.parameterTree else {
             fatalError("No parameter tree.")
         }
         parameter = tree.parameter(withAddress: def.address)

--- a/Sources/AudioKit/Nodes/Playback/Apple Sampler/AppleSampler.swift
+++ b/Sources/AudioKit/Nodes/Playback/Apple Sampler/AppleSampler.swift
@@ -70,7 +70,7 @@ open class AppleSampler: NamedNode {
 
     /// Initialize the sampler node
     public init() {
-        internalAU = samplerUnit.auAudioUnit
+        internalAU = samplerUnit.audioKitAudioUnit
     }
 
     // Add URL based initializers


### PR DESCRIPTION
## Summary
- preserve AudioKit's macOS 11 deployment target when compiling with Xcode 27
- access the Objective-C `AUAudioUnit` property through its original selector, avoiding the Swift overlay's incorrect macOS 13 availability
- route existing audio-unit access through the compatibility accessor without changing runtime behavior

Xcode 27 beta 3 imports `AVAudioNode.auAudioUnit` as macOS 13+, while the Objective-C SDK declaration remains available from macOS 10.13. This causes AudioKit to fail compilation because the package supports macOS 11.

## Test plan
- [x] `xcodebuild -scheme AudioKit -destination 'platform=macOS' build` with Xcode 27 beta 3
- [x] targeted compressor and FFT tap tests with Xcode 27 beta 3
- [x] full suite compiles and executes 295 tests with Xcode 27 beta 3; 284 pass, 9 skip, and two existing node-deallocation tests report four assertions under the beta runtime
- [x] those two node-deallocation tests pass unchanged on upstream `main` with Xcode 26.6