### PR TITLE
Add optional XCFramework distribution tooling

### DIFF
--- a/XCFramework/AudioKitFramework.xcodeproj/project.pbxproj
+++ b/XCFramework/AudioKitFramework.xcodeproj/project.pbxproj
@@ -1,0 +1,314 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 100;
+	objects = {
+
+/* Begin PBXFileReference section */
+		A12000000000000000000001 /* AudioKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AudioKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A14000000000000000000001 /* Sources/AudioKit */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ../Sources/AudioKit;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A15000000000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A16000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				A14000000000000000000001 /* Sources/AudioKit */,
+				A16000000000000000000002 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A16000000000000000000002 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A12000000000000000000001 /* AudioKit.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A1A000000000000000000001 /* AudioKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1D000000000000000000002 /* Build configuration list for PBXNativeTarget "AudioKit" */;
+			buildPhases = (
+				A18000000000000000000001 /* Sources */,
+				A15000000000000000000001 /* Frameworks */,
+				A19000000000000000000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A14000000000000000000001 /* Sources/AudioKit */,
+			);
+			name = AudioKit;
+			packageProductDependencies = (
+			);
+			productName = AudioKit;
+			productReference = A12000000000000000000001 /* AudioKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A1B000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
+				TargetAttributes = {
+					A1A000000000000000000001 = {
+						CreatedOnToolsVersion = 26.6;
+					};
+				};
+			};
+			buildConfigurationList = A1D000000000000000000001 /* Build configuration list for PBXProject "AudioKitFramework" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A16000000000000000000001;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 100;
+			productRefGroup = A16000000000000000000002 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A1A000000000000000000001 /* AudioKit */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A19000000000000000000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A18000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A1C000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A1C000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				ONLY_ACTIVE_ARCH = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A1C000000000000000000003 /* ReleaseSwift6Preview */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				ONLY_ACTIVE_ARCH = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "Swift6 $(inherited)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = ReleaseSwift6Preview;
+		};
+		A1C000000000000000000004 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = mh_dylib;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 5.7.2;
+				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
+				PRODUCT_MODULE_NAME = AudioKit;
+				PRODUCT_NAME = AudioKit;
+				SKIP_INSTALL = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A1C000000000000000000005 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = mh_dylib;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 5.7.2;
+				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
+				PRODUCT_MODULE_NAME = AudioKit;
+				PRODUCT_NAME = AudioKit;
+				SKIP_INSTALL = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERIFY_EMITTED_MODULE_INTERFACE = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A1C000000000000000000006 /* ReleaseSwift6Preview */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = mh_dylib;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 5.7.2;
+				PRODUCT_BUNDLE_IDENTIFIER = io.audiokit.AudioKit;
+				PRODUCT_MODULE_NAME = AudioKit;
+				PRODUCT_NAME = AudioKit;
+				SKIP_INSTALL = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERIFY_EMITTED_MODULE_INTERFACE = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = ReleaseSwift6Preview;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A1D000000000000000000001 /* Build configuration list for PBXProject "AudioKitFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1C000000000000000000001 /* Debug */,
+				A1C000000000000000000002 /* Release */,
+				A1C000000000000000000003 /* ReleaseSwift6Preview */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1D000000000000000000002 /* Build configuration list for PBXNativeTarget "AudioKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1C000000000000000000004 /* Debug */,
+				A1C000000000000000000005 /* Release */,
+				A1C000000000000000000006 /* ReleaseSwift6Preview */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A1B000000000000000000001 /* Project object */;
+}

--- a/XCFramework/AudioKitFramework.xcodeproj/xcshareddata/xcschemes/AudioKitFramework.xcscheme
+++ b/XCFramework/AudioKitFramework.xcodeproj/xcshareddata/xcschemes/AudioKitFramework.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1A000000000000000000001"
+               BuildableName = "AudioKit.framework"
+               BlueprintName = "AudioKit"
+               ReferencedContainer = "container:AudioKitFramework.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/XCFramework/README.md
+++ b/XCFramework/README.md
@@ -1,0 +1,65 @@
+# Building AudioKit as an XCFramework
+
+This directory contains optional tooling for building AudioKit as a precompiled
+XCFramework for iOS and macOS. The existing Swift Package Manager workflow
+remains unchanged, and `Package.swift` is not involved in this build path.
+
+## Requirements
+
+- Xcode 27
+- A clean checkout based on an AudioKit release tag
+- iOS 15 deployment support
+- macOS 12 deployment support
+
+## Build
+
+To build with a double-click, open `build.command` in
+Finder. The wrapper uses a sibling `AudioKitBinary` directory when it exists;
+otherwise it writes to `.build/xcframework-output`. Set
+`AUDIOKIT_XCFRAMEWORK_OUTPUT` to override that destination.
+
+From the repository root, run:
+
+```sh
+./XCFramework/build-xcframework.sh [output-directory]
+```
+
+When no output directory is provided, artifacts are written to
+`.build/xcframework-output`.
+
+During an interactive terminal run, the script asks for both deployment
+targets and whether to include Intel Mac support. Pressing Return selects
+iOS 15, macOS 12, and an arm64-only macOS slice. Non-interactive builds use
+the same defaults without prompting.
+
+Archive steps use a single updating terminal line that reports the current
+build step and elapsed time. `xcodebuild` does not expose reliable per-file
+progress or an exact percentage for archive operations.
+
+The choices can also be supplied as environment variables for automation:
+
+```sh
+XCFRAMEWORK_IOS_DEPLOYMENT_TARGET=18.0 \
+XCFRAMEWORK_MACOS_DEPLOYMENT_TARGET=15.0 \
+XCFRAMEWORK_MACOS_ARCHITECTURES="arm64 x86_64" \
+./XCFramework/build-xcframework.sh [output-directory]
+```
+
+`XCFRAMEWORK_MACOS_ARCHITECTURES` accepts `arm64` or `arm64 x86_64`.
+
+The script produces:
+
+- `AudioKit.xcframework`
+- `BUILD_INFO.md` with source and toolchain provenance
+
+The XCFramework contains an arm64 iOS device slice, an arm64/x86_64 iOS
+Simulator slice, and a native macOS slice with the selected architectures.
+The build includes stable module interfaces and matching dSYMs.
+
+Before installing the output, the script validates architectures, dynamic
+linkage, module interfaces, dSYM UUIDs, and source-free iOS and macOS consumer
+links. Output replacement is atomic, so a failed build does not overwrite a
+previously valid artifact.
+
+This repository does not publish prebuilt artifacts. The generated output can
+be packaged by downstream distribution infrastructure when needed.

--- a/XCFramework/build-xcframework.sh
+++ b/XCFramework/build-xcframework.sh
@@ -1,0 +1,525 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+    printf 'error: %s\n' "$1" >&2
+    exit 1
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        fail "required command not found: $1"
+    fi
+}
+
+readonly SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SOURCE_ROOT="$(cd "${SCRIPT_DIRECTORY}/.." && pwd -P)"
+
+if [[ "$#" -gt 1 ]]; then
+    fail "usage: $0 [output-directory]"
+fi
+
+for required_command in git xcodebuild xcrun plutil lipo otool file shasum ditto; do
+    require_command "${required_command}"
+done
+
+readonly PROJECT="${SCRIPT_DIRECTORY}/AudioKitFramework.xcodeproj"
+readonly SCHEME="AudioKitFramework"
+readonly FRAMEWORK_NAME="AudioKit"
+readonly OUTPUT_CANDIDATE="${1:-${SOURCE_ROOT}/.build/xcframework-output}"
+
+ios_deployment_target="${XCFRAMEWORK_IOS_DEPLOYMENT_TARGET:-}"
+macos_deployment_target="${XCFRAMEWORK_MACOS_DEPLOYMENT_TARGET:-}"
+macos_architectures="${XCFRAMEWORK_MACOS_ARCHITECTURES:-}"
+
+if [[ -t 0 ]]; then
+    if [[ -z "${ios_deployment_target}" ]]; then
+        printf 'Minimum iOS deployment target [15.0]: '
+        if IFS= read -r entered_ios_target && [[ -n "${entered_ios_target}" ]]; then
+            ios_deployment_target="${entered_ios_target}"
+        fi
+    fi
+
+    if [[ -z "${macos_deployment_target}" ]]; then
+        printf 'Minimum macOS deployment target [12.0]: '
+        if IFS= read -r entered_macos_target && [[ -n "${entered_macos_target}" ]]; then
+            macos_deployment_target="${entered_macos_target}"
+        fi
+    fi
+
+    if [[ -z "${macos_architectures}" ]]; then
+        while true; do
+            printf 'Include Intel Mac support? [y/N]: '
+            if ! IFS= read -r include_intel; then
+                break
+            fi
+
+            case "${include_intel}" in
+                ""|n|N|no|No|NO)
+                    macos_architectures="arm64"
+                    break
+                    ;;
+                y|Y|yes|Yes|YES)
+                    macos_architectures="arm64 x86_64"
+                    break
+                    ;;
+                *)
+                    printf 'Please answer y or n.\n' >&2
+                    ;;
+            esac
+        done
+    fi
+fi
+
+readonly MINIMUM_IOS_VERSION="${ios_deployment_target:-15.0}"
+readonly MINIMUM_MACOS_VERSION="${macos_deployment_target:-12.0}"
+readonly MACOS_ARCHITECTURES="${macos_architectures:-arm64}"
+
+[[ "${MINIMUM_IOS_VERSION}" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]] \
+    || fail "invalid iOS deployment target: ${MINIMUM_IOS_VERSION}"
+[[ "${MINIMUM_MACOS_VERSION}" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]] \
+    || fail "invalid macOS deployment target: ${MINIMUM_MACOS_VERSION}"
+
+case "${MACOS_ARCHITECTURES}" in
+    arm64)
+        readonly MACOS_SLICE_IDENTIFIER="macos-arm64"
+        ;;
+    "arm64 x86_64")
+        readonly MACOS_SLICE_IDENTIFIER="macos-arm64_x86_64"
+        ;;
+    *)
+        fail "unsupported macOS architectures: ${MACOS_ARCHITECTURES}; use arm64 or arm64 x86_64"
+        ;;
+esac
+
+[[ -f "${PROJECT}/project.pbxproj" ]] || fail "project not found: ${PROJECT}"
+/bin/mkdir -p "${OUTPUT_CANDIDATE}"
+readonly OUTPUT_DIRECTORY="$(cd "${OUTPUT_CANDIDATE}" && pwd -P)"
+
+readonly SOURCE_COMMIT="$(/usr/bin/git -C "${SOURCE_ROOT}" rev-parse HEAD)"
+readonly SOURCE_ORIGIN="$(/usr/bin/git -C "${SOURCE_ROOT}" remote get-url origin)"
+
+upstream_tag="${AUDIOKIT_UPSTREAM_TAG:-$(/usr/bin/git -C "${SOURCE_ROOT}" describe --tags --abbrev=0 HEAD 2>/dev/null || true)}"
+[[ -n "${upstream_tag}" ]] || fail "unable to determine the upstream release tag; set AUDIOKIT_UPSTREAM_TAG"
+readonly UPSTREAM_TAG="${upstream_tag}"
+readonly UPSTREAM_TAG_OBJECT="$(/usr/bin/git -C "${SOURCE_ROOT}" rev-parse "${UPSTREAM_TAG}")"
+readonly UPSTREAM_COMMIT="$(/usr/bin/git -C "${SOURCE_ROOT}" rev-parse "${UPSTREAM_TAG}^{}")"
+
+if ! /usr/bin/git -C "${SOURCE_ROOT}" merge-base --is-ancestor "${UPSTREAM_COMMIT}" HEAD; then
+    fail "upstream tag ${UPSTREAM_TAG} is not an ancestor of HEAD"
+fi
+
+if ! /usr/bin/git -C "${SOURCE_ROOT}" diff --quiet "${UPSTREAM_TAG}" -- Package.swift Sources/AudioKit; then
+    fail "Package.swift or Sources/AudioKit differ from upstream release ${UPSTREAM_TAG}"
+fi
+
+source_state="clean"
+if [[ -n "$(/usr/bin/git -C "${SOURCE_ROOT}" status --porcelain --untracked-files=all)" ]]; then
+    source_state="dirty development build"
+fi
+readonly SOURCE_STATE="${source_state}"
+
+if [[ "${SOURCE_STATE}" != "clean" && "${ALLOW_DIRTY_BUILD:-0}" != "1" ]]; then
+    fail "source repository is dirty; commit the build infrastructure or rerun with ALLOW_DIRTY_BUILD=1 for a non-publishable development artifact"
+fi
+
+if [[ "${SOURCE_STATE}" != "clean" ]]; then
+    printf 'warning: building a non-publishable dirty development artifact\n' >&2
+fi
+
+readonly CACHE_ROOT="${SOURCE_ROOT}/.build/xcframework"
+readonly DERIVED_DATA="${CACHE_ROOT}/DerivedData"
+/bin/mkdir -p "${DERIVED_DATA}"
+
+readonly WORK_ROOT="$(/usr/bin/mktemp -d /private/tmp/AudioKitXCFramework.XXXXXX)"
+readonly DEVICE_ARCHIVE="${WORK_ROOT}/AudioKit-iOS.xcarchive"
+readonly SIMULATOR_ARCHIVE="${WORK_ROOT}/AudioKit-Simulator.xcarchive"
+readonly MACOS_ARCHIVE="${WORK_ROOT}/AudioKit-macOS.xcarchive"
+readonly BUILT_XCFRAMEWORK="${WORK_ROOT}/AudioKit.xcframework"
+readonly GENERATED_BUILD_INFO="${WORK_ROOT}/BUILD_INFO.md"
+readonly SMOKE_SOURCE="${WORK_ROOT}/AudioKitBinarySmoke.swift"
+readonly SMOKE_LIBRARY="${WORK_ROOT}/libAudioKitBinarySmoke.dylib"
+readonly MACOS_ARM64_SMOKE_LIBRARY="${WORK_ROOT}/libAudioKitBinarySmoke-macOS-arm64.dylib"
+readonly MACOS_X86_64_SMOKE_LIBRARY="${WORK_ROOT}/libAudioKitBinarySmoke-macOS-x86_64.dylib"
+readonly DESTINATION_XCFRAMEWORK="${OUTPUT_DIRECTORY}/AudioKit.xcframework"
+readonly INSTALL_STAGE="${OUTPUT_DIRECTORY}/.AudioKit.xcframework.new.$$"
+readonly BUILD_INFO_STAGE="${OUTPUT_DIRECTORY}/.BUILD_INFO.md.new.$$"
+
+BACKUP_XCFRAMEWORK=""
+ACTIVE_BUILD_PID=""
+
+readonly BUILD_STEP_COUNT=8
+
+safe_remove() {
+    local path="$1"
+
+    case "${path}" in
+        "${WORK_ROOT}"|"${OUTPUT_DIRECTORY}"/.AudioKit.xcframework.new.*|"${OUTPUT_DIRECTORY}"/.AudioKit.xcframework.previous.*|"${OUTPUT_DIRECTORY}"/.BUILD_INFO.md.new.*)
+            if [[ -e "${path}" ]]; then
+                /bin/rm -rf -- "${path}"
+            fi
+            ;;
+        *)
+            printf 'warning: refused to remove unexpected path %s\n' "${path}" >&2
+            ;;
+    esac
+}
+
+cleanup() {
+    local status="$?"
+
+    if [[ -n "${ACTIVE_BUILD_PID}" ]] && /bin/kill -0 "${ACTIVE_BUILD_PID}" 2>/dev/null; then
+        /bin/kill "${ACTIVE_BUILD_PID}" 2>/dev/null || true
+        wait "${ACTIVE_BUILD_PID}" 2>/dev/null || true
+    fi
+
+    if [[ -n "${BACKUP_XCFRAMEWORK}" && -e "${BACKUP_XCFRAMEWORK}" ]]; then
+        if [[ ! -e "${DESTINATION_XCFRAMEWORK}" ]]; then
+            /bin/mv "${BACKUP_XCFRAMEWORK}" "${DESTINATION_XCFRAMEWORK}"
+        else
+            safe_remove "${BACKUP_XCFRAMEWORK}"
+        fi
+    fi
+
+    safe_remove "${INSTALL_STAGE}"
+    safe_remove "${BUILD_INFO_STAGE}"
+    safe_remove "${WORK_ROOT}"
+
+    trap - EXIT
+    exit "${status}"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+archive_framework() {
+    local destination="$1"
+    local archive_path="$2"
+    local label="$3"
+    local architectures="$4"
+    local step_number="$5"
+    local build_log="${WORK_ROOT}/${label// /-}.log"
+    local started_at
+    local current_time
+    local build_status
+    local spinner='|/-\'
+    local spinner_index=0
+
+    /usr/bin/xcodebuild archive \
+        -project "${PROJECT}" \
+        -scheme "${SCHEME}" \
+        -configuration Release \
+        -destination "${destination}" \
+        -archivePath "${archive_path}" \
+        -derivedDataPath "${DERIVED_DATA}" \
+        CODE_SIGNING_ALLOWED=NO \
+        SKIP_INSTALL=NO \
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+        ARCHS="${architectures}" \
+        ONLY_ACTIVE_ARCH=NO \
+        IPHONEOS_DEPLOYMENT_TARGET="${MINIMUM_IOS_VERSION}" \
+        MACOSX_DEPLOYMENT_TARGET="${MINIMUM_MACOS_VERSION}" \
+        DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
+        >"${build_log}" 2>&1 &
+
+    ACTIVE_BUILD_PID="$!"
+    started_at="$(/bin/date +%s)"
+
+    while /bin/kill -0 "${ACTIVE_BUILD_PID}" 2>/dev/null; do
+        current_time="$(/bin/date +%s)"
+        if [[ -t 1 ]]; then
+            printf '\r\033[2K[%d/%d] %s %c %ss' \
+                "${step_number}" "${BUILD_STEP_COUNT}" "${label}" "${spinner:spinner_index%4:1}" \
+                "$((current_time - started_at))"
+
+            spinner_index=$((spinner_index + 1))
+        fi
+        /bin/sleep 1
+    done
+
+    if wait "${ACTIVE_BUILD_PID}"; then
+        build_status=0
+    else
+        build_status="$?"
+    fi
+    ACTIVE_BUILD_PID=""
+
+    if [[ "${build_status}" -ne 0 ]]; then
+        if [[ -t 1 ]]; then
+            printf '\r\033[2K'
+        fi
+        printf '[%d/%d] %s failed. Last 200 build-log lines:\n' \
+            "${step_number}" "${BUILD_STEP_COUNT}" "${label}" >&2
+        /usr/bin/tail -n 200 "${build_log}" >&2
+        fail "${label} failed with exit code ${build_status}"
+    fi
+
+    current_time="$(/bin/date +%s)"
+    if [[ -t 1 ]]; then
+        printf '\r\033[2K'
+    fi
+    printf '[%d/%d] %s finished in %ss.\n' \
+        "${step_number}" "${BUILD_STEP_COUNT}" "${label}" "$((current_time - started_at))"
+}
+
+require_path() {
+    [[ -e "$1" ]] || fail "expected build output is missing: $1"
+}
+
+uuid_list() {
+    /usr/bin/xcrun dwarfdump --uuid "$1" \
+        | /usr/bin/awk '{ print $2 " " $3 }' \
+        | /usr/bin/sort
+}
+
+uuid_summary() {
+    /usr/bin/xcrun dwarfdump --uuid "$1" \
+        | /usr/bin/awk 'BEGIN { separator = "" } { printf "%s%s %s", separator, $2, $3; separator = ", " } END { print "" }'
+}
+
+assert_matching_uuids() {
+    local binary="$1"
+    local dsym="$2"
+    local binary_uuids
+    local dsym_uuids
+
+    binary_uuids="$(uuid_list "${binary}")"
+    dsym_uuids="$(uuid_list "${dsym}")"
+
+    if [[ "${binary_uuids}" != "${dsym_uuids}" ]]; then
+        printf 'Binary UUIDs:\n%s\n' "${binary_uuids}" >&2
+        printf 'dSYM UUIDs:\n%s\n' "${dsym_uuids}" >&2
+        fail "framework and dSYM UUIDs do not match"
+    fi
+}
+
+assert_build_version() {
+    local binary="$1"
+    local expected_platform="$2"
+    local expected_minimum="$3"
+    local build_versions
+
+    build_versions="$(/usr/bin/xcrun vtool -show-build "${binary}")"
+
+    if ! /usr/bin/printf '%s\n' "${build_versions}" \
+        | /usr/bin/grep -E -q "^[[:space:]]*platform ${expected_platform}$"; then
+        fail "unexpected platform in binary: ${binary}"
+    fi
+
+    if ! /usr/bin/printf '%s\n' "${build_versions}" \
+        | /usr/bin/grep -E -q "^[[:space:]]*minos ${expected_minimum}$"; then
+        fail "unexpected minimum deployment target in binary: ${binary}"
+    fi
+}
+
+assert_no_unexpected_runtime_dependency() {
+    local binary="$1"
+    local label="$2"
+
+    if /usr/bin/otool -L "${binary}" \
+        | /usr/bin/grep -v -E 'AudioKit.framework|/System/Library/Frameworks/|/usr/lib/|@rpath/libswift_[A-Za-z0-9_]+\.dylib' \
+        | /usr/bin/grep -q .; then
+        /usr/bin/otool -L "${binary}" >&2
+        fail "${label} has an unexpected non-system runtime dependency"
+    fi
+}
+
+printf '\nBuilding AudioKit %s.\n' "${UPSTREAM_TAG}"
+
+archive_framework "generic/platform=iOS" "${DEVICE_ARCHIVE}" "iOS device" "arm64" 1
+
+archive_framework "generic/platform=iOS Simulator" "${SIMULATOR_ARCHIVE}" "iOS Simulator" "arm64 x86_64" 2
+
+archive_framework "generic/platform=macOS" "${MACOS_ARCHIVE}" "macOS" "${MACOS_ARCHITECTURES}" 3
+
+readonly DEVICE_FRAMEWORK="${DEVICE_ARCHIVE}/Products/Library/Frameworks/AudioKit.framework"
+readonly DEVICE_DSYM="${DEVICE_ARCHIVE}/dSYMs/AudioKit.framework.dSYM"
+readonly SIMULATOR_FRAMEWORK="${SIMULATOR_ARCHIVE}/Products/Library/Frameworks/AudioKit.framework"
+readonly SIMULATOR_DSYM="${SIMULATOR_ARCHIVE}/dSYMs/AudioKit.framework.dSYM"
+readonly MACOS_FRAMEWORK="${MACOS_ARCHIVE}/Products/Library/Frameworks/AudioKit.framework"
+readonly MACOS_DSYM="${MACOS_ARCHIVE}/dSYMs/AudioKit.framework.dSYM"
+
+require_path "${DEVICE_FRAMEWORK}/AudioKit"
+require_path "${DEVICE_DSYM}"
+require_path "${SIMULATOR_FRAMEWORK}/AudioKit"
+require_path "${SIMULATOR_DSYM}"
+require_path "${MACOS_FRAMEWORK}/AudioKit"
+require_path "${MACOS_DSYM}"
+
+printf '[4/%d] Creating AudioKit.xcframework...\n' "${BUILD_STEP_COUNT}"
+/usr/bin/xcodebuild -create-xcframework \
+    -framework "${DEVICE_FRAMEWORK}" \
+    -debug-symbols "${DEVICE_DSYM}" \
+    -framework "${SIMULATOR_FRAMEWORK}" \
+    -debug-symbols "${SIMULATOR_DSYM}" \
+    -framework "${MACOS_FRAMEWORK}" \
+    -debug-symbols "${MACOS_DSYM}" \
+    -output "${BUILT_XCFRAMEWORK}"
+
+readonly DEVICE_SLICE="${BUILT_XCFRAMEWORK}/ios-arm64"
+readonly SIMULATOR_SLICE="${BUILT_XCFRAMEWORK}/ios-arm64_x86_64-simulator"
+readonly MACOS_SLICE="${BUILT_XCFRAMEWORK}/${MACOS_SLICE_IDENTIFIER}"
+readonly DEVICE_BINARY="${DEVICE_SLICE}/AudioKit.framework/AudioKit"
+readonly DEVICE_XCFRAMEWORK_DSYM="${DEVICE_SLICE}/dSYMs/AudioKit.framework.dSYM"
+readonly SIMULATOR_BINARY="${SIMULATOR_SLICE}/AudioKit.framework/AudioKit"
+readonly SIMULATOR_XCFRAMEWORK_DSYM="${SIMULATOR_SLICE}/dSYMs/AudioKit.framework.dSYM"
+readonly MACOS_BINARY="${MACOS_SLICE}/AudioKit.framework/Versions/A/AudioKit"
+readonly MACOS_XCFRAMEWORK_DSYM="${MACOS_SLICE}/dSYMs/AudioKit.framework.dSYM"
+
+require_path "${BUILT_XCFRAMEWORK}/Info.plist"
+require_path "${DEVICE_BINARY}"
+require_path "${DEVICE_XCFRAMEWORK_DSYM}"
+require_path "${SIMULATOR_BINARY}"
+require_path "${SIMULATOR_XCFRAMEWORK_DSYM}"
+require_path "${MACOS_BINARY}"
+require_path "${MACOS_XCFRAMEWORK_DSYM}"
+require_path "${DEVICE_SLICE}/AudioKit.framework/PrivacyInfo.xcprivacy"
+require_path "${SIMULATOR_SLICE}/AudioKit.framework/PrivacyInfo.xcprivacy"
+require_path "${MACOS_SLICE}/AudioKit.framework/Versions/A/Resources/PrivacyInfo.xcprivacy"
+
+printf '[5/%d] Validating slices, linkage, interfaces, resources, and dSYMs...\n' "${BUILD_STEP_COUNT}"
+/usr/bin/plutil -lint "${BUILT_XCFRAMEWORK}/Info.plist" >/dev/null
+/usr/bin/lipo "${DEVICE_BINARY}" -verify_arch arm64
+/usr/bin/lipo "${SIMULATOR_BINARY}" -verify_arch arm64
+/usr/bin/lipo "${SIMULATOR_BINARY}" -verify_arch x86_64
+for macos_architecture in ${MACOS_ARCHITECTURES}; do
+    /usr/bin/lipo "${MACOS_BINARY}" -verify_arch "${macos_architecture}"
+done
+
+if ! /usr/bin/file "${DEVICE_BINARY}" | /usr/bin/grep -q 'dynamically linked shared library'; then
+    fail "device slice is not a dynamic framework"
+fi
+
+if ! /usr/bin/file "${SIMULATOR_BINARY}" | /usr/bin/grep -q 'dynamically linked shared library'; then
+    fail "simulator slice is not a dynamic framework"
+fi
+
+if ! /usr/bin/file "${MACOS_BINARY}" | /usr/bin/grep -q 'dynamically linked shared library'; then
+    fail "macOS slice is not a dynamic framework"
+fi
+
+assert_build_version "${DEVICE_BINARY}" IOS "${MINIMUM_IOS_VERSION}"
+assert_build_version "${SIMULATOR_BINARY}" IOSSIMULATOR "${MINIMUM_IOS_VERSION}"
+assert_build_version "${MACOS_BINARY}" MACOS "${MINIMUM_MACOS_VERSION}"
+
+assert_no_unexpected_runtime_dependency "${DEVICE_BINARY}" "device slice"
+assert_no_unexpected_runtime_dependency "${SIMULATOR_BINARY}" "simulator slice"
+assert_no_unexpected_runtime_dependency "${MACOS_BINARY}" "macOS slice"
+
+interface_count="$(/usr/bin/find "${BUILT_XCFRAMEWORK}" -type f -name '*.swiftinterface' | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+[[ "${interface_count}" -ge 3 ]] || fail "stable Swift module interfaces are missing"
+
+assert_matching_uuids "${DEVICE_BINARY}" "${DEVICE_XCFRAMEWORK_DSYM}"
+assert_matching_uuids "${SIMULATOR_BINARY}" "${SIMULATOR_XCFRAMEWORK_DSYM}"
+assert_matching_uuids "${MACOS_BINARY}" "${MACOS_XCFRAMEWORK_DSYM}"
+
+printf '[6/%d] Linking a clean iOS Simulator smoke module against the binary only...\n' "${BUILD_STEP_COUNT}"
+/usr/bin/printf '%s\n' \
+    'import AudioKit' \
+    '' \
+    'public func makeBinarySmokeMixer() -> Mixer {' \
+    '    Mixer(name: "AudioKit binary smoke")' \
+    '}' \
+    >"${SMOKE_SOURCE}"
+
+readonly SIMULATOR_SDK="$(/usr/bin/xcrun --sdk iphonesimulator --show-sdk-path)"
+/usr/bin/xcrun --sdk iphonesimulator swiftc \
+    "${SMOKE_SOURCE}" \
+    -parse-as-library \
+    -emit-library \
+    -target "arm64-apple-ios${MINIMUM_IOS_VERSION}-simulator" \
+    -sdk "${SIMULATOR_SDK}" \
+    -F "${SIMULATOR_SLICE}" \
+    -framework AudioKit \
+    -o "${SMOKE_LIBRARY}"
+require_path "${SMOKE_LIBRARY}"
+
+printf '[7/%d] Linking clean macOS smoke modules against the binary only...\n' "${BUILD_STEP_COUNT}"
+readonly MACOS_SDK="$(/usr/bin/xcrun --sdk macosx --show-sdk-path)"
+for macos_architecture in ${MACOS_ARCHITECTURES}; do
+    if [[ "${macos_architecture}" == "arm64" ]]; then
+        macos_smoke_library="${MACOS_ARM64_SMOKE_LIBRARY}"
+    else
+        macos_smoke_library="${MACOS_X86_64_SMOKE_LIBRARY}"
+    fi
+
+    /usr/bin/xcrun --sdk macosx swiftc \
+        "${SMOKE_SOURCE}" \
+        -parse-as-library \
+        -emit-library \
+        -target "${macos_architecture}-apple-macosx${MINIMUM_MACOS_VERSION}" \
+        -sdk "${MACOS_SDK}" \
+        -F "${MACOS_SLICE}" \
+        -framework AudioKit \
+        -o "${macos_smoke_library}"
+    require_path "${macos_smoke_library}"
+done
+
+readonly BUILD_DATE="$(/bin/date '+%Y-%m-%d %H:%M:%S %Z')"
+readonly XCODE_VERSION="$(/usr/bin/xcodebuild -version | /usr/bin/awk 'NR == 1 { name = $0 } NR == 2 { print name " (" $3 ")" }')"
+readonly SWIFT_VERSION="$(/usr/bin/xcrun swift --version 2>&1 | /usr/bin/awk 'NR == 1 { sub(/^.*Apple Swift version/, "Apple Swift version"); print; exit }')"
+readonly DEVICE_ARCHITECTURES="$(/usr/bin/lipo -archs "${DEVICE_BINARY}")"
+readonly SIMULATOR_ARCHITECTURES="$(/usr/bin/lipo -archs "${SIMULATOR_BINARY}")"
+readonly BUILT_MACOS_ARCHITECTURES="$(/usr/bin/lipo -archs "${MACOS_BINARY}")"
+readonly DEVICE_UUIDS="$(uuid_summary "${DEVICE_BINARY}")"
+readonly SIMULATOR_UUIDS="$(uuid_summary "${SIMULATOR_BINARY}")"
+readonly MACOS_UUIDS="$(uuid_summary "${MACOS_BINARY}")"
+readonly DEVICE_SHA256="$(/usr/bin/shasum -a 256 "${DEVICE_BINARY}" | /usr/bin/awk '{ print $1 }')"
+readonly SIMULATOR_SHA256="$(/usr/bin/shasum -a 256 "${SIMULATOR_BINARY}" | /usr/bin/awk '{ print $1 }')"
+readonly MACOS_SHA256="$(/usr/bin/shasum -a 256 "${MACOS_BINARY}" | /usr/bin/awk '{ print $1 }')"
+
+{
+    printf '# Build information\n\n'
+    printf -- '- Artifact: `AudioKit.xcframework`\n'
+    printf -- '- AudioKit release: `%s`\n' "${UPSTREAM_TAG}"
+    printf -- '- Upstream tag object: `%s`\n' "${UPSTREAM_TAG_OBJECT}"
+    printf -- '- Upstream source commit: `%s`\n' "${UPSTREAM_COMMIT}"
+    printf -- '- Build-infrastructure commit: `%s`\n' "${SOURCE_COMMIT}"
+    printf -- '- Source repository: `%s`\n' "${SOURCE_ORIGIN}"
+    printf -- '- Source state: `%s`\n' "${SOURCE_STATE}"
+    printf -- '- Built: `%s`\n' "${BUILD_DATE}"
+    printf -- '- Xcode: `%s`\n' "${XCODE_VERSION}"
+    printf -- '- Swift: `%s`\n' "${SWIFT_VERSION}"
+    printf -- '- Configuration: `Release`\n'
+    printf -- '- Library evolution: enabled\n'
+    printf -- '- Minimum iOS: `%s`\n' "${MINIMUM_IOS_VERSION}"
+    printf -- '- Minimum macOS: `%s`\n\n' "${MINIMUM_MACOS_VERSION}"
+    printf '## Slices and dSYM UUIDs\n\n'
+    printf -- '- iOS %s: `%s`\n' "${DEVICE_ARCHITECTURES}" "${DEVICE_UUIDS}"
+    printf -- '- iOS Simulator %s: `%s`\n' "${SIMULATOR_ARCHITECTURES}" "${SIMULATOR_UUIDS}"
+    printf -- '- macOS %s: `%s`\n\n' "${BUILT_MACOS_ARCHITECTURES}" "${MACOS_UUIDS}"
+    printf '## Binary SHA-256\n\n'
+    printf -- '- iOS %s: `%s`\n' "${DEVICE_ARCHITECTURES}" "${DEVICE_SHA256}"
+    printf -- '- iOS Simulator %s: `%s`\n' "${SIMULATOR_ARCHITECTURES}" "${SIMULATOR_SHA256}"
+    printf -- '- macOS %s: `%s`\n\n' "${BUILT_MACOS_ARCHITECTURES}" "${MACOS_SHA256}"
+    printf 'All slices contain `PrivacyInfo.xcprivacy`, stable Swift interfaces, and matching dSYMs. '
+    printf 'The smoke checks import `AudioKit`, create a `Mixer`, and link on iOS Simulator plus the selected macOS architectures without source dependencies.\n'
+} >"${GENERATED_BUILD_INFO}"
+
+if [[ -e "${INSTALL_STAGE}" || -e "${BUILD_INFO_STAGE}" ]]; then
+    fail "temporary install path already exists in output directory"
+fi
+
+printf '[8/%d] Installing the verified artifact into %s...\n' "${BUILD_STEP_COUNT}" "${OUTPUT_DIRECTORY}"
+/usr/bin/ditto "${BUILT_XCFRAMEWORK}" "${INSTALL_STAGE}"
+/bin/cp "${GENERATED_BUILD_INFO}" "${BUILD_INFO_STAGE}"
+
+if [[ -e "${DESTINATION_XCFRAMEWORK}" ]]; then
+    BACKUP_XCFRAMEWORK="${OUTPUT_DIRECTORY}/.AudioKit.xcframework.previous.$$"
+    /bin/mv "${DESTINATION_XCFRAMEWORK}" "${BACKUP_XCFRAMEWORK}"
+fi
+
+/bin/mv "${INSTALL_STAGE}" "${DESTINATION_XCFRAMEWORK}"
+/bin/mv -f "${BUILD_INFO_STAGE}" "${OUTPUT_DIRECTORY}/BUILD_INFO.md"
+
+if [[ -n "${BACKUP_XCFRAMEWORK}" && -e "${BACKUP_XCFRAMEWORK}" ]]; then
+    safe_remove "${BACKUP_XCFRAMEWORK}"
+    BACKUP_XCFRAMEWORK=""
+fi
+
+printf '\nAudioKit XCFramework is ready:\n%s\n' "${DESTINATION_XCFRAMEWORK}"
+printf 'Device UUIDs: %s\n' "${DEVICE_UUIDS}"
+printf 'Simulator UUIDs: %s\n' "${SIMULATOR_UUIDS}"
+printf 'macOS UUIDs: %s\n' "${MACOS_UUIDS}"

--- a/XCFramework/build.command
+++ b/XCFramework/build.command
@@ -1,0 +1,39 @@
+#!/bin/zsh
+
+set -u
+
+readonly COMMAND_DIRECTORY="${0:A:h}"
+readonly SOURCE_ROOT="${COMMAND_DIRECTORY:h}"
+readonly BUILD_SCRIPT="${COMMAND_DIRECTORY}/build-xcframework.sh"
+
+if [[ -n "${AUDIOKIT_XCFRAMEWORK_OUTPUT:-}" ]]; then
+    output_directory="${AUDIOKIT_XCFRAMEWORK_OUTPUT}"
+elif [[ -d "${SOURCE_ROOT}/../AudioKitBinary" ]]; then
+    output_directory="${SOURCE_ROOT}/../AudioKitBinary"
+else
+    output_directory="${SOURCE_ROOT}/.build/xcframework-output"
+fi
+
+readonly OUTPUT_DIRECTORY="${output_directory}"
+clear
+printf 'AudioKit XCFramework builder\n\n'
+printf 'Output directory:\n%s\n\n' "${OUTPUT_DIRECTORY}"
+
+if [[ ! -x "${BUILD_SCRIPT}" ]]; then
+    printf 'Error: build script was not found or is not executable:\n%s\n' "${BUILD_SCRIPT}" >&2
+    build_status=1
+else
+    "${BUILD_SCRIPT}" "${OUTPUT_DIRECTORY}"
+    build_status="$?"
+fi
+
+if [[ "${build_status}" -eq 0 ]]; then
+    printf '\nDone. AudioKit.xcframework was built successfully.\n'
+else
+    printf '\nThe build failed with exit code %s.\n' "${build_status}" >&2
+fi
+
+printf '\nPress Return to close this window...'
+read -r
+
+exit "${build_status}"


### PR DESCRIPTION
## Summary

Adds an isolated, opt-in build path for producing `AudioKit.xcframework` for:

- iOS devices
- iOS Simulator
- Native macOS

Swift Package Manager remains the default integration path. This change does not add or publish prebuilt binaries.

## Motivation

Projects that reuse a pinned AudioKit release across multiple applications, extensions, internal packages, or CI jobs may repeatedly compile the same sources.

Without a repository-owned build recipe, downstream teams must maintain private Xcode projects and scripts that can drift from the source layout or omit important distribution details such as resources, stable module interfaces, dSYMs, Simulator architectures, and native macOS support.

Keeping the recipe next to the canonical sources provides a reproducible and reviewable foundation for internal binary caching without duplicating production code.

## Included tooling

- A file-system-synchronized framework project referencing `Sources/AudioKit`
- A command-line builder and Finder-friendly `build.command` wrapper
- Configurable iOS and macOS deployment targets
- Optional Intel Mac support
- Stable Swift interfaces through `BUILD_LIBRARY_FOR_DISTRIBUTION`
- Matching dSYMs and `PrivacyInfo.xcprivacy`
- Source and toolchain provenance
- Atomic output replacement

## Safety and validation

The builder:

- Requires a clean checkout based on an AudioKit release tag
- Verifies that `Package.swift` and `Sources/AudioKit` still match that release
- Validates architectures, deployment targets, dynamic linkage, module interfaces, resources, and dSYM UUIDs
- Runs a clean binary-only smoke consumer that imports AudioKit and creates a `Mixer` for iOS Simulator and every selected macOS architecture

## Project impact

- No changes to AudioKit production sources or public API
- No changes to `Package.swift` behavior
- No changes to the existing SwiftPM workflow or default CI path
- All tooling is isolated under `XCFramework` and is fully opt-in
- Binary hosting and release policy remain downstream decisions